### PR TITLE
(225) Chore: local environment uses mssql server

### DIFF
--- a/.env.database.example
+++ b/.env.database.example
@@ -1,0 +1,6 @@
+# Environment for Microsoft SQL Server
+# https://hub.docker.com/_/microsoft-mssql-server
+#
+# SA_PASSWORD must be at least 8 characters including uppercase, lowercase letters, base-10 digits and/or non-alphanumeric symbols
+ACCEPT_EULA=Y
+SA_PASSWORD=

--- a/.env.development
+++ b/.env.development
@@ -3,8 +3,5 @@
 # This file commits safe environment variables for the development environment.
 # For managing sensitive values and overrides use `/.env.development.local`
 #
-# If a required key is added, make sure it is also added in `config/initializers/dotenv.rb`
-#
-# Reference: https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
-
-DATABASE_URL=postgres://postgres@localhost:5432/dfe-complete-academies-development
+DATABASE_USER=sa
+DATABASE_HOST=localhost

--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,13 @@
 # If a required key is added, make sure it is also added in `config/initializers/dotenv.rb`
 #
 # Reference: https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
-
-DATABASE_URL=postgres://postgres@localhost:5432/database-name
+#
+# Database
+#
+#
+DATABASE_USER=sa
+DATABASE_HOST=localhost
+DATABASE_PASSWORD=database_password
 
 # Azure Active Directory
 #

--- a/.env.test
+++ b/.env.test
@@ -3,15 +3,9 @@
 # This file commits safe environment variables for the test environment.
 # For managing sensitive values and overrides use `/.env.test.local`
 #
-# If a required key is added, make sure it is also added in `config/initializers/dotenv.rb`
-#
-# Reference: https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
+DATABASE_USER=sa
+DATABASE_HOST=localhost
 
-DATABASE_URL=postgres://postgres@localhost:5432/dfe-complete-academies-test
-
-# Azure Active Directory
-#
-# Admin url: https://portal.azure.com.mcas.ms/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/05b7db93-6384-4b44-9d27-23eb6bd97366/isMSAApp~/false
 AZURE_APPLICATION_CLIENT_ID=AZURE_APPLICATION_CLIENT_ID
 AZURE_APPLICATION_CLIENT_SECRET=AZURE_APPLICATION_CLIENT_SECRET
 AZURE_TENANT_ID=AZURE_TENANT_ID

--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,3 @@
 brew "rbenv"
 brew "nodenv"
+brew "docker"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,13 @@ RUN \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | \
   tee /etc/apt/sources.list.d/yarn.list
 
+RUN curl http://www.freetds.org/files/stable/freetds-1.1.24.tar.gz --output freetds-1.1.24.tar.gz
+RUN tar -xzf freetds-1.1.24.tar.gz
+WORKDIR freetds-1.1.24
+RUN ./configure --prefix=/usr/local --with-tdsver=7.3
+RUN make
+RUN make install
+
 RUN \
   apt-get update && \
   apt-get install -y --fix-missing --no-install-recommends \

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,9 @@ gem "rails", "~> 7.0.3"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 
-# Use postgresql as the database for Active Record
-gem "pg", "~> 1.4"
+# Use MS SQL Server  as the database for Active Record
+# https://github.com/rails-sqlserver/activerecord-sqlserver-adapter
+gem "activerecord-sqlserver-adapter"
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,9 @@ GEM
     activerecord (7.0.3.1)
       activemodel (= 7.0.3.1)
       activesupport (= 7.0.3.1)
+    activerecord-sqlserver-adapter (7.0.0.0)
+      activerecord (~> 7.0.0)
+      tiny_tds
     activestorage (7.0.3.1)
       actionpack (= 7.0.3.1)
       activejob (= 7.0.3.1)
@@ -193,7 +196,6 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
-    pg (1.4.2)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -308,6 +310,7 @@ GEM
     thor (1.2.1)
     tilt (2.0.10)
     timeout (0.3.0)
+    tiny_tds (2.1.5)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.2.0)
@@ -337,6 +340,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-sqlserver-adapter
   bootsnap
   brakeman
   bullet
@@ -351,7 +355,6 @@ DEPENDENCIES
   omniauth
   omniauth-azure-activedirectory-v2
   omniauth-rails_csrf_protection
-  pg (~> 1.4)
   pry-rails
   puma (~> 5.0)
   pundit (~> 2.2)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,39 @@
 
 ## Getting started
 
