### PR TITLE
Validate establishment exists on Project creation

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,17 +2,24 @@ class Project < ApplicationRecord
   has_many :sections, dependent: :destroy
 
   validates :urn, presence: true, numericality: {only_integer: true}
+  validate :establishment_exists, on: :create
 
   belongs_to :delivery_officer, class_name: "User", optional: true
 
   def establishment
-    @establishment ||= retrieve_establishment
+    @establishment || retrieve_establishment
+  end
+
+  private def establishment_exists
+    retrieve_establishment
+  rescue AcademiesApi::Client::NotFoundError
+    errors.add(:urn, :no_establishment_found)
   end
 
   private def retrieve_establishment
     result = AcademiesApi::Client.new.get_establishment(urn)
     raise result.error if result.error.present?
 
-    result.object
+    @establishment = result.object
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,3 +78,9 @@ en:
       project:
         urn: This is the URN of the existing school which is converting to an academy.
         delivery_officer_id: The delivery officer responsible for this project
+
+  activerecord:
+    errors:
+      models:
+        project:
+          no_establishment_found: No establishment found with that URN. Enter a valid URN.

--- a/spec/features/users_can_create_projects_spec.rb
+++ b/spec/features/users_can_create_projects_spec.rb
@@ -62,6 +62,8 @@ RSpec.feature "Team leaders can create a new project" do
   end
 
   context "the URN is empty" do
+    before { mock_successful_api_establishment_response(urn: any_args) }
+
     scenario "the user is shown an error message" do
       click_button("Continue")
       expect(page).to have_content("can't be blank")
@@ -69,6 +71,8 @@ RSpec.feature "Team leaders can create a new project" do
   end
 
   context "the URN is invalid" do
+    before { mock_successful_api_establishment_response(urn: any_args) }
+
     scenario "the user is shown an error message" do
       fill_in "project-urn-field", with: "three"
       click_button("Continue")

--- a/spec/features/users_can_view_projects_spec.rb
+++ b/spec/features/users_can_view_projects_spec.rb
@@ -6,12 +6,12 @@ RSpec.feature "Users can view a list of projects" do
   let(:user_2) { create(:user, email: "user2@education.gov.uk") }
 
   before do
-    @unassigned_project = Project.create!(urn: 1001)
-    @user1_project = Project.create!(urn: 1002, delivery_officer: user_1)
-    @user2_project = Project.create!(urn: 1003, delivery_officer: user_2)
     mock_successful_api_establishment_response(urn: 1001)
     mock_successful_api_establishment_response(urn: 1002)
     mock_successful_api_establishment_response(urn: 1003)
+    @unassigned_project = Project.create!(urn: 1001)
+    @user1_project = Project.create!(urn: 1002, delivery_officer: user_1)
+    @user2_project = Project.create!(urn: 1003, delivery_officer: user_2)
   end
 
   context "the user is a team leader" do

--- a/spec/helpers/task_list_helper_spec.rb
+++ b/spec/helpers/task_list_helper_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe TaskListHelper, type: :helper do
   describe "#task_status_id" do
-    let(:task) { create(:task) }
+    let(:task) { Task.new(title: "Clear land questionnaire") }
 
     it "returns the task title as kebab case with '-status' appended" do
       expect(helper.task_status_id(task)).to eq "clear-land-questionnaire-status"

--- a/spec/services/task_list_creator_spec.rb
+++ b/spec/services/task_list_creator_spec.rb
@@ -2,17 +2,20 @@ require "rails_helper"
 
 RSpec.describe TaskListCreator do
   let(:task_list_creator) { TaskListCreator.new }
-
   let(:mock_workflow) { file_fixture("workflows/conversion.yml") }
   let(:workflow_path) { Rails.root.join("app", "workflows", "conversion.yml") }
+  let(:urn) { 12345 }
+
   before do
     allow(YAML).to receive(:load_file).with(workflow_path).and_return(
       YAML.load_file(mock_workflow)
     )
+
+    mock_successful_api_establishment_response(urn: urn)
   end
 
   describe "#call" do
-    let(:project) { Project.create(urn: 12345) }
+    let(:project) { Project.create(urn: urn) }
 
     subject! { task_list_creator.call(project) }
 


### PR DESCRIPTION
We fetch establishment information from the API by URN. We want to enforce that the establishment exists at the point of Project creation.

<img width="1021" alt="image" src="https://user-images.githubusercontent.com/47089130/179257471-6d651032-7b10-4deb-9217-d9703a8146d6.png">

I've tried to reduce the mocking by having a default establishment on the project factory `establishment { build(:academies_api_establishment) }`, but it didn't help much. I've also used `any_args` a couple of times where we are testing the other validations. You can't control the order of validation, and mocking a specific URN doesn't make sense in those tests (we could also potentially remove the feature specs as the model specs cover the validations anyway)
