### PR TITLE
(99040) Add simplecov to monitor test coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ end
 group :test do
   gem "capybara"
   gem "climate_control"
+  gem "simplecov", "~> 0.21.2"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,8 +86,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    coderay (1.1.3)
     climate_control (1.1.1)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     debug (1.5.0)
@@ -95,6 +95,7 @@ GEM
       reline (>= 0.2.7)
     diff-lcs (1.5.0)
     digest (3.1.0)
+    docile (1.4.0)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
@@ -228,6 +229,12 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -260,6 +267,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -276,6 +284,7 @@ DEPENDENCIES
   rails (~> 7.0.3)
   rspec-rails
   sass-rails
+  simplecov (~> 0.21.2)
   sprockets-rails
   standard
   tzinfo-data

--- a/doc/decisions/0002-use-simplecov-to-monitor-code-test-coverage.md
+++ b/doc/decisions/0002-use-simplecov-to-monitor-code-test-coverage.md
@@ -1,0 +1,30 @@
+# 2. use-coveralls-to-monitor-test-coverage
+
+Date: 2022-06-22
+
+## Status
+
+Accepted
+
+## Context
+
+We want to keep our test coverage as high as possible without having to run
+manual checks as these take time and are easy to forget.
+
+## Decision
+
+Use Simplecov with RSpec to monitor coverage changes on every test run
+
+## Consequences
+
+- Simplecov is not dependent on a third-party service such as Coveralls.io
+- Simplecov can be used on private or public Github repositories
+- Being part of the test suite allows feedback to be providing locally to give
+  feedback soon
+- Being part of the test suite allows pull requests to automatically be marked
+  as failed and block merging of new code that introduces gaps
+- We have to choose a coverage threshold to return an exit code in order to
+  block deploys. The right default value is a matter of opinion however teams
+  can easily change it
+- Not using a service like Coveralls means we won't have their features like
+  coverage over time, badges, notifications etc

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,10 @@
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
+require "simplecov"
+SimpleCov.minimum_coverage 100
+SimpleCov.start "rails"
+
 # Add Capybara
 require "capybara/rspec"
 


### PR DESCRIPTION
As per [dxw RFC 173](https://github.com/dxw/tech-team-rfcs/blob/main/rfc-173-testing-our-work.md), set up test coverage monitoring so that anything less than 100% coverage counts as a test failure.