### PR TITLE
Validate a single matching conversion project exists on project creation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,3 +86,5 @@ en:
       models:
         project:
           no_establishment_found: No establishment found with that URN. Enter a valid URN.
+          no_conversion_project_found: No existing conversion project found with that URN. Check that the URN has a matching conversion project.
+          multiple_conversion_projects_found: Multiple conversion projects have been found for that URN. Unable to continue.

--- a/spec/features/users_can_create_projects_spec.rb
+++ b/spec/features/users_can_create_projects_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Team leaders can create a new project" do
   context "the URN is valid" do
     let(:urn) { 19283746 }
 
-    before { mock_successful_api_establishment_response(urn: urn) }
+    before { mock_successful_api_responses(urn: urn) }
 
     scenario "a new project is created" do
       fill_in "project-urn-field", with: urn
@@ -62,7 +62,7 @@ RSpec.feature "Team leaders can create a new project" do
   end
 
   context "the URN is empty" do
-    before { mock_successful_api_establishment_response(urn: any_args) }
+    before { mock_successful_api_responses(urn: any_args) }
 
     scenario "the user is shown an error message" do
       click_button("Continue")
@@ -71,7 +71,7 @@ RSpec.feature "Team leaders can create a new project" do
   end
 
   context "the URN is invalid" do
-    before { mock_successful_api_establishment_response(urn: any_args) }
+    before { mock_successful_api_responses(urn: any_args) }
 
     scenario "the user is shown an error message" do
       fill_in "project-urn-field", with: "three"

--- a/spec/features/users_can_update_projects_spec.rb
+++ b/spec/features/users_can_update_projects_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Users can reach the edit project page" do
   let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
   let(:delivery_officer) { create(:user, email: "user1@education.gov.uk") }
 
-  before { mock_successful_api_establishment_response(urn: urn) }
+  before { mock_successful_api_responses(urn: urn) }
 
   context "the user is a team leader" do
     before do
@@ -54,7 +54,7 @@ RSpec.feature "Users can update a project" do
   context "the user is a team leader" do
     before do
       sign_in_with_user(team_leader)
-      mock_successful_api_establishment_response(urn: urn)
+      mock_successful_api_responses(urn: urn)
     end
 
     context "when the project has no delivery officer" do

--- a/spec/features/users_can_view_projects_spec.rb
+++ b/spec/features/users_can_view_projects_spec.rb
@@ -6,9 +6,9 @@ RSpec.feature "Users can view a list of projects" do
   let(:user_2) { create(:user, email: "user2@education.gov.uk") }
 
   before do
-    mock_successful_api_establishment_response(urn: 1001)
-    mock_successful_api_establishment_response(urn: 1002)
-    mock_successful_api_establishment_response(urn: 1003)
+    mock_successful_api_responses(urn: 1001)
+    mock_successful_api_responses(urn: 1002)
+    mock_successful_api_responses(urn: 1003)
     @unassigned_project = Project.create!(urn: 1001)
     @user1_project = Project.create!(urn: 1002, delivery_officer: user_1)
     @user2_project = Project.create!(urn: 1003, delivery_officer: user_2)
@@ -47,7 +47,10 @@ RSpec.feature "Users can view a single project" do
   let(:urn) { 19283746 }
   let(:establishment) { build(:academies_api_establishment) }
 
-  before { mock_successful_api_establishment_response(urn: urn, establishment: establishment) }
+  before do
+    mock_successful_api_establishment_response(urn: urn, establishment: establishment)
+    mock_successful_api_responses(urn: urn)
+  end
 
   scenario "by following a link from the home page" do
     sign_in_with_user(create(:user, :team_leader))

--- a/spec/services/task_list_creator_spec.rb
+++ b/spec/services/task_list_creator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TaskListCreator do
       YAML.load_file(mock_workflow)
     )
 
-    mock_successful_api_establishment_response(urn: urn)
+    mock_successful_api_responses(urn: urn)
   end
 
   describe "#call" do

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -1,4 +1,9 @@
 module AcademiesApiHelpers
+  def mock_successful_api_responses(urn:)
+    mock_successful_api_establishment_response(urn:)
+    mock_successful_api_conversion_project_response(urn:)
+  end
+
   def mock_successful_api_establishment_response(urn:, establishment: nil)
     establishment = build(:academies_api_establishment) if establishment.nil?
 


### PR DESCRIPTION
When creating a project, catch any exceptions around either missing or multiple conversion projects from the API and present an in-form error message to the user.

Simplifies places in the feature specs where the `mock_successful_api_establishment_response` helper is called with the new `mock_successful_api_responses`, which mocks both establishment and conversion project calls in one go.

## Screenshots

![localhost_3000_projects](https://user-images.githubusercontent.com/619082/179760954-e2627711-1e2f-4294-b6a3-2fb6686ad8a1.png)
