### PR TITLE
(108) Retrieve establisment name from Academies API

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,3 +6,7 @@ $govuk-global-styles: true;
 @import "govuk-frontend/govuk/all";
 
 @import "components/task-list";
+
+.inline {
+  display: inline;
+}

--- a/app/models/academies_api/base_api_model.rb
+++ b/app/models/academies_api/base_api_model.rb
@@ -1,0 +1,18 @@
+class AcademiesApi::BaseApiModel
+  include ActiveModel::Serializers::JSON
+
+  class AttributeMapMissingError < RuntimeError; end
+
+  def attributes=(hash)
+    hash.each do |key, value|
+      next unless self.class.attribute_map.value?(key)
+
+      attribute_name = self.class.attribute_map.key(key)
+      send("#{attribute_name}=", value)
+    end
+  end
+
+  def self.attribute_map
+    raise AttributeMapMissingError, ".attribute_map hasn't been overridden"
+  end
+end

--- a/app/models/academies_api/client.rb
+++ b/app/models/academies_api/client.rb
@@ -20,7 +20,7 @@ class AcademiesApi::Client
 
     case response.status
     when 200
-      Result.new(AcademiesApi::Establishment.new(response.body), nil)
+      Result.new(AcademiesApi::Establishment.new.from_json(response.body), nil)
     when 404
       Result.new(nil, NotFoundError.new(I18n.t("academies_api.get_establishment.errors.not_found", urn: urn)))
     else

--- a/app/models/academies_api/establishment.rb
+++ b/app/models/academies_api/establishment.rb
@@ -1,9 +1,9 @@
-class AcademiesApi::Establishment
-  def initialize(body)
-    @raw = JSON.parse(body)
-  end
+class AcademiesApi::Establishment < AcademiesApi::BaseApiModel
+  attr_accessor :name
 
-  def name
-    @raw.fetch("establishmentName")
+  def self.attribute_map
+    {
+      name: "establishmentName"
+    }
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,4 +4,15 @@ class Project < ApplicationRecord
   validates :urn, presence: true, numericality: {only_integer: true}
 
   belongs_to :delivery_officer, class_name: "User", optional: true
+
+  def establishment
+    @establishment ||= retrieve_establishment
+  end
+
+  private def retrieve_establishment
+    result = AcademiesApi::Client.new.get_establishment(urn)
+    raise result.error if result.error.present?
+
+    result.object
+  end
 end

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -4,20 +4,17 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-  
+
     <h1 class="govuk-heading-l">
       <%= t("project.index.title.all") %> (<%= @projects.count %>)
     </h1>
 
     <% @projects.each do |project| %>
+      <h2 class="govuk-heading-m govuk-heading-m--school-name">
+        <%= link_to project.establishment.name, project_path(project) %>
+        <span class="govuk-caption-l inline"><%= "- #{project.urn}" %></span>
+      </h2>
       <dl class="govuk-summary-list govuk-summary-list--school-details govuk-!-margin-bottom-9">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            <h2 class="govuk-heading-m govuk-heading-m--school-name">
-              <span><%= link_to "URN #{project.urn}", project_path(project) %></span>
-            </h2>
-          </dt>
-        </div>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             <%= t('project.summary.delivery_officer.title') %>
@@ -33,7 +30,7 @@
       <p><%= link_to t('project.index.new_button.text'),
         new_project_path,
         class: 'govuk-button',
-        data: {module: "govuk-button"}
+        data: { module: "govuk-button" }
       %></p>
     <% end %>
 

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -5,6 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <span class="govuk-caption-l">URN <%= @project.urn %></span>
+    <h1 class="govuk-heading-l"><%= @project.establishment.name %></h1>
     <div class="govuk-inset-text">
       <p class="govuk-body govuk-!-margin-0">
         <span class="govuk-!-font-weight-bold"><%= t('project.summary.delivery_officer.title') %>:</span>
@@ -18,6 +19,5 @@
   </div>
 </div>
 
-<h1 class="govuk-heading-l"><%= t('project.show.title') %></h1>
-
+<h2 class="govuk-heading-l"><%= t('project.show.title') %></h2>
 <%= render "shared/task_list" %>

--- a/spec/factories/academies_api/establishment.rb
+++ b/spec/factories/academies_api/establishment.rb
@@ -1,13 +1,5 @@
 FactoryBot.define do
   factory :academies_api_establishment, class: "AcademiesApi::Establishment" do