+### Setup Microsoft SQL Server
+
+As we run Microsoft SQL Server, we have to run it inside a container. To make
+this as simple as we can we use docker-compose to launch an appropriate
+instance.
+
+Duplicate `.env.database.example` as `.env.database` and set:
+
+```
+ACCEPT_EULA=Y
+SA_PASSWORD=<database_password>
+```
+
+Where `<database_password>` is at least 8 characters including uppercase,
+lowercase letters, base-10 digits and/or non-alphanumeric symbols, see the
+[image docs](https://hub.docker.com/_/microsoft-mssql-server).
+
+These are then used by the `docker-compose-database.local.yml` to launch and
+instance of SQL Server.
+
+Create `.env.development.local` and `.env.test.local` and add:
+
+```
+DATABASE_PASSWORD=<database_password>
+```
+
+Where `<database_password>` is the same as in `.env.database`.
+
+The applicaiton will use these credentials to access the database and so must
+all be the same.
+
+### Setup everything else
+
 This repository follows the
 [Scripts To Rule Them All](https://github.com/dxw/tech-team-rfcs/blob/main/rfc-023-use-scripts-to-rule-them-all.md)
 pattern. To get started with development (or to restore your environment to a

--- a/app/services/task_list_creator.rb
+++ b/app/services/task_list_creator.rb
@@ -23,11 +23,8 @@ class TaskListCreator
   end
 
   private def create_actions(workflow_task, task)
-    all_actions = []
     workflow_task.fetch("actions").each_with_index do |workflow_action, index|
-      all_actions << workflow_action.merge({order: index, task_id: task.id})
+      Action.create(workflow_action.merge({order: index, task_id: task.id}))
     end
-
-    Action.insert_all(all_actions) unless all_actions.empty?
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,86 +1,24 @@
-# PostgreSQL. Versions 9.3 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On macOS with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On macOS with MacPorts:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem "pg"
-#
 default: &default
-  adapter: postgresql
-  encoding: unicode
+  adapter:  sqlserver
+  port:     1433
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: <%= ENV["DATABASE_USER"] %>
+  password: <%= ENV["DATABASE_PASSWORD"] %>
+  host: <%= ENV["DATABASE_HOST"] %>
 
 development:
   <<: *default
-  database: dfe_complete_conversions_transfers_and_changes_development
-
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user running Rails.
-  #username: dfe_complete_conversions_transfers_and_changes
-
-  # The password associated with the postgres role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
+  database: sip_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: dfe_complete_conversions_transfers_and_changes_test
+  database: sip_test
 
-# As with config/credentials.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password or a full connection URL as an environment
-# variable when you boot the app. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# If the connection URL is provided in the special DATABASE_URL environment
-# variable, Rails will automatically merge its configuration values on top of
-# the values provided in this file. Alternatively, you can specify a connection
-# URL environment variable explicitly:
-#
-#   production:
-#     url: <%= ENV["MY_APP_DATABASE_URL"] %>
-#
-# Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full overview on how database connection configuration can be specified.
-#
 production:
   <<: *default
-  database: dfe_complete_conversions_transfers_and_changes_production
-  username: dfe_complete_conversions_transfers_and_changes
-  password: <%= ENV["DFE_COMPLETE_CONVERSIONS_TRANSFERS_AND_CHANGES_DATABASE_PASSWORD"] %>
+  database: sip

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,6 +77,6 @@ Rails.application.configure do
   #
   # In production all out tables exist in a 'schema' called `complete` so we
   # tell Rails to look for it's internal tables there.
-  config.active_record.schema_migrations_table_name = "complete.schema_migrations"
-  config.active_record.internal_metadata_table_name = "complete.ar_internal_metadata"
+  config.active_record.schema_migrations_table_name = "#{ENV["SQL_SERVER_SCHEMA_NAME"]}.schema_migrations"
+  config.active_record.internal_metadata_table_name = "#{ENV["SQL_SERVER_SCHEMA_NAME"]}.ar_internal_metadata"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,4 +72,11 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # SQL server table config
+  #
+  # In production all out tables exist in a 'schema' called `complete` so we
+  # tell Rails to look for it's internal tables there.
+  config.active_record.schema_migrations_table_name = "complete.schema_migrations"
+  config.active_record.internal_metadata_table_name = "complete.ar_internal_metadata"
 end

--- a/config/initializers/dontenv.rb
+++ b/config/initializers/dontenv.rb
@@ -1,6 +1,5 @@
 if defined?(Dotenv)
   Dotenv.require_keys(
-    "DATABASE_URL",
     "AZURE_APPLICATION_CLIENT_ID",
     "AZURE_APPLICATION_CLIENT_SECRET",
     "AZURE_TENANT_ID"

--- a/db/migrate/20220620083237_create_users.rb
+++ b/db/migrate/20220620083237_create_users.rb
@@ -1,7 +1,5 @@
 class CreateUsers < ActiveRecord::Migration[7.0]
   def change
-    enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
-
     create_table :users, id: :uuid do |t|
       t.string :email, index: {unique: true}
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2022_07_26_143808) do
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "pgcrypto"
-  enable_extension "plpgsql"
-
-  create_table "actions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
     t.boolean "completed", default: false, null: false
@@ -25,7 +21,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_26_143808) do
     t.index ["task_id"], name: "index_actions_on_task_id"
   end
 
-  create_table "projects", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "projects", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.integer "urn", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -36,7 +32,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_26_143808) do
     t.index ["urn"], name: "index_projects_on_urn"
   end
 
-  create_table "sections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "sections", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
     t.uuid "project_id"
@@ -45,7 +41,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_26_143808) do
     t.index ["project_id"], name: "index_sections_on_project_id"
   end
 
