### PR TITLE
(172) Model ConversionProject in the Academies API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ group :test do
   gem "climate_control"
   gem "simplecov", "~> 0.21.2"
   gem "shoulda-matchers", "~> 5.1"
+  gem "webmock", "~> 3.14"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,8 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     debug (1.6.1)
       irb (>= 1.3.6)
@@ -118,6 +120,7 @@ GEM
       activemodel (>= 6.1)
       activesupport (>= 6.1)
       html-attributes-utils (~> 0.9, >= 0.9.2)
+    hashdiff (1.0.1)
     hashie (5.0.0)
     html-attributes-utils (0.9.2)
       activesupport (>= 6.1.4.4)
@@ -303,6 +306,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -342,6 +349,7 @@ DEPENDENCIES
   standard
   tzinfo-data
   web-console
+  webmock (~> 3.14)
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/app/models/academies_api/base_api_model.rb
+++ b/app/models/academies_api/base_api_model.rb
@@ -3,6 +3,11 @@ class AcademiesApi::BaseApiModel
 
   class AttributeMapMissingError < RuntimeError; end
 
+  def from_hash(hash)
+    self.attributes = hash.stringify_keys
+    self
+  end
+
   def attributes=(hash)
     hash.each do |key, value|
       next unless self.class.attribute_map.value?(key)

--- a/app/models/academies_api/client.rb
+++ b/app/models/academies_api/client.rb
@@ -5,6 +5,8 @@ class AcademiesApi::Client
 
   class NotFoundError < StandardError; end
 
+  class MultipleResultsError < StandardError; end
+
   attr_reader :connection
 
   def initialize(connection: nil)
@@ -25,6 +27,31 @@ class AcademiesApi::Client
       Result.new(nil, NotFoundError.new(I18n.t("academies_api.get_establishment.errors.not_found", urn: urn)))
     else
       Result.new(nil, Error.new(I18n.t("academies_api.get_establishment.errors.other", urn: urn)))
+    end
+  end
+
+  def get_conversion_project(urn)
+    begin
+      response = @connection.get("/v2/conversion-projects", {urn: urn})
+    rescue Faraday::Error => error
+      raise Error.new(error)
+    end
+
+    case response.status
+    when 200
+      data = JSON.parse(response.body)
+
+      record_count = data["paging"]["recordCount"]
+
+      if record_count == 0
+        Result.new(nil, NotFoundError.new(I18n.t("academies_api.get_conversion_project.errors.not_found", urn: urn)))
+      elsif record_count > 1
+        Result.new(nil, MultipleResultsError.new(I18n.t("academies_api.get_conversion_project.errors.multiple_results", urn: urn, record_count: record_count)))
+      else
+        Result.new(AcademiesApi::ConversionProject.new.from_hash(data["data"][0]), nil)
+      end
+    else
+      Result.new(nil, Error.new(I18n.t("academies_api.get_conversion_project.errors.other", urn: urn)))
     end
   end
 

--- a/app/models/academies_api/conversion_project.rb
+++ b/app/models/academies_api/conversion_project.rb
@@ -1,0 +1,9 @@
+class AcademiesApi::ConversionProject < AcademiesApi::BaseApiModel
+  attr_accessor :name_of_trust
+
+  def self.attribute_map
+    {
+      name_of_trust: "nameOfTrust"
+    }
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -10,6 +10,10 @@ class Project < ApplicationRecord
     @establishment || retrieve_establishment
   end
 
+  def conversion_project
+    @conversion_project ||= retrieve_conversion_project
+  end
+
   private def establishment_exists
     retrieve_establishment
   rescue AcademiesApi::Client::NotFoundError
@@ -21,5 +25,12 @@ class Project < ApplicationRecord
     raise result.error if result.error.present?
 
     @establishment = result.object
+  end
+
+  private def retrieve_conversion_project
+    result = AcademiesApi::Client.new.get_conversion_project(urn)
+    raise result.error if result.error.present?
+
+    result.object
   end
 end