-    transient do
-      name { "Caludon Castle School" }
-    end
-
-    initialize_with { new(JSON.generate(api_response_mapping)) }
+    name { "Caludon Castle School" }
   end
-end
-
-private def api_response_mapping
-  {establishmentName: name}
 end

--- a/spec/factories/academies_api/establishment.rb
+++ b/spec/factories/academies_api/establishment.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :academies_api_establishment, class: "AcademiesApi::Establishment" do
+    transient do
+      name { "Caludon Castle School" }
+    end
+
+    initialize_with { new(JSON.generate(api_response_mapping)) }
+  end
+end
+
+private def api_response_mapping
+  {establishmentName: name}
+end

--- a/spec/features/users_can_create_projects_spec.rb
+++ b/spec/features/users_can_create_projects_spec.rb
@@ -1,13 +1,6 @@
 require "rails_helper"
 
 RSpec.feature "Users can view the new project form" do
-  let(:establishment_result) { AcademiesApi::Client::Result.new(establishment, nil) }
-
-  before do
-    allow_any_instance_of(AcademiesApi::Client).to \
-      receive(:get_establishment) { establishment_result }
-  end
-
   context "the user is a team leader" do
     before(:each) do
       sign_in_with_user(create(:user, :team_leader))
@@ -44,8 +37,6 @@ end
 RSpec.feature "Team leaders can create a new project" do
   let(:mock_workflow) { file_fixture("workflows/conversion.yml") }
   let(:team_leader) { create(:user, :team_leader) }
-  let(:establishment) { build(:academies_api_establishment) }
-  let(:establishment_result) { AcademiesApi::Client::Result.new(establishment, nil) }
 
   before do
     sign_in_with_user(team_leader)
@@ -54,14 +45,15 @@ RSpec.feature "Team leaders can create a new project" do
     allow(YAML).to receive(:load_file).with("workflows/conversion.yml").and_return(
       YAML.load_file(mock_workflow)
     )
-
-    allow_any_instance_of(AcademiesApi::Client).to \
-      receive(:get_establishment) { establishment_result }
   end
 
   context "the URN is valid" do
+    let(:urn) { 19283746 }
+
+    before { mock_successful_api_establishment_response(urn: urn) }
+
     scenario "a new project is created" do
-      fill_in "project-urn-field", with: "19283746"
+      fill_in "project-urn-field", with: urn
       click_button("Continue")
       expect(page).to have_content("Project task list")
       expect(page).to have_content("Starting the project")

--- a/spec/features/users_can_create_projects_spec.rb
+++ b/spec/features/users_can_create_projects_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
 
 RSpec.feature "Users can view the new project form" do
+  let(:establishment_result) { AcademiesApi::Client::Result.new(establishment, nil) }
+
+  before do
+    allow_any_instance_of(AcademiesApi::Client).to \
+      receive(:get_establishment) { establishment_result }
+  end
+
   context "the user is a team leader" do
     before(:each) do
       sign_in_with_user(create(:user, :team_leader))
@@ -36,16 +43,20 @@ end
 
 RSpec.feature "Team leaders can create a new project" do
   let(:mock_workflow) { file_fixture("workflows/conversion.yml") }
-
   let(:team_leader) { create(:user, :team_leader) }
+  let(:establishment) { build(:academies_api_establishment) }
+  let(:establishment_result) { AcademiesApi::Client::Result.new(establishment, nil) }
 
-  before(:each) do
+  before do
     sign_in_with_user(team_leader)
     visit new_project_path
 
     allow(YAML).to receive(:load_file).with("workflows/conversion.yml").and_return(
       YAML.load_file(mock_workflow)
     )
+
+    allow_any_instance_of(AcademiesApi::Client).to \
+      receive(:get_establishment) { establishment_result }
   end
 
   context "the URN is valid" do

--- a/spec/features/users_can_update_projects_spec.rb
+++ b/spec/features/users_can_update_projects_spec.rb
@@ -3,6 +3,13 @@ require "rails_helper"
 RSpec.feature "Users can reach the edit project page" do
   let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
   let(:delivery_officer) { create(:user, email: "user1@education.gov.uk") }
