### PR TITLE
(173) Task list view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   gem "bullet"
   gem "standard"
   gem "dotenv-rails"
+  gem "factory_bot_rails"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,11 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.10.0)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     faraday (2.3.0)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
@@ -316,6 +321,7 @@ DEPENDENCIES
   climate_control
   debug
   dotenv-rails
+  factory_bot_rails
   faraday
   govuk_design_system_formbuilder (~> 3.1)
   omniauth

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,3 +4,5 @@ $govuk-image-url-function: "image-url";
 $govuk-global-styles: true;
 
 @import "govuk-frontend/govuk/all";
+
+@import "components/task-list";

--- a/app/assets/stylesheets/components/task-list.scss
+++ b/app/assets/stylesheets/components/task-list.scss
@@ -1,0 +1,74 @@
+// https://github.com/alphagov/govuk-prototype-kit/blob/027ecc48a7b20862e68a83552e08f47696794cd4/app/assets/sass/patterns/_task-list.scss
+
+// Task list pattern
+
+.app-task-list {
+  list-style-type: none;
+  padding-left: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+
+  @include govuk-media-query($from: tablet) {
+    min-width: 550px;
+  }
+}
+
+.app-task-list__section {
+  display: table;
+  @include govuk-font($size: 24, $weight: bold);
+}
+
+.app-task-list__section-number {
+  display: table-cell;
+
+  @include govuk-media-query($from: tablet) {
+    min-width: govuk-spacing(6);
+    padding-right: 0;
+  }
+}
+
+.app-task-list__items {
+  @include govuk-font($size: 19);
+  @include govuk-responsive-margin(9, "bottom");
+  list-style: none;
+  padding-left: 0;
+
+  @include govuk-media-query($from: tablet) {
+    padding-left: govuk-spacing(6);
+  }
+}
+
+.app-task-list__item {
+  border-bottom: 1px solid $govuk-border-colour;
+  margin-bottom: 0 !important;
+  padding-top: govuk-spacing(2);
+  padding-bottom: govuk-spacing(2);
+  @include govuk-clearfix;
+}
+
+.app-task-list__item:first-child {
+  border-top: 1px solid $govuk-border-colour;
+}
+
+.app-task-list__task-name {
+  display: block;
+
+  @include govuk-media-query($from: 450px) {
+    float: left;
+  }
+}
+
+// The `app-task-list__task-completed` class was previously used on the task
+// list for the completed tag (changed in 86c90ec) – it's still included here to
+// avoid breaking task lists in existing prototypes.
+.app-task-list__tag,
+.app-task-list__task-completed {
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(1);
+
+  @include govuk-media-query($from: 450px) {
+    float: right;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -6,7 +6,7 @@ class ProjectsController < ApplicationController
   end
 
   def show
-    @project = Project.find(params[:id])
+    @project = Project.includes(sections: [:tasks]).find(params[:id])
   end
 
   def new
@@ -19,6 +19,8 @@ class ProjectsController < ApplicationController
     if @project.valid?
       @project.save
       flash[:notice] = I18n.t("project.create.success")
+      TaskListCreator.new.call(@project)
+
       redirect_to project_path(@project)
     else
       render :new

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -1,0 +1,5 @@
+module TaskListHelper
+  def task_status_id(task)
+    "#{task.title.parameterize}-status"
+  end
+end

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :pre_content_nav do %>
-<%= link_to "Back", root_path, class: "govuk-back-link" %>
+  <%= link_to "Back", root_path, class: "govuk-back-link" %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -15,3 +15,7 @@
     </p>
   </div>
 </div>
+
+<h1 class="govuk-heading-l"><%= t('project.show.title') %></h1>
+
+<%= render "shared/task_list" %>

--- a/app/views/shared/_task_list.html.erb
+++ b/app/views/shared/_task_list.html.erb
@@ -1,0 +1,21 @@
+<ol class="app-task-list">
+  <% @project.sections.each do |section| %>
+    <li>
+      <h2 class="app-task-list__section">
+        <span class="app-task-list__section-number"><%= section.order + 1 %>. </span> <%= section.title %>
+      </h2>
+      <ul class="app-task-list__items">
+        <% section.tasks.each do |task| %>
+          <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                <a href="#" aria-describedby=<%= task_status_id(task) %>>
+                  <%= task.title %>
+                </a>
+              </span>
+            <strong class="govuk-tag app-task-list__tag" id=<%= task_status_id(task) %>>Completed</strong>
+          </li>
+        <% end %>
+      </ul>
+    </li>
+  <% end %>
+</ol>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,7 @@ en:
       title:
         all: All projects
     show:
+      title: Project task list
       edit_button:
         text: Edit
     new:

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :project, class: "Project" do
+    urn { 12345 }
+  end
+end

--- a/spec/factories/section_factory.rb
+++ b/spec/factories/section_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :section, class: "Section" do
+    title { "Clear legal documents" }
+    order { 0 }
+    project { create(:project) }
+  end
+end

--- a/spec/factories/task_factory.rb
+++ b/spec/factories/task_factory.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :task, class: "Task" do
+    title { "Clear land questionnaire" }
+    completed { false }
+    order { 0 }
+    section { create(:section) }
+  end
+end

--- a/spec/features/users_can_create_projects_spec.rb
+++ b/spec/features/users_can_create_projects_spec.rb
@@ -1,16 +1,24 @@
 require "rails_helper"
 
 RSpec.feature "Users can create a new project" do
+  let(:mock_workflow) { file_fixture("workflows/conversion.yml") }
+
   before(:each) do
     sign_in_with_user("user@education.gov.uk")
     visit new_project_path
+
+    allow(YAML).to receive(:load_file).with("workflows/conversion.yml").and_return(
+      YAML.load_file(mock_workflow)
+    )
   end
 
   context "the URN is valid" do
     scenario "a new project is created" do
       fill_in "project-urn-field", with: "19283746"
       click_button("Continue")
-      expect(page).to have_content("19283746")
+      expect(page).to have_content("Project task list")
+      expect(page).to have_content("Starting the project")
+      expect(page).to have_content("Understand history and complete handover from Pre-AB")
     end
   end
 

--- a/spec/helpers/task_list_helper_spec.rb
+++ b/spec/helpers/task_list_helper_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe TaskListHelper, type: :helper do
+  describe "#task_status_id" do
+    let(:task) { create(:task) }
+
+    it "returns the task title as kebab case with '-status' appended" do
+      expect(helper.task_status_id(task)).to eq "clear-land-questionnaire-status"
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,6 +65,7 @@ RSpec.configure do |config|
   # Include helpers for tests
   config.include SignInHelpers
   config.include FeatureHelpers, type: :feature
+  config.include FactoryBot::Syntax::Methods
 
   # cleanup Omniauth after each example
   config.after(:each) do |example|


### PR DESCRIPTION
https://trello.com/c/YpH2TlYQ

### Add task list view
- Add a task list the the project `show` page. The GOV.UK task list component is currently in a "being worked on" state, meaning that we have to pull in the styling from the prototype kit for now.

- Generate a task list on project creation, via the TaskListCreator.

- Add the `FactoryBot` Gem, along with minimal factories for project, section, and task, so that we can easily create models in various states for easier testing.

<img width="1071" alt="image" src="https://user-images.githubusercontent.com/47089130/177977962-ac817425-da34-44a0-926d-cebd1c7d0616.png">
