### PR TITLE
Add freetds dependency to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,4 @@
 brew "rbenv"
 brew "nodenv"
 brew "docker"
+brew "freetds"


### PR DESCRIPTION
## Changes

The free_tds gem requires the freetds library be installed in order to build. This change ensures it is installed as part of the Homebrew dependencies.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
