### PR TITLE
(404) Task level hints and guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - A regional delivery officer must be selected at the time of project creation.
   A regional delivery officer can only see project they are assigned to on the
   projects index page.
+- Add hint text and guidance text to tasks.
 
 ### Removed
 

--- a/app/services/task_list_creator.rb
+++ b/app/services/task_list_creator.rb
@@ -15,7 +15,14 @@ class TaskListCreator
       section = Section.create(title: workflow_section.fetch("title"), order: index, project: project)
 
       workflow_section.fetch("tasks").each_with_index do |workflow_task, index|
-        task = Task.create(title: workflow_task.fetch("title"), order: index, section: section)
+        task = Task.create(
+          title: workflow_task.fetch("title"),
+          hint: workflow_task.fetch("hint", nil),
+          guidance_summary: workflow_task.fetch("guidance_summary", nil),
+          guidance_text: workflow_task.fetch("guidance_text", nil),
+          order: index,
+          section: section
+        )
 
         create_actions(workflow_task, task)
       end

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -4,6 +4,16 @@
 
 <h1 class="govuk-heading-l"><%= @task.title %></h1>
 
+<% if @task.hint? %>
+  <p class="govuk-body"><%= sanitize GovukMarkdown.render(@task.hint) %></p>
+<% end %>
+
+<% if @task.guidance_summary? %>
+  <%= govuk_details(summary_text: @task.guidance_summary) do %>
+    <%= sanitize GovukMarkdown.render(@task.guidance_text) %>
+  <% end %>
+<% end %>
+
 <%= form_for :task, url: project_task_path, method: :put do |form| %>
   <%= form.govuk_check_boxes_fieldset :actions, legend: { text: "Actions", size: "m" } do %>
     <% @task.actions.each do |action| %>

--- a/app/workflows/schemas/task-list.json
+++ b/app/workflows/schemas/task-list.json
@@ -16,6 +16,9 @@
               "type": "object",
               "properties": {
                 "title": { "type": "string" },
+                "hint": { "type": "string" },
+                "guidance_summary": { "type": "string" },
+                "guidance_text": { "type": "string" },
                 "actions": {
                   "type": "array",
                   "items": {

--- a/db/migrate/20220818142154_add_hints_and_guidance_to_tasks.rb
+++ b/db/migrate/20220818142154_add_hints_and_guidance_to_tasks.rb
@@ -1,0 +1,7 @@
+class AddHintsAndGuidanceToTasks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :tasks, :hint, :text, null: true
+    add_column :tasks, :guidance_summary, :string, null: true
+    add_column :tasks, :guidance_text, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_15_100605) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_18_142154) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -76,6 +76,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_15_100605) do
     t.uuid "section_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "hint"
+    t.string "guidance_summary"
+    t.text "guidance_text"
     t.index ["section_id"], name: "index_tasks_on_section_id"
   end
 

--- a/spec/factories/action_factory.rb
+++ b/spec/factories/action_factory.rb
@@ -2,6 +2,13 @@ FactoryBot.define do
   factory :action, class: "Action" do
     title { "Have you received the land questionnaire?" }
     order { 0 }
+    hint { "Select if you have received the land questionnaire" }
+    guidance_summary { "Help receiving the land questionnaire" }
+    guidance_text do
+      "You'll need to [check the guidance (opens in new tab)]" \
+      "(https://www.gov.uk/government/publications/academy-land-questionnaires) about the land questionnaire."
+    end
+
     task
   end
 end

--- a/spec/factories/task_factory.rb
+++ b/spec/factories/task_factory.rb
@@ -1,8 +1,18 @@
 FactoryBot.define do
   factory :task, class: "Task" do
-    title { "Clear land questionnaire" }
+    title { "Have you cleared the Supplementary funding agreement?" }
+    hint do
+      "Check the Supplementary funding agreement for changes from the model documents." \
+      "[View the model documents (opens in new tab)](https://www.gov.uk/government/collections/convert-to-an-academy-documents-for-schools)."
+    end
+    guidance_summary { "Help checking for changes" }
+    guidance_text do
+      "You'll need to [contact the policy team (opens in new tab)]" \
+      "(https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Commissioning%20Form.aspx) about changes to clause text."
+    end
     completed { false }
     order { 0 }
+
     section
   end
 end

--- a/spec/features/users_can_view_the_actions_for_a_task_spec.rb
+++ b/spec/features/users_can_view_the_actions_for_a_task_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Users can view the Actions for a Task" do
-  let(:user_1) { create(:user, email: "user1@education.gov.uk") }
+  let(:user) { create(:user, email: "user1@education.gov.uk") }
   let(:action) { create(:action) }
   let(:task_id) { action.task.id }
   let(:project_id) { action.task.section.project.id }
@@ -9,13 +9,30 @@ RSpec.feature "Users can view the Actions for a Task" do
   before do
     mock_successful_api_responses(urn: 12345, ukprn: 10061021)
 
-    sign_in_with_user(user_1)
+    sign_in_with_user(user)
   end
 
