### PR TITLE
(181) Do not flag linters to auto fix in CI

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -21,7 +21,6 @@ services:
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       SECRET_KEY_BASE: secret
       CI: "true"
-      AUTOMATICALLY_FIX_LINTING: "false"
     networks:
       - test-ci
 

--- a/script/all/test
+++ b/script/all/test
@@ -2,6 +2,8 @@
 
 # Run the test suite for the application. Optionally pass in a path to an
 # individual test file to run a single test.
+#
+# Do not set AUTOMATICALLY_FIX_LINTING if you want to disable linter fixing
 
 set -e
 


### PR DESCRIPTION
We kept seeing PRs with all tests passing but we knew the PR contained
linting errors.

It turns out our scripts test for the presence of the
AUTOMATICALLY_FIX_LINTING variable, not it's value, you can set it to
true or false and see the same behaviour.

As we do not want to run in fix mode, we remove the variable from the ci
docker compose file and so, switch the statement in `script/all/test`.