### PR TITLE
(370) Move the new note form onto its own page

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,8 +1,11 @@
 class NotesController < ApplicationController
   before_action :find_project
-  before_action :find_notes
+  before_action :find_notes, only: :index
 
   def index
+  end
+
+  def new
     @note = Note.new(project: @project, user_id:)
   end
 
@@ -14,7 +17,7 @@ class NotesController < ApplicationController
 
       redirect_to project_notes_path(@project), notice: I18n.t("note.create.success")
     else
-      render :index
+      render :new
     end
   end
 

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -1,0 +1,5 @@
+module NotesHelper
+  def has_notes?(notes)
+    notes.present? && notes.any?
+  end
+end

--- a/app/views/notes/_notes.html.erb
+++ b/app/views/notes/_notes.html.erb
@@ -1,14 +1,10 @@
-<% if @notes.present? && @notes.any? %>
-  <% @notes.each_with_index do |note, index| %>
-    <% unless index == 0 %>
-      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-    <% end %>
-
-    <span class="govuk-caption-m"><%= note.created_at.to_date.to_formatted_s(:govuk) %></span>
-    <h3 class="govuk-heading-m"><%= note.user.email %></h3>
-
-    <p class="govuk-body"><%= note.body %></p>
+<% @notes.each_with_index do |note, index| %>
+  <% unless index == 0 %>
+    <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
   <% end %>
-<% else %>
-  <h3 class="govuk-heading-m"><%= t("note.index.no_notes_yet") %></h3>
+
+  <span class="govuk-caption-m"><%= note.created_at.to_date.to_formatted_s(:govuk) %></span>
+  <h3 class="govuk-heading-m"><%= note.user.email %></h3>
+
+  <p class="govuk-body"><%= note.body %></p>
 <% end %>

--- a/app/views/notes/_notes.html.erb
+++ b/app/views/notes/_notes.html.erb
@@ -1,15 +1,14 @@
 <% if @notes.present? && @notes.any? %>
-  <% @notes.each do |note| %>
-    <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+  <% @notes.each_with_index do |note, index| %>
+    <% unless index == 0 %>
+      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+    <% end %>
 
     <span class="govuk-caption-m"><%= note.created_at.to_date.to_formatted_s(:govuk) %></span>
-
     <h3 class="govuk-heading-m"><%= note.user.email %></h3>
 
     <p class="govuk-body"><%= note.body %></p>
   <% end %>
 <% else %>
-  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
   <h3 class="govuk-heading-m"><%= t("note.index.no_notes_yet") %></h3>
 <% end %>

--- a/app/views/notes/_submission_form.html.erb
+++ b/app/views/notes/_submission_form.html.erb
@@ -1,7 +1,0 @@
-<%= form_for @note, url: project_notes_path, method: :post do |form| %>
-  <%= form.govuk_error_summary %>
-
-  <%= form.govuk_text_area :body, label: { tag: "h2", size: "l" } %>
-
-  <%= form.govuk_submit t("note.index.add_note_button") %>
-<% end %>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -8,7 +8,11 @@
 
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-two-thirds">
-   <%= render "submission_form" %>
+    <h2 class="govuk-heading-l"><%= t("note.index.notes") %></h2>
+
+    <div class="govuk-!-margin-bottom-5">
+      <%= govuk_button_link_to t("note.index.add_note_button"), new_project_note_path(@project) %>
+    </div>
 
    <%= render "notes/notes" %>
   </div>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -10,10 +10,16 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l"><%= t("note.index.notes") %></h2>
 
+    <% unless has_notes?(@notes) %>
+      <%= govuk_inset_text(text: t("note.index.no_notes_yet")) %>
+    <% end %>
+
     <div class="govuk-!-margin-bottom-5">
       <%= govuk_button_link_to t("note.index.add_note_button"), new_project_note_path(@project) %>
     </div>
 
-   <%= render "notes/notes" %>
+    <% if has_notes?(@notes) %>
+      <%= render "notes/notes" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,0 +1,17 @@
+<% content_for :pre_content_nav do %>
+  <%= govuk_back_link(href: project_notes_path(@project)) %>
+<% end %>
+
+<div class="govuk-grid-row govuk-body">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @note, url: project_notes_path, method: :post do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_text_area :body, label: { tag: "h1", size: "l" } %>
+
+      <%= form.govuk_submit t("note.new.save_note_button") do %>
+        <%= govuk_link_to "Cancel", project_notes_path(@project) %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,7 +106,7 @@ en:
     index:
       notes: Notes
       add_note_button: Add note
