### PR TITLE
(389) - Improve validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   lose any currently assigned delivery officers.
 - Add validation that checks URN is 6 digits long.
 - Add validation that checks UKPRN is 8 digits long and starts with a 1.
+- Add validation that checks the target completion date is in the future when a
+  new project is created.
 
 ## [Release 1][release-1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Rename any references of "Delivery officer" to "Caseworker". Projects will
   lose any currently assigned delivery officers.
 - Add validation that checks URN is 6 digits long.
+- Add validation that checks UKPRN is 8 digits long and starts with a 1.
 
 ## [Release 1][release-1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The task list is now referred to as "Task list" not "Project task list"
 - Rename any references of "Delivery officer" to "Caseworker". Projects will
   lose any currently assigned delivery officers.
+- Add validation that checks URN is 6 digits long.
 
 ## [Release 1][release-1]
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -9,7 +9,7 @@ class Project < ApplicationRecord
   validates :team_leader, presence: true
   validates :regional_delivery_officer_id, presence: true, allow_blank: false
   validate :establishment_exists, :trust_exists, on: :create
-  validate :target_completion_date, :first_day_of_month
+  validate :first_day_of_month, :trust_ukprn_is_correct_format
 
   belongs_to :caseworker, class_name: "User", optional: true
   belongs_to :team_leader, class_name: "User", optional: false
@@ -55,6 +55,17 @@ class Project < ApplicationRecord
     # Target completion date is always the 1st of the month.
     if target_completion_date.day != 1
       errors.add(:target_completion_date, :must_be_first_of_the_month)
+    end
+  end
+
+  private def trust_ukprn_is_correct_format
+    return if trust_ukprn.nil?
+
+    number_of_digits = trust_ukprn.digits.count
+    first_digit = trust_ukprn.to_s.first.to_i
+
+    if number_of_digits != 8 || first_digit != 1
+      errors.add(:trust_ukprn, :must_be_correct_format)
     end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,8 +8,10 @@ class Project < ApplicationRecord
   validates :target_completion_date, presence: true
   validates :team_leader, presence: true
   validates :regional_delivery_officer_id, presence: true, allow_blank: false
-  validate :establishment_exists, :trust_exists, on: :create
+
   validate :first_day_of_month, :trust_ukprn_is_correct_format
+  validate :target_completion_date_is_in_the_future, on: :create
+  validate :establishment_exists, :trust_exists, on: :create
 
   belongs_to :caseworker, class_name: "User", optional: true
   belongs_to :team_leader, class_name: "User", optional: false
@@ -66,6 +68,14 @@ class Project < ApplicationRecord
 
     if number_of_digits != 8 || first_digit != 1
       errors.add(:trust_ukprn, :must_be_correct_format)
+    end
+  end
+
+  private def target_completion_date_is_in_the_future
+    return if target_completion_date.nil?
+
+    unless target_completion_date.future?
+      errors.add(:target_completion_date, :must_be_in_the_future)
     end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,7 +3,7 @@ class Project < ApplicationRecord
   has_many :notes, dependent: :destroy
   has_many :contacts, dependent: :destroy
 
-  validates :urn, presence: true, numericality: {only_integer: true}
+  validates :urn, presence: true, numericality: {only_integer: true}, length: {is: 6}
   validates :trust_ukprn, presence: true, numericality: {only_integer: true}
   validates :target_completion_date, presence: true
   validates :team_leader, presence: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -180,6 +180,7 @@ en:
             target_completion_date:
               blank: Enter a target conversion month and year
               must_be_first_of_the_month: Target completion date must be on the first day of the month
+              must_be_in_the_future: Target conversion date must be in the future.
             regional_delivery_officer_id:
               blank: Choose a regional delivery officer
         note:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,6 +171,7 @@ en:
               blank: Enter a school URN
               no_establishment_found: There’s no school with that URN. Check the number you entered is correct.
               not_a_number: School URN can only contain numbers. No letters or special characters.
+              wrong_length: URN must be 6 digits long. For example, 123456.
             trust_ukprn:
               blank: Enter a UKPRN
               no_trust_found: There’s no trust with that UKPRN. Check the number you entered is correct.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -176,6 +176,7 @@ en:
               blank: Enter a UKPRN
               no_trust_found: There’s no trust with that UKPRN. Check the number you entered is correct.
               not_a_number: UKPRN can only contain numbers. No letters or special characters.
+              must_be_correct_format: UKPRN must be 8 digits long and start with a 1. For example, 12345678.
             target_completion_date:
               blank: Enter a target conversion month and year
               must_be_first_of_the_month: Target completion date must be on the first day of the month

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :project, class: "Project" do
-    urn { 12345 }
+    urn { 123456 }
     trust_ukprn { 10061021 }
     target_completion_date { Date.new(2025, 12, 1) }
     team_leader { association :user, :team_leader, email: "team-leader-#{SecureRandom.uuid}@education.gov.uk" }

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :project, class: "Project" do
     urn { 123456 }
     trust_ukprn { 10061021 }
