### PR TITLE
(137) Chore: Switch omniauth strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,4 @@ DATABASE_URL=postgres://postgres@localhost:5432/database-name
 # Admin url: https://portal.azure.com.mcas.ms/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/05b7db93-6384-4b44-9d27-23eb6bd97366/isMSAApp~/false
 AZURE_APPLICATION_CLIENT_ID=AZURE_APPLICATION_CLIENT_ID
 AZURE_APPLICATION_CLIENT_SECRET=AZURE_APPLICATION_CLIENT_SECRET
+AZURE_TENANT_ID=AZURE_TENANT_ID

--- a/.env.test
+++ b/.env.test
@@ -8,3 +8,10 @@
 # Reference: https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 
 DATABASE_URL=postgres://postgres@localhost:5432/dfe-complete-academies-test
+
+# Azure Active Directory
+#
+# Admin url: https://portal.azure.com.mcas.ms/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/05b7db93-6384-4b44-9d27-23eb6bd97366/isMSAApp~/false
+AZURE_APPLICATION_CLIENT_ID=AZURE_APPLICATION_CLIENT_ID
+AZURE_APPLICATION_CLIENT_SECRET=AZURE_APPLICATION_CLIENT_SECRET
+AZURE_TENANT_ID=AZURE_TENANT_ID

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "sass-rails"
 # Use Omniauth for authentication
 gem "omniauth"
 gem "omniauth-rails_csrf_protection"
-gem "omniauth-microsoft_graph"
+gem "omniauth-azure-activedirectory-v2"
 
 gem "govuk_design_system_formbuilder", "~> 3.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,9 +164,8 @@ GEM
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
-    omniauth-microsoft_graph (1.1.0)
-      omniauth (~> 2.0)
-      omniauth-oauth2 (~> 1.7.1)
+    omniauth-azure-activedirectory-v2 (1.0.0)
+      omniauth-oauth2 (~> 1.7)
     omniauth-oauth2 (1.7.2)
       oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
@@ -317,7 +316,7 @@ DEPENDENCIES
   dotenv-rails
   govuk_design_system_formbuilder (~> 3.0)
   omniauth
