### PR TITLE
(348) show team lead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The project information view displays the school type, phase of education,
   and age range.
+- The project information view displays the team lead.
 
 ## [Release 1][release-1]
 

--- a/app/views/project_information/_project_information_list.erb
+++ b/app/views/project_information/_project_information_list.erb
@@ -4,6 +4,10 @@
     row.key { t('project_information.show.project_details.rows.delivery_officer') }
     row.value { @project.delivery_officer&.email or t('project.summary.delivery_officer.unassigned') }
   end
+  summary_list.row do |row|
+    row.key { t('project_information.show.project_details.rows.team_lead') }
+    row.value { @project.team_leader.email }
+  end
 end %>
 
 <h2 class="govuk-heading-l" id="schoolDetails"><%= t('project_information.show.school_details.title') %></h2>

--- a/app/views/project_information/_project_information_list.erb
+++ b/app/views/project_information/_project_information_list.erb
@@ -1,5 +1,5 @@
 <h2 class="govuk-heading-l" id="projectDetails"><%= t('project_information.show.project_details.title') %></h2>
-<%= govuk_summary_list do |summary_list|
+<%= govuk_summary_list(actions: false) do |summary_list|
   summary_list.row do |row|
     row.key { t('project_information.show.project_details.rows.delivery_officer') }
     row.value { @project.delivery_officer&.email or t('project.summary.delivery_officer.unassigned') }
@@ -11,7 +11,7 @@
 end %>
 
 <h2 class="govuk-heading-l" id="schoolDetails"><%= t('project_information.show.school_details.title') %></h2>
-<%= govuk_summary_list do |summary_list|
+<%= govuk_summary_list(actions: false) do |summary_list|
   summary_list.row do |row|
     row.key { t('project_information.show.school_details.rows.original_school_name') }
     row.value { @project.establishment.name }
@@ -35,7 +35,7 @@ end %>
 end %>
 
 <h2 class="govuk-heading-l" id="localAuthorityDetails"><%= t('project_information.show.local_authority_details.title') %></h2>
-<%= govuk_summary_list do |summary_list|
+<%= govuk_summary_list(actions: false) do |summary_list|
   summary_list.row do |row|
     row.key { t('project_information.show.local_authority_details.rows.local_authority') }
     row.value { @project.establishment.local_authority }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,6 +83,7 @@ en:
         title: Project details
         rows:
           delivery_officer: Delivery officer
+          team_lead: Team lead
       school_details:
         title: School details
         rows:

--- a/spec/features/users_can_view_project_information_spec.rb
+++ b/spec/features/users_can_view_project_information_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature "Users can view project information" do
 
     expect(page).to have_content("Project details")
     page_has_project_information_list_row(label: "Delivery officer", information: "user@education.gov.uk")
+    page_has_project_information_list_row(label: "Team lead", information: project.team_leader.email)
 
     expect(page).to have_content("School details")
     page_has_project_information_list_row(label: "Original school name", information: "Caludon Castle School")


### PR DESCRIPTION
### 1. Show team lead on the project information tab
The user who creates the project is assigned as the team lead. We want to display this in the project information tab.

### 2. Update CHANGELOG

<img width="1189" alt="image" src="https://user-images.githubusercontent.com/47089130/182127351-6e65c01e-ab50-4548-8904-dd421f900eaf.png">