-    target_completion_date { Date.new(2025, 12, 1) }
+    target_completion_date { (Date.today + 2.years).at_beginning_of_month }
     team_leader { association :user, :team_leader, email: "team-leader-#{SecureRandom.uuid}@education.gov.uk" }
     regional_delivery_officer { association :user, :regional_delivery_officer, email: "regional-delivery-officer-#{SecureRandom.uuid}@education.gov.uk" }
   end

--- a/spec/features/users_can_create_and_view_contacts_spec.rb
+++ b/spec/features/users_can_create_and_view_contacts_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Users can view contacts" do
   let(:project_id) { project.id }
 
   before do
-    mock_successful_api_responses(urn: 12345, ukprn: 10061021)
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
     sign_in_with_user(user)
 
     create(:contact, project: project)

--- a/spec/features/users_can_create_and_view_notes_spec.rb
+++ b/spec/features/users_can_create_and_view_notes_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Users can create and view notes" do
   let(:existing_note_created_at) {}
 
   before do
-    mock_successful_api_responses(urn: 12345, ukprn: 10061021)
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
     sign_in_with_user(user)
 
     travel_to Date.yesterday do

--- a/spec/features/users_can_create_projects_spec.rb
+++ b/spec/features/users_can_create_projects_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Team leaders can create a new project" do
   end
 
   context "when the URN and UKPRN are valid" do
-    let(:urn) { 19283746 }
+    let(:urn) { 123456 }
     let(:ukprn) { 10061021 }
 
     before { mock_successful_api_responses(urn: urn, ukprn: ukprn) }

--- a/spec/features/users_can_mark_optional_tasks_as_not_applicable_spec.rb
+++ b/spec/features/users_can_mark_optional_tasks_as_not_applicable_spec.rb
@@ -4,11 +4,11 @@ RSpec.feature "Users can mark optional tasks as not applicable to a project" do
   let(:user_one) { create(:user, email: "user.one@education.gov.uk") }
 
   before do
-    mock_successful_api_responses(urn: 123456, ukprn: 123456)
+    mock_successful_api_responses(urn: 123456, ukprn: 12345678)
     sign_in_with_user(user_one)
   end
 
-  let(:project) { create(:project, urn: 123456, trust_ukprn: 123456) }
+  let(:project) { create(:project, urn: 123456, trust_ukprn: 12345678) }
   let!(:section) { create(:section, project: project) }
   let(:task) { create(:task, :not_applicable, title: "Not applicable task", section: section) }
   let!(:actions) { create_list(:action, 3, task: task, completed: true) }

--- a/spec/features/users_can_update_projects_spec.rb
+++ b/spec/features/users_can_update_projects_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Users can reach the edit project page" do
-  let(:urn) { 12345 }
+  let(:urn) { 123456 }
   let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
   let(:caseworker) { create(:user, email: "user1@education.gov.uk") }
   let(:unassigned_project) { create(:project, urn: urn) }
@@ -54,7 +54,7 @@ RSpec.feature "Users can update a project" do
   context "the user is a team leader" do
     before do
       sign_in_with_user(team_leader)
-      mock_successful_api_responses(urn: 12345, ukprn: 10061021)
+      mock_successful_api_responses(urn: 123456, ukprn: 10061021)
     end
 
     context "when the project has no caseworker" do

--- a/spec/features/users_can_update_the_actions_for_a_task_spec.rb
+++ b/spec/features/users_can_update_the_actions_for_a_task_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Users can update the Actions for a Task" do
   let(:task_id) { task.id }
 
   before do
-    mock_successful_api_responses(urn: 12345, ukprn: 10061021)
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
 
     sign_in_with_user(user)
   end

--- a/spec/features/users_can_view_project_information_spec.rb
+++ b/spec/features/users_can_view_project_information_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Users can view project information" do
   let(:project_id) { project.id }
 
   before do
-    mock_successful_api_responses(urn: 12345, ukprn: 10061021)
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
     sign_in_with_user(user)
   end
 
@@ -20,7 +20,7 @@ RSpec.feature "Users can view project information" do
 
     expect(page).to have_content("School details")
     page_has_project_information_list_row(label: "Original school name", information: "Caludon Castle School")
-    page_has_project_information_list_row(label: "Old Unique Reference Number", information: "12345")
+    page_has_project_information_list_row(label: "Old Unique Reference Number", information: "123456")
     page_has_project_information_list_row(label: "School type", information: "Academy converter")
     page_has_project_information_list_row(label: "Age range", information: "11 to 18")
     page_has_project_information_list_row(label: "School phase", information: "Secondary")

