### PR TITLE
(419) Feature: tasks can be optional i.e. not applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Project contacts can be added and edited
 - Add hint text and guidance text to actions.
 - A regional delivery officer must be selected at the time of project creation.
-  A regional delivery officer can only see project they are assigned to on the
+- A regional delivery officer can only see project they are assigned to on the
   projects index page.
 - Add hint text and guidance text to tasks.
+- Optional tasks can be marked 'Not applicable' to the project
 
 ### Removed
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -6,18 +6,29 @@ class TasksController < ApplicationController
 
   def update
     @task.actions.each do |action|
-      action_completed = action.id.in?(action_params[:completed_action_ids] || [])
+      action_completed = action.id.in?(task_params[:completed_action_ids] || [])
       Action.update(action.id, completed: action_completed)
     end
+
+    @task.update(not_applicable: not_applicable)
+    unset_all_actions if @task.not_applicable?
 
     redirect_to(project_path(@task.project))
   end
 
-  def action_params
-    params.require(:task).permit(completed_action_ids: [])
+  def task_params
+    params.require(:task).permit(:not_applicable, completed_action_ids: [])
   end
 
   private def find_task
     @task = Task.find(params[:id])
+  end
+
+  private def not_applicable
+    params.dig("task", "not_applicable")
+  end
+
+  private def unset_all_actions
+    @task.actions.update_all(completed: false)
   end
 end

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -18,6 +18,10 @@ module TaskListHelper
         text: "Complete",
         colour: "turquoise"
       },
+      not_applicable: {
+        text: "Not applicable",
+        colour: "grey"
+      },
       unknown: {
         text: "Unknown",
         colour: "grey"

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -15,6 +15,8 @@ class Task < ApplicationRecord
   end
 
   def status
+    return :not_applicable if not_applicable? && optional?
+
     if completed_actions_count == 0
       :not_started
     elsif completed_actions_count == actions_count

--- a/app/services/task_list_creator.rb
+++ b/app/services/task_list_creator.rb
@@ -21,7 +21,8 @@ class TaskListCreator
           guidance_summary: workflow_task.fetch("guidance_summary", nil),
           guidance_text: workflow_task.fetch("guidance_text", nil),
           order: index,
-          section: section
+          section: section,
+          optional: workflow_task.fetch("optional", false)
         )
 
         create_actions(workflow_task, task)

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -29,9 +29,15 @@
           <%= sanitize GovukMarkdown.render(action.guidance_text) %>
         <% end %>
       <% end %>
+    <% end %>
 
+    <% if @task.optional? %>
+      <%= form.govuk_check_box_divider %>
+      <%= form.govuk_check_box :not_applicable,
+                                true,
+                                label: { text: t("tasks.not_applicable") },
+                                checked: @task.not_applicable? %>
     <% end %>
   <% end %>
-
   <%= form.govuk_submit %>
 <% end %>

--- a/app/workflows/conversion.yml
+++ b/app/workflows/conversion.yml
@@ -82,42 +82,49 @@ sections:
           - title: Saved in SharePoint
 
       - title: Church supplementary agreement
+        optional: true
         actions:
           - title: Received
           - title: Cleared
           - title: Saved in SharePoint
 
       - title: Master funding agreement
+        optional: true
         actions:
           - title: Received
           - title: Cleared
           - title: Saved in SharePoint
 
       - title: Articles of association
+        optional: true
         actions:
           - title: Received
           - title: Cleared
           - title: Saved in SharePoint
 
       - title: Deed of variation
+        optional: true
         actions:
           - title: Received
           - title: Cleared
           - title: Saved in SharePoint
 
       - title: Trust modification order
+        optional: true
         actions:
           - title: Received
           - title: Cleared
           - title: Saved in SharePoint
 
       - title: Trust modification order
+        optional: true
         actions:
           - title: Received
           - title: Cleared
           - title: Saved in SharePoint
 
       - title: Direction to transfer
+        optional: true
         actions:
           - title: Received
           - title: Cleared

--- a/app/workflows/schemas/task-list.json
+++ b/app/workflows/schemas/task-list.json
@@ -19,6 +19,7 @@
                 "hint": { "type": "string" },
                 "guidance_summary": { "type": "string" },
                 "guidance_text": { "type": "string" },
+                "optional": { "type": "boolean" },
                 "actions": {
                   "type": "array",
                   "items": {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
   unauthorised_action:
     message: You are not authorised to perform this action.
   tasks:
+    not_applicable: Not applicable
     users:
       create:
         error: You must provide a users email address e.g. bin/rails users:create EMAIL_ADDRESS=name@example.com

--- a/db/migrate/20220819104914_add_optional_to_task.rb
+++ b/db/migrate/20220819104914_add_optional_to_task.rb
@@ -1,0 +1,5 @@
+class AddOptionalToTask < ActiveRecord::Migration[7.0]
+  def change
+    add_column :tasks, :optional, :boolean, defualt: false
+  end
+end

--- a/db/migrate/20220819121534_add_not_applicable_to_task.rb
+++ b/db/migrate/20220819121534_add_not_applicable_to_task.rb
@@ -1,0 +1,5 @@
+class AddNotApplicableToTask < ActiveRecord::Migration[7.0]
+  def change
+    add_column :tasks, :not_applicable, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_18_142154) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_19_104914) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -79,6 +79,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_18_142154) do
     t.text "hint"
     t.string "guidance_summary"
     t.text "guidance_text"
+    t.boolean "optional"
     t.index ["section_id"], name: "index_tasks_on_section_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_19_104914) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_19_121534) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -80,6 +80,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_19_104914) do
     t.string "guidance_summary"
     t.text "guidance_text"
     t.boolean "optional"
