### PR TITLE
(194) View and update actions

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -10,7 +10,7 @@ class TasksController < ApplicationController
     @task.actions.update_all(completed: false)
     @task.actions.where(title: titles).update_all(completed: true)
 
-    redirect_to(project_path(params[:project_id]))
+    redirect_to(project_path(@task.project))
   end
 
   def action_params
@@ -18,6 +18,6 @@ class TasksController < ApplicationController
   end
 
   private def find_task
-    @task = Task.joins(:section).where(section: {project: params[:project_id]}).find(params[:id])
+    @task = Task.find(params[:id])
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,0 +1,5 @@
+class TasksController < ApplicationController
+  def show
+    @task = Task.joins(:section).where(section: { project: params[:project_id] }).find(params[:id])
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,6 +9,8 @@ class TasksController < ApplicationController
 
     @task.actions.update_all(completed: false)
     @task.actions.where(title: titles).update_all(completed: true)
+
+    redirect_to(project_path(params[:project_id]))
   end
 
   def action_params

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,21 @@
 class TasksController < ApplicationController
+  before_action :find_task
+
   def show
-    @task = Task.joins(:section).where(section: { project: params[:project_id] }).find(params[:id])
+  end
+
+  def update
+    titles = action_params[:action_titles]
+
+    @task.actions.update_all(completed: false)
+    @task.actions.where(title: titles).update_all(completed: true)
+  end
+
+  def action_params
+    params.require(:task).permit(action_titles: [])
+  end
+
+  private def find_task
+    @task = Task.joins(:section).where(section: {project: params[:project_id]}).find(params[:id])
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,16 +5,16 @@ class TasksController < ApplicationController
   end
 
   def update
-    titles = action_params[:action_titles]
-
-    @task.actions.update_all(completed: false)
-    @task.actions.where(title: titles).update_all(completed: true)
+    @task.actions.each do |action|
+      action_completed = action.id.in?(action_params[:completed_action_ids] || [])
+      Action.update(action.id, completed: action_completed)
+    end
 
     redirect_to(project_path(@task.project))
   end
 
   def action_params
-    params.require(:task).permit(action_titles: [])
+    params.require(:task).permit(completed_action_ids: [])
   end
 
   private def find_task

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -1,3 +1,5 @@
 class Action < ApplicationRecord
   belongs_to :task
+
+  default_scope { order(order: "asc") }
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,4 +1,6 @@
 class Section < ApplicationRecord
   belongs_to :project
   has_many :tasks, dependent: :destroy
+
+  default_scope { order(order: "asc") }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,8 @@
 class Task < ApplicationRecord
   belongs_to :section
   has_many :actions, dependent: :destroy
+
+  default_scope { order(order: "asc") }
+
+  delegate :project, to: :section
 end

--- a/app/views/shared/_task_list.html.erb
+++ b/app/views/shared/_task_list.html.erb
@@ -9,7 +9,7 @@
           <li class="app-task-list__item">
               <span class="app-task-list__task-name">
                 <a href="#" aria-describedby=<%= task_status_id(task) %>>
-                  <%= task.title %>
+                  <%= link_to(task.title, project_task_path(@project.id, task.id), class: "govuk-link") %>
                 </a>
               </span>
             <strong class="govuk-tag app-task-list__tag" id=<%= task_status_id(task) %>>Completed</strong>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -2,7 +2,7 @@
   <%= govuk_back_link(href: project_path(@task.project)) %>
 <% end %>
 
-<h1><%= @task.title %></h1>
+<h1 class="govuk-heading-l"><%= @task.title %></h1>
 
 <%= form_for :task, url: project_task_path, method: :put do |form| %>
   <%= form.govuk_check_boxes_fieldset :actions, legend: { text: "Actions", size: "m" } do %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -5,7 +5,12 @@
 <h1><%= @task.title %></h1>
 
 <%= form_for :task, url: project_task_path, method: :put do |form| %>
-  <%= form.govuk_collection_check_boxes :actions, @task.actions, :completed?, :title %>
+  <%= form.govuk_check_boxes_fieldset :actions, legend: { text: "Actions", size: "m" } do %>
+    <% @task.actions.each do |action| %>
+      <%= form.govuk_check_box :action_titles, action.title, label: { text: action.title }, link_errors: true, checked: action.completed? %>
+    <% end %>
+  <% end %>
 
   <%= form.govuk_submit %>
 <% end %>
+

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -7,7 +7,7 @@
 <%= form_for :task, url: project_task_path, method: :put do |form| %>
   <%= form.govuk_check_boxes_fieldset :actions, legend: { text: "Actions", size: "m" } do %>
     <% @task.actions.each do |action| %>