--- a/config/locales/academies_api_en.yml
+++ b/config/locales/academies_api_en.yml
@@ -4,3 +4,8 @@ en:
       errors:
         not_found: Could not find establishment with URN %{urn}
         other: There was an error connecting to the Academies API, could not fetch establishment for URN %{urn}
+    get_conversion_project:
+      errors:
+        not_found: Could not find conversion project for establishment with URN %{urn}
+        multiple_results: Found multiple conversion projects (%{record_count} total) for establishment with URN %{urn}
+        other: There was an error connecting to the Academies API, could not fetch conversion project for establishment with URN %{urn}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,8 @@ en:
       delivery_officer:
         title: Delivery officer
         unassigned: Not yet assigned
+      incoming_trust:
+        title: Incoming trust
   helpers:
     label:
       project:

--- a/spec/factories/academies_api/conversion_project.rb
+++ b/spec/factories/academies_api/conversion_project.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :academies_api_conversion_project, class: "AcademiesApi::ConversionProject" do
+    name_of_trust { "THE RETICULATED SPLINES TRUST" }
+  end
+end

--- a/spec/models/academies_api/base_api_model_spec.rb
+++ b/spec/models/academies_api/base_api_model_spec.rb
@@ -1,18 +1,21 @@
 require "rails_helper"
 
 RSpec.describe AcademiesApi::BaseApiModel do
-  context "when .attribute_map is not overridden" do
-    let(:error_message) { ".attribute_map hasn't been overridden" }
-    let(:testing_model) { Class.new(AcademiesApi::BaseApiModel) }
+  describe ".attribute_map" do
+    context "when .attribute_map is not overridden" do
+      let(:error_message) { ".attribute_map hasn't been overridden" }
+      let(:testing_model) { Class.new(AcademiesApi::BaseApiModel) }
 
-    it "raises a #{AcademiesApi::BaseApiModel::AttributeMapMissingError}" do
-      expect { testing_model.attribute_map }.to raise_error(AcademiesApi::BaseApiModel::AttributeMapMissingError, error_message)
+      it "raises a #{AcademiesApi::BaseApiModel::AttributeMapMissingError}" do
+        expect { testing_model.attribute_map }.to raise_error(AcademiesApi::BaseApiModel::AttributeMapMissingError, error_message)
+      end
     end
   end
 
   context "when the attribute map is defined correctly" do
     let(:establishment_name) { "Caludon castle school" }
-    let(:response) { JSON.generate({establishmentName: establishment_name, otherProperty: "value"}) }
+    let(:response) { {establishmentName: establishment_name} }
+    let(:json_response) { JSON.generate(response) }
     let(:testing_model) do
       Class.new(AcademiesApi::BaseApiModel) do
         attr_accessor :name
@@ -25,17 +28,25 @@ RSpec.describe AcademiesApi::BaseApiModel do
 
     subject { testing_model.new }
 
-    it "maps JSON response to attributes" do
-      expect(subject.from_json(response).name).to eq establishment_name
+    describe "#from_json" do
+      it "can map a JSON response to attributes" do
+        expect(subject.from_json(json_response).name).to eq establishment_name
+      end
+
+      context "when there are attributes that are undefined on the model" do
+        let(:response) { JSON.generate({establishmentName: establishment_name, otherProperty: "value"}) }
+
+        before { allow(subject).to receive(:send) }
+
+        it "only maps defined attributes" do
+          expect(subject.from_json(response)).to have_received(:send).once
+        end
+      end
     end
 
-    context "when there are attributes that are undefined on the model" do
-      let(:response) { JSON.generate({establishmentName: establishment_name, otherProperty: "value"}) }
-
-      before { allow(subject).to receive(:send) }
-
-      it "only maps defined attributes" do
-        expect(subject.from_json(response)).to have_received(:send).once
+    describe "#from_hash" do
+      it "can map a hash to attributes" do
+        expect(subject.from_hash(response).name).to eq establishment_name
       end
     end
   end

