### PR TITLE
(195) Project tabs

### DIFF
--- a/app/controllers/project_information_controller.rb
+++ b/app/controllers/project_information_controller.rb
@@ -1,0 +1,7 @@
+class ProjectInformationController < ApplicationController
+  include Authentication
+
+  def show
+    @project = Project.find(params[:id])
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,4 +1,5 @@
 class TasksController < ApplicationController
+  include Authentication
   before_action :find_task
 
   def show

--- a/app/views/project_information/show.html.erb
+++ b/app/views/project_information/show.html.erb
@@ -5,6 +5,3 @@
 <%= render partial: "shared/key_information" %>
 
 <%= render partial: "shared/project_tabs_list" %>
-
-<h2 class="govuk-heading-l"><%= t('project.show.title') %></h2>
-<%= render "shared/task_list" %>

--- a/app/views/shared/_key_information.html.erb
+++ b/app/views/shared/_key_information.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <span class="govuk-caption-l">URN <%= @project.urn %></span>
+    <h1 class="govuk-heading-l"><%= @project.establishment.name %></h1>
+
+    <%= govuk_inset_text do %>
+      <p class="govuk-body govuk-!-margin-0">
+        <span class="govuk-!-font-weight-bold"><%= t('project.summary.delivery_officer.title') %>:</span>
+        <%= @project.delivery_officer&.email or t('project.summary.delivery_officer.unassigned') %>
+      </p>
+    <% end %>
+
+    <% if policy(@project).edit? %>
+      <p class="govuk-body">
+        <%= link_to t('project.show.edit_button.text'), edit_project_path(@project), class: "govuk-link" %>
+      </p>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/shared/_project_tabs_list.html.erb
+++ b/app/views/shared/_project_tabs_list.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-tabs">
+  <h2 class="govuk-tabs__title">
+    Project subnavigation
+  </h2>
+  <ul class="govuk-tabs__list">
+    <%= render partial: "shared/tab", locals: { name: t("subnavigation.project_task_list"), path: project_path(@project) } %>
+    <%= render partial: "shared/tab", locals: { name: t("subnavigation.project_information"), path: project_information_path(@project) } %>
+  </ul>
+</div>

--- a/app/views/shared/_tab.html.erb
+++ b/app/views/shared/_tab.html.erb
@@ -1,0 +1,3 @@
+<li class="govuk-tabs__list-item <%= "govuk-tabs__list-item--selected" if current_page?(path) %>">
+  <%= link_to_unless_current name, path, class: "govuk-tabs__tab" %>
+</li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,9 @@ en:
         unassigned: Not yet assigned
       incoming_trust:
         title: Incoming trust
+  subnavigation:
+    project_task_list: Project task list
+    project_information: Project information
   helpers:
     label:
       project:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,5 @@ Rails.application.routes.draw do
     resources :tasks
   end
 
-  resources :project_information, path: "/projects/information"
+  get "/projects/:id/information", to: "project_information#show", as: :project_information
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,4 +17,6 @@ Rails.application.routes.draw do
   resources :projects do
     resources :tasks
   end
+
+  resources :project_information, path: "/projects/information"
 end

--- a/spec/requests/project_information_controller_spec.rb
+++ b/spec/requests/project_information_controller_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe ProjectInformationController, type: :request do
+  let(:user) { User.create!(email: "user@education.gov.uk") }
+
+  before do
+    mock_successful_authentication(user.email)
+    mock_successful_api_responses(urn: 12345)
+    allow_any_instance_of(ProjectInformationController).to receive(:user_id).and_return(user.id)
+  end
+
+  describe "#show" do
+    let(:project) { create(:project) }
+    let(:project_id) { project.id }
+
+    subject(:perform_request) do
+      get project_information_path(project_id)
+      response
+    end
+
+    context "when the Project is not found" do
+      let(:project_id) { SecureRandom.uuid }
+
+      it { expect { perform_request }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    it "returns a successful response" do
+      expect(subject).to have_http_status :success
+    end
+  end
+end

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
 
 RSpec.describe TasksController, type: :request do
+  let(:user) { User.create!(email: "user@education.gov.uk") }
+
+  before do
+    mock_successful_authentication(user.email)
+    allow_any_instance_of(TasksController).to receive(:user_id).and_return(user.id)
+  end
+
   describe "#show" do
     let(:task) { create(:task) }
     let(:project_id) { task.section.project.id }


### PR DESCRIPTION
1. Add project subnavigation tabs
We want to use the GOV.UK tab component to navigate between the project task list page and the project information page. Move the "key information" into a partial, add partials to build the tab component, and add a basic controller and view for the new project information page.

2. Include authentication on the TasksController


[screen-capture (1).webm](https://user-images.githubusercontent.com/47089130/180465758-43689642-a63b-4637-83fc-f90b56b8ff94.webm)