-  create_table "tasks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "tasks", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
     t.boolean "completed", default: false, null: false
@@ -55,7 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_26_143808) do
     t.index ["section_id"], name: "index_tasks_on_section_id"
   end
 
-  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/doc/decisions/0008-variance-between-local-and-production-environments.md
+++ b/doc/decisions/0008-variance-between-local-and-production-environments.md
@@ -1,0 +1,37 @@
+# 8. Variance between local and production environments
+
+Date: 2022-07-27
+
+## Status
+
+Accepted
+
+## Context
+
+The application will connect to a Microsoft SQL server to store data. This
+presents a number of challenges in setting up a local development environment
+with complete parity to production.
+
+In production the application connects with the credentials of a database user
+who can only access the tables inside a 'schema', this guarantees the integrity
+of the wider database.
+
+Locally Rails assumes it can drop databases at will, this is difficult to
+replicate along with the login, database user and permissions to exactly mirror
+production.
+
+For example the users in production must never drop the database, as it contains
+schemas from other applications, locally the test database is routinely dropped
+to clear it.
+
+## Decision
+
+We will use MS SQL Server locally but forego the same schema and user
+restrictions as in production. We can use the per environment configuration to
+ensure production is setup as expected.
+
+## Consequences
+
+We usually seek parity between our local and production environments and whilst
+there is risk in this variance, it is far better to have a fast and efficient
+developer experience.

--- a/doc/environment-variables.md
+++ b/doc/environment-variables.md
@@ -1,0 +1,8 @@
+# Environment variables
+
+`SQL_SERVER_SCHEMA_NAME`
+
+This is the SQL Server schema name used in production and
+pre-production/staging. Must be set in those environments, not used locally, see
+[SQL Server documentation](./microsoft-sql-server.md) for more information on
+schema in this context.