--- a/spec/models/academies_api/client_spec.rb
+++ b/spec/models/academies_api/client_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AcademiesApi::Client do
   end
 
   describe "#get_establishment" do
-    let(:client) { described_class.new(connection: fake_successful_connection(12345678, fake_response)) }
+    let(:client) { described_class.new(connection: fake_successful_establishment_connection(12345678, fake_response)) }
 
     context "when the establishment can be found" do
       let(:fake_response) { [200, nil, {establishmentName: "Establishment Name"}.to_json] }
@@ -53,14 +53,14 @@ RSpec.describe AcademiesApi::Client do
 
     context "when the connection fails" do
       it "raises an Error" do
-        client = described_class.new(connection: fake_failed_connection(12345678))
+        client = described_class.new(connection: fake_failed_establishment_connection(12345678))
 
         expect { client.get_establishment(12345678) }.to raise_error(AcademiesApi::Client::Error)
       end
     end
   end
 
-  def fake_successful_connection(urn, response)
+  def fake_successful_establishment_connection(urn, response)
     Faraday.new do |builder|
       builder.adapter :test do |stub|
         stub.get("/establishment/urn/#{urn}") do |env|
@@ -70,10 +70,104 @@ RSpec.describe AcademiesApi::Client do
     end
   end
 
-  def fake_failed_connection(urn)
+  def fake_failed_establishment_connection(urn)
     Faraday.new do |builder|
       builder.adapter :test do |stub|
         stub.get("/establishment/urn/#{urn}") do |env|
+          raise Faraday::Error
+        end
+      end
+    end
+  end
+
+  describe "#get_conversion_project" do
+    let(:client) { described_class.new(connection: fake_successful_conversion_project_connection(12345678, fake_response)) }
+
+    context "when the project can be found" do
+      let(:fake_response) {
+        [200, nil, {data: [{nameOfTrust: "THE RETICULATED SPLINES TRUST"}], paging: {
+          page: 1,
+          recordCount: 1,
+          nextPageUrl: nil
+        }}.to_json]
+      }
+
+      it "returns a Result with the project and no error" do
+        result = client.get_conversion_project(12345678)
+
+        expect(result.object.name_of_trust).to eql("THE RETICULATED SPLINES TRUST")
+        expect(result.error).to be_nil
+      end
+    end
+
+    context "when the project cannot be found" do
+      let(:fake_response) {
+        [200, nil, {data: [], paging: {
+          page: 1,
+          recordCount: 0,
+          nextPageUrl: nil
+        }}.to_json]
+      }
+
+      it "returns a Result with a NotFoundError and no establishment" do
+        the_result = client.get_conversion_project(12345678)
+
+        expect(the_result.object).to be_nil
+        expect(the_result.error).to be_a(AcademiesApi::Client::NotFoundError)
+      end
+    end
+
+    context "when there are multiple matching projects" do
+      let(:fake_response) {
+        [200, nil, {data: [{nameOfTrust: "THE RETICULATED SPLINES TRUST"}, {nameOfTrust: "THE TRUST OF RETICULATES SPLINES"}], paging: {
+          page: 1,
+          recordCount: 2,
+          nextPageUrl: nil
+        }}.to_json]
+      }
+
+      it "returns a Result with a MultipleResultsError and no project" do
+        the_result = client.get_conversion_project(12345678)
+
+        expect(the_result.object).to be_nil
+        expect(the_result.error).to be_a(AcademiesApi::Client::MultipleResultsError)
+      end
+    end
+
+    context "when there is any other error" do
+      let(:fake_response) { [500, nil, nil] }
+
+      it "returns a Result with an Error and no conversion project" do
+        the_result = client.get_conversion_project(12345678)
+
+        expect(the_result.object).to be_nil
+        expect(the_result.error).to be_a(AcademiesApi::Client::Error)
+      end
+    end
+
+    context "when the connection fails" do
+      it "raises an Error" do
+        client = described_class.new(connection: fake_failed_conversion_project_connection(12345678))
+
+        expect { client.get_conversion_project(12345678) }.to raise_error(AcademiesApi::Client::Error)
+      end
+    end
+  end
+
+  def fake_successful_conversion_project_connection(urn, response)
+    Faraday.new do |builder|
+      builder.adapter :test do |stub|
+        stub.get("/v2/conversion-projects?urn=#{urn}") do |env|
+          response
+        end
+      end
+    end
+  end
+
+  def fake_failed_conversion_project_connection(urn)
+    Faraday.new do |builder|
+      builder.adapter :test do |stub|
+        stub.get("/v2/conversion-projects?urn=#{urn}") do |env|
           raise Faraday::Error
         end
       end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -76,4 +76,47 @@ RSpec.describe Project, type: :model do
       end
     end
   end