-  omniauth-microsoft_graph
+  omniauth-azure-activedirectory-v2
   omniauth-rails_csrf_protection
   pg (~> 1.4)
   pry-rails

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ available at [`http://localhost:3000/`](http://localhost:3000/).
 
 To run the test suite, run `script/test`.
 
+## Environment variables
+
+See .env.example
+
 ## ADRs
 
 You can find the [ADRs](https://adr.github.io/) for this project in the

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -2,6 +2,6 @@
   Sign in
 </h1>
 
-<%= form_tag("/auth/microsoft_graph", method: "post") do %>
+<%= form_tag("/auth/azure_activedirectory_v2", method: "post") do %>
   <%= button_tag(t("sign_in.button", type: :submit), class: "govuk-button") %>
 <% end %>

--- a/config/initializers/dontenv.rb
+++ b/config/initializers/dontenv.rb
@@ -1,5 +1,8 @@
 if defined?(Dotenv)
   Dotenv.require_keys(
-    "DATABASE_URL"
+    "DATABASE_URL",
+    "AZURE_APPLICATION_CLIENT_ID",
+    "AZURE_APPLICATION_CLIENT_SECRET",
+    "AZURE_TENANT_ID"
   )
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,10 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :microsoft_graph, ENV["AZURE_APPLICATION_CLIENT_ID"], ENV["AZURE_APPLICATION_CLIENT_SECRET"]
+  provider :azure_activedirectory_v2,
+    {
+      client_id: ENV["AZURE_APPLICATION_CLIENT_ID"],
+      client_secret: ENV["AZURE_APPLICATION_CLIENT_SECRET"],
+      tenant_id: ENV["AZURE_TENANT_ID"]
+    }
 end
 
 OmniAuth.config.on_failure = proc { |env|

--- a/doc/decisions/0003-user-sign-in.md
+++ b/doc/decisions/0003-user-sign-in.md
@@ -1,0 +1,49 @@
+# 3. User sign in
+
+Date: 2022-06-28
+
+## Status
+
+Accepted
+
+## Context
+
+Our application will require users to sign in. Doing so allows us to meet both
+user and business needs such as personalisation and data security.
+
+DfE already has an Active Directory service running in Azure. Our first user
+group will have accounts in the directory as part of the their DfE onboarding.
+
+Connecting to and utilising an existing authorisation service like this reduces
+the amount of effort required from our team.
+
+## Decision
+
+Our Rails app will connect to the DfE Active Directory to authorise users via
+Oauth2.
+
+We will use off the shelf gems to achieve this in the Rails application:
+
+- Omniauth https://github.com/omniauth/omniauth
+- Omniauth Microsoft Azure Active Directory
+  https://github.com/RIPGlobal/omniauth-azure-activedirectory-v2
+
+We chose the Microsoft Azure Active Directory strategy as we want to use single
+tenant mode, so that only DfE users can authenticate and because it is the most
+up-to-date fork of the original Microsoft gem.
+
+## Consequences
+
+DfE users are required to have a DfE Microsoft account.
+
+For the majority of users, the authentication will have already occurred and
+will be a familiar experience if it is required.
+
+Setting up and maintaining the access to the Active Directory in Azure. This
+will be minimal as it already exists and most of the work will be carried out
+during initial development.
+
+Potential for any DfE user to authenticate to the application, mitigated by
+storing 'registered' users in the application. The list of registered users will
+initially be managed by developers only, if prioritised, we can allow management
+within the application later.

--- a/spec/features/users_can_sign_in_spec.rb
+++ b/spec/features/users_can_sign_in_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Users can sign in to the application" do
 
   context "when the authentication fails" do
     before do
-      OmniAuth.config.mock_auth[:microsoft_graph] = :invalid_credentials
+      OmniAuth.config.mock_auth[:azure_activedirectory_v2] = :invalid_credentials
       OmniAuth.config.test_mode = true
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,6 +68,6 @@ RSpec.configure do |config|
 
   # cleanup Omniauth after each example
   config.after(:each) do |example|
-    OmniAuth.config.mock_auth[:microsoft_graph] = nil
+    OmniAuth.config.mock_auth[:azure_activedirectory_v2] = nil
   end
 end

--- a/spec/requests/sign_in_spec.rb
+++ b/spec/requests/sign_in_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Sign in" do
 
     before do
       User.create!(email: "another.user@education.gov.uk")
-      OmniAuth.config.mock_auth[:microsoft_graph] = OmniAuth::AuthHash.new({
+      OmniAuth.config.mock_auth[:azure_activedirectory_v2] = OmniAuth::AuthHash.new({
         info: {
           email: user_email_address
         }
@@ -39,7 +39,7 @@ RSpec.describe "Sign in" do
     end
 
     it "redirects to the sign in page and shows a helpful message" do
-      get "/auth/microsoft_graph/callback"
+      get "/auth/azure_activedirectory_v2/callback"
 
       expect(request).to redirect_to(sign_in_path)
       expect(flash.to_h.values).to include I18n.t("unknown_user.message", email_address: user_email_address)

--- a/spec/requests/sign_out_spec.rb
+++ b/spec/requests/sign_out_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Sign out" do
 
     before do
       User.create!(email: user_email_address)
-      OmniAuth.config.mock_auth[:microsoft_graph] = OmniAuth::AuthHash.new({
+      OmniAuth.config.mock_auth[:azure_activedirectory_v2] = OmniAuth::AuthHash.new({
         info: {
           email: user_email_address
         }

--- a/spec/support/sign_in_helpers.rb
+++ b/spec/support/sign_in_helpers.rb
@@ -1,7 +1,7 @@
 module SignInHelpers
   def mock_auth_with_user(user_email_address)
     User.create!(email: user_email_address)
-    OmniAuth.config.mock_auth[:microsoft_graph] = OmniAuth::AuthHash.new({
+    OmniAuth.config.mock_auth[:azure_activedirectory_v2] = OmniAuth::AuthHash.new({
       info: {
         email: user_email_address
       }


### PR DESCRIPTION
Whilst writing the included ADR we realised that we should support 'single tenant' mode in Azure Active Directory. This means only DfE users can authenticate, which will give us more confidence in the security of the applicaiton.

The previous Omniauth strategy did not support this mode of operation so we found one that does.

Once switched, we add some environment variable documentation and the ADR to cover sign in.

https://trello.com/c/ERSuVJsi