--- a/doc/microsoft-sql-server.md
+++ b/doc/microsoft-sql-server.md
@@ -1,0 +1,55 @@
+# Microsoft SQL Server
+
+As per this [ADR](./0007-use-the-academies-db-as-the-datastore.md), the
+application must store data in the 'Academies Database' which runs on Microsoft
+SQL Server.
+
+As this setup is relatively unconventional, this documentation may be of use.
+
+## Setup
+
+See the [Setup Microsoft SQL Server](../README.md#setup-microsoft-sql-server) in
+the readme for more information.
+
+## Running the server
+
+As SQL Server does not run natively on macOS we use the
+[official Docker image](https://hub.docker.com/_/microsoft-mssql-server).
+
+If you use the scripts to rule them all pattern, the container will be started
+for you, but bear in mind, it may not be stopped for you.
+
+To run the container manually:
+
+```bash
+docker-compose -f docker-compose.database.local.yml up -d
+```
+
+And to stop the container:
+
+```bash
+docker-compose -f docker-compose.database.local.yml down
+```
+
+## Tooling
+
+[Azure Data Studio](https://docs.microsoft.com/en-gb/sql/azure-data-studio/download-azure-data-studio?view=sql-server-ver16)
+is a native application to connect to the local SQL server.
+
+## SQL Server 'schemas'
+
+In an unfortunate naming collision, the term 'schema' is used in SQL Server to
+allow:
+
+> ...for more flexibility in managing database object permissions.[1]
+
+In production, the application only has access to a single schema and creates
+all database tables within that schema.
+
+Locally, the overhead of creating and maintaining the login, users, schemas and
+permissions was felt to be to high and so we do not use a custom schema in our
+development setup, creating tables in the default `dbo` schema. More detail on
+this decision is in this
+[ADR](./decisions/0007-use-the-academies-db-as-the-datastore.md).
+
+[1](https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/ownership-and-user-schema-separation?view=sql-server-ver16)

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -17,7 +17,7 @@ services:
     env_file:
        - .env.test
     environment:
-      DATABASE_URL: postgres://postgres:password@test-db:5432/dfe-academies-test
+      DATABASE_URL: sqlserver://sa:strongPassword&@test-db:1433/sip_test
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       SECRET_KEY_BASE: secret
       CI: "true"
@@ -25,12 +25,10 @@ services:
       - test-ci
 
   test-db:
-    image: postgres
+    image: mcr.microsoft.com/mssql/server:2019-latest
     environment:
-      POSTGRES_DB: app-academies-test
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
-      POSTGRES_HOST_AUTH_METHOD: trust
+      ACCEPT_EULA: Y
+      SA_PASSWORD: strongPassword&
     networks:
       - test-ci
 

--- a/docker-compose.database.local.yml
+++ b/docker-compose.database.local.yml
@@ -6,3 +6,7 @@ services:
     env_file: .env.database
     ports:
       - 1433:1433
+    volumes:
+      - sql-server-data:/var/opt/mssql
+volumes:
+  sql-server-data:

--- a/docker-compose.database.local.yml
+++ b/docker-compose.database.local.yml
@@ -1,6 +1,7 @@
 version: "2.8"
 services:
   db:
+    container_name: dfe-complete-sql-server
     image: mcr.microsoft.com/mssql/server:2019-latest
     env_file: .env.database
     ports:

--- a/docker-compose.database.local.yml
+++ b/docker-compose.database.local.yml
@@ -1,0 +1,7 @@
+version: "2.8"
+services:
+  db:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    env_file: .env.database
+    ports:
+      - 1433:1433

--- a/script/no-docker/console
+++ b/script/no-docker/console
@@ -21,6 +21,9 @@ else
   echo "==> Updating..."
   script/no-docker/update
 
+  echo "==> Starting SQL Server container..."
+  script/no-docker/database
+
   echo "==> Starting a local Rails console..."
   bundle exec rails console
 fi

--- a/script/no-docker/database
+++ b/script/no-docker/database
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Check if the SQL Server container is already running and if not, run it
+
+if ! docker-compose ps | grep -q "dfe-complete-sql-server\|Up"; then
+  docker-compose -f docker-compose.database.local.yml up -d
+fi

--- a/script/no-docker/server
+++ b/script/no-docker/server
@@ -10,5 +10,8 @@ cd "$(dirname "$0")/../.."
 echo "==> Updating..."
 script/no-docker/update
 
+echo "==> Starting SQL Server container..."
+script/no-docker/database
+
 echo "==> Starting the development server..."
 bundle exec rails server

--- a/script/no-docker/setup
+++ b/script/no-docker/setup
@@ -8,6 +8,9 @@ set -e
 # Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/../.."
 
+echo "==> Starting SQL Server container..."
+script/no-docker/database
+
 if [ -d vendor/bundle ]; then
   echo "==> Cleaning installed Ruby dependencies..."
   git clean -x --force -- vendor/bundle

--- a/script/no-docker/update
+++ b/script/no-docker/update
@@ -7,6 +7,9 @@ set -e
 echo "==> Bootstrapping..."
 script/no-docker/bootstrap
 
+echo "==> Starting SQL Server container..."
+script/no-docker/database
+
 echo "==> Running database migrations..."
 bundle exec rails db:migrate
 


### PR DESCRIPTION
This is a first attempt to switch our development environment from Postgres to Microsoft SQL Server. The reasons for doing so are in this [ADR](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/blob/develop/doc/decisions/0007-use-the-academies-db-as-the-datastore.md).

There is a lot here, take your time and please ask anything, but I'll be the frist to say this is not something I am super experienced with!

As SQL Server cannot be run natively on Mac OS we have to use Docker, this renders the whole Docker/No Docker thing even more confusing, but we are essentially still running Ruby and Rails natively. I haven't updated the Docker parts yet as:

- no one on the team uses them
- we have no production environment using them

I've have tried to update the  no-docker scripts, but I don't use them (for reasons) so I cannot test them, I'd appreciate feedback on that part of the work!

The important part is probably the decision to let our local development environments differ from production slightly in order to make the day-to-day usage simpler - details in the ADR, but in summary: using a SQL Server schema locally means  day-to-day developer task become incredibly complex and the trade off just doesn't seem worth it.

I don't think we need perfection at this point as I expect we'll be back here soon with Devops help and can do more then - the main goal is to make the switch before work starts on our deployments.


 