-      no_notes_yet: No notes yet
+      no_notes_yet: There aren't any notes for this project yet.
     create:
       success: Note has been added successfully
     new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,10 +104,13 @@ en:
           local_authority: Local authority
   note:
     index:
+      notes: Notes
       add_note_button: Add note
       no_notes_yet: No notes yet
     create:
       success: Note has been added successfully
+    new:
+      save_note_button: Save note
   subnavigation:
     project_task_list: Project task list
     project_information: Project information
@@ -119,7 +122,7 @@ en:
         trust_ukprn: Incoming trust UK Provider Reference Number (UKPRN)
         delivery_officer_id: Delivery officer
       note:
-        body: Notes
+        body: Enter note
     legend:
       project:
         target_completion_date: Target conversion date

--- a/spec/features/users_can_create_and_view_notes_spec.rb
+++ b/spec/features/users_can_create_and_view_notes_spec.rb
@@ -25,10 +25,15 @@ RSpec.feature "Users can create and view notes" do
       user: user.email, date: Date.yesterday.to_formatted_s(:govuk), body: "Just had a very interesting phone call with the headteacher about land law"
     )
 
-    fill_in "Notes", with: new_note_body
+    click_link "Add note" # Link styled as button
 
-    click_button("Add note")
+    expect(page).to have_current_path(new_project_note_path(project))
 
+    fill_in "Enter note", with: new_note_body
+
+    click_button("Save note")
+
+    expect(page).to have_current_path(project_notes_path(project_id))
     expect_page_to_have_note(user: user.email, date: Date.today.to_formatted_s(:govuk), body: new_note_body)
   end
 

--- a/spec/helpers/notes_helper_spec.rb
+++ b/spec/helpers/notes_helper_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe NotesHelper, type: :helper do
+  describe "#has_notes?" do
+    context "when notes is nil" do
+      let(:notes) { nil }
+
+      it "returns false" do
+        expect(helper.has_notes?(notes)).to be false
+      end
+    end
+
+    context "when notes is an empty array" do
+      let(:notes) { [] }
+
+      it "returns false" do
+        expect(helper.has_notes?(notes)).to be false
+      end
+    end
+
+    context "when there are notes" do
+      let(:notes) { [build(:note)] }
+
+      it "returns true" do
+        expect(helper.has_notes?(notes)).to be true
+      end
+    end
+  end
+end

--- a/spec/requests/notes_controller_spec.rb
+++ b/spec/requests/notes_controller_spec.rb
@@ -29,6 +29,26 @@ RSpec.describe NotesController, type: :request do
     end
   end
 
+  describe "#new" do
+    let(:project) { create(:project) }
+    let(:project_id) { project.id }
+
+    subject(:perform_request) do
+      get new_project_note_path(project_id)
+      response
+    end
+
+    context "when the Project is not found" do
+      let(:project_id) { SecureRandom.uuid }
+
+      it { expect { perform_request }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    it "returns a successful response" do
+      expect(subject).to have_http_status :success
+    end
+  end
+
   describe "#create" do
     let(:project) { create(:project) }
     let(:project_id) { project.id }
@@ -52,8 +72,8 @@ RSpec.describe NotesController, type: :request do
         allow(mock_note).to receive(:valid?).and_return false
       end
 
-      it "re-renders the index view" do
-        expect(perform_request).to render_template :index
+      it "renders the new template" do
+        expect(perform_request).to render_template :new
       end
     end
 


### PR DESCRIPTION
Currently, the new note form is underneath the project summary and subnavigation. This means that the error summary sits halfway down the page, whereas the GOV.UK guidance says it should sit at the top.

After a chat with our interaction designer, we have decided to move the new note form onto its own page. This solves the error message issue, and has an additional benefit that editing messages will be easier if we choose to implement that in the future.

This includes a few style updates:
- Add a cancel link to the new note form
- Rename the textarea label from "Notes" to "Enter note"
- Change the notes form submission button from "Add note" to "Save note"
- Remove the top separator of the list of notes

## Screenshots
![image](https://user-images.githubusercontent.com/47089130/183902874-9edc7b4e-99aa-42e4-9036-cc12fdceca51.png)
![image](https://user-images.githubusercontent.com/47089130/183902983-89410a25-2d81-4319-96a0-2bfe1fb02832.png)
![image](https://user-images.githubusercontent.com/47089130/183903107-6f2e7842-8dfc-4865-8114-3b8a0c51b280.png)


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