+  let(:establishment) { build(:academies_api_establishment) }
+  let(:establishment_result) { AcademiesApi::Client::Result.new(establishment, nil) }
+
+  before do
+    allow_any_instance_of(AcademiesApi::Client).to \
+      receive(:get_establishment) { establishment_result }
+  end
 
   context "the user is a team leader" do
     before(:each) do
@@ -46,6 +53,13 @@ RSpec.feature "Users can update a project" do
   let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
   let(:delivery_officer) { create(:user, email: "user1@education.gov.uk") }
   let(:delivery_officer_2) { create(:user, email: "user2@education.gov.uk") }
+  let(:establishment) { build(:academies_api_establishment) }
+  let(:establishment_result) { AcademiesApi::Client::Result.new(establishment, nil) }
+
+  before do
+    allow_any_instance_of(AcademiesApi::Client).to \
+      receive(:get_establishment) { establishment_result }
+  end
 
   context "the user is a team leader" do
     before(:each) do

--- a/spec/features/users_can_update_projects_spec.rb
+++ b/spec/features/users_can_update_projects_spec.rb
@@ -1,20 +1,16 @@
 require "rails_helper"
 
 RSpec.feature "Users can reach the edit project page" do
+  let(:urn) { 12345 }
   let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
   let(:delivery_officer) { create(:user, email: "user1@education.gov.uk") }
-  let(:establishment) { build(:academies_api_establishment) }
-  let(:establishment_result) { AcademiesApi::Client::Result.new(establishment, nil) }
 
-  before do
-    allow_any_instance_of(AcademiesApi::Client).to \
-      receive(:get_establishment) { establishment_result }
-  end
+  before { mock_successful_api_establishment_response(urn: urn) }
 
   context "the user is a team leader" do
-    before(:each) do
+    before do
       sign_in_with_user(team_leader)
-      @unassigned_project = Project.create!(urn: 1001)
+      @unassigned_project = Project.create!(urn: urn)
     end
 
     scenario "by following a link from the show project page" do
@@ -32,9 +28,9 @@ RSpec.feature "Users can reach the edit project page" do
   end
 
   context "the user is not a team leader" do
-    before(:each) do
+    before do
       sign_in_with_user(delivery_officer)
-      @user1_project = Project.create!(urn: 1002, delivery_officer: delivery_officer)
+      @user1_project = Project.create!(urn: urn, delivery_officer: delivery_officer)
     end
 
     scenario "there is no edit link on the show project page" do
@@ -50,25 +46,20 @@ RSpec.feature "Users can reach the edit project page" do
 end
 
 RSpec.feature "Users can update a project" do
+  let(:urn) { 12345 }
   let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
   let(:delivery_officer) { create(:user, email: "user1@education.gov.uk") }
   let(:delivery_officer_2) { create(:user, email: "user2@education.gov.uk") }
-  let(:establishment) { build(:academies_api_establishment) }
-  let(:establishment_result) { AcademiesApi::Client::Result.new(establishment, nil) }
-
-  before do
-    allow_any_instance_of(AcademiesApi::Client).to \
-      receive(:get_establishment) { establishment_result }
-  end
 
   context "the user is a team leader" do
-    before(:each) do
+    before do
       sign_in_with_user(team_leader)
+      mock_successful_api_establishment_response(urn: urn)
     end
 
     context "when the project has no delivery officer" do
-      before(:each) do
-        @unassigned_project = Project.create!(urn: 1001)
+      before do
+        @unassigned_project = Project.create!(urn: urn)
         @delivery_officer = delivery_officer
       end
 
@@ -82,7 +73,7 @@ RSpec.feature "Users can update a project" do
 
     context "when the project already has a delivery officer" do
       before(:each) do
-        @assigned_project = Project.create!(urn: 1002, delivery_officer: delivery_officer)
+        @assigned_project = Project.create!(urn: urn, delivery_officer: delivery_officer)
       end
 
       scenario "the delivery officer can be changed" do

--- a/spec/features/users_can_view_projects_spec.rb
+++ b/spec/features/users_can_view_projects_spec.rb
@@ -4,11 +4,15 @@ RSpec.feature "Users can view a list of projects" do
   let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
   let(:user_1) { create(:user, email: "user1@education.gov.uk") }
   let(:user_2) { create(:user, email: "user2@education.gov.uk") }
+  let(:establishment) { build(:academies_api_establishment) }
+  let(:establishment_result) { AcademiesApi::Client::Result.new(establishment, nil) }
 
