### PR TITLE
(336) Regional delivery officer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   name for each project on the projects index page.
 - Project contacts can be added and edited
 - Add hint text and guidance text to actions.
+- A regional delivery officer must be selected at the time of project creation.
+  A regional delivery officer can only see project they are assigned to on the
+  projects index page.
 
 ### Removed
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,4 +1,5 @@
 class ProjectsController < ApplicationController
+  before_action :find_regional_delivery_officers, only: %i[new create]
   after_action :verify_authorized
   after_action :verify_policy_scoped, only: :index
 
@@ -51,8 +52,18 @@ class ProjectsController < ApplicationController
     redirect_to project_information_path(@project)
   end
 
+  private def find_regional_delivery_officers
+    @regional_delivery_officers = User.where(regional_delivery_officer: true)
+  end
+
   private def project_params
-    params.require(:project).permit(:urn, :trust_ukprn, :target_completion_date, :delivery_officer_id)
+    params.require(:project).permit(
+      :urn,
+      :trust_ukprn,
+      :target_completion_date,
+      :delivery_officer_id,
+      :regional_delivery_officer_id
+    )
   end
 
   private def assign_team_leader

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,11 +7,13 @@ class Project < ApplicationRecord
   validates :trust_ukprn, presence: true, numericality: {only_integer: true}
   validates :target_completion_date, presence: true
   validates :team_leader, presence: true
+  validates :regional_delivery_officer_id, presence: true, allow_blank: false
   validate :establishment_exists, :trust_exists, on: :create
   validate :target_completion_date, :first_day_of_month
 
   belongs_to :delivery_officer, class_name: "User", optional: true
   belongs_to :team_leader, class_name: "User", optional: false
+  belongs_to :regional_delivery_officer, class_name: "User", optional: true
 
   def establishment
     @establishment || retrieve_establishment

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -39,6 +39,8 @@ class ProjectPolicy
     def resolve
       if user.team_leader?
         scope.all
+      elsif user.regional_delivery_officer?
+        scope.where(regional_delivery_officer: user)
       else
         scope.where(delivery_officer: user)
       end

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -8,6 +8,10 @@
     row.key { t('project_information.show.project_details.rows.team_lead') }
     row.value { @project.team_leader.email }
   end
+  summary_list.row do |row|
+    row.key { t('project_information.show.project_details.rows.regional_delivery_officer') }
+    row.value { @project.regional_delivery_officer.email }
+  end
 end %>
 
 <h2 class="govuk-heading-l" id="schoolDetails"><%= t('project_information.show.school_details.title') %></h2>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -8,9 +8,15 @@
 
   <h1 class="govuk-heading-l"><%= t("project.new.title") %></h1>
 
-  <%= form.govuk_text_field :urn, label: { tag: 'h3', size: 'm' }, width: 10 %>
-  <%= form.govuk_text_field :trust_ukprn, label: { tag: 'h3', size: 'm' }, width: 10 %>
+  <%= form.govuk_text_field :urn, label: { size: 'm' }, width: 10 %>
+  <%= form.govuk_text_field :trust_ukprn, label: { size: 'm' }, width: 10 %>
   <%= form.govuk_date_field :target_completion_date, omit_day: true %>
+  <%= form.govuk_collection_select :regional_delivery_officer_id,
+                                   @regional_delivery_officers,
+                                   :id,
+                                   :email,
+                                   label: { size: 'm' },
+                                   options: { include_blank: true } %>
 
   <%= form.govuk_submit %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -142,6 +142,7 @@ en:
         urn: School URN
         trust_ukprn: Incoming trust UK Provider Reference Number (UKPRN)
         delivery_officer_id: Delivery officer
+        regional_delivery_officer_id: Regional delivery officer
       note:
         body: Enter note
       contact:
@@ -175,6 +176,8 @@ en:
             target_completion_date:
               blank: Enter a target conversion month and year
               must_be_first_of_the_month: Target completion date must be on the first day of the month
+            regional_delivery_officer_id:
+              blank: Choose a regional delivery officer
         note:
           attributes:
             body:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,7 @@ en:
         rows:
           delivery_officer: Delivery officer
           team_lead: Team lead
+          regional_delivery_officer: Regional delivery officer
       school_details:
         title: School details
         rows:

--- a/db/migrate/20220815100605_add_regional_delivery_officer_to_users.rb
+++ b/db/migrate/20220815100605_add_regional_delivery_officer_to_users.rb
@@ -1,0 +1,6 @@
+class AddRegionalDeliveryOfficerToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :regional_delivery_officer, :boolean, null: false, default: false
+    add_reference :projects, :regional_delivery_officer, null: false, foreign_key: {to_table: :users}, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_12_103655) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_15_100605) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -53,7 +53,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_12_103655) do
     t.uuid "team_leader_id", null: false
     t.integer "trust_ukprn", null: false
     t.date "target_completion_date", null: false
+    t.uuid "regional_delivery_officer_id", null: false
     t.index ["delivery_officer_id"], name: "index_projects_on_delivery_officer_id"
+    t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"
     t.index ["team_leader_id"], name: "index_projects_on_team_leader_id"
     t.index ["urn"], name: "index_projects_on_urn"
   end
@@ -82,6 +84,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_12_103655) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "team_leader", default: false
+    t.boolean "regional_delivery_officer", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
@@ -90,6 +93,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_12_103655) do
   add_foreign_key "notes", "projects"
   add_foreign_key "notes", "users"
   add_foreign_key "projects", "users", column: "delivery_officer_id"
