### PR TITLE
Feature/271 add team leader

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -21,6 +21,7 @@ class ProjectsController < ApplicationController
   def create
     @project = Project.new(project_params)
     authorize @project
+    assign_team_leader
 
     if @project.valid?
       @project.save
@@ -51,9 +52,11 @@ class ProjectsController < ApplicationController
     redirect_to project_information_path(@project)
   end
 
-  private
-
-  def project_params
+  private def project_params
     params.require(:project).permit(:urn, :delivery_officer_id)
+  end
+
+  private def assign_team_leader
+    @project.team_leader_id = user_id
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,9 +2,11 @@ class Project < ApplicationRecord
   has_many :sections, dependent: :destroy
 
   validates :urn, presence: true, numericality: {only_integer: true}
+  validates :team_leader, presence: true
   validate :establishment_exists, :conversion_project_exists, on: :create
 
   belongs_to :delivery_officer, class_name: "User", optional: true
+  belongs_to :team_leader, class_name: "User", optional: false
 
   def establishment
     @establishment || retrieve_establishment

--- a/db/migrate/20220726143808_add_team_leader_id_to_project.rb
+++ b/db/migrate/20220726143808_add_team_leader_id_to_project.rb
@@ -1,0 +1,5 @@
+class AddTeamLeaderIdToProject < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :projects, :team_leader, null: false, foreign_key: {to_table: :users}, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_12_092157) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_26_143808) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -30,7 +30,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_12_092157) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "delivery_officer_id"
+    t.uuid "team_leader_id", null: false
     t.index ["delivery_officer_id"], name: "index_projects_on_delivery_officer_id"
+    t.index ["team_leader_id"], name: "index_projects_on_team_leader_id"
     t.index ["urn"], name: "index_projects_on_urn"
   end
 
@@ -63,6 +65,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_12_092157) do
 
   add_foreign_key "actions", "tasks"
   add_foreign_key "projects", "users", column: "delivery_officer_id"
+  add_foreign_key "projects", "users", column: "team_leader_id"
   add_foreign_key "sections", "projects"
   add_foreign_key "tasks", "sections"
 end

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :project, class: "Project" do
     urn { 12345 }
+    team_leader { association :user, :team_leader, email: "team-leader-#{SecureRandom.uuid}@education.gov.uk" }
   end
 end

--- a/spec/features/users_can_update_projects_spec.rb
+++ b/spec/features/users_can_update_projects_spec.rb
@@ -4,42 +4,43 @@ RSpec.feature "Users can reach the edit project page" do
   let(:urn) { 12345 }
   let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
   let(:delivery_officer) { create(:user, email: "user1@education.gov.uk") }
+  let(:unassigned_project) { create(:project, urn: urn) }
 
   before { mock_successful_api_responses(urn: urn) }
 
   context "the user is a team leader" do
     before do
       sign_in_with_user(team_leader)
-      @unassigned_project = Project.create!(urn: urn)
     end
 
     scenario "by following a link from the show project page" do
-      visit project_path(@unassigned_project)
+      visit project_path(unassigned_project)
       click_on I18n.t("project.show.edit_button.text")
       expect(page).to have_content(I18n.t("project.edit.title"))
-      expect(page).to have_content(@unassigned_project.urn.to_s)
+      expect(page).to have_content(unassigned_project.urn.to_s)
     end
 
     scenario "by visiting the edit project page directly" do
-      visit edit_project_path(@unassigned_project)
+      visit edit_project_path(unassigned_project)
       expect(page).to have_content(I18n.t("project.edit.title"))
-      expect(page).to have_content(@unassigned_project.urn.to_s)
+      expect(page).to have_content(unassigned_project.urn.to_s)
     end
   end
 
   context "the user is not a team leader" do
+    let(:user_1_project) { create(:project, urn: urn, delivery_officer: delivery_officer) }
+
     before do
       sign_in_with_user(delivery_officer)
-      @user1_project = Project.create!(urn: urn, delivery_officer: delivery_officer)
     end
 
     scenario "there is no edit link on the show project page" do
-      visit project_path(@user1_project)
+      visit project_path(user_1_project)
       expect(page).to_not have_content(I18n.t("project.show.edit_button.text"))
     end
 
     scenario "cannot visit edit project page directly" do
-      visit edit_project_path(@user1_project)
+      visit edit_project_path(user_1_project)
       expect(page).to have_content(I18n.t("unauthorised_action.message"))
     end
   end
@@ -48,8 +49,8 @@ end
 RSpec.feature "Users can update a project" do
   let(:urn) { 12345 }
   let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
-  let(:delivery_officer) { create(:user, email: "user1@education.gov.uk") }
-  let(:delivery_officer_2) { create(:user, email: "user2@education.gov.uk") }
+  let!(:delivery_officer) { create(:user, email: "user1@education.gov.uk") }
+  let!(:delivery_officer_2) { create(:user, email: "user2@education.gov.uk") }
 
   context "the user is a team leader" do
     before do