-  before(:each) do
+  before do
     @unassigned_project = Project.create!(urn: 1001)
     @user1_project = Project.create!(urn: 1002, delivery_officer: user_1)
     @user2_project = Project.create!(urn: 1003, delivery_officer: user_2)
+    allow_any_instance_of(AcademiesApi::Client).to \
+      receive(:get_establishment) { establishment_result }
   end
 
   context "the user is a team leader" do
@@ -41,13 +45,21 @@ RSpec.feature "Users can view a list of projects" do
 end
 
 RSpec.feature "Users can view a single project" do
+  let(:establishment) { build(:academies_api_establishment) }
+  let(:establishment_result) { AcademiesApi::Client::Result.new(establishment, nil) }
+
+  before do
+    allow_any_instance_of(AcademiesApi::Client).to \
+      receive(:get_establishment) { establishment_result }
+  end
+
   scenario "by following a link from the home page" do
     sign_in_with_user(create(:user, :team_leader))
 
     single_project = Project.create!(urn: 19283746)
 
     visit root_path
-    click_on single_project.urn.to_s
+    click_on establishment.name
     expect(page).to have_content(single_project.urn.to_s)
   end
 

--- a/spec/models/academies_api/base_api_model_spec.rb
+++ b/spec/models/academies_api/base_api_model_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe AcademiesApi::BaseApiModel do
+  context "when .attribute_map is not overridden" do
+    let(:error_message) { ".attribute_map hasn't been overridden" }
+    let(:testing_model) { Class.new(AcademiesApi::BaseApiModel) }
+
+    it "raises a #{AcademiesApi::BaseApiModel::AttributeMapMissingError}" do
+      expect { testing_model.attribute_map }.to raise_error(AcademiesApi::BaseApiModel::AttributeMapMissingError, error_message)
+    end
+  end
+
+  context "when the attribute map is defined correctly" do
+    let(:establishment_name) { "Caludon castle school" }
+    let(:response) { JSON.generate({establishmentName: establishment_name, otherProperty: "value"}) }
+    let(:testing_model) do
+      Class.new(AcademiesApi::BaseApiModel) do
+        attr_accessor :name
+
+        def self.attribute_map
+          {name: "establishmentName"}
+        end
+      end
+    end
+
+    subject { testing_model.new }
+
+    it "maps JSON response to attributes" do
+      expect(subject.from_json(response).name).to eq establishment_name
+    end
+
+    context "when there are attributes that are undefined on the model" do
+      let(:response) { JSON.generate({establishmentName: establishment_name, otherProperty: "value"}) }
+
+      before { allow(subject).to receive(:send) }
+
+      it "only maps defined attributes" do
+        expect(subject.from_json(response)).to have_received(:send).once
+      end
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -19,22 +19,25 @@ RSpec.describe Project, type: :model do
   describe "#establishment" do
     let(:urn) { 12345 }
     let(:establishment) { build(:academies_api_establishment) }
-    let(:establishment_result) { AcademiesApi::Client::Result.new(establishment, nil) }
 
-    subject { described_class.new(urn:) }
+    subject { described_class.new(urn: urn) }
 
-    before do
-      allow_any_instance_of(AcademiesApi::Client).to \
-        receive(:get_establishment).with(urn) { establishment_result }
-    end
+    context "when the API returns a successful response" do
+      before { mock_successful_api_establishment_response(urn: urn, establishment:) }
 
-    it "retreives establishment data from the Academies API" do
-      expect(subject.establishment).to be establishment
+      it "retreives establishment data from the Academies API" do
+        expect(subject.establishment).to eq establishment
+      end
     end
 
     context "when the Academies API client returns a #{AcademiesApi::Client::NotFoundError}" do
       let(:error_message) { "Could not find establishment with URN: 12345" }
-      let(:establishment_result) { AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError.new(error_message)) }
+      let(:error) { AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError.new(error_message)) }
+
+      before do
+        allow_any_instance_of(AcademiesApi::Client).to \
+          receive(:get_establishment).with(urn) { error }
+      end
 
       it "raises the error" do
         expect { subject.establishment }.to raise_error(AcademiesApi::Client::NotFoundError, error_message)