-      <%= form.govuk_check_box :action_titles, action.title, label: { text: action.title }, link_errors: true, checked: action.completed? %>
+      <%= form.govuk_check_box :completed_action_ids, action.id, label: { text: action.title }, link_errors: true, checked: action.completed? %>
     <% end %>
   <% end %>
 

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,0 +1,11 @@
+<% content_for :pre_content_nav do %>
+  <%= govuk_back_link(href: project_path(@task.project)) %>
+<% end %>
+
+<h1><%= @task.title %></h1>
+
+<%= form_for :task, url: project_task_path, method: :put do |form| %>
+  <%= form.govuk_collection_check_boxes :actions, @task.actions, :completed?, :title %>
+
+  <%= form.govuk_submit %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   # Omniauth callbacks
   get "auth/:provider/callback", to: "sessions#create"
 
-  # Projects
-  resources :projects
+  resources :projects do
+    resources :tasks
+  end
 end

--- a/spec/factories/action_factory.rb
+++ b/spec/factories/action_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :action, class: "Action" do
+    title { "Have you received the land questionnaire?" }
+    order { 0 }
+    task
+  end
+end

--- a/spec/factories/section_factory.rb
+++ b/spec/factories/section_factory.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :section, class: "Section" do
     title { "Clear legal documents" }
     order { 0 }
-    project { create(:project) }
+    project
   end
 end

--- a/spec/factories/task_factory.rb
+++ b/spec/factories/task_factory.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     title { "Clear land questionnaire" }
     completed { false }
     order { 0 }
-    section { create(:section) }
+    section
   end
 end

--- a/spec/features/users_can_update_the_actions_for_a_task_spec.rb
+++ b/spec/features/users_can_update_the_actions_for_a_task_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.feature "Users can update the Actions for a Task" do
+  let(:user) { create(:user, email: "user1@education.gov.uk") }
+  let(:completed_action) { create(:action, title: "Action 1", completed: true) }
+  let(:incomplete_action) { create(:action, title: "Action 2") }
+  let(:task) { create(:task, actions: [completed_action, incomplete_action]) }
+  let(:project_id) { task.section.project.id }
+  let(:task_id) { task.id }
+
+  before do
+    mock_successful_api_responses(urn: 12345)
+
+    sign_in_with_user(user)
+  end
+
+  scenario "User updates a completed action and an incomplete action" do
+    visit project_task_path(project_id, task_id)
+
+    page.uncheck("Action 1")
+    page.check("Action 2")
+
+    click_button("Continue")
+
+    expect(incomplete_action.reload.completed?).to be true
+    expect(completed_action.reload.completed?).to be false
+  end
+end

--- a/spec/features/users_can_update_the_actions_for_a_task_spec.rb
+++ b/spec/features/users_can_update_the_actions_for_a_task_spec.rb
@@ -17,12 +17,14 @@ RSpec.feature "Users can update the Actions for a Task" do
   scenario "User updates a completed action and an incomplete action" do
     visit project_task_path(project_id, task_id)
 
-    page.uncheck("Action 1")
-    page.check("Action 2")
+    uncheck("Action 1")
+    check("Action 2")
 
     click_button("Continue")
 
     expect(incomplete_action.reload.completed?).to be true
     expect(completed_action.reload.completed?).to be false
+
+    expect(page).to have_current_path(project_path(project_id))
   end
 end

--- a/spec/features/users_can_view_the_actions_for_a_task_spec.rb
+++ b/spec/features/users_can_view_the_actions_for_a_task_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.feature "Users can view the Actions for a Task" do
+  let(:user_1) { create(:user, email: "user1@education.gov.uk") }
+  let(:action) { create(:action) }
+  let(:task_id) { action.task.id }
+  let(:project_id) { action.task.section.project.id }
+
+  before do
+    mock_successful_api_responses(urn: 12345)
+
+    sign_in_with_user(user_1)
+  end
+
+  scenario "User views the list of tasks" do
+    visit project_task_path(project_id, task_id)
+
+    expect(page).to have_content("Clear land questionnaire")
+    expect(page).to have_content("Have you received the land questionnaire?")
+  end
+end

--- a/spec/models/action_spec.rb
+++ b/spec/models/action_spec.rb
@@ -10,4 +10,17 @@ RSpec.describe Action do
   describe "Relationships" do
     it { is_expected.to belong_to(:task) }
   end
+
+  describe "Scopes" do
+    before { mock_successful_api_responses(urn: any_args) }
+
+    describe "default_scope" do
+      let!(:action_1) { create(:action, order: 1) }
+      let!(:action_2) { create(:action, order: 0) }
+
+      it "orders ascending by the 'order' attribute" do
+        expect(Action.all).to eq [action_2, action_1]
+      end
+    end
+  end
 end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -10,4 +10,17 @@ RSpec.describe Section, type: :model do
     it { is_expected.to have_many(:tasks).dependent(:destroy) }
     it { is_expected.to belong_to(:project) }
   end
