### PR TITLE
(98752) Feature: authenticate users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,9 @@
 # Reference: https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 
 DATABASE_URL=postgres://postgres@localhost:5432/database-name
+
+# Azure Active Directory
+#
+# Admin url: https://portal.azure.com.mcas.ms/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/05b7db93-6384-4b44-9d27-23eb6bd97366/isMSAApp~/false
+AZURE_APPLICATION_CLIENT_ID=AZURE_APPLICATION_CLIENT_ID
+AZURE_APPLICATION_CLIENT_SECRET=AZURE_APPLICATION_CLIENT_SECRET

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,11 @@ gem "bootsnap", require: false
 # Use Sass to process CSS
 gem "sass-rails"
 
+# Use Omniauth for authentication
+gem "omniauth"
+gem "omniauth-rails_csrf_protection"
+gem "omniauth-microsoft_graph"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,14 +101,20 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.10.0)
+    faraday (2.3.0)
+      faraday-net_http (~> 2.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (2.0.3)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hashie (5.0.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
     irb (1.4.1)
       reline (>= 0.3.0)
+    jwt (2.4.1)
     loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -120,6 +126,8 @@ GEM
     mini_mime (1.1.2)
     minitest (5.16.1)
     msgpack (1.5.2)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -139,6 +147,25 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
+    oauth2 (1.4.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    omniauth (2.1.0)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-microsoft_graph (1.1.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.7.1)
+    omniauth-oauth2 (1.7.2)
+      oauth2 (~> 1.4)
+      omniauth (>= 1.9, < 3)
+    omniauth-rails_csrf_protection (1.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -153,6 +180,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3.1)
+    rack-protection (2.2.0)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (7.0.3)
@@ -219,6 +248,7 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -280,6 +310,9 @@ DEPENDENCIES
   dotenv-rails
   pg (~> 1.4)
   pry-rails
+  omniauth
+  omniauth-microsoft_graph
+  omniauth-rails_csrf_protection
   puma (~> 5.0)
   rails (~> 7.0.3)
   rspec-rails

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -1,0 +1,29 @@
+module Authentication
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :redirect_unauthenticated_user
+
+    helper_method :current_user
+  end
+
+  private
+
+  def redirect_unauthenticated_user
+    redirect_to sign_in_path, notice: t("sign_in.message.unauthenticated") unless user_authenticated?
+  end
+
+  def user_authenticated?
+    user_id.present?
+  end
+
+  def current_user
+    return unless user_authenticated?
+
+    @current_user ||= User.find(user_id)
+  end
+
+  def user_id
+    session[:user_id]
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,6 @@
 class HomeController < ApplicationController
+  include Authentication
+
   def index
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,40 @@
+class SessionsController < ApplicationController
+  def new
+  end
+
+  def create
+    if registered_user
+      create_session
+      redirect_to root_path
+    else
+      redirect_to sign_in_path, notice: I18n.t("unknown_user.message", email_address: authenticated_user_email_address)
+    end
+  end
+
+  def delete
+    session.destroy
+    redirect_to sign_in_path, notice: I18n.t("sign_out.message.success")
+  end
+
+  def failure
+    redirect_to sign_in_path, notice: I18n.t("sign_in.message.failure")
+  end
+
+  private
+
+  def registered_user
+    @registered_user ||= User.find_by(email: authenticated_user_email_address)
+  end
+
+  def create_session
+    session[:user_id] = registered_user.id
+  end
+
+  def authenticated_user_info
+    request.env["omniauth.auth"].info
+  end
+
+  def authenticated_user_email_address
+    authenticated_user_info.email.downcase
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,2 +1,3 @@
 <h1 class="govuk-heading-l">Home</h1>
-<p>Welcome to the complete conversions transfers and changes service!</p>
+<p>Welcome to the Complete conversions transfers and changes service!</p>
+<p>You are signed in with the email address <%= current_user.email %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,6 +33,8 @@
 
     <div class="govuk-width-container ">
       <main class="govuk-main-wrapper " id="main-content" role="main">
+        <%= render partial: "shared/flash" %>
+
         <%= yield %>
       </main>
     </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,7 @@
+<h1 class="govuk-heading-xl">
+  Sign in
+</h1>
+
+<%= form_tag("/auth/microsoft_graph", method: "post") do %>
+  <%= button_tag(t("sign_in.button", type: :submit), class: "govuk-button") %>
+<% end %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,0 +1,16 @@
+<% if flash.present? %>
+<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <% flash.each do |type, msg| %>
+      <div class="flash <%= type %>">
+        <p><%= msg %></p>
+      </div>
+    <% end %>
+  </div>
+</div>
+<% end %>

--- a/config/initializers/dontenv.rb
+++ b/config/initializers/dontenv.rb
@@ -1,3 +1,5 @@
-Dotenv.require_keys(
-  "DATABASE_URL"
-) if defined?(Dotenv)
+if defined?(Dotenv)
+  Dotenv.require_keys(
+    "DATABASE_URL"
+  )
+end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,5 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :microsoft_graph, ENV['AZURE_APPLICATION_CLIENT_ID'], ENV['AZURE_APPLICATION_CLIENT_SECRET']
+  provider :microsoft_graph, ENV["AZURE_APPLICATION_CLIENT_ID"], ENV["AZURE_APPLICATION_CLIENT_SECRET"]
 end
 
 OmniAuth.config.on_failure = proc { |env|

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,7 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :microsoft_graph, ENV['AZURE_APPLICATION_CLIENT_ID'], ENV['AZURE_APPLICATION_CLIENT_SECRET']
+end
+
+OmniAuth.config.on_failure = proc { |env|
+  OmniAuth::FailureEndpoint.new(env).redirect_to_failure
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,16 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  sign_in:
+    button: Sign in with your DfE Microsoft account
+    message:
+      unauthenticated: You must sign in to use this service.
+      failure: Authentication failed.
+  sign_out:
+    message:
+      success: You have signed out. You may still be signed in to your Microsoft account.
+  unknown_user:
+    message: The email address %{email_address} is not registered to use this service.
   tasks:
     users:
       create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,14 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "home#index"
+
+  # Sign in
+  get "/sign-in", to: "sessions#new"
+  # Sign out
+  get "/sign-out", to: "sessions#delete"
+  # Sign in fails
+  get "auth/failure", to: "sessions#failure"
+
+  # Omniauth callbacks
+  get "auth/:provider/callback", to: "sessions#create"
 end

--- a/db/migrate/20220620083237_create_users.rb
+++ b/db/migrate/20220620083237_create_users.rb
@@ -3,7 +3,7 @@ class CreateUsers < ActiveRecord::Migration[7.0]
     enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
 
     create_table :users, id: :uuid do |t|
-      t.string :email, index: { unique: true }
+      t.string :email, index: {unique: true}
       t.timestamps
     end
   end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -5,6 +5,6 @@ namespace :users do
 
     abort I18n.t("tasks.users.create.error") if email_address.nil?
 
-    User.create!(email: email_address)
+    User.create!(email: email_address.downcase)
   end
 end

--- a/spec/features/users_can_sign_in_spec.rb
+++ b/spec/features/users_can_sign_in_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.feature "Users can sign in to the application" do
+  context "when the authentication is successful" do
+    let(:user_email_address) { "user@education.gov.uk" }
+
+    before do
+      User.create!(email: user_email_address)
+      OmniAuth.config.mock_auth[:microsoft_graph] = OmniAuth::AuthHash.new({
+        info: {
+          email: user_email_address
+        }
+      })
+      OmniAuth.config.test_mode = true
+    end
+
+    scenario "from the sign in page" do
+      visit sign_in_path
+      click_button("Sign in with your DfE Microsoft account")
+
+      expect(page).not_to have_button(I18n.t("sign_in.button"))
+      expect(page).to have_users_email_address
+    end
+
+    scenario "from any page, they are redirected to the sign in page" do
+      visit root_path
+      click_button("Sign in with your DfE Microsoft account")
+
+      expect(page).to have_users_email_address
+    end
+  end
+
+  context "when the authentication fails" do
+    before do
+      OmniAuth.config.mock_auth[:microsoft_graph] = :invalid_credentials
+      OmniAuth.config.test_mode = true
+    end
+
+    scenario "they are redirected to the sign in page and shown a helpful message" do
+      visit sign_in_path
+      click_button("Sign in with your DfE Microsoft account")
+
+      expect(page).to have_button(I18n.t("sign_in.button"))
+      within(".flash") do
+        expect(page).to have_content(I18n.t("sign_in.message.failure"))
+      end
+    end
+  end
+
+  def have_users_email_address
+    have_content(user_email_address)
+  end
+end

--- a/spec/features/users_can_sign_out_spec.rb
+++ b/spec/features/users_can_sign_out_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.feature "Users can sign out of the applicaiton" do
+  scenario "by visiting the `/sign-out` url" do
+    visit sign_out_path
+
+    expect(page).to have_content(I18n.t("sign_out.message.success"))
+    expect(page).to have_button(I18n.t("sign_in.button"))
+    expect(page.current_path).to eq "/sign-in"
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,9 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # cleanup Omniauth after each example
+  config.after(:each) do |example|
+    OmniAuth.config.mock_auth[:microsoft_graph] = nil
+  end
 end

--- a/spec/requests/sign_in_spec.rb
+++ b/spec/requests/sign_in_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe "Sign in" do
+  context "when the user is signed out" do
+    it "redirects them to the sign in page and shows a helpful message" do
+      get root_path
+
+      expect(request).to redirect_to(sign_in_path)
+      expect(flash.to_h.values).to include I18n.t("sign_in.message.unauthenticated")
+    end
+  end
+
+  context "when the user is signed in" do
+    let(:user_email_address) { "user@education.gov.uk" }
+
+    before do
+      User.create!(email: user_email_address)
+      OmniAuth.config.mock_auth[:microsoft_graph] = OmniAuth::AuthHash.new({
+        info: {
+          email: user_email_address
+        }
+      })
+      OmniAuth.config.test_mode = true
+    end
+
+    it "loads the requested page" do
+      get root_path
+      follow_redirect!
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  context "when the users is not known by the application" do
+    let(:user_email_address) { "user@education.gov.uk" }
+
+    before do
+      User.create!(email: "another.user@education.gov.uk")
+      OmniAuth.config.mock_auth[:microsoft_graph] = OmniAuth::AuthHash.new({
+        info: {
+          email: user_email_address
+        }
+      })
+      OmniAuth.config.test_mode = true
+    end
+
+    it "redirects to the sign in page and shows a helpful message" do
+      get "/auth/microsoft_graph/callback"
+
+      expect(request).to redirect_to(sign_in_path)
+      expect(flash.to_h.values).to include I18n.t("unknown_user.message", email_address: user_email_address)
+    end
+  end
+end

--- a/spec/requests/sign_out_spec.rb
+++ b/spec/requests/sign_out_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "Sign out" do
+  context "when the user is signed in" do
+    let(:user_email_address) { "user@education.gov.uk" }
+
+    before do
+      User.create!(email: user_email_address)
+      OmniAuth.config.mock_auth[:microsoft_graph] = OmniAuth::AuthHash.new({
+        info: {
+          email: user_email_address
+        }
+      })
+      OmniAuth.config.test_mode = true
+    end
+
+    it "signs out, redirects to the sign in page and shows a helpful message" do
+      get sign_out_path
+
+      expect(session[:user_id]).to be_nil
+      expect(request).to redirect_to(sign_in_path)
+      expect(flash.to_h.values).to include I18n.t("sign_out.message.success")
+    end
+  end
+end


### PR DESCRIPTION
We will be using Microsoft to authenticate users as we know all DfE users of our service will have an acoount.

To do so we use the Omniauth gem, a light touch way of intergrating with authentication services. Along with Omniauth, we'll use a Microsoft Graph plugin to orchistrate the authentication.

Initially we will authorise users by storing 'registered' users in our applicaiton and checking the user authenticatin has an email address we know of, this prevents any DfE user access our application.

Once we have an authenticated and authorised user, we store our user id in the secure Rails session cookie, the presence of this id tells us a user is authenticated.

The sign in flow is based around the idea of returning the user to the sign in page whenever something happens:

- successful sign out
- email address not recognised
- authentication failure

And showing a helpful message. The design and content of the messages has been through a brief design review and is our first attempt, we're not looking for perfection there!

Upon a successful authentication and authorisation, users are simply redirected to the existing placeholder home page. Again, we know this is set to change, but we prove the user is signed in by showing their email address.

At this point we don't feel the need to provide a sign out UI as it seems unnecessary as our users would need to sign out of all Microsoft authenticated services in order to do so. We have added a sign out route here and can always add UI should it be seen as helpful.

Most of the work here is done in the final commit, I wanted to break this up, but I am struggling to do so, apologies for the size.

We need to add an ADR for all this, but this PR is large enough so I will follow up with that.