+
+  describe "#conversion_project" do
+    let(:urn) { 12345 }
+    let(:conversion_project) { build(:academies_api_conversion_project) }
+
+    subject { described_class.new(urn: urn) }
+
+    context "when the API returns a successful response" do
+      before { mock_successful_api_conversion_project_response(urn: urn, conversion_project:) }
+
+      it "retreives conversion_project data from the Academies API" do
+        expect(subject.conversion_project).to eq conversion_project
+      end
+    end
+
+    context "when the Academies API client returns a #{AcademiesApi::Client::NotFoundError}" do
+      let(:error_message) { "Could not find conversion project with URN: 12345" }
+      let(:error) { AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError.new(error_message)) }
+
+      before do
+        allow_any_instance_of(AcademiesApi::Client).to \
+          receive(:get_conversion_project).with(urn) { error }
+      end
+
+      it "raises the error" do
+        expect { subject.conversion_project }.to raise_error(AcademiesApi::Client::NotFoundError, error_message)
+      end
+    end
+
+    context "when the Academies API client returns a #{AcademiesApi::Client::Error}" do
+      let(:error_message) { "There was an error connecting to the Academies API, could not fetch conversion project for URN: 12345" }
+      let(:error) { AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::Error.new(error_message)) }
+
+      before do
+        allow_any_instance_of(AcademiesApi::Client).to \
+          receive(:get_conversion_project).with(urn) { error }
+      end
+
+      it "raises the error" do
+        expect { subject.conversion_project }.to raise_error(AcademiesApi::Client::Error, error_message)
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,9 @@ SimpleCov.start "rails"
 # Add Capybara
 require "capybara/rspec"
 
+# Add Webmock
+require 'webmock/rspec'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ SimpleCov.start "rails"
 require "capybara/rspec"
 
 # Add Webmock
-require 'webmock/rspec'
+require "webmock/rspec"
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -8,4 +8,14 @@ module AcademiesApiHelpers
     allow(test_client).to receive(:get_establishment).with(urn).and_return(fake_result)
     allow(AcademiesApi::Client).to receive(:new).and_return(test_client)
   end
+
+  def mock_successful_api_conversion_project_response(urn:, conversion_project: nil)
+    conversion_project = build(:academies_api_conversion_project) if conversion_project.nil?
+
+    fake_result = AcademiesApi::Client::Result.new(conversion_project, nil)
+    test_client = AcademiesApi::Client.new
+
+    allow(test_client).to receive(:get_conversion_project).with(urn).and_return(fake_result)
+    allow(AcademiesApi::Client).to receive(:new).and_return(test_client)
+  end
 end


### PR DESCRIPTION
To allow us to retrieve details of existing conversion projects (such as those from pre-AB), implement a new class which fronts Academies API to retrieve those objects.

This PR also adds [webmock](https://github.com/bblimke/webmock), which _could_ be used to simplify mocking in future but is mostly added because it prevents all outgoing HTTP calls and causes test failures unless those calls have been mocked. This gives us confidence that we're not accidentally interacting with an external service.