--- a/spec/features/users_can_view_projects_spec.rb
+++ b/spec/features/users_can_view_projects_spec.rb
@@ -2,18 +2,18 @@ require "rails_helper"
 
 RSpec.feature "Users can view a list of projects" do
   before do
-    mock_successful_api_responses(urn: 1001, ukprn: 10061021)
-    mock_successful_api_responses(urn: 1002, ukprn: 10061021)
-    mock_successful_api_responses(urn: 1003, ukprn: 10061021)
+    mock_successful_api_responses(urn: 100001, ukprn: 10061021)
+    mock_successful_api_responses(urn: 100002, ukprn: 10061021)
+    mock_successful_api_responses(urn: 100003, ukprn: 10061021)
   end
 
   let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
   let(:regional_delivery_officer) { create(:user, :regional_delivery_officer, email: "regionaldeliveryofficer@education.gov.uk") }
   let(:user_1) { create(:user, email: "user1@education.gov.uk") }
   let(:user_2) { create(:user, email: "user2@education.gov.uk") }
-  let!(:unassigned_project) { create(:project, urn: 1001) }
-  let!(:user_1_project) { create(:project, urn: 1002, caseworker: user_1) }
-  let!(:user_2_project) { create(:project, urn: 1003, caseworker: user_2, regional_delivery_officer: regional_delivery_officer) }
+  let!(:unassigned_project) { create(:project, urn: 100001) }
+  let!(:user_1_project) { create(:project, urn: 100002, caseworker: user_1) }
+  let!(:user_2_project) { create(:project, urn: 100003, caseworker: user_2, regional_delivery_officer: regional_delivery_officer) }
 
   context "when the user is a team leader" do
     before do
@@ -70,7 +70,7 @@ RSpec.feature "Users can view a list of projects" do
 end
 
 RSpec.feature "Users can view a single project" do
-  let(:urn) { 19283746 }
+  let(:urn) { 123456 }
   let(:establishment) { build(:academies_api_establishment) }
 
   before do
@@ -104,7 +104,7 @@ RSpec.feature "Users can view a single project" do
     scenario "the project list shows an assigned caseworker" do
       sign_in_with_user(create(:user, :team_leader, email: user_email_address))
       user = User.find_by(email: user_email_address)
-      create(:project, urn: 19283746, caseworker: user)
+      create(:project, urn: 123456, caseworker: user)
 
       visit projects_path
       expect(page).to have_content(user_email_address)

--- a/spec/features/users_can_view_the_actions_for_a_task_spec.rb
+++ b/spec/features/users_can_view_the_actions_for_a_task_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Users can view the Actions for a Task" do
   let(:project_id) { action.task.section.project.id }
 
   before do
-    mock_successful_api_responses(urn: 12345, ukprn: 10061021)
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
 
     sign_in_with_user(user)
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -102,6 +102,24 @@ RSpec.describe Project, type: :model do
           expect(subject.errors[:target_completion_date]).to include(I18n.t("activerecord.errors.models.project.attributes.target_completion_date.must_be_first_of_the_month"))
         end
       end
+
+      context "when date is today" do
+        subject { build(:project, target_completion_date: Date.today) }
+
+        it "is invalid" do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:target_completion_date]).to include(I18n.t("activerecord.errors.models.project.attributes.target_completion_date.must_be_in_the_future"))
+        end
+      end
+
+      context "when date is in the past" do
+        subject { build(:project, target_completion_date: Date.yesterday) }
+
+        it "is invalid" do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:target_completion_date]).to include(I18n.t("activerecord.errors.models.project.attributes.target_completion_date.must_be_in_the_future"))
+        end
+      end
     end
 
     describe "#team_leader" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe Project, type: :model do
     describe "#urn" do
       it { is_expected.to validate_presence_of(:urn) }
       it { is_expected.to validate_numericality_of(:urn).only_integer }
+      it { is_expected.to allow_value(123456).for(:urn) }
+      it { is_expected.not_to allow_values(12345, 1234567).for(:urn) }
 
       context "when no establishment with that URN exists in the API" do
         let(:no_establishment_found_result) do
@@ -106,7 +108,7 @@ RSpec.describe Project, type: :model do
   end
 
   describe "#establishment" do
-    let(:urn) { 12345 }
+    let(:urn) { 123456 }
     let(:establishment) { build(:academies_api_establishment) }
 
     subject { described_class.new(urn: urn) }
@@ -123,7 +125,7 @@ RSpec.describe Project, type: :model do
     end
 
     context "when the Academies API client returns a #{AcademiesApi::Client::NotFoundError}" do
-      let(:error_message) { "Could not find establishment with URN: 12345" }
+      let(:error_message) { "Could not find establishment with URN: 123456" }
       let(:error) { AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError.new(error_message)) }
 
       before do