@@ -43,7 +46,12 @@ RSpec.describe Project, type: :model do
 
     context "when the Academies API client returns a #{AcademiesApi::Client::Error}" do
       let(:error_message) { "There was an error connecting to the Academies API, could not fetch establishment for URN: 12345" }
-      let(:establishment_result) { AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::Error.new(error_message)) }
+      let(:error) { AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::Error.new(error_message)) }
+
+      before do
+        allow_any_instance_of(AcademiesApi::Client).to \
+          receive(:get_establishment).with(urn) { error }
+      end
 
       it "raises the error" do
         expect { subject.establishment }.to raise_error(AcademiesApi::Client::Error, error_message)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -15,4 +15,39 @@ RSpec.describe Project, type: :model do
   describe "Relationships" do
     it { is_expected.to have_many(:sections) }
   end
+
+  describe "#establishment" do
+    let(:urn) { 12345 }
+    let(:establishment) { build(:academies_api_establishment) }
+    let(:establishment_result) { AcademiesApi::Client::Result.new(establishment, nil) }
+
+    subject { described_class.new(urn:) }
+
+    before do
+      allow_any_instance_of(AcademiesApi::Client).to \
+        receive(:get_establishment).with(urn) { establishment_result }
+    end
+
+    it "retreives establishment data from the Academies API" do
+      expect(subject.establishment).to be establishment
+    end
+
+    context "when the Academies API client returns a #{AcademiesApi::Client::NotFoundError}" do
+      let(:error_message) { "Could not find establishment with URN: 12345" }
+      let(:establishment_result) { AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError.new(error_message)) }
+
+      it "raises the error" do
+        expect { subject.establishment }.to raise_error(AcademiesApi::Client::NotFoundError, error_message)
+      end
+    end
+
+    context "when the Academies API client returns a #{AcademiesApi::Client::Error}" do
+      let(:error_message) { "There was an error connecting to the Academies API, could not fetch establishment for URN: 12345" }
+      let(:establishment_result) { AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::Error.new(error_message)) }
+
+      it "raises the error" do
+        expect { subject.establishment }.to raise_error(AcademiesApi::Client::Error, error_message)
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,6 +66,7 @@ RSpec.configure do |config|
 
   # Include helpers for tests
   config.include SignInHelpers
+  config.include AcademiesApiHelpers
   config.include FeatureHelpers, type: :feature
 
   # cleanup Omniauth after each example

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,7 +67,6 @@ RSpec.configure do |config|
   # Include helpers for tests
   config.include SignInHelpers
   config.include FeatureHelpers, type: :feature
-  config.include FactoryBot::Syntax::Methods
 
   # cleanup Omniauth after each example
   config.after(:each) do |example|

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -1,0 +1,11 @@
+module AcademiesApiHelpers
+  def mock_successful_api_establishment_response(urn:, establishment: nil)
+    establishment = build(:academies_api_establishment) if establishment.nil?
+
+    fake_result = AcademiesApi::Client::Result.new(establishment, nil)
+    test_client = AcademiesApi::Client.new
+
+    allow(test_client).to receive(:get_establishment).with(urn).and_return(fake_result)
+    allow(AcademiesApi::Client).to receive(:new).and_return(test_client)
+  end
+end


### PR DESCRIPTION
### Retrieve establishment name from Academies API

We want fetch establishment information from the Academies API - for now, starting with the name.

The establishment data should be present, as we are going to validate that it exists on project creation. Therefore, we want to raise an error if establishment data is not available.

### Remove duplicated FactoryBot configuration
We are accidentally adding FactoryBot configuration twice. Remove one.

### DRY up Academies API establishment mocking
Because establishment is a property of Project, we need to mock the Academies API in quite a few places.

For now we want to use a helper to DRY these up, but we may come up with a better solution soon.

### Update how we define API models
Currently, we pass the JSON response from the API into the constructorcof our API models. However, this doesn't work nicely with FactoryBot,where we have to use the `initialize_with` method in order to create mock objects.

Use the `ActiveModel::Serializers::JSON` along with an `attribute_map` in order to map API response property names to the desired attribute names. Abstract it to a base class so we can keep the API models DRY.
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/47089130/178963977-00abb5b6-10d6-4286-8549-276343d17748.png">
<img width="1064" alt="image" src="https://user-images.githubusercontent.com/47089130/178759521-2a3895cc-956d-4cf0-8d68-1540de19f1c9.png">
