### PR TITLE
(358) Project notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The project information view has a Trust details section, which displays the
   incoming trust name, UKPRN, and Companies House number.
 - Users must provide the target completion date when creating a project.
+- Users can add notes to a project, and view previous project notes.
 
 ## [Release 1][release-1]
 

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,5 +1,27 @@
 class NotesController < ApplicationController
+  before_action :find_project
+
   def index
+    @note = Note.new(project: @project, user_id:)
+  end
+
+  def create
+    @note = Note.new(project: @project, user_id:, **note_params)
+
+    if @note.valid?
+      @note.save
+
+      redirect_to project_notes_path(@project), notice: I18n.t("note.create.success")
+    else
+      render :index
+    end
+  end
+
+  private def find_project
     @project = Project.find(params[:project_id])
+  end
+
+  private def note_params
+    params.require(:note).permit(:body)
   end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,5 +1,6 @@
 class NotesController < ApplicationController
   before_action :find_project
+  before_action :find_notes
 
   def index
     @note = Note.new(project: @project, user_id:)
@@ -19,6 +20,10 @@ class NotesController < ApplicationController
 
   private def find_project
     @project = Project.find(params[:project_id])
+  end
+
+  private def find_notes
+    @notes = Note.includes([:user]).where(project: @project)
   end
 
   private def note_params

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,0 +1,5 @@
+class NotesController < ApplicationController
+  def index
+    @project = Project.find(params[:project_id])
+  end
+end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -3,4 +3,6 @@ class Note < ApplicationRecord
   belongs_to :user
 
   validates :body, presence: true, allow_blank: false
+
+  default_scope { order(created_at: "desc") }
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,6 @@
+class Note < ApplicationRecord
+  belongs_to :project
+  belongs_to :user
+
+  validates :body, presence: true, allow_blank: false
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,6 @@
 class Project < ApplicationRecord
   has_many :sections, dependent: :destroy
+  has_many :notes
 
   validates :urn, presence: true, numericality: {only_integer: true}
   validates :trust_ukprn, presence: true, numericality: {only_integer: true}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
 class User < ApplicationRecord
   has_many :projects, foreign_key: "delivery_officer"
+  has_many :notes
 end

--- a/app/views/notes/_notes.html.erb
+++ b/app/views/notes/_notes.html.erb
@@ -1,0 +1,15 @@
+<% if @notes.present? && @notes.any? %>
+  <% @notes.each do |note| %>
+    <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+    <span class="govuk-caption-m"><%= note.created_at.to_date.to_formatted_s(:govuk) %></span>
+
+    <h3 class="govuk-heading-m"><%= note.user.email %></h3>
+
+    <p class="govuk-body"><%= note.body %></p>
+  <% end %>
+<% else %>
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+  <h3 class="govuk-heading-m"><%= t("note.index.no_notes_yet") %></h3>
+<% end %>

--- a/app/views/notes/_submission_form.html.erb
+++ b/app/views/notes/_submission_form.html.erb
@@ -1,0 +1,7 @@
+<%= form_for @note, url: project_notes_path, method: :post do |form| %>
+  <%= form.govuk_error_summary %>
+
+  <%= form.govuk_text_area :body, label: { tag: "h2", size: "l" } %>
+
+  <%= form.govuk_submit t("note.index.add_note_button") %>
+<% end %>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -9,5 +9,7 @@
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-two-thirds">
    <%= render "submission_form" %>
+
+   <%= render "notes/notes" %>
   </div>
 </div>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :pre_content_nav do %>
+  <%= govuk_back_link(href: root_path) %>
+<% end %>
+
+<%= render partial: "shared/project_summary" %>
+
+<%= render partial: "shared/project_sub_navigation" %>
+
+<div class="govuk-grid-row govuk-body">
+
+</div>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -7,5 +7,7 @@
 <%= render partial: "shared/project_sub_navigation" %>
 
 <div class="govuk-grid-row govuk-body">
-
+  <div class="govuk-grid-column-two-thirds">
+   <%= render "submission_form" %>
+  </div>
 </div>

--- a/app/views/shared/_project_sub_navigation.html.erb
+++ b/app/views/shared/_project_sub_navigation.html.erb
@@ -5,5 +5,7 @@
 
     <%= render partial: "shared/sub_navigation_item", locals: { name: t("subnavigation.project_information"), path: project_information_path(@project) } %>
 
+    <%= render partial: "shared/sub_navigation_item", locals: { name: t("subnavigation.notes"), path: project_notes_path(@project) } %>
+
   </ul>
 </nav>

