### PR TITLE
Add phase banner and breadcrumbs block to layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,19 @@
     <%= render partial: "shared/header" %>
 
     <div class="govuk-width-container ">
+
+      <div class="govuk-phase-banner">
+        <p class="govuk-phase-banner__content">
+          <strong class="govuk-tag govuk-phase-banner__content__tag">
+            <%= t("phase_banner.phase") %>
+          </strong>
+          <span class="govuk-phase-banner__text">
+            <%= t("phase_banner.text") %>
+          </span>
+        </p>
+      </div>
+
+      <%= yield :breadcrumbs %>
       <main class="govuk-main-wrapper " id="main-content" role="main">
         <%= yield %>
       </main>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,9 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  phase_banner:
+    phase: pre-alpha
+    text: This is a service so new you can't even give us feedback yet.
   tasks:
     users:
       create:


### PR DESCRIPTION
Add the phase banner to the top of the site layout, and a block which can be used for breadcrumb navigation.

## Screenshots

### Before
![localhost_3000_ (1)](https://user-images.githubusercontent.com/619082/175048658-c73b6265-39df-4784-a178-e303e6653d0c.png)

### After
![localhost_3000_ (2)](https://user-images.githubusercontent.com/619082/175048665-f47674c1-01be-4368-a089-8b61438aa813.png)
