### PR TITLE
Change dependabot target branch to `main`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,4 +17,4 @@ updates:
       timezone: Europe/London
     open-pull-requests-limit: 10
     versioning-strategy: auto
-    target-branch: develop
+    target-branch: main


### PR DESCRIPTION
We have recently switched to trunk-based development. We want dependabot to target our working `main` branch instead of the `develop` branch we used to use.