### PR TITLE
(279) Move authentication to be included in ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include Authentication
   include Pundit::Authorization
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder

--- a/app/controllers/project_information_controller.rb
+++ b/app/controllers/project_information_controller.rb
@@ -1,6 +1,4 @@
 class ProjectInformationController < ApplicationController
-  include Authentication
-
   def show
     @project = Project.find(params[:id])
   end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,5 +1,4 @@
 class ProjectsController < ApplicationController
-  include Authentication
   after_action :verify_authorized
   after_action :verify_policy_scoped, only: :index
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_before_action :redirect_unauthenticated_user, only: [:new, :create, :delete, :failure]
+
   def new
   end
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,4 @@
 class TasksController < ApplicationController
-  include Authentication
   before_action :find_task
 
   def show


### PR DESCRIPTION
This change means that all controller actions are now automatically authenticated unless explicitly instructed otherwise using `skip_before_action` (as in `SessionsController`).

In the case of `SessionsController` we use `only` to explicitly list actions which should be excluded from authentication. Although in this case we list every action, it means that if we add a new action to the controller it will be protected unless we make the conscious decision to also exclude it.