### PR TITLE
(365) YAML guidance and hint text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Show the school type, target completion date, trust name, and local authority
   name for each project on the projects index page.
 - Project contacts can be added and edited
+- Add hint text and guidance text to actions.
 
 ### Removed
 

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,9 @@ gem "pundit", "~> 2.2"
 gem "govuk-components", "~> 3.1"
 gem "govuk_design_system_formbuilder", "~> 3.1"
 
+# Use govuk_markdown to transform Markdown into GOV.UK Frontend-compliant HTML
+gem "govuk_markdown"
+
 gem "faraday"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,9 @@ GEM
       activemodel (>= 6.1)
       activesupport (>= 6.1)
       html-attributes-utils (~> 0.9, >= 0.9.2)
+    govuk_markdown (1.0.0)
+      activesupport
+      redcarpet
     hashdiff (1.0.1)
     hashie (5.0.0)
     html-attributes-utils (0.9.2)
@@ -244,6 +247,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    redcarpet (3.5.1)
     regexp_parser (2.5.0)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -356,6 +360,7 @@ DEPENDENCIES
   faraday
   govuk-components (~> 3.1)
   govuk_design_system_formbuilder (~> 3.1)
+  govuk_markdown
   omniauth
   omniauth-azure-activedirectory-v2
   omniauth-rails_csrf_protection

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 ## Getting started
 
 If this is your first time running the application, see the
-[`getting started documentation`](/doc/getting-started.md)
-for instructions.
+[`getting started documentation`](/doc/getting-started.md) for instructions.
 
 ## Running a server
 
@@ -26,8 +25,26 @@ See .env.example
 Use the [release process template in Trello](https://trello.com/c/8enGdMyy) to
 start a new release.
 
+## Including Markdown in the workflow
+
+We define task list workflows in YAML. To include Markdown while preserving
+newlines and whitespace we can use the _literal style_. This is indicated by a
+pipe (`|`) character followed by indented content. For example:
+
+```yaml
+guidance_text: |
+  # A h1 title header
+
+  ## Lists
+
+  This is a list:
+
+  * of multiple
+  * things
+  * and such
+```
+
 ## ADRs
 
 You can find the [ADRs](https://adr.github.io/) for this project in the
-[`doc/decisions`](/doc/decisions)
-folder.
+[`doc/decisions`](/doc/decisions) folder.

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -7,10 +7,21 @@
 <%= form_for :task, url: project_task_path, method: :put do |form| %>
   <%= form.govuk_check_boxes_fieldset :actions, legend: { text: "Actions", size: "m" } do %>
     <% @task.actions.each do |action| %>
-      <%= form.govuk_check_box :completed_action_ids, action.id, label: { text: action.title }, link_errors: true, checked: action.completed? %>
+      <%= form.govuk_check_box :completed_action_ids,
+                               action.id,
+                               label: { text: action.title },
+                               hint: { text: action.hint },
+                               link_errors: true,
+                               checked: action.completed? %>
+
+      <% if action.guidance_summary? %>
+        <%= govuk_details(summary_text: action.guidance_summary) do %>
+          <%= sanitize GovukMarkdown.render(action.guidance_text) %>
+        <% end %>
+      <% end %>
+
     <% end %>
   <% end %>
 
   <%= form.govuk_submit %>
 <% end %>
-

--- a/app/workflows/conversion.yml
+++ b/app/workflows/conversion.yml
@@ -6,7 +6,7 @@ sections:
       - title: Handover with Regional Delivery Officer
         actions:
           - title:
-              Recieve email with handover proforma and check it's saved in
+              Receive email with handover proforma and check it's saved in
               SharePoint
           - title:
               "Check the 'application to convert', 'academy order' and any other
@@ -24,7 +24,7 @@ sections:
 
       - title: Local authority questionnaire
         actions:
-          - title: Local Authority questionnaire recieved
+          - title: Local Authority questionnaire received
           - title: Save Local Authority questionnaire in SharePoint
       - title: External stakeholder kick off
         actions:
@@ -65,41 +65,41 @@ sections:
     tasks:
       - title: Land questionnaire & land registry title plans
         actions:
-          - title: Land questionnaire recieved
-          - title: Land registry title plans recieved
+          - title: Land questionnaire received
+          - title: Land registry title plans received
           - title: Check and clear land questionnaire
           - title: Check and clear land registry title plans
-          - title: Trust Modification Order recieved (if applicable)
-          - title: Direction to Transfer recieved (if applicable)
+          - title: Trust Modification Order received (if applicable)
+          - title: Direction to Transfer received (if applicable)
           - title: Save documents in SharePoint
 
       - title: Articles of associations
         actions:
-          - title: Recieved
+          - title: Received
           - title: Cleared
           - title: Saved in SharePoint
 
       - title: Supplementary Funding Agreement (SFA)
         actions:
-          - title: Recieved
+          - title: Received
           - title: Cleared
           - title: Saved in SharePoint
 
       - title: Church Supplementary Agreement  (CSA)
         actions:
-          - title: Recieved
+          - title: Received
           - title: Cleared
           - title: Saved in SharePoint
 
       - title: Deed of Novation & Variation (DoNV)
         actions:
-          - title: Recieved
+          - title: Received
           - title: Cleared
           - title: Saved in SharePoint
 
       - title: Master Funding Agreement (MFA)
         actions:
-          - title: Recieved
+          - title: Received
           - title: Cleared
           - title: Saved in SharePoint
 
@@ -135,7 +135,7 @@ sections:
         actions:
           - title: Email final checklist to external stakeholders
           - title:
-              Recieve email of responses to final checklist from external
+              Receive email of responses to final checklist from external
               stakeholders
           - title:
               Save final checklist email response from external stakeholders in

--- a/app/workflows/conversion.yml
+++ b/app/workflows/conversion.yml
@@ -66,6 +66,18 @@ sections:
       - title: Land questionnaire & land registry title plans
         actions:
           - title: Land questionnaire received
+            hint: Select if you have received the land questionnaire
+            guidance_summary: Additional guidance
+            guidance_text: |
+              # A h1 title header
+
+              ## Lists
+
+              This is a list:
+
+              * of multiple
+              * things
+              * and such
           - title: Land registry title plans received
           - title: Check and clear land questionnaire
           - title: Check and clear land registry title plans

--- a/app/workflows/schemas/task-list.json
+++ b/app/workflows/schemas/task-list.json
@@ -21,7 +21,10 @@
                   "items": {
                     "type": "object",
                     "properties": {
-                      "title": { "type": "string" }
+                      "title": { "type": "string" },
+                      "hint": { "type": "string" },
+                      "guidance_summary": { "type": "string" },
+                      "guidance_text": { "type": "string" }
                     },
                     "required": ["title"]
                   }

--- a/db/migrate/20220812103655_add_hint_and_guidance_to_actions.rb
+++ b/db/migrate/20220812103655_add_hint_and_guidance_to_actions.rb
@@ -1,0 +1,7 @@
+class AddHintAndGuidanceToActions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :actions, :hint, :text, null: true
+    add_column :actions, :guidance_summary, :string, null: true
+    add_column :actions, :guidance_text, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_08_132231) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_12_103655) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -18,6 +18,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_08_132231) do
     t.uuid "task_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "hint"