+
+  describe "Scopes" do
+    before { mock_successful_api_responses(urn: any_args) }
+
+    describe "default_scope" do
+      let!(:section_1) { create(:section, order: 1) }
+      let!(:section_2) { create(:section, order: 0) }
+
+      it "orders ascending by the 'order' attribute" do
+        expect(Section.all).to eq [section_2, section_1]
+      end
+    end
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -11,4 +11,17 @@ RSpec.describe Task, type: :model do
     it { is_expected.to belong_to(:section) }
     it { is_expected.to have_many(:actions).dependent(:destroy) }
   end
+
+  describe "Scopes" do
+    before { mock_successful_api_responses(urn: any_args) }
+
+    describe "default_scope" do
+      let!(:task_1) { create(:task, order: 1) }
+      let!(:task_2) { create(:task, order: 0) }
+
+      it "orders ascending by the 'order' attribute" do
+        expect(Task.all).to eq [task_2, task_1]
+      end
+    end
+  end
 end

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -58,9 +58,10 @@ RSpec.describe TasksController, type: :request do
       it { expect { perform_request }.to raise_error(ActiveRecord::RecordNotFound) }
     end
 
-    it "updates the Actions completed attribute" do
+    it "updates the actions and redirects to the project show page" do
       perform_request
 
+      expect(response).to redirect_to(project_path(project_id))
       expect(incomplete_action.reload.completed?).to be true
       expect(completed_action.reload.completed?).to be false
     end

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe TasksController, type: :request do
+  describe "#show" do
+    let(:task) { create(:task) }
+    let(:project_id) { task.section.project.id }
+    let(:task_id) { task.id }
+
+    subject(:perform_request) do
+      get project_task_path(project_id, task_id)
+      response
+    end
+
+    before { mock_successful_api_responses(urn: 12345) }
+
+    context "when the Task does not belong to the project" do
+      let(:project_id) { SecureRandom.uuid }
+
+      it { expect { perform_request }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    context "when the Task is not found" do
+      let(:task_id) { SecureRandom.uuid }
+
+      it { expect { perform_request }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    it "returns a successful response" do
+      expect(subject).to have_http_status :success
+      expect(subject.body).to include("Clear land questionnaire")
+    end
+  end
+end

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -13,12 +13,6 @@ RSpec.describe TasksController, type: :request do
 
     before { mock_successful_api_responses(urn: 12345) }
 
-    context "when the Task does not belong to the project" do
-      let(:project_id) { SecureRandom.uuid }
-
-      it { expect { perform_request }.to raise_error(ActiveRecord::RecordNotFound) }
-    end
-
     context "when the Task is not found" do
       let(:task_id) { SecureRandom.uuid }
 
@@ -45,12 +39,6 @@ RSpec.describe TasksController, type: :request do
     end
 
     before { mock_successful_api_responses(urn: 12345) }
-
-    context "when the Task does not belong to the project" do
-      let(:project_id) { SecureRandom.uuid }
-
-      it { expect { perform_request }.to raise_error(ActiveRecord::RecordNotFound) }
-    end
 
     context "when the Task is not found" do
       let(:task_id) { SecureRandom.uuid }

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe TasksController, type: :request do
     let(:task) { create(:task, actions: [completed_action, incomplete_action]) }
     let(:project_id) { task.section.project.id }
     let(:task_id) { task.id }
-    let(:params) { {task: {action_titles: [incomplete_action.title]}} }
+    let(:params) { {task: {completed_action_ids: [incomplete_action.id]}} }
 
     subject(:perform_request) do
       put project_task_path(project_id, task_id), params: params

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -30,4 +30,39 @@ RSpec.describe TasksController, type: :request do
       expect(subject.body).to include("Clear land questionnaire")
     end
   end
+
+  describe "#update" do
+    let(:completed_action) { create(:action, title: "Action 1", completed: true) }
+    let(:incomplete_action) { create(:action, title: "Action 2") }
+    let(:task) { create(:task, actions: [completed_action, incomplete_action]) }
+    let(:project_id) { task.section.project.id }
+    let(:task_id) { task.id }
+    let(:params) { {task: {action_titles: [incomplete_action.title]}} }
+
+    subject(:perform_request) do
+      put project_task_path(project_id, task_id), params: params
+      response
+    end
+
+    before { mock_successful_api_responses(urn: 12345) }
+
+    context "when the Task does not belong to the project" do
+      let(:project_id) { SecureRandom.uuid }
+
+      it { expect { perform_request }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    context "when the Task is not found" do
+      let(:task_id) { SecureRandom.uuid }
+
+      it { expect { perform_request }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    it "updates the Actions completed attribute" do
+      perform_request
+
+      expect(incomplete_action.reload.completed?).to be true
+      expect(completed_action.reload.completed?).to be false
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/CsNfWkNp

### Show a checklist of Actions on the individual Task page
Initially, we want to show our YAML Actions as a completable checklist on each individual Task page.

### DRY up relationships in existing factories
We can simply use the name of the related factory when declaring relationships in FactoryBot.

### Add update action to Task controller
Users need to be able to complete Actions, and for this to be persisted.