+  add_foreign_key "projects", "users", column: "regional_delivery_officer_id"
   add_foreign_key "projects", "users", column: "team_leader_id"
   add_foreign_key "sections", "projects"
   add_foreign_key "tasks", "sections"

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     trust_ukprn { 10061021 }
     target_completion_date { Date.new(2025, 12, 1) }
     team_leader { association :user, :team_leader, email: "team-leader-#{SecureRandom.uuid}@education.gov.uk" }
+    regional_delivery_officer { association :user, :regional_delivery_officer, email: "regional-delivery-officer-#{SecureRandom.uuid}@education.gov.uk" }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,9 +2,14 @@ FactoryBot.define do
   factory :user do
     email { "user@education.gov.uk" }
     team_leader { false }
+    regional_delivery_officer { false }
 
     trait :team_leader do
       team_leader { true }
+    end
+
+    trait :regional_delivery_officer do
+      regional_delivery_officer { true }
     end
   end
 end

--- a/spec/features/users_can_create_projects_spec.rb
+++ b/spec/features/users_can_create_projects_spec.rb
@@ -37,6 +37,8 @@ end
 RSpec.feature "Team leaders can create a new project" do
   let(:mock_workflow) { file_fixture("workflows/conversion.yml") }
   let(:team_leader) { create(:user, :team_leader) }
+  let(:regional_delivery_officer_email) { "regional-deliver-officer@education.gov.uk" }
+  let!(:regional_delivery_officer) { create(:user, :regional_delivery_officer, email: regional_delivery_officer_email) }
 
   before do
     sign_in_with_user(team_leader)
@@ -58,6 +60,7 @@ RSpec.feature "Team leaders can create a new project" do
       fill_in "Incoming trust UK Provider Reference Number (UKPRN)", with: ukprn
       fill_in "Month", with: 12
       fill_in "Year", with: 2025
+      select regional_delivery_officer_email, from: "Regional delivery officer"
 
       click_button("Continue")
 

--- a/spec/features/users_can_view_project_information_spec.rb
+++ b/spec/features/users_can_view_project_information_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature "Users can view project information" do
     expect(page).to have_content("Project details")
     page_has_project_information_list_row(label: "Delivery officer", information: "user@education.gov.uk")
     page_has_project_information_list_row(label: "Team lead", information: project.team_leader.email)
+    page_has_project_information_list_row(label: "Regional delivery officer", information: project.regional_delivery_officer.email)
 
     expect(page).to have_content("School details")
     page_has_project_information_list_row(label: "Original school name", information: "Caludon Castle School")

--- a/spec/features/users_can_view_projects_spec.rb
+++ b/spec/features/users_can_view_projects_spec.rb
@@ -8,13 +8,14 @@ RSpec.feature "Users can view a list of projects" do
   end
 
   let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
+  let(:regional_delivery_officer) { create(:user, :regional_delivery_officer, email: "regionaldeliveryofficer@education.gov.uk") }
   let(:user_1) { create(:user, email: "user1@education.gov.uk") }
   let(:user_2) { create(:user, email: "user2@education.gov.uk") }
   let!(:unassigned_project) { create(:project, urn: 1001) }
   let!(:user_1_project) { create(:project, urn: 1002, delivery_officer: user_1) }
-  let!(:user_2_project) { create(:project, urn: 1003, delivery_officer: user_2) }
+  let!(:user_2_project) { create(:project, urn: 1003, delivery_officer: user_2, regional_delivery_officer: regional_delivery_officer) }
 
-  context "the user is a team leader" do
+  context "when the user is a team leader" do
     before do
       sign_in_with_user(team_leader)
     end
@@ -28,7 +29,21 @@ RSpec.feature "Users can view a list of projects" do
     end
   end
 
-  context "the user is not a team leader" do
+  context "when the user is a regional delivery officer" do
+    before do
+      sign_in_with_user(regional_delivery_officer)
+    end
+
+    scenario "can only see assigned projects on the projects list" do
+      visit projects_path
+
+      expect(page).to_not have_content(unassigned_project.urn.to_s)
+      expect(page).not_to have_content(user_1_project.urn.to_s)
+      page_has_project(user_2_project)
+    end
+  end
+
+  context "when the user does not have an assigned role" do
     before(:each) do
       sign_in_with_user(user_1)
     end

--- a/spec/requests/projects_controller_spec.rb
+++ b/spec/requests/projects_controller_spec.rb
@@ -33,11 +33,12 @@ RSpec.describe ProjectsController, type: :request do
       before do
         mock_successful_api_responses(urn: 12345, ukprn: 10061021)
         allow(Project).to receive(:new).and_return(project)
+        allow(project).to receive(:valid?).and_return(true)
       end
 
       it "assigns the team leader, calls the TaskListCreator, and redirects to the project path" do
         expect_any_instance_of(TaskListCreator).to receive(:call).with(project)
-        expect(subject).to redirect_to(project_path(project.id))
+        expect(perform_request).to redirect_to(project_path(project.id))
         expect(project.team_leader_id).to eq team_leader.id
       end
     end


### PR DESCRIPTION
## Changes
### Add regional deliver officer to project
We want to add a new role of `regional delivery officer` to the User model.

On project creation, a regional delivery officer must be selected from a drop down to be associated with the project.

### Show regional delivery officer on the project information tab
Now that a project has a regional delivery officer, we want to display this on the project information tab.

### Only show assigned projects to regional delivery officers
We only want regional delivery officer to see projects that they are associated with.

We don't policy scope the `show` view currently, so this only applies to the `index` view.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