@@ -58,34 +59,29 @@ RSpec.feature "Users can update a project" do
     end
 
     context "when the project has no delivery officer" do
-      before do
-        @unassigned_project = Project.create!(urn: urn)
-        @delivery_officer = delivery_officer
-      end
+      let(:unassigned_project) { create(:project, urn: urn) }
 
       scenario "the delivery officer can be set" do
-        visit edit_project_path(@unassigned_project)
-        select @delivery_officer.email, from: "project-delivery-officer-id-field"
+        visit edit_project_path(unassigned_project)
+        select delivery_officer.email, from: "project-delivery-officer-id-field"
         click_on "Continue"
-        expect(page).to have_content(@delivery_officer.email)
+        expect(page).to have_content(delivery_officer.email)
       end
     end
 
     context "when the project already has a delivery officer" do
-      before(:each) do
-        @assigned_project = Project.create!(urn: urn, delivery_officer: delivery_officer)
-      end
+      let(:assigned_project) { create(:project, urn: urn, delivery_officer: delivery_officer) }
 
       scenario "the delivery officer can be changed" do
-        @delivery_officer_2 = delivery_officer_2
-        visit edit_project_path(@assigned_project)
+        delivery_officer_2
+        visit edit_project_path(assigned_project)
         select delivery_officer_2.email, from: "project-delivery-officer-id-field"
         click_on "Continue"
         expect(page).to have_content(delivery_officer_2.email)
       end
 
       scenario "the delivery officer can be unset" do
-        visit edit_project_path(@assigned_project)
+        visit edit_project_path(assigned_project)
         select "", from: "project-delivery-officer-id-field"
         click_on "Continue"
         expect(page).to have_content(I18n.t("project.summary.delivery_officer.unassigned"))

--- a/spec/features/users_can_view_projects_spec.rb
+++ b/spec/features/users_can_view_projects_spec.rb
@@ -1,30 +1,30 @@
 require "rails_helper"
 
 RSpec.feature "Users can view a list of projects" do
-  let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
-  let(:user_1) { create(:user, email: "user1@education.gov.uk") }
-  let(:user_2) { create(:user, email: "user2@education.gov.uk") }
-
   before do
     mock_successful_api_responses(urn: 1001)
     mock_successful_api_responses(urn: 1002)
     mock_successful_api_responses(urn: 1003)
-    @unassigned_project = Project.create!(urn: 1001)
-    @user1_project = Project.create!(urn: 1002, delivery_officer: user_1)
-    @user2_project = Project.create!(urn: 1003, delivery_officer: user_2)
   end
 
+  let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
+  let(:user_1) { create(:user, email: "user1@education.gov.uk") }
+  let(:user_2) { create(:user, email: "user2@education.gov.uk") }
+  let!(:unassigned_project) { create(:project, urn: 1001) }
+  let!(:user_1_project) { create(:project, urn: 1002, delivery_officer: user_1) }
+  let!(:user_2_project) { create(:project, urn: 1003, delivery_officer: user_2) }
+
   context "the user is a team leader" do
-    before(:each) do
+    before do
       sign_in_with_user(team_leader)
     end
 
     scenario "can see all projects on the project list regardless of assignment" do
       visit projects_path
 
-      expect(page).to have_content(@unassigned_project.urn.to_s)
-      expect(page).to have_content(@user1_project.urn.to_s)
-      expect(page).to have_content(@user2_project.urn.to_s)
+      expect(page).to have_content(unassigned_project.urn.to_s)
+      expect(page).to have_content(user_1_project.urn.to_s)
+      expect(page).to have_content(user_2_project.urn.to_s)
     end
   end
 
@@ -36,9 +36,9 @@ RSpec.feature "Users can view a list of projects" do
     scenario "can only see assigned projects on the projects list" do
       visit projects_path
 
-      expect(page).to_not have_content(@unassigned_project.urn.to_s)
-      expect(page).to have_content(@user1_project.urn.to_s)
-      expect(page).to_not have_content(@user2_project.urn.to_s)
+      expect(page).to_not have_content(unassigned_project.urn.to_s)
+      expect(page).to have_content(user_1_project.urn.to_s)
+      expect(page).to_not have_content(user_2_project.urn.to_s)
     end
   end
 end
@@ -55,7 +55,7 @@ RSpec.feature "Users can view a single project" do
   scenario "by following a link from the home page" do
     sign_in_with_user(create(:user, :team_leader))
 
-    single_project = Project.create!(urn: urn)
+    single_project = create(:project, urn: urn)
 
     visit root_path
     click_on establishment.name
@@ -65,7 +65,7 @@ RSpec.feature "Users can view a single project" do
   context "when a project does not have an assigned delivery officer" do
     scenario "the project list shows an unassigned delivery officer" do
       sign_in_with_user(create(:user, :team_leader))