@@ -137,7 +139,7 @@ RSpec.describe Project, type: :model do
     end
 
     context "when the Academies API client returns a #{AcademiesApi::Client::Error}" do
-      let(:error_message) { "There was an error connecting to the Academies API, could not fetch establishment for URN: 12345" }
+      let(:error_message) { "There was an error connecting to the Academies API, could not fetch establishment for URN: 123456" }
       let(:error) { AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::Error.new(error_message)) }
 
       before do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -71,6 +71,8 @@ RSpec.describe Project, type: :model do
     describe "#trust_ukprn" do
       it { is_expected.to validate_presence_of(:trust_ukprn) }
       it { is_expected.to validate_numericality_of(:trust_ukprn).only_integer }
+      it { is_expected.to allow_value(12345678).for(:trust_ukprn) }
+      it { is_expected.not_to allow_values(1234567, 123456789, 23456789).for(:trust_ukprn) }
 
       context "when no trust with that UKPRN exists in the API" do
         let(:no_trust_found_result) do

--- a/spec/requests/contacts_controller_spec.rb
+++ b/spec/requests/contacts_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ContactsController, type: :request do
 
   before do
     mock_successful_authentication(user.email)
-    mock_successful_api_responses(urn: 12345, ukprn: 10061021)
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
     allow_any_instance_of(ContactsController).to receive(:user_id).and_return(user.id)
   end
 

--- a/spec/requests/notes_controller_spec.rb
+++ b/spec/requests/notes_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe NotesController, type: :request do
 
   before do
     mock_successful_authentication(user.email)
-    mock_successful_api_responses(urn: 12345, ukprn: 10061021)
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
     allow_any_instance_of(NotesController).to receive(:user_id).and_return(user.id)
   end
 

--- a/spec/requests/project_information_controller_spec.rb
+++ b/spec/requests/project_information_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ProjectInformationController, type: :request do
 
   before do
     mock_successful_authentication(user.email)
-    mock_successful_api_responses(urn: 12345, ukprn: 10061021)
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
     allow_any_instance_of(ProjectInformationController).to receive(:user_id).and_return(user.id)
   end
 

--- a/spec/requests/projects_controller_spec.rb
+++ b/spec/requests/projects_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ProjectsController, type: :request do
 
   describe "#create" do
     subject(:perform_request) do
-      post projects_path, params: {project: {urn: 12345}}
+      post projects_path, params: {project: {urn: 123456}}
       response
     end
 
@@ -31,7 +31,7 @@ RSpec.describe ProjectsController, type: :request do
       let(:project) { build(:project, team_leader: nil) }
 
       before do
-        mock_successful_api_responses(urn: 12345, ukprn: 10061021)
+        mock_successful_api_responses(urn: 123456, ukprn: 10061021)
         allow(Project).to receive(:new).and_return(project)
         allow(project).to receive(:valid?).and_return(true)
       end

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe TasksController, type: :request do
       response
     end
 
-    before { mock_successful_api_responses(urn: 12345, ukprn: 10061021) }
+    before { mock_successful_api_responses(urn: 123456, ukprn: 10061021) }
 
     context "when the Task is not found" do
       let(:task_id) { SecureRandom.uuid }
@@ -45,7 +45,7 @@ RSpec.describe TasksController, type: :request do
       response
     end
 
-    before { mock_successful_api_responses(urn: 12345, ukprn: 10061021) }
+    before { mock_successful_api_responses(urn: 123456, ukprn: 10061021) }
 
     context "when the Task is not found" do
       let(:task_id) { SecureRandom.uuid }

--- a/spec/services/task_list_creator_spec.rb
+++ b/spec/services/task_list_creator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe TaskListCreator do
       YAML.load_file(mock_workflow)
     )
 
-    mock_successful_api_responses(urn: 12345, ukprn: 10061021)
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
   end
 
   describe "#call" do


### PR DESCRIPTION
## Changes
### Validate correct length of URN
Establishment URNs are always 6 digits long. We can provide some help to the users by showing a useful message if the URN is not the right length.

### Validate correct format of trust UKPRN
UKPRNs are always 8 digits long and start with a 1. We can provide some help to the users by showing a useful message if the UKPRN is not the right format.

### Validate that completion date is in the future
We think it's very unlikely that users will need to set a completion date that isn't in the future.

Add some validation to cover this.

_NOTE: The Trello card says to validate that caseworker cannot be blank on the update page. However, there is a spec which tests the unsetting of a caseworker, so this sounds like an intentional thing, and I haven't added the validation_

## Screenshots
<img width="1048" alt="image" src="https://user-images.githubusercontent.com/47089130/185966345-9ec9e23c-f024-4234-bd06-d881d1febe81.png">

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
