### PR TITLE
(168) Implement permission control for resources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,9 @@ gem "omniauth"
 gem "omniauth-rails_csrf_protection"
 gem "omniauth-azure-activedirectory-v2"
 
+# Use pundit for authorisation management
+gem "pundit", "~> 2.2"
+
 gem "govuk_design_system_formbuilder", "~> 3.1"
 
 gem "faraday"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,8 @@ GEM
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
+    pundit (2.2.0)
+      activesupport (>= 3.0.0)
     racc (1.6.0)
     rack (2.2.3.1)
     rack-protection (2.2.0)
@@ -330,6 +332,7 @@ DEPENDENCIES
   pg (~> 1.4)
   pry-rails
   puma (~> 5.0)
+  pundit (~> 2.2)
   rails (~> 7.0.3)
   rspec-rails
   sass-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,14 @@
 class ApplicationController < ActionController::Base
+  include Pundit::Authorization
+
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
+
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  private
+
+  def user_not_authorized
+    flash[:alert] = I18n.t("unauthorised_action.message")
+    redirect_back(fallback_location: root_path)
+  end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,20 +1,25 @@
 class ProjectsController < ApplicationController
   include Authentication
+  after_action :verify_authorized
 
   def index
+    authorize Project
     @projects = Project.all
   end
 
   def show
     @project = Project.includes(sections: [:tasks]).find(params[:id])
+    authorize @project
   end
 
   def new
+    authorize Project
     @project = Project.new
   end
 
   def create
     @project = Project.new(project_params)
+    authorize @project
 
     if @project.valid?
       @project.save
@@ -29,11 +34,15 @@ class ProjectsController < ApplicationController
 
   def edit
     @project = Project.find(params[:id])
+    authorize @project
+
     @users = User.all
   end
 
   def update
     @project = Project.find(params[:id])
+    authorize @project
+
     @project.assign_attributes(project_params)
 
     @project.save

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,10 +1,11 @@
 class ProjectsController < ApplicationController
   include Authentication
   after_action :verify_authorized
+  after_action :verify_policy_scoped, only: :index
 
   def index
     authorize Project
-    @projects = Project.all
+    @projects = policy_scope(Project).includes([:delivery_officer])
   end
 
   def show

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -23,7 +23,7 @@ class ProjectPolicy
   end
 
   def edit?
-    true
+    user.team_leader?
   end
 
   def update?

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -29,4 +29,23 @@ class ProjectPolicy
   def update?
     edit?
   end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      if user.team_leader?
+        scope.all
+      else
+        scope.where(delivery_officer: user)
+      end
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
 end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -1,0 +1,32 @@
+class ProjectPolicy
+  attr_reader :user, :project
+
+  def initialize(user, project)
+    @user = user
+    @record = project
+  end
+
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    user.team_leader?
+  end
+
+  def new?
+    create?
+  end
+
+  def edit?
+    true
+  end
+
+  def update?
+    edit?
+  end
+end

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -29,11 +29,13 @@
       </dl>
     <% end %>
 
-    <p><%= link_to "Add a new project",
-      new_project_path,
-      class: 'govuk-button',
-      data: {module: "govuk-button"}
-    %></p>
+    <% if policy(:project).new? %>
+      <p><%= link_to t('project.index.new_button.text'),
+        new_project_path,
+        class: 'govuk-button',
+        data: {module: "govuk-button"}
+      %></p>
+    <% end %>
 
   </div>
 </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -10,9 +10,11 @@
         <span class="govuk-!-font-weight-bold"><%= t('project.summary.delivery_officer.title') %>:</span>
         <%= @project.delivery_officer&.email or t('project.summary.delivery_officer.unassigned') %></p>
     </div>
-    <p class="govuk-body">
-      <%= link_to t('project.show.edit_button.text'), edit_project_path(@project), class: "govuk-link" %>
-    </p>
+    <% if policy(@project).edit? %>
+      <p class="govuk-body">
+        <%= link_to t('project.show.edit_button.text'), edit_project_path(@project), class: "govuk-link" %>
+      </p>
+    <% end %>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,8 @@ en:
       success: You have signed out. You may still be signed in to your Microsoft account.
   unknown_user:
     message: The email address %{email_address} is not registered to use this service.
+  unauthorised_action:
+    message: You are not authorised to perform this action.
   tasks:
     users:
       create:
@@ -49,6 +51,8 @@ en:
     index:
       title:
         all: All projects
+      new_button:
+        text: Add a new project
     show:
       title: Project task list
       edit_button:

