### PR TITLE
(376) Mini content review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Improvements to the text inputs and hints on the new project form to make
   clearer what is expected from users.
+- Improvements to the existing error messages on the new project form and new
+  notes form.
+
 ## [Release 1][release-1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - No longer show the assigned delivery officer on the projects index page.
 
+### Changed
+
+- Improvements to the text inputs and hints on the new project form to make
+  clearer what is expected from users.
 ## [Release 1][release-1]
 
 ### Added

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -8,8 +8,8 @@
 
   <h1 class="govuk-heading-l"><%= t("project.new.title") %></h1>
 
-  <%= form.govuk_text_field :urn, label: { tag: 'h3', size: 'm' } %>
-  <%= form.govuk_text_field :trust_ukprn, label: { tag: 'h3', size: 'm' } %>
+  <%= form.govuk_text_field :urn, label: { tag: 'h3', size: 'm' }, width: 10 %>
+  <%= form.govuk_text_field :trust_ukprn, label: { tag: 'h3', size: 'm' }, width: 10 %>
   <%= form.govuk_date_field :target_completion_date, omit_day: true %>
 
   <%= form.govuk_submit %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,7 +128,8 @@ en:
         target_completion_date: Target conversion date
     hint:
       project:
-        urn: This is the URN of the existing school which is converting to an academy.
+        urn: This is the URN of the existing school which is converting to an academy. URN is a 6-digit number.
+        trust_ukprn: UKPRN is an 8-digit number that always starts with a 1.
         delivery_officer_id: The delivery officer responsible for this project
         target_completion_date: The target conversion date is always the 1st of the month.
       note:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,6 +139,19 @@ en:
     errors:
       models:
         project:
-          no_establishment_found: No establishment found with that URN. Enter a valid URN.
-          no_trust_found: No trust found with that UKPRN. Enter a valid UKPRN.
-          must_be_first_of_the_month: Target completion date must be on the first day of the month.
+          attributes:
+            urn:
+              blank: Enter a school URN
+              no_establishment_found: There’s no school with that URN. Check the number you entered is correct.
+              not_a_number: School URN can only contain numbers. No letters or special characters.
+            trust_ukprn:
+              blank: Enter a UKPRN
+              no_trust_found: There’s no trust with that UKPRN. Check the number you entered is correct.
+              not_a_number: UKPRN can only contain numbers. No letters or special characters.
+            target_completion_date:
+              blank: Enter a target conversion month and year
+              must_be_first_of_the_month: Target completion date must be on the first day of the month
+        note:
+          attributes:
+            body:
+              blank: Enter a note

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Project, type: :model do
 
         it "is invalid" do
           expect(subject).to_not be_valid
-          expect(subject.errors[:urn]).to include(I18n.t("activerecord.errors.models.project.no_establishment_found"))
+          expect(subject.errors[:urn]).to include(I18n.t("activerecord.errors.models.project.attributes.urn.no_establishment_found"))
         end
       end
     end
@@ -58,7 +58,7 @@ RSpec.describe Project, type: :model do
 
         it "is invalid" do
           expect(subject).to_not be_valid
-          expect(subject.errors[:trust_ukprn]).to include(I18n.t("activerecord.errors.models.project.no_trust_found"))
+          expect(subject.errors[:trust_ukprn]).to include(I18n.t("activerecord.errors.models.project.attributes.trust_ukprn.no_trust_found"))
         end
       end
     end
@@ -71,7 +71,7 @@ RSpec.describe Project, type: :model do
 
         it "is invalid" do
           expect(subject).to_not be_valid
-          expect(subject.errors[:target_completion_date]).to include(I18n.t("activerecord.errors.models.project.must_be_first_of_the_month"))
+          expect(subject.errors[:target_completion_date]).to include(I18n.t("activerecord.errors.models.project.attributes.target_completion_date.must_be_first_of_the_month"))
         end
       end
     end


### PR DESCRIPTION
## Changes
### Small style/content updates based on designer feedback
Our interaction designer suggested that we could improve our hint text and use of text inputs on the new project page.

- Add hint text to the UKPRN and URN specifying what kind of input is expected.
- Use more appropriate widths for the input boxes. When we know the length of
the content, the guidance says we should use matching fixed-width inputs. 

### Update error messages as per mini review

We did a mini review of our error messages because so far we have been making them up on the fly, or using the Rails default messages.

Update the messages based on input from our content and interaction designers.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
