### PR TITLE
(256) Tags in the task list reflect the actual state of a task

### DIFF
--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -2,4 +2,9 @@ module TaskListHelper
   def task_status_id(task)
     "#{task.title.parameterize}-status"
   end
+
+  def task_status_tag(task)
+
+    govuk_tag(text: 'Completed', classes: "app-task-list__tag", html_attributes: {id: task_status_id(task)})
+  end
 end

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -4,7 +4,20 @@ module TaskListHelper
   end
 
   def task_status_tag(task)
+    # Colours as per https://govuk-components.netlify.app/components/tag/
     tags_for_states = {
+      not_started: {
+        text: "Not started",
+        colour: "blue"
+      },
+      in_progress: {
+        text: "In progress",
+        colour: "orange"
+      },
+      completed: {
+        text: "Complete",
+        colour: "turquoise"
+      },
       unknown: {
         text: "Unknown",
         colour: "grey"

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -4,7 +4,20 @@ module TaskListHelper
   end
 
   def task_status_tag(task)
+    tags_for_states = {
+      unknown: {
+        text: "Unknown",
+        colour: "grey"
+      }
+    }
 
-    govuk_tag(text: 'Completed', classes: "app-task-list__tag", html_attributes: {id: task_status_id(task)})
+    task_state = tags_for_states.fetch(task.status, tags_for_states[:unknown])
+
+    govuk_tag(
+      text: task_state[:text],
+      colour: task_state[:colour],
+      classes: "app-task-list__tag",
+      html_attributes: {id: task_status_id(task)}
+    )
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,7 +6,21 @@ class Task < ApplicationRecord
 
   delegate :project, to: :section
 
+  def actions_count
+    @actions_count ||= actions.all.count
+  end
+
+  def completed_actions_count
+    @completed_actions_count ||= actions.where(completed: true).count
+  end
+
   def status
-    :unknown
+    if completed_actions_count == 0
+      :not_started
+    elsif completed_actions_count == actions_count
+      :completed
+    elsif completed_actions_count < actions_count
+      :in_progress
+    end
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,4 +5,8 @@ class Task < ApplicationRecord
   default_scope { order(order: "asc") }
 
   delegate :project, to: :section
+
+  def status
+    :unknown
+  end
 end

--- a/app/views/shared/_task_list.html.erb
+++ b/app/views/shared/_task_list.html.erb
@@ -12,7 +12,7 @@
                   <%= link_to(task.title, project_task_path(@project.id, task.id), class: "govuk-link") %>
                 </a>
               </span>
-              <%= govuk_tag(text: 'Completed', classes: "app-task-list__tag", html_attributes: {id: task_status_id(task)}) %>
+              <%= task_status_tag(task) %>
           </li>
         <% end %>
       </ul>

--- a/app/views/shared/_task_list.html.erb
+++ b/app/views/shared/_task_list.html.erb
@@ -12,7 +12,7 @@
                   <%= link_to(task.title, project_task_path(@project.id, task.id), class: "govuk-link") %>
                 </a>
               </span>
-            <strong class="govuk-tag app-task-list__tag" id=<%= task_status_id(task) %>>Completed</strong>
+              <%= govuk_tag(text: 'Completed', classes: "app-task-list__tag", html_attributes: {id: task_status_id(task)}) %>
           </li>
         <% end %>
       </ul>

--- a/spec/helpers/task_list_helper_spec.rb
+++ b/spec/helpers/task_list_helper_spec.rb
@@ -12,7 +12,13 @@ RSpec.describe TaskListHelper, type: :helper do
   describe "#task_status_tag" do
     let(:task) { Task.new(title: "Clear land questionnaire") }
 
-    it "returns a tag representing the task status" do
+    it "returns a tag representing the task status when the status is known" do
+      allow(task).to receive(:status).and_return(:completed)
+      expect(helper.task_status_tag(task)).to eq '<strong class="govuk-tag govuk-tag--turquoise app-task-list__tag" id="clear-land-questionnaire-status">Complete</strong>'
+    end
+
+    it "returns a tag representing an unknown status where the status is not known" do
+      allow(task).to receive(:status).and_return(:unexpected)
       expect(helper.task_status_tag(task)).to eq '<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="clear-land-questionnaire-status">Unknown</strong>'
     end
   end

--- a/spec/helpers/task_list_helper_spec.rb
+++ b/spec/helpers/task_list_helper_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TaskListHelper, type: :helper do
     let(:task) { Task.new(title: "Clear land questionnaire") }
 
     it "returns a tag representing the task status" do
-      expect(helper.task_status_tag(task)).to eq '<strong class="govuk-tag app-task-list__tag" id="clear-land-questionnaire-status">Completed</strong>'
+      expect(helper.task_status_tag(task)).to eq '<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="clear-land-questionnaire-status">Unknown</strong>'
     end
   end
 end

--- a/spec/helpers/task_list_helper_spec.rb
+++ b/spec/helpers/task_list_helper_spec.rb
@@ -8,4 +8,12 @@ RSpec.describe TaskListHelper, type: :helper do
       expect(helper.task_status_id(task)).to eq "clear-land-questionnaire-status"
     end
   end
+
+  describe "#task_status_tag" do
+    let(:task) { Task.new(title: "Clear land questionnaire") }
+
+    it "returns a tag representing the task status" do
+      expect(helper.task_status_tag(task)).to eq '<strong class="govuk-tag app-task-list__tag" id="clear-land-questionnaire-status">Completed</strong>'
+    end
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -24,4 +24,16 @@ RSpec.describe Task, type: :model do
       end
     end
   end
+
+  describe "#actions_count" do
+    let(:task) { create(:task) }
+
+    describe "status" do
+      let!(:task) { create(:task) }
+
+      it "returns an unknown state" do
+        expect(task.status).to eq :unknown
+      end
+    end
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -28,11 +28,64 @@ RSpec.describe Task, type: :model do
   describe "#actions_count" do
     let(:task) { create(:task) }
 
-    describe "status" do
-      let!(:task) { create(:task) }
+    before do
+      mock_successful_api_responses(urn: any_args)
+      FactoryBot.create_list(:action, 3, task:)
+    end
 
-      it "returns an unknown state" do
-        expect(task.status).to eq :unknown
+    it "returns the number of actions associated with the task" do
+      expect(task.actions_count).to eq 3
+    end
+  end
+
+  describe "#completed_actions_count" do
+    let(:task) { create(:task) }
+
+    before do
+      mock_successful_api_responses(urn: any_args)
+      FactoryBot.create_list(:action, 1, task:)
+      FactoryBot.create_list(:action, 2, task:, completed: true)
+    end
+
+    it "returns the number of completed actions associated with the task" do
+      expect(task.completed_actions_count).to eq 2
+    end
+  end
+
+  describe "#status" do
+    let(:task) { create(:task) }
+
+    context "there are no completed actions" do
+      before do
+        mock_successful_api_responses(urn: any_args)
+        FactoryBot.create_list(:action, 3, task:)
+      end
+
+      it "returns a not_started state" do
+        expect(task.status).to eq :not_started
+      end
+    end
+
+    context "the number of completed actions is equal to the total number of actions" do
+      before do
+        mock_successful_api_responses(urn: any_args)
+        FactoryBot.create_list(:action, 3, task:, completed: true)
+      end
+
+      it "returns a completed state" do
+        expect(task.status).to eq :completed
+      end
+    end
+
+    context "there are fewer completed actions than the total number of actions" do
+      before do
+        mock_successful_api_responses(urn: any_args)
+        FactoryBot.create_list(:action, 1, task:)
+        FactoryBot.create_list(:action, 2, task:, completed: true)
+      end
+
+      it "returns an in_progress state" do
+        expect(task.status).to eq :in_progress
       end
     end
   end


### PR DESCRIPTION
The completion status of each item in the task list should reflect reality instead of all being marked as "Completed".

## Screenshots

### Before
![localhost_3000_projects_f7e0efd0-dad6-47a3-a9da-e0e8e318db3e (1)](https://user-images.githubusercontent.com/619082/180776346-5368a8b3-207e-456b-9892-56afb5e9c049.png)

### After
![localhost_3000_projects_f7e0efd0-dad6-47a3-a9da-e0e8e318db3e](https://user-images.githubusercontent.com/619082/180776355-729976b3-e640-4207-91a8-0f7fb7a35b24.png)