-      Project.create!(urn: 19283746)
+      create(:project, urn: 19283746)
 
       visit projects_path
       expect(page).to have_content(I18n.t("project.summary.delivery_officer.unassigned"))
@@ -73,7 +73,7 @@ RSpec.feature "Users can view a single project" do
 
     scenario "the project page shows an unassigned delivery officer" do
       sign_in_with_user(create(:user, :team_leader))
-      single_project = Project.create!(urn: urn)
+      single_project = create(:project, urn: urn)
 
       visit project_information_path(single_project)
       expect(page).to have_content(I18n.t("project.summary.delivery_officer.unassigned"))
@@ -86,7 +86,7 @@ RSpec.feature "Users can view a single project" do
     scenario "the project list shows an assigned delivery officer" do
       sign_in_with_user(create(:user, :team_leader, email: user_email_address))
       user = User.find_by(email: user_email_address)
-      Project.create!(urn: 19283746, delivery_officer: user)
+      create(:project, urn: 19283746, delivery_officer: user)
 
       visit projects_path
       expect(page).to have_content(user_email_address)
@@ -95,7 +95,7 @@ RSpec.feature "Users can view a single project" do
     scenario "the project page shows an assigned delivery officer" do
       sign_in_with_user(create(:user, :team_leader, email: user_email_address))
       user = User.find_by(email: user_email_address)
-      single_project = Project.create!(urn: urn, delivery_officer: user)
+      single_project = create(:project, urn: urn, delivery_officer: user)
 
       visit project_information_path(single_project.id)
       expect(page).to have_content(user_email_address)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -3,6 +3,16 @@ require "rails_helper"
 RSpec.describe Project, type: :model do
   describe "Columns" do
     it { is_expected.to have_db_column(:urn).of_type :integer }
+    it { is_expected.to have_db_column(:delivery_officer_id).of_type :uuid }
+    it { is_expected.to have_db_column(:team_leader_id).of_type :uuid }
+  end
+
+  describe "Relationships" do
+    before { mock_successful_api_responses(urn: any_args) }
+
+    it { is_expected.to have_many(:sections).dependent(:destroy) }
+    it { is_expected.to belong_to(:delivery_officer).required(false) }
+    it { is_expected.to belong_to(:team_leader).required(true) }
   end
 
   describe "Validations" do
@@ -63,10 +73,10 @@ RSpec.describe Project, type: :model do
         end
       end
     end
-  end
 
-  describe "Relationships" do
-    it { is_expected.to have_many(:sections).dependent(:destroy) }
+    describe "#team_leader" do
+      it { is_expected.to validate_presence_of(:team_leader) }
+    end
   end
 
   describe "#establishment" do

--- a/spec/requests/projects_controller_spec.rb
+++ b/spec/requests/projects_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ProjectsController, type: :request do
 
   describe "#create" do
     subject(:perform_request) do
-      post projects_path, params: { project: { urn: 12345 } }
+      post projects_path, params: {project: {urn: 12345}}
       response
     end
 
@@ -19,7 +19,7 @@ RSpec.describe ProjectsController, type: :request do
 
       before do
         mock_successful_api_responses(urn: 12345)
-        allow(Project).to receive(:new).with(any_args).and_return(project)
+        allow(Project).to receive(:new).and_return(project)
       end
 
       it "assigns the team leader, calls the TaskListCreator, and redirects to the project path" do

--- a/spec/requests/projects_controller_spec.rb
+++ b/spec/requests/projects_controller_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ProjectsController, type: :request do
+  let(:team_leader) { create(:user, :team_leader) }
+
+  before do
+    mock_successful_authentication(team_leader.email)
+    allow_any_instance_of(ProjectsController).to receive(:user_id).and_return(team_leader.id)
+  end
+
+  describe "#create" do
+    subject(:perform_request) do
+      post projects_path, params: { project: { urn: 12345 } }
+      response
+    end
+
+    context "when the project is valid" do
+      let(:project) { build(:project, team_leader: nil) }
+
+      before do
+        mock_successful_api_responses(urn: 12345)
+        allow(Project).to receive(:new).with(any_args).and_return(project)
+      end
+
+      it "assigns the team leader, calls the TaskListCreator, and redirects to the project path" do
+        expect_any_instance_of(TaskListCreator).to receive(:call).with(project)
+        expect(subject).to redirect_to(project_path(project.id))
+        expect(project.team_leader_id).to eq team_leader.id
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Add team lead to project on creation
The current assumption is that the team lead for a project is the user who creates the project. Assign them on project creation.

### Refactor tests now that team leader ID is a non-nullable field
We have added a non-nullable association to `team_leader` on the `project` record.

Update the project factory with a team_leader association. This uses a random email address so that when we create multiple `project`s in a spec, we don't see a record not unique error (due to the unique constraint on the email column in `user`).

Some specs were written before we started to use FactoryBot. Update these to use the `project` factory for the above reason.