--- a/doc/decisions/0004-use-pundit-to-manage-authorisation.md
+++ b/doc/decisions/0004-use-pundit-to-manage-authorisation.md
@@ -1,0 +1,28 @@
+# 4. Use pundit gem to manage authorisation
+
+Date: 2022-07-07
+
+## Status
+
+Accepted
+
+## Context
+
+During research, users have indicated a potential need for only some types of
+users (team leaders) to be able to perform certain actions, and for other users
+to only be presented with a list of projects they are currently working on.
+
+Ideally, this functionality would be provided by a lightweight layer which
+authorises a user (who meets a given set of criteria) to perform actions.
+
+## Decision
+
+We have decided to implement user authorisation management using the
+[pundit](https://github.com/varvet/pundit) gem.
+
+## Consequences
+
+- Users may find that actions they could take previously are no longer available
+  to them.
+- Developers must be aware that some actions should be subject to authorisation
+  controls, and develop new features accordingly.

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,5 +2,9 @@ FactoryBot.define do
   factory :user do
     email { "user@education.gov.uk" }
     team_leader { false }
+
+    trait :team_leader do
+      team_leader { true }
+    end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    email { "user@education.gov.uk" }
+    team_leader { false }
+  end
+end

--- a/spec/features/users_can_create_projects_spec.rb
+++ b/spec/features/users_can_create_projects_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Users can create a new project" do
   let(:mock_workflow) { file_fixture("workflows/conversion.yml") }
 
   before(:each) do
-    sign_in_with_user("user@education.gov.uk")
+    sign_in_with_user(create(:user))
     visit new_project_path
 
     allow(YAML).to receive(:load_file).with("workflows/conversion.yml").and_return(

--- a/spec/features/users_can_create_projects_spec.rb
+++ b/spec/features/users_can_create_projects_spec.rb
@@ -1,10 +1,46 @@
 require "rails_helper"
 
-RSpec.feature "Users can create a new project" do
+RSpec.feature "Users can view the new project form" do
+  context "the user is a team leader" do
+    before(:each) do
+      sign_in_with_user(create(:user, :team_leader))
+    end
+
+    scenario "can see the new project button" do
+      visit projects_path
+      expect(page).to have_content(I18n.t("project.index.new_button.text"))
+    end
+
+    scenario "can see the new project form" do
+      visit new_project_path
+      expect(page).to have_content(I18n.t("project.new.title"))
+    end
+  end
+
+  context "the user is not a team leader" do
+    before(:each) do
+      sign_in_with_user(create(:user))
+    end
+
+    scenario "cannot see the new project button" do
+      visit projects_path
+      expect(page).to_not have_content(I18n.t("project.index.new_button.text"))
+    end
+
+    scenario "cannot see the new project form" do
+      visit new_project_path
+      expect(page).to have_content(I18n.t("unauthorised_action.message"))
+    end
+  end
+end
+
+RSpec.feature "Team leaders can create a new project" do
   let(:mock_workflow) { file_fixture("workflows/conversion.yml") }
 
+  let(:team_leader) { create(:user, :team_leader) }
+
   before(:each) do
-    sign_in_with_user(create(:user))
+    sign_in_with_user(team_leader)
     visit new_project_path
 
     allow(YAML).to receive(:load_file).with("workflows/conversion.yml").and_return(

--- a/spec/features/users_can_sign_in_spec.rb
+++ b/spec/features/users_can_sign_in_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Users can sign in to the application" do
   context "when the authentication is successful" do
-    let(:user) { User.create!(email: "user@education.gov.uk") }
+    let(:user) { create(:user) }
 
     before do
       mock_successful_authentication(user.email)

--- a/spec/features/users_can_update_projects_spec.rb
+++ b/spec/features/users_can_update_projects_spec.rb
@@ -1,71 +1,90 @@
 require "rails_helper"
 
 RSpec.feature "Users can reach the edit project page" do
-  scenario "by following a link from the show project page" do
-    sign_in_with_user(create(:user))
+  let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
+  let(:delivery_officer) { create(:user, email: "user1@education.gov.uk") }
 
-    single_project = Project.create!(urn: 19283746)
+  context "the user is a team leader" do
+    before(:each) do
+      sign_in_with_user(team_leader)
+      @unassigned_project = Project.create!(urn: 1001)
+    end
 
-    visit project_path(single_project.id)
-    click_on I18n.t("project.show.edit_button.text")
-    expect(page).to have_content(I18n.t("project.edit.title"))
-    expect(page).to have_content(single_project.urn.to_s)
+    scenario "by following a link from the show project page" do
+      visit project_path(@unassigned_project)
+      click_on I18n.t("project.show.edit_button.text")
+      expect(page).to have_content(I18n.t("project.edit.title"))
+      expect(page).to have_content(@unassigned_project.urn.to_s)
+    end
+
+    scenario "by visiting the edit project page directly" do
+      visit edit_project_path(@unassigned_project)
+      expect(page).to have_content(I18n.t("project.edit.title"))
+      expect(page).to have_content(@unassigned_project.urn.to_s)
+    end
+  end
+
+  context "the user is not a team leader" do
+    before(:each) do
+      sign_in_with_user(delivery_officer)
+      @user1_project = Project.create!(urn: 1002, delivery_officer: delivery_officer)
+    end
+
+    scenario "there is no edit link on the show project page" do
+      visit project_path(@user1_project)
+      expect(page).to_not have_content(I18n.t("project.show.edit_button.text"))
+    end
+
+    scenario "cannot visit edit project page directly" do
+      visit edit_project_path(@user1_project)
+      expect(page).to have_content(I18n.t("unauthorised_action.message"))
+    end
   end
 end
 
 RSpec.feature "Users can update a project" do
-  let(:user_email) { "user@education.gov.uk" }
+  let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
+  let(:delivery_officer) { create(:user, email: "user1@education.gov.uk") }
+  let(:delivery_officer_2) { create(:user, email: "user2@education.gov.uk") }
 
-  before(:each) do
-    sign_in_with_user(create(:user, email: user_email))
-  end
-
-  context "when the project has no delivery officer" do
-    scenario "the delivery officer can be set" do
-      single_project = Project.create!(urn: 19283746)
-
-      visit edit_project_path(single_project.id)
-      select user_email, from: "project-delivery-officer-id-field"
-      click_on "Continue"
-      expect(page).to have_content(user_email)
-    end
-  end
-
-  context "when the project already has a delivery officer" do
-    scenario "the delivery officer can be changed" do
-      user2 = create(:user, email: "user2@education.gov.uk")
-
-      single_project = Project.create!(urn: 19283746, delivery_officer: user2)
-
-      visit edit_project_path(single_project.id)
-      select user_email, from: "project-delivery-officer-id-field"
-      click_on "Continue"
-      expect(page).to have_content(user_email)
+  context "the user is a team leader" do
+    before(:each) do
+      sign_in_with_user(team_leader)
     end
 
-    scenario "the delivery officer can be unset" do
-      user = User.find_by(email: "user@education.gov.uk")
+    context "when the project has no delivery officer" do
+      before(:each) do
+        @unassigned_project = Project.create!(urn: 1001)
+        @delivery_officer = delivery_officer
+      end
 
-      single_project = Project.create!(urn: 19283746, delivery_officer: user)
-
-      visit edit_project_path(single_project.id)
-      select "", from: "project-delivery-officer-id-field"
-      click_on "Continue"
-      expect(page).to have_content(I18n.t("project.summary.delivery_officer.unassigned"))
+      scenario "the delivery officer can be set" do
+        visit edit_project_path(@unassigned_project)
+        select @delivery_officer.email, from: "project-delivery-officer-id-field"
+        click_on "Continue"
+        expect(page).to have_content(@delivery_officer.email)
+      end
     end
-  end
-end
 
-RSpec.feature "Users can unset the delivery officer of a project" do
-  scenario "when the project already has a delivery officer" do
-    sign_in_with_user(create(:user))
-    user = User.find_by(email: "user@education.gov.uk")
+    context "when the project already has a delivery officer" do
+      before(:each) do
+        @assigned_project = Project.create!(urn: 1002, delivery_officer: delivery_officer)
+      end
 
-    single_project = Project.create!(urn: 19283746, delivery_officer: user)
+      scenario "the delivery officer can be changed" do
+        @delivery_officer_2 = delivery_officer_2
+        visit edit_project_path(@assigned_project)
+        select delivery_officer_2.email, from: "project-delivery-officer-id-field"
+        click_on "Continue"
+        expect(page).to have_content(delivery_officer_2.email)
+      end
 
-    visit edit_project_path(single_project.id)
-    select "", from: "project-delivery-officer-id-field"
-    click_on "Continue"
-    expect(page).to have_content(I18n.t("project.summary.delivery_officer.unassigned"))
+      scenario "the delivery officer can be unset" do
+        visit edit_project_path(@assigned_project)
+        select "", from: "project-delivery-officer-id-field"
+        click_on "Continue"
+        expect(page).to have_content(I18n.t("project.summary.delivery_officer.unassigned"))
+      end
+    end
   end
 end

--- a/spec/features/users_can_update_projects_spec.rb
+++ b/spec/features/users_can_update_projects_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Users can reach the edit project page" do
   scenario "by following a link from the show project page" do
-    sign_in_with_user("user@education.gov.uk")
+    sign_in_with_user(create(:user))
 
     single_project = Project.create!(urn: 19283746)
 
@@ -14,8 +14,10 @@ RSpec.feature "Users can reach the edit project page" do
 end
 
 RSpec.feature "Users can update a project" do
+  let(:user_email) { "user@education.gov.uk" }
+
   before(:each) do
-    sign_in_with_user("user@education.gov.uk")
+    sign_in_with_user(create(:user, email: user_email))
   end
 
   context "when the project has no delivery officer" do
@@ -23,22 +25,22 @@ RSpec.feature "Users can update a project" do
       single_project = Project.create!(urn: 19283746)
 
       visit edit_project_path(single_project.id)
-      select "user@education.gov.uk", from: "project-delivery-officer-id-field"
+      select user_email, from: "project-delivery-officer-id-field"
       click_on "Continue"
-      expect(page).to have_content("user@education.gov.uk")
+      expect(page).to have_content(user_email)
     end
   end
 
   context "when the project already has a delivery officer" do
     scenario "the delivery officer can be changed" do
-      user2 = User.create(email: "user2@education.gov.uk")
+      user2 = create(:user, email: "user2@education.gov.uk")
 
       single_project = Project.create!(urn: 19283746, delivery_officer: user2)
 
       visit edit_project_path(single_project.id)
-      select "user@education.gov.uk", from: "project-delivery-officer-id-field"
+      select user_email, from: "project-delivery-officer-id-field"
       click_on "Continue"
-      expect(page).to have_content("user@education.gov.uk")
+      expect(page).to have_content(user_email)
     end
 
     scenario "the delivery officer can be unset" do
@@ -56,7 +58,7 @@ end
 
 RSpec.feature "Users can unset the delivery officer of a project" do
   scenario "when the project already has a delivery officer" do
-    sign_in_with_user("user@education.gov.uk")
+    sign_in_with_user(create(:user))
     user = User.find_by(email: "user@education.gov.uk")
 
     single_project = Project.create!(urn: 19283746, delivery_officer: user)

--- a/spec/features/users_can_view_projects_spec.rb
+++ b/spec/features/users_can_view_projects_spec.rb
@@ -1,19 +1,48 @@
 require "rails_helper"
 
 RSpec.feature "Users can view a list of projects" do
-  scenario "on the home page" do
-    sign_in_with_user(create(:user))
+  let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
+  let(:user_1) { create(:user, email: "user1@education.gov.uk") }
+  let(:user_2) { create(:user, email: "user2@education.gov.uk") }
 
-    single_project = Project.create!(urn: 19283746)
+  before(:each) do
+    @unassigned_project = Project.create!(urn: 1001)
+    @user1_project = Project.create!(urn: 1002, delivery_officer: user_1)
+    @user2_project = Project.create!(urn: 1003, delivery_officer: user_2)
+  end
 
-    visit root_path
-    expect(page).to have_content(single_project.urn.to_s)
+  context "the user is a team leader" do
+    before(:each) do
+      sign_in_with_user(team_leader)
+    end
+
+    scenario "can see all projects on the project list regardless of assignment" do
+      visit projects_path
+
+      expect(page).to have_content(@unassigned_project.urn.to_s)
+      expect(page).to have_content(@user1_project.urn.to_s)
+      expect(page).to have_content(@user2_project.urn.to_s)
+    end
+  end
+
+  context "the user is not a team leader" do
+    before(:each) do
+      sign_in_with_user(user_1)
+    end
+
+    scenario "can only see assigned projects on the projects list" do
+      visit projects_path
+
+      expect(page).to_not have_content(@unassigned_project.urn.to_s)
+      expect(page).to have_content(@user1_project.urn.to_s)
+      expect(page).to_not have_content(@user2_project.urn.to_s)
+    end
   end
 end
 
 RSpec.feature "Users can view a single project" do
   scenario "by following a link from the home page" do
-    sign_in_with_user(create(:user))
+    sign_in_with_user(create(:user, :team_leader))
 
     single_project = Project.create!(urn: 19283746)
 
@@ -24,7 +53,7 @@ RSpec.feature "Users can view a single project" do
 
   context "when a project does not have an assigned delivery officer" do
     scenario "the project list shows an unassigned delivery officer" do
-      sign_in_with_user(create(:user))
+      sign_in_with_user(create(:user, :team_leader))
       Project.create!(urn: 19283746)
 
       visit projects_path
@@ -32,7 +61,7 @@ RSpec.feature "Users can view a single project" do
     end
 
     scenario "the project page shows an unassigned delivery officer" do
-      sign_in_with_user(create(:user))
+      sign_in_with_user(create(:user, :team_leader))
       single_project = Project.create!(urn: 19283746)
 
       visit project_path(single_project)
@@ -44,7 +73,7 @@ RSpec.feature "Users can view a single project" do
     let(:user_email_address) { "user@education.gov.uk" }
 
     scenario "the project list shows an assigned delivery officer" do
-      sign_in_with_user(create(:user, email: user_email_address))
+      sign_in_with_user(create(:user, :team_leader, email: user_email_address))
       user = User.find_by(email: user_email_address)
       Project.create!(urn: 19283746, delivery_officer: user)
 
@@ -53,7 +82,7 @@ RSpec.feature "Users can view a single project" do
     end
 
     scenario "the project page shows an assigned delivery officer" do
-      sign_in_with_user(create(:user, email: user_email_address))
+      sign_in_with_user(create(:user, :team_leader, email: user_email_address))
       user = User.find_by(email: user_email_address)
       single_project = Project.create!(urn: 19283746, delivery_officer: user)
 

--- a/spec/features/users_can_view_projects_spec.rb
+++ b/spec/features/users_can_view_projects_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Users can view a list of projects" do
   scenario "on the home page" do
-    sign_in_with_user("user@education.gov.uk")
+    sign_in_with_user(create(:user))
 
     single_project = Project.create!(urn: 19283746)
 
@@ -13,7 +13,7 @@ end
 
 RSpec.feature "Users can view a single project" do
   scenario "by following a link from the home page" do
-    sign_in_with_user("user@education.gov.uk")
+    sign_in_with_user(create(:user))
 
     single_project = Project.create!(urn: 19283746)
 
@@ -24,7 +24,7 @@ RSpec.feature "Users can view a single project" do
 
   context "when a project does not have an assigned delivery officer" do
     scenario "the project list shows an unassigned delivery officer" do
-      sign_in_with_user("user@education.gov.uk")
+      sign_in_with_user(create(:user))
       Project.create!(urn: 19283746)
 
       visit projects_path
@@ -32,7 +32,7 @@ RSpec.feature "Users can view a single project" do
     end
 
     scenario "the project page shows an unassigned delivery officer" do
-      sign_in_with_user("user@education.gov.uk")
+      sign_in_with_user(create(:user))
       single_project = Project.create!(urn: 19283746)
 
       visit project_path(single_project)
@@ -44,7 +44,7 @@ RSpec.feature "Users can view a single project" do
     let(:user_email_address) { "user@education.gov.uk" }
 
     scenario "the project list shows an assigned delivery officer" do
-      sign_in_with_user(user_email_address)
+      sign_in_with_user(create(:user, email: user_email_address))
       user = User.find_by(email: user_email_address)
       Project.create!(urn: 19283746, delivery_officer: user)
 
@@ -53,7 +53,7 @@ RSpec.feature "Users can view a single project" do
     end
 
     scenario "the project page shows an assigned delivery officer" do
-      sign_in_with_user(user_email_address)
+      sign_in_with_user(create(:user, email: user_email_address))
       user = User.find_by(email: user_email_address)
       single_project = Project.create!(urn: 19283746, delivery_officer: user)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,8 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
+require "support/factory_bot"
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,7 +1,6 @@
 module FeatureHelpers
-  def sign_in_with_user(user_email_address)
-    User.create!(email: user_email_address)
-    mock_successful_authentication(user_email_address)
+  def sign_in_with_user(user)
+    mock_successful_authentication(user.email)
     visit sign_in_path
     click_button(I18n.t("sign_in.button"))
   end


### PR DESCRIPTION
We should appropriately control who has access to which resources and functionality

## Acceptance

- [x] Users have a concept of 'lead' (99e13bfa26249b39312d03a955869f60fc7b391e)
- [x] A user who is not a team lead can only view the projects on which they are the assigned DO
- [x] A user who is not a lead cannot assign or reassign a project
- [x] A user who is not a lead cannot create a new project
- [x] A user who is a lead can view all projects, even if not assigned
- [x] A user who is a lead can assign or reassign a project
- [x] A user who is a lead can create a new project