+    t.boolean "not_applicable", default: false
     t.index ["section_id"], name: "index_tasks_on_section_id"
   end
 

--- a/spec/factories/task_factory.rb
+++ b/spec/factories/task_factory.rb
@@ -15,9 +15,15 @@ FactoryBot.define do
 
     section
     optional { false }
+    not_applicable { false }
 
     trait :optional do
       optional { true }
+    end
+
+    trait :not_applicable do
+      optional { true }
+      not_applicable { true }
     end
   end
 end

--- a/spec/factories/task_factory.rb
+++ b/spec/factories/task_factory.rb
@@ -14,5 +14,10 @@ FactoryBot.define do
     order { 0 }
 
     section
+    optional { false }
+
+    trait :optional do
+      optional { true }
+    end
   end
 end

--- a/spec/features/users_can_mark_optional_tasks_as_not_applicable_spec.rb
+++ b/spec/features/users_can_mark_optional_tasks_as_not_applicable_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.feature "Users can mark optional tasks as not applicable to a project" do
+  let(:user_one) { create(:user, email: "user.one@education.gov.uk") }
+
+  before do
+    mock_successful_api_responses(urn: 123456, ukprn: 123456)
+    sign_in_with_user(user_one)
+  end
+
+  let(:project) { create(:project, urn: 123456, trust_ukprn: 123456) }
+  let!(:section) { create(:section, project: project) }
+  let(:task) { create(:task, :not_applicable, title: "Not applicable task", section: section) }
+  let!(:actions) { create_list(:action, 3, task: task, completed: true) }
+
+  scenario "they can edit the task and see the status changed to 'not applicable'" do
+    visit project_task_path(project, task)
+    check "Not applicable"
+    click_button "Continue"
+
+    within("#not-applicable-task-status") do
+      expect(page).to have_content(I18n.t("tasks.not_applicable"))
+    end
+  end
+end

--- a/spec/fixtures/files/workflows/conversion.yml
+++ b/spec/fixtures/files/workflows/conversion.yml
@@ -17,7 +17,8 @@ sections:
             guidance_summary: Action one guidance summary
             guidance_text: Action one guidance text
           - title: Action two
-      - title: Note concerns or issues from handover
+      - title: Optional note concerns or issues from handover
+        optional: true
         actions:
           - title: Action one
           - title: Action two

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Task, type: :model do
     it { is_expected.to have_db_column(:order).of_type :integer }
     it { is_expected.to have_db_column(:completed).of_type :boolean }
     it { is_expected.to have_db_column(:optional).of_type :boolean }
+    it { is_expected.to have_db_column(:not_applicable).of_type :boolean }
   end
 
   describe "Relationships" do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Task, type: :model do
     it { is_expected.to have_db_column(:title).of_type :string }
     it { is_expected.to have_db_column(:order).of_type :integer }
     it { is_expected.to have_db_column(:completed).of_type :boolean }
+    it { is_expected.to have_db_column(:optional).of_type :boolean }
   end
 
   describe "Relationships" do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -90,5 +90,17 @@ RSpec.describe Task, type: :model do
         expect(task.status).to eq :in_progress
       end
     end
+
+    context "when the task is not applicable" do
+      let(:task) { create(:task, not_applicable: true, optional: true) }
+
+      before do
+        mock_successful_api_responses(urn: any_args, ukprn: any_args)
+      end
+
+      it "returns an not_applicable state" do
+        expect(task.status).to eq :not_applicable
+      end
+    end
   end
 end

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -60,5 +60,16 @@ RSpec.describe TasksController, type: :request do
       expect(incomplete_action.reload.completed?).to be true
       expect(completed_action.reload.completed?).to be false
     end
+
+    context "when the task is not applicable" do
+      let(:task) { create(:task, :not_applicable, actions: [completed_action, completed_action]) }
+
+      it "sets all the tasks actions completed state to false" do
+        perform_request
+
+        expect(task.reload.actions.first.completed?).to be false
+        expect(task.reload.actions.last.completed?).to be false
+      end
+    end
   end
 end

--- a/spec/services/task_list_creator_spec.rb
+++ b/spec/services/task_list_creator_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe TaskListCreator do
       ).to exist
     end
 
+    it "creates optional tasks" do
+      expect(Task.where(title: "Optional note concerns or issues from handover", optional: true)).to exist
+    end
+
     it "creates actions from the workflow" do
       section = Section.find_by(title: "Starting the project")
       task = section.tasks.find_by(title: "Understand history and complete handover from Pre-AB")


### PR DESCRIPTION
## Changes

Not all Tasks apply to every Project, a simple example would be the Church fundung agreement is not applicable to non-fatih establishments.

For the moment Users want to be able to mark this kind of task as 'Not applicable' in the applicaiton. To do this we need two things:

1. the ability to control which Tasks can be made not applicable i.e. the Task is optional
2. the ability to store the state i.e is the Task applicable to the Project

We've settled on `optional` for controlling which Tasks can be 'not applicable' and `not_applicable` to store the state. We settled on `not_applicable` as this reflects the UI and the way users think about this, being true when checked.

Allow users to do this and showing not applicable tasks in the task list means users get a clear view of what Task are out standing.

## Screen shots
![Screenshot 2022-08-22 at 11-00-21 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/185900035-6fcc9ec8-3b18-445b-89ff-ead330898769.png)

![Screenshot 2022-08-22 at 11-00-32 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/185900057-247e75cc-1594-44ff-9dcb-58501f3db5d1.png)

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.

https://trello.com/c/l5nCjxDI
