### PR TITLE
(413) Destroy a projects notes along with the project

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,6 @@
 class Project < ApplicationRecord
   has_many :sections, dependent: :destroy
-  has_many :notes
+  has_many :notes, dependent: :destroy
   has_many :contacts, dependent: :destroy
 
   validates :urn, presence: true, numericality: {only_integer: true}


### PR DESCRIPTION
Leaving any of a Projects associated entities will create orphans.

Here we destroy a Projects notes along with the other associations
(Contacts and Sections (which in turn destroy Tasks and Actions)).

We also add some coverage around this behaviour to document it and make
it explicit.

https://trello.com/c/qqY8bE6H

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