--- a/app/views/shared/_sub_navigation_item.html.erb
+++ b/app/views/shared/_sub_navigation_item.html.erb
@@ -1,3 +1,3 @@
 <li class="moj-sub-navigation__item">
-<%= link_to name, path, class: "moj-sub-navigation__link", 'aria-current': (current_page?(path) ? 'page' : nil) %>
+<%= link_to name, path, class: "moj-sub-navigation__link", 'aria-current': (request.path == path ? 'page' : nil) %>
 </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,11 @@ en:
         title: Local authority details
         rows:
           local_authority: Local authority
+  note:
+    index:
+      add_note_button: Add note
+    create:
+      success: Note has been created successfully
   subnavigation:
     project_task_list: Project task list
     project_information: Project information
@@ -112,6 +117,8 @@ en:
         urn: School URN
         trust_ukprn: Incoming trust UK Provider Reference Number (UKPRN)
         delivery_officer_id: Delivery officer
+      note:
+        body: Notes
     legend:
       project:
         target_completion_date: Target conversion date
@@ -120,6 +127,8 @@ en:
         urn: This is the URN of the existing school which is converting to an academy.
         delivery_officer_id: The delivery officer responsible for this project
         target_completion_date: The target conversion date is always the 1st of the month.
+      note:
+        body: Do not include personal or financial information.
 
   activerecord:
     errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,6 +105,7 @@ en:
   note:
     index:
       add_note_button: Add note
+      no_notes_yet: No notes yet
     create:
       success: Note has been created successfully
   subnavigation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,7 +107,7 @@ en:
       add_note_button: Add note
       no_notes_yet: No notes yet
     create:
-      success: Note has been created successfully
+      success: Note has been added successfully
   subnavigation:
     project_task_list: Project task list
     project_information: Project information

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,6 +105,7 @@ en:
   subnavigation:
     project_task_list: Project task list
     project_information: Project information
+    notes: Notes
   helpers:
     label:
       project:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
 
   resources :projects do
     resources :tasks
+    resources :notes
   end
 
   get "/projects/:id/information", to: "project_information#show", as: :project_information

--- a/db/migrate/20220804103138_create_notes.rb
+++ b/db/migrate/20220804103138_create_notes.rb
@@ -1,0 +1,12 @@
+class CreateNotes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :notes, id: :uuid do |t|
+      t.text :body
+
+      t.references :project, index: true, foreign_key: true, type: :uuid
+      t.references :user, index: true, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_04_093743) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_04_103138) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -19,6 +19,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_04_093743) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["task_id"], name: "index_actions_on_task_id"
+  end
+
+  create_table "notes", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+    t.text "body"
+    t.uuid "project_id"
+    t.uuid "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id"], name: "index_notes_on_project_id"
+    t.index ["user_id"], name: "index_notes_on_user_id"
   end
 
   create_table "projects", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
@@ -62,6 +72,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_04_093743) do
   end
 
   add_foreign_key "actions", "tasks"
+  add_foreign_key "notes", "projects"
+  add_foreign_key "notes", "users"
   add_foreign_key "projects", "users", column: "delivery_officer_id"
   add_foreign_key "projects", "users", column: "team_leader_id"
   add_foreign_key "sections", "projects"

--- a/spec/factories/note_factory.rb
+++ b/spec/factories/note_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :note do
+    body { "Just had a very interesting phone call with the headteacher about land law" }
+  end
+end

--- a/spec/factories/note_factory.rb
+++ b/spec/factories/note_factory.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :note do
     body { "Just had a very interesting phone call with the headteacher about land law" }
+
+    project
+    user { association :user, email: "user-#{SecureRandom.uuid}@education.gov.uk" }
   end
 end

