### PR TITLE
(107) Feature: academies api client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem "omniauth-azure-activedirectory-v2"
 
 gem "govuk_design_system_formbuilder", "~> 3.1"
 
+gem "faraday"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,6 +314,7 @@ DEPENDENCIES
   climate_control
   debug
   dotenv-rails
+  faraday
   govuk_design_system_formbuilder (~> 3.1)
   omniauth
   omniauth-azure-activedirectory-v2

--- a/app/models/academies_api/client.rb
+++ b/app/models/academies_api/client.rb
@@ -1,0 +1,22 @@
+class AcademiesApi::Client
+  ACADEMIES_API_TIMEOUT = 0.6
+
+  attr_reader :connection
+
+  def initialize(connection: nil)
+    @connection = connection || default_connection
+  end
+
+  private def default_connection
+    Faraday.new(
+      url: ENV["ACADEMIES_API_HOST"],
+      request: {
+        timeout: ACADEMIES_API_TIMEOUT
+      },
+      headers: {
+        "Content-Type": "application/json",
+        ApiKey: ENV["ACADEMIES_API_KEY"]
+      }
+    )
+  end
+end

--- a/app/models/academies_api/establishment.rb
+++ b/app/models/academies_api/establishment.rb
@@ -1,0 +1,9 @@
+class AcademiesApi::Establishment
+  def initialize(body)
+    @raw = JSON.parse(body)
+  end
+
+  def name
+    @raw.fetch("establishmentName")
+  end
+end

--- a/config/locales/academies_api_en.yml
+++ b/config/locales/academies_api_en.yml
@@ -1,0 +1,6 @@
+en:
+  academies_api:
+    get_establishment:
+      errors:
+        not_found: Could not find establishment with URN %{urn}
+        other: There was an error connecting to the Academies API, could not fetch establishment for URN %{urn}

--- a/spec/models/academies_api/client_spec.rb
+++ b/spec/models/academies_api/client_spec.rb
@@ -14,4 +14,69 @@ RSpec.describe AcademiesApi::Client do
       expect(client_connection.options[:timeout]).to eql AcademiesApi::Client::ACADEMIES_API_TIMEOUT
     end
   end
+
+  describe "#get_establishment" do
+    let(:client) { described_class.new(connection: fake_successful_connection(12345678, fake_response)) }
+
+    context "when the establishment can be found" do
+      let(:fake_response) { [200, nil, {establishmentName: "Establishment Name"}.to_json] }
+
+      it "returns a Result with the establishment and no error" do
+        result = client.get_establishment(12345678)
+
+        expect(result.object.name).to eql("Establishment Name")
+        expect(result.error).to be_nil
+      end
+    end
+
+    context "when the establishment cannot be found" do
+      let(:fake_response) { [404, nil, nil] }
+
+      it "returns a Result with a NotFoundError and no establishment" do
+        the_result = client.get_establishment(12345678)
+
+        expect(the_result.object).to be_nil
+        expect(the_result.error).to be_a(AcademiesApi::Client::NotFoundError)
+      end
+    end
+
+    context "when there is any other error" do
+      let(:fake_response) { [500, nil, nil] }
+
+      it "returns a Result with an Error and no establishment" do
+        the_result = client.get_establishment(12345678)
+
+        expect(the_result.object).to be_nil
+        expect(the_result.error).to be_a(AcademiesApi::Client::Error)
+      end
+    end
+
+    context "when the connection fails" do
+      it "raises an Error" do
+        client = described_class.new(connection: fake_failed_connection(12345678))
+
+        expect { client.get_establishment(12345678) }.to raise_error(AcademiesApi::Client::Error)
+      end
+    end
+  end
+
+  def fake_successful_connection(urn, response)
+    Faraday.new do |builder|
+      builder.adapter :test do |stub|
+        stub.get("/establishment/urn/#{urn}") do |env|
+          response
+        end
+      end
+    end
+  end
+
+  def fake_failed_connection(urn)
+    Faraday.new do |builder|
+      builder.adapter :test do |stub|
+        stub.get("/establishment/urn/#{urn}") do |env|
+          raise Faraday::Error
+        end
+      end
+    end
+  end
 end

--- a/spec/models/academies_api/client_spec.rb
+++ b/spec/models/academies_api/client_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe AcademiesApi::Client do
+  it "uses the environment variables to build the connection" do
+    ClimateControl.modify(
+      ACADEMIES_API_HOST: "https://test.academies.api",
+      ACADEMIES_API_KEY: "api-key"
+    ) do
+      client_connection = described_class.new.connection
+
+      expect(client_connection.scheme).to eql "https"
+      expect(client_connection.host).to eql "test.academies.api"
+      expect(client_connection.headers["ApiKey"]).to eql "api-key"
+      expect(client_connection.options[:timeout]).to eql AcademiesApi::Client::ACADEMIES_API_TIMEOUT
+    end
+  end
+end


### PR DESCRIPTION
This is a basic wrapper for the Academies API, here we shape the Client and the Establishment.

This work let's you fetch `Establishment` objects from the Rails console by URN (123456 is a real URN):

```
client = AcademiesApi::Client.new
establshment = client.get_establishment(123456)
```

Right now we only model the Establishment name:

```
establishment.name
```

I am not sure what a reasonable timeout for connecting to the Academies API is, but poking about led me to this 0.6 second value for now.

Our next steps will be to use the Establishment alongside the `Project` so we can show users more useful information.

https://trello.com/c/R4v0B6W4