+    t.string "guidance_summary"
+    t.text "guidance_text"
     t.index ["task_id"], name: "index_actions_on_task_id"
   end
 

--- a/spec/fixtures/files/workflows/conversion.yml
+++ b/spec/fixtures/files/workflows/conversion.yml
@@ -10,6 +10,9 @@ sections:
       - title: Understand history and complete handover from Pre-AB
         actions:
           - title: Action one
+            hint: Action one hint
+            guidance_summary: Guidance summary
+            guidance_text: Guidance text
           - title: Action two
       - title: Note concerns or issues from handover
         actions:

--- a/spec/models/action_spec.rb
+++ b/spec/models/action_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe Action do
     it { is_expected.to have_db_column(:title).of_type :string }
     it { is_expected.to have_db_column(:order).of_type :integer }
     it { is_expected.to have_db_column(:completed).of_type :boolean }
+    it { is_expected.to have_db_column(:hint).of_type :text }
+    it { is_expected.to have_db_column(:guidance_summary).of_type :string }
+    it { is_expected.to have_db_column(:guidance_text).of_type :text }
   end
 
   describe "Relationships" do

--- a/spec/services/task_list_creator_spec.rb
+++ b/spec/services/task_list_creator_spec.rb
@@ -35,11 +35,20 @@ RSpec.describe TaskListCreator do
     end
 
     it "creates actions from the workflow" do
-      section = Section.find_by(title: "Clear legal documents")
-      task = section.tasks.find_by(title: "Clear land questionnaire")
+      section = Section.find_by(title: "Starting the project")
+      task = section.tasks.find_by(title: "Understand history and complete handover from Pre-AB")
 
       expect(Action.count).to eql 6
-      expect(Action.where(title: "Action one", order: 0, task: task)).to exist
+      expect(
+        Action.where(
+          title: "Action one",
+          order: 0,
+          hint: "Action one hint",
+          guidance_summary: "Guidance summary",
+          guidance_text: "Guidance text",
+          task: task
+        )
+      ).to exist
     end
   end
 end


### PR DESCRIPTION
## Changes
### Fix spelling of received/receive
IDE highlighted this so I thought I might as well fix it while I was there

### Add hint and guidance to actions
We want to offer users some additional hints and guidance. 

Update the models to include the new columns, and update the conversions workflow to match.

### Render hints and guidance
For now, render the hint as part of the checkbox, and conditionally render the guidance.

The guidance (rendered as a details component) currently sits within the checkbox fieldset (because we have modelled actions checkboxes within a fieldset). I can imagine this will change as move move toward each action being a distinct thing.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