--- a/spec/features/users_can_create_and_view_notes_spec.rb
+++ b/spec/features/users_can_create_and_view_notes_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.feature "Users can create and view notes" do
+  let(:user) { create(:user, email: "user@education.gov.uk") }
+  let(:project) { create(:project) }
+  let(:project_id) { project.id }
+  let(:new_note_body) { "Just shared some important documents with the solictor." }
+  let(:existing_note_created_at) {}
+
+  before do
+    mock_successful_api_responses(urn: 12345, ukprn: 10061021)
+    sign_in_with_user(user)
+
+    travel_to Date.yesterday do
+      create(:note, user: user, project: project)
+    end
+
+    freeze_time
+  end
+
+  scenario "User creates and views notes" do
+    visit project_notes_path(project_id)
+
+    expect_page_to_have_note(
+      user: user.email, date: Date.yesterday.to_formatted_s(:govuk), body: "Just had a very interesting phone call with the headteacher about land law"
+    )
+
+    fill_in "Notes", with: new_note_body
+
+    click_button("Add note")
+
+    expect_page_to_have_note(user: user.email, date: Date.today.to_formatted_s(:govuk), body: new_note_body)
+  end
+
+  private def expect_page_to_have_note(user:, date:, body:)
+    expect(page).to have_content(user)
+    expect(page).to have_content(date)
+    expect(page).to have_content(body)
+  end
+end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Note, type: :model do
+  describe "Columns" do
+    it { is_expected.to have_db_column(:body).of_type :text }
+  end
+
+  describe "Relationships" do
+    it { is_expected.to belong_to(:project) }
+    it { is_expected.to belong_to(:user) }
+  end
+
+  describe "Validations" do
+    describe "#body" do
+      it { is_expected.to validate_presence_of(:body) }
+      it { is_expected.to_not allow_values("", nil).for(:body) }
+    end
+  end
+end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Note, type: :model do
         create(:note, body: "Today's note.")
       end
 
-      it "orders ascending by the 'order' attribute" do
+      it "orders descending by the 'created_at' attribute" do
         expect(Note.first.body).to eq "Today's note."
       end
     end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -16,4 +16,20 @@ RSpec.describe Note, type: :model do
       it { is_expected.to_not allow_values("", nil).for(:body) }
     end
   end
+
+  describe "Scopes" do
+    describe "default_scope" do
+      before do
+        mock_successful_api_responses(urn: any_args, ukprn: any_args)
+
+        freeze_time
+        travel_to(Date.yesterday) { create(:note, body: "Yesterday's note.") }
+        create(:note, body: "Today's note.")
+      end
+
+      it "orders ascending by the 'order' attribute" do
+        expect(Note.first.body).to eq "Today's note."
+      end
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Project, type: :model do
     before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 
     it { is_expected.to have_many(:sections).dependent(:destroy) }
+    it { is_expected.to have_many(:notes) }
     it { is_expected.to belong_to(:delivery_officer).required(false) }
     it { is_expected.to belong_to(:team_leader).required(true) }
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,6 +65,7 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   # Include helpers for tests
+  config.include ActiveSupport::Testing::TimeHelpers
   config.include SignInHelpers
   config.include AcademiesApiHelpers
   config.include FeatureHelpers, type: :feature

--- a/spec/requests/notes_controller_spec.rb
+++ b/spec/requests/notes_controller_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe NotesController, type: :request do
+  let(:user) { User.create!(email: "user@education.gov.uk") }
+
+  before do
+    mock_successful_authentication(user.email)
+    mock_successful_api_responses(urn: 12345, ukprn: 10061021)
+    allow_any_instance_of(NotesController).to receive(:user_id).and_return(user.id)
+  end
+
+  describe "#index" do
+    let(:project) { create(:project) }
+    let(:project_id) { project.id }
+
+    subject(:perform_request) do
+      get project_notes_path(project_id)
+      response
+    end
+
+    context "when the Project is not found" do
+      let(:project_id) { SecureRandom.uuid }
+
+      it { expect { perform_request }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    it "returns a successful response" do
+      expect(subject).to have_http_status :success
+    end
+  end
+end


### PR DESCRIPTION
## Changes

### 1. [Scaffold the basic structure for a project Note](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/97/commits/2e189b7f6c83c14e56a96739bb53d7437ebada16)

Users must be able to add notes to a project.

Scaffold the basic structure for now. This will be followed by commits which enable users to add and view notes.

### 2. [Enable users to create a new note via a textbox on the note tab](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/97/commits/da71a3a79bdbe112c9bafe1959d5616ef8b51d78)

Users need a way to add notes to a project. Add a form at the top of the notes index view as in the prototype.

### 3. [Allow users to view previous project notes](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/97/commits/d4adde8367f3c5c0c32d003d814c86d8d93ce4c2)

Users must be able to see the previous notes for a project, including the name of the author (email for now), the date the note was created, and the body of the note. 

Order notes in descending order by `created_at`, so that the most recent notes are first. Add the `ActiveSupport::Testing::TimeHelpers` module to make testing this easy.

### 4. [Ensure the subnavigation current page highlight works for POST requests](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/97/commits/b4682b4a5db6ad729137cc0e2d780737f1407478)

The `current_page?` helper always returns false on POST requests. Currently, this means that the subnavigation component won't show which page the user is on when they submit a new note form with an error. 

Instead, use `request.path` as a workaround.

![image](https://user-images.githubusercontent.com/47089130/183115581-31951c84-e3e0-45ff-ba03-cd1d3064604e.png)

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
