### PR TITLE
(321) Use a changelog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,8 @@
+## Changes
+
+_Add a summary of the changes in this pull request_
+
+## Checklist
+
+- [ ] Attach this pull request to the appropriate card in Trello.
+- [ ] Update the `CHANGELOG.md` if needed.

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,7 @@
+## Checklist
+
+- [ ] Check that this pull request has the correct version number.
+- [ ] Attach this pull request to the appropriate card in Trello.
+- [ ] Update the `CHANGELOG.md` to move Unreleased changes into a new version.
+- [ ] Update the release links at the bottom of `CHANGELOG.md` to reflect the
+      new version.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Changes
+
+_Add a summary of the changes in this pull request_
+
+## Checklist
+
+- [ ] Attach this PR to the appropriate card in Trello
+- [ ] Update the CHANGELOG if needed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,0 @@
-## Changes
-
-_Add a summary of the changes in this pull request_
-
-## Checklist
-
-- [ ] Attach this PR to the appropriate card in Trello
-- [ ] Update the CHANGELOG if needed

--- a/.github/workflows/tasks-completed-check.yml
+++ b/.github/workflows/tasks-completed-check.yml
@@ -1,0 +1,12 @@
+name: "PR Tasks Completed Check"
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  task-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/task-completed-checker-action@v0.1.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Added
+
+- Users can sign in to the application using a DfE Microsoft account
+- A new conversion project can be started by entering a valid URN of a school
+  currently undergoing conversion
+- A list of all tasks for a conversion project is displayed
+- Actions within a task can be marked as done, and the status of the task is
+  updated
+- Projects display a summary of key information
+- The Project Information view displays further information about each project
+- Users can be assigned to each project as a delivery officer
+- The team leader who creates a new project is automatically marked as the
+  project's team leader
+
+[unreleased]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/commits/develop

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ To run the test suite, run `script/test`.
 
 See .env.example
 
+## Release process
+
+Use the [release process template in Trello](https://trello.com/c/8enGdMyy) to
+start a new release.
+
 ## ADRs
 
 You can find the [ADRs](https://adr.github.io/) for this project in the

--- a/doc/decisions/0008-use-a-changelog-for-tracking-changes-in-a-release.md
+++ b/doc/decisions/0008-use-a-changelog-for-tracking-changes-in-a-release.md
@@ -1,0 +1,27 @@
+# 8. Use a changelog for tracking changes in a release
+
+Date: 2022-07-28
+
+## Status
+
+Accepted
+
+## Context
+
+Documenting changes for a release can be challenging. It often involves reading
+back through commit messages and PRs, looking for and classifying changes, which
+is a time consuming and error prone process.
+
+## Decision
+
+We will use a changelog (`CHANGELOG.md`) in the
+[Keep a Changelog 1.0.0](https://keepachangelog.com/en/1.0.0/) format to be
+updated when code changes happen, rather than at release time.
+
+## Consequences
+
+This will make compiling releases much simpler, as the process for determining
+changes in a release is simply a matter of looking at the changelog.
+
+This does add some overhead to making code changes, and requires that releases
+update the changelog as part of their process, but those overheads are small.

--- a/doc/decisions/0009-use-sequential-numbering-for-release-versions.md
+++ b/doc/decisions/0009-use-sequential-numbering-for-release-versions.md
@@ -1,0 +1,28 @@
+# 9. Use sequential numbering for release versions
+
+Date: 2022-07-28
+
+## Status
+
+Accepted
+
+## Context
+
+As part of implementing a process for releasing versions of the software, we
+need to decide how each version should be numbered. There are various options
+for this, including [Semantic Versioning](https://semver.org/), or simple
+sequential version numbering.
+
+The application is being built in an iterative manner, which means that it is
+likely we will be frequently releasing small changes. If we were using Semantic
+Versioning, this could lead to a rapid increase in version numbers which could
+imply more significant changes to functionality than have actually taken place.
+
+## Decision
+
+Each release version is numbered sequentially from the previous.
+
+## Consequences
+
+There is no need to consider as part of the release process if a version
+implements a breaking change or represents new functionality.


### PR DESCRIPTION
## Changes

We should be keeping a curated list of key changes between versions, so that interested parties can easily see what has been done.

This PR:
- Adds an ADR for the above decision
- Adds a CHANGELOG.md with key features so far
- Adds a PR template to remind developers to update the changelog
- Adds a new Github action to check that tasks in a PR description have been completed
- Documents the process for creating a new release

## Checklist

- [x] Attach this PR to the appropriate card in Trello
- [x] Update the CHANGELOG if needed
