### PR TITLE
(215) Add cascading deletes for projects

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,5 @@
 class Project < ApplicationRecord
-  has_many :sections
+  has_many :sections, dependent: :destroy
 
   validates :urn, presence: true, numericality: {only_integer: true}
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,4 +1,4 @@
 class Section < ApplicationRecord
   belongs_to :project
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,4 @@
 class Task < ApplicationRecord
   belongs_to :section
-  has_many :actions
+  has_many :actions, dependent: :destroy
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Project, type: :model do
   end
 
   describe "Relationships" do
-    it { is_expected.to have_many(:sections) }
+    it { is_expected.to have_many(:sections).dependent(:destroy) }
   end
 
   describe "#establishment" do

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Section, type: :model do
   end
 
   describe "Relationships" do
-    it { is_expected.to have_many(:tasks) }
+    it { is_expected.to have_many(:tasks).dependent(:destroy) }
     it { is_expected.to belong_to(:project) }
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe Task, type: :model do
 
   describe "Relationships" do
     it { is_expected.to belong_to(:section) }
-    it { is_expected.to have_many(:actions) }
+    it { is_expected.to have_many(:actions).dependent(:destroy) }
   end
 end


### PR DESCRIPTION
Deleting a project should also delete associated sections, tasks and actions so we don't end up with orphaned entities (or relational integrity preventing the deletion).