### PR TITLE
Add local authority name to the project information list

### DIFF
--- a/app/views/project_information/_project_information_list.erb
+++ b/app/views/project_information/_project_information_list.erb
@@ -17,3 +17,11 @@ end %>
     row.value { @project.urn.to_s }
   end
 end %>
+
+<h2 class="govuk-heading-l" id="localAuthorityDetails"><%= t('project_information.show.local_authority_details.title') %></h2>
+<%= govuk_summary_list do |summary_list|
+  summary_list.row do |row|
+    row.key { t('project_information.show.local_authority_details.rows.local_authority') }
+    row.value { @project.establishment.local_authority }
+  end
+end %>

--- a/app/views/project_information/_side_navigation.html.erb
+++ b/app/views/project_information/_side_navigation.html.erb
@@ -3,5 +3,6 @@
   <ul class="list-style-none govuk-!-padding-0">
     <%= render partial: "shared/side_navigation_item", locals: { name: t("project_information.show.project_details.title"), path: "#projectDetails" } %>
     <%= render partial: "shared/side_navigation_item", locals: { name: t("project_information.show.school_details.title"), path: "#schoolDetails" } %>
+    <%= render partial: "shared/side_navigation_item", locals: { name: t("project_information.show.local_authority_details.title"), path: "#localAuthorityDetails" } %>
   </ul>
 </nav>

--- a/app/views/project_information/show.html.erb
+++ b/app/views/project_information/show.html.erb
@@ -11,7 +11,7 @@
     <%= render partial: "side_navigation" %>
   </div>
 
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds" id="projectInformationList">
     <%= render partial: "project_information_list" %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,6 +88,10 @@ en:
         rows:
           original_school_name: Original school name
           old_urn: Old Unique Reference Number
+      local_authority_details:
+        title: Local authority details
+        rows:
+          local_authority: Local authority
   subnavigation:
     project_task_list: Project task list
     project_information: Project information

--- a/spec/features/users_can_view_project_information_spec.rb
+++ b/spec/features/users_can_view_project_information_spec.rb
@@ -14,16 +14,25 @@ RSpec.feature "Users can view project information" do
     visit project_information_path(project_id)
 
     expect(page).to have_content("Project details")
-
-    delivery_officer_label = page.find("dt", text: "Delivery officer")
-    delivery_officer_label.ancestor(".govuk-summary-list__row").find("dd", text: "user@education.gov.uk")
+    page_has_project_information_list_row(label: "Delivery officer", information: "user@education.gov.uk")
 
     expect(page).to have_content("School details")
+    page_has_project_information_list_row(label: "Original school name", information: "Caludon Castle School")
+    page_has_project_information_list_row(label: "Old Unique Reference Number", information: "12345")
 
-    original_school_name_label = page.find("dt", text: "Original school name")
-    original_school_name_label.ancestor(".govuk-summary-list__row").find("dd", text: "Caludon Castle School")
+    expect(page).to have_content("Local authority details")
+    page_has_project_information_list_row(label: "Local authority", information: "West Placefield Council")
+  end
 
-    old_urn_label = page.find("dt", text: "Old Unique Reference Number")
-    old_urn_label.ancestor(".govuk-summary-list__row").find("dd", text: "12345")
+  private def page_has_project_information_list_row(label:, information:)
+    project_information_list = page.find("#projectInformationList")
+
+    within project_information_list do
+      label = find("dt", text: label)
+      information = label.ancestor(".govuk-summary-list__row").find("dd", text: information)
+
+      assert label
+      assert information
+    end
   end
 end


### PR DESCRIPTION
We currently show the local authority name in the at-a-glance summary list, we want to include it in the full project information list as well.