-  scenario "User views the list of tasks" do
+  scenario "user can view task and actions with hints and guidance" do
     visit project_task_path(project_id, task_id)
 
-    expect(page).to have_content("Clear land questionnaire")
+    # Task
+    expect(page).to have_css(".govuk-heading-l", text: "Have you cleared the Supplementary funding agreement?")
+
+    # Task hint
+    expect(page).to have_link("View the model documents (opens in new tab)", href: "https://www.gov.uk/government/collections/convert-to-an-academy-documents-for-schools")
+
+    # Task guidance
+    find("span", text: "Help checking for changes").click
+    expect(page).to have_link("contact the policy team (opens in new tab)", href: "https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Commissioning%20Form.aspx")
+
+    # Action
     expect(page).to have_content("Have you received the land questionnaire?")
+
+    # Action hint
+    expect(page).to have_css(".govuk-checkboxes__hint", text: "Select if you have received the land questionnaire")
+
+    # Action guidance
+    find("span", text: "Help receiving the land questionnaire").click
+    expect(page).to have_link("check the guidance (opens in new tab)", href: "https://www.gov.uk/government/publications/academy-land-questionnaires")
   end
 end

--- a/spec/fixtures/files/workflows/conversion.yml
+++ b/spec/fixtures/files/workflows/conversion.yml
@@ -8,11 +8,14 @@ sections:
   - title: Starting the project
     tasks:
       - title: Understand history and complete handover from Pre-AB
+        hint: Understand history hint
+        guidance_summary: Understand history guidance summary
+        guidance_text: Understand history guidance text
         actions:
           - title: Action one
             hint: Action one hint
-            guidance_summary: Guidance summary
-            guidance_text: Guidance text
+            guidance_summary: Action one guidance summary
+            guidance_text: Action one guidance text
           - title: Action two
       - title: Note concerns or issues from handover
         actions:

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe TasksController, type: :request do
 
     it "returns a successful response" do
       expect(subject).to have_http_status :success
-      expect(subject.body).to include("Clear land questionnaire")
+      expect(subject.body).to include("Have you cleared the Supplementary funding agreement?")
     end
   end
 

--- a/spec/services/task_list_creator_spec.rb
+++ b/spec/services/task_list_creator_spec.rb
@@ -31,7 +31,16 @@ RSpec.describe TaskListCreator do
       section = Section.find_by(title: "Starting the project")
 
       expect(Task.count).to be 3
-      expect(Task.where(title: "Understand history and complete handover from Pre-AB", order: 0, section: section)).to exist
+      expect(
+        Task.where(
+          title: "Understand history and complete handover from Pre-AB",
+          order: 0,
+          hint: "Understand history hint",
+          guidance_summary: "Understand history guidance summary",
+          guidance_text: "Understand history guidance text",
+          section: section
+        )
+      ).to exist
     end
 
     it "creates actions from the workflow" do
@@ -44,11 +53,45 @@ RSpec.describe TaskListCreator do
           title: "Action one",
           order: 0,
           hint: "Action one hint",
-          guidance_summary: "Guidance summary",
-          guidance_text: "Guidance text",
+          guidance_summary: "Action one guidance summary",
+          guidance_text: "Action one guidance text",
           task: task
         )
       ).to exist
+    end
+
+    context "when the workflow's optional fields are empty" do
+      it "creates tasks from the workflow" do
+        section = Section.find_by(title: "Clear legal documents")
+
+        expect(Task.count).to be 3
+        expect(
+          Task.where(
+            title: "Clear land questionnaire",
+            order: 0,
+            hint: nil,
+            guidance_summary: nil,
+            guidance_text: nil,
+            section: section
+          )
+        ).to exist
+      end
+
+      it "creates actions from the workflow" do
+        section = Section.find_by(title: "Clear legal documents")
+        task = section.tasks.find_by(title: "Clear land questionnaire")
+
+        expect(
+          Action.where(
+            title: "Action one",
+            order: 0,
+            hint: nil,
+            guidance_summary: nil,
+            guidance_text: nil,
+            task: task
+          )
+        ).to exist
+      end
     end
   end
 end


### PR DESCRIPTION
## Changes
### Add hints and guidance to Task model
Tasks will have hints and guidance in the same form that Actions do.

Add the model attributes.

### Update the workflow and TaskListCreator to handle hints and guidance
The TaskListCreator and workflow need updating to handle task-level hints and guidance. Update them, following the sam structure as used for the action-level hints and guidance.

Because some of the keys of the workflow task are now optional, this also replaces any calls to `fetch` with `[]` in the TaskListCreator. `fetch` raises an error when the key isn't found, whereas `[]` does not.

### Render task hints and guidance
We want to render the task-level hints and guidance as GOV.UK Frontend content.

Follow the same pattern as the action-level guidance, and call the GovukMarkdown gem with the workflow markdown.


NOTE: I haven't updated the real workflow at all yet. Here it is working though 👇 
<img width="1091" alt="image" src="https://user-images.githubusercontent.com/47089130/185661002-e5a22690-6f60-4224-877b-5685990a9503.png">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
