### PR TITLE
(424) Feature: change the project creation journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add validation that checks UKPRN is 8 digits long and starts with a 1.
 - Add validation that checks the target completion date is in the future when a
   new project is created.
+- a Team lead can no longer create a new project, it is the responsibility of
+  the Regional delivery officer to do so.
 
 ## [Release 1][release-1]
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -21,7 +21,7 @@ class ProjectsController < ApplicationController
   def create
     @project = Project.new(project_params)
     authorize @project
-    assign_team_leader
+    assign_regional_delivery_officer
 
     if @project.valid?
       @project.save
@@ -68,5 +68,9 @@ class ProjectsController < ApplicationController
 
   private def assign_team_leader
     @project.team_leader_id = user_id
+  end
+
+  private def assign_regional_delivery_officer
+    @project.regional_delivery_officer_id = user_id
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -37,7 +37,7 @@ class ProjectsController < ApplicationController
     @project = Project.find(params[:id])
     authorize @project
 
-    @users = User.all
+    @users = User.caseworkers
   end
 
   def update

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -25,10 +25,9 @@ class ProjectsController < ApplicationController
 
     if @project.valid?
       @project.save
-      flash[:notice] = I18n.t("project.create.success")
       TaskListCreator.new.call(@project)
 
-      redirect_to project_path(@project)
+      redirect_to project_path(@project), notice: I18n.t("project.create.success")
     else
       render :new
     end
@@ -45,11 +44,11 @@ class ProjectsController < ApplicationController
     @project = Project.find(params[:id])
     authorize @project
 
-    @project.assign_attributes(project_params)
+    @project.assign_attributes(case_worker_id)
+    assign_team_leader
 
     @project.save
-    flash[:notice] = I18n.t("project.update.success")
-    redirect_to project_information_path(@project)
+    redirect_to project_information_path(@project), notice: I18n.t("project.update.success")
   end
 
   private def find_regional_delivery_officers
@@ -61,9 +60,12 @@ class ProjectsController < ApplicationController
       :urn,
       :trust_ukprn,
       :target_completion_date,
-      :caseworker_id,
       :regional_delivery_officer_id
     )
+  end
+
+  private def case_worker_id
+    params.require(:project).permit(:caseworker_id)
   end
 
   private def assign_team_leader

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,15 +6,13 @@ class Project < ApplicationRecord
   validates :urn, presence: true, numericality: {only_integer: true}, length: {is: 6}
   validates :trust_ukprn, presence: true, numericality: {only_integer: true}
   validates :target_completion_date, presence: true
-  validates :team_leader, presence: true
-  validates :regional_delivery_officer_id, presence: true, allow_blank: false
 
   validate :first_day_of_month, :trust_ukprn_is_correct_format
   validate :target_completion_date_is_in_the_future, on: :create
   validate :establishment_exists, :trust_exists, on: :create
 
   belongs_to :caseworker, class_name: "User", optional: true
-  belongs_to :team_leader, class_name: "User", optional: false
+  belongs_to :team_leader, class_name: "User", optional: true
   belongs_to :regional_delivery_officer, class_name: "User", optional: true
 
   def establishment

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
   has_many :projects, foreign_key: "caseworker"
   has_many :notes
+
+  scope :caseworkers, -> { where(team_leader: false).and(where(regional_delivery_officer: false)) }
 end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -15,7 +15,7 @@ class ProjectPolicy
   end
 
   def create?
-    user.team_leader?
+    user.regional_delivery_officer?
   end
 
   def new?

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -2,11 +2,11 @@
 <%= govuk_summary_list(actions: false) do |summary_list|
   summary_list.row do |row|
     row.key { t('project_information.show.project_details.rows.caseworker') }
-    row.value { @project.caseworker&.email or t('project.summary.caseworker.unassigned') }
+    row.value { @project.caseworker&.email or t('project_information.show.project_details.rows.unassigned') }
   end
   summary_list.row do |row|
     row.key { t('project_information.show.project_details.rows.team_lead') }
-    row.value { @project.team_leader.email }
+    row.value { @project.team_leader&.email or t('project_information.show.project_details.rows.unassigned') }
   end
   summary_list.row do |row|
     row.key { t('project_information.show.project_details.rows.regional_delivery_officer') }

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -11,12 +11,5 @@
   <%= form.govuk_text_field :urn, label: { size: 'm' }, width: 10 %>
   <%= form.govuk_text_field :trust_ukprn, label: { size: 'm' }, width: 10 %>
   <%= form.govuk_date_field :target_completion_date, omit_day: true %>
-  <%= form.govuk_collection_select :regional_delivery_officer_id,
-                                   @regional_delivery_officers,
-                                   :id,
-                                   :email,
-                                   label: { size: 'm' },
-                                   options: { include_blank: true } %>
-
   <%= form.govuk_submit %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,6 +86,7 @@ en:
           caseworker: Caseworker
           team_lead: Team lead
           regional_delivery_officer: Regional delivery officer
+          unassigned: Not yet assigned
       school_details:
         title: School details
         rows:

--- a/db/migrate/20220823081934_remove_null_constraints_on_team_lead_and_regional_delivery_officer.rb
+++ b/db/migrate/20220823081934_remove_null_constraints_on_team_lead_and_regional_delivery_officer.rb
@@ -1,0 +1,6 @@
+class RemoveNullConstraintsOnTeamLeadAndRegionalDeliveryOfficer < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :projects, :team_leader_id, true
+    change_column_null :projects, :regional_delivery_officer_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_22_104025) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_23_081934) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -49,10 +49,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_22_104025) do
     t.integer "urn", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "team_leader_id", null: false
+    t.uuid "team_leader_id"
     t.integer "trust_ukprn", null: false
     t.date "target_completion_date", null: false
-    t.uuid "regional_delivery_officer_id", null: false
+    t.uuid "regional_delivery_officer_id"
     t.uuid "caseworker_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -4,12 +4,18 @@ FactoryBot.define do
     team_leader { false }
     regional_delivery_officer { false }
 
+    trait :caseworker do
+      email { "caseworker@education.gov.uk" }
+    end
+
     trait :team_leader do
       team_leader { true }
+      email { "team.lead@education.gov.uk" }
     end
 
     trait :regional_delivery_officer do
       regional_delivery_officer { true }
+      email { "regional.delivery.officer@education.gov.uk" }
     end
   end
 end

--- a/spec/features/users_can_assign_users_to_projects_spec.rb
+++ b/spec/features/users_can_assign_users_to_projects_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.feature "Users can assign users to projects" do
+  before do
+    mock_successful_api_responses(urn: project.urn, ukprn: project.trust_ukprn)
+    sign_in_with_user(user)
+  end
+
+  context "when the user is a team lead" do
+    let(:user) { create(:user, :team_leader) }
+    let!(:caseworker_user) { create(:user, :caseworker) }
+    let(:project) { create_unassigned_project }
+
+    scenario "they can assign a user to the caseworker role" do
+      visit project_path(project)
+      click_on "Edit"
+      select caseworker_user.email, from: "Caseworker"
+      click_on "Continue"
+      click_on "Project information"
+
+      expect(page).to have_content caseworker_user.email
+    end
+  end
+end

--- a/spec/features/users_can_create_projects_spec.rb
+++ b/spec/features/users_can_create_projects_spec.rb
@@ -1,13 +1,11 @@
 require "rails_helper"
 
-RSpec.feature "Team leaders can create a new project" do
+RSpec.feature "Users can create new projects" do
   let(:mock_workflow) { file_fixture("workflows/conversion.yml") }
-  let(:team_leader) { create(:user, :team_leader) }
-  let(:regional_delivery_officer_email) { "regional-deliver-officer@education.gov.uk" }
-  let!(:regional_delivery_officer) { create(:user, :regional_delivery_officer, email: regional_delivery_officer_email) }
+  let(:regional_delivery_officer) { create(:user, :regional_delivery_officer) }
 
   before do
-    sign_in_with_user(team_leader)
+    sign_in_with_user(regional_delivery_officer)
     visit new_project_path
 
     allow(YAML).to receive(:load_file).with(Rails.root.join("app", "workflows", "conversion.yml")).and_return(
@@ -26,7 +24,6 @@ RSpec.feature "Team leaders can create a new project" do
       fill_in "Incoming trust UK Provider Reference Number (UKPRN)", with: ukprn
       fill_in "Month", with: 12
       fill_in "Year", with: 2025
-      select regional_delivery_officer_email, from: "Regional delivery officer"
 
       click_button("Continue")
 

--- a/spec/features/users_can_create_projects_spec.rb
+++ b/spec/features/users_can_create_projects_spec.rb
@@ -1,39 +1,5 @@
 require "rails_helper"
 
-RSpec.feature "Users can view the new project form" do
-  context "the user is a team leader" do
-    before(:each) do
-      sign_in_with_user(create(:user, :team_leader))
-    end
-
-    scenario "can see the new project button" do
-      visit projects_path
-      expect(page).to have_content(I18n.t("project.index.new_button.text"))
-    end
-
-    scenario "can see the new project form" do
-      visit new_project_path
-      expect(page).to have_content(I18n.t("project.new.title"))
-    end
-  end
-
-  context "the user is not a team leader" do
-    before(:each) do
-      sign_in_with_user(create(:user))
-    end
-
-    scenario "cannot see the new project button" do
-      visit projects_path
-      expect(page).to_not have_content(I18n.t("project.index.new_button.text"))
-    end
-
-    scenario "cannot see the new project form" do
-      visit new_project_path
-      expect(page).to have_content(I18n.t("unauthorised_action.message"))
-    end
-  end
-end
-
 RSpec.feature "Team leaders can create a new project" do
   let(:mock_workflow) { file_fixture("workflows/conversion.yml") }
   let(:team_leader) { create(:user, :team_leader) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_many(:sections).dependent(:destroy) }
     it { is_expected.to have_many(:notes).dependent(:destroy) }
     it { is_expected.to belong_to(:caseworker).required(false) }
-    it { is_expected.to belong_to(:team_leader).required(true) }
+    it { is_expected.to belong_to(:team_leader).required(false) }
 
     describe "delete related entities" do
       context "when the project is deleted" do
@@ -120,10 +120,6 @@ RSpec.describe Project, type: :model do
           expect(subject.errors[:target_completion_date]).to include(I18n.t("activerecord.errors.models.project.attributes.target_completion_date.must_be_in_the_future"))
         end
       end
-    end
-
-    describe "#team_leader" do
-      it { is_expected.to validate_presence_of(:team_leader) }
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe User do
+  describe "scopes" do
+    describe "caseworkers" do
+      it "only includes users that are not team lead or regional delivery officer" do
+        caseworker = create(:user, :caseworker)
+        team_lead = create(:user, :team_leader)
+        regional_delivery_officer = create(:user, :regional_delivery_officer)
+
+        caseworkers = User.caseworkers
+
+        expect(caseworkers).not_to include team_lead
+        expect(caseworkers).not_to include regional_delivery_officer
+        expect(caseworkers).to include caseworker
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,6 +69,7 @@ RSpec.configure do |config|
   config.include SignInHelpers
   config.include AcademiesApiHelpers
   config.include FeatureHelpers, type: :feature
+  config.include ProjectHelpers
 
   # cleanup Omniauth after each example
   config.after(:each) do |example|

--- a/spec/requests/project_assignment_spec.rb
+++ b/spec/requests/project_assignment_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe "Project assignment" do
+  describe "assigning a project" do
+    let(:project) { create_unassigned_project }
+
+    before do
+      mock_successful_authentication(user.email)
+      mock_successful_api_responses(urn: project.urn, ukprn: project.trust_ukprn)
+      allow_any_instance_of(ProjectsController).to receive(:user_id).and_return(user.id)
+    end
+
+    context "when the user is a team lead" do
+      let(:user) { create(:user, :team_leader) }
+
+      it "shows the edit project button" do
+        get project_path(project)
+        expect(response.body).to include("Edit")
+      end
+
+      it "allows the action and renders the edit template" do
+        get edit_project_path(project)
+
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:edit)
+      end
+
+      it "assigns the current user as the team lead" do
+        case_worker = create(:user, email: "case.worker@education.gov.uk")
+        patch project_path(project, params: {project: {case_worker_id: case_worker.id}})
+
+        expect(project.reload.team_leader).to eq user
+      end
+    end
+
+    context "when a user is not a team lead or regional delivery officer" do
+      let(:user) { create(:user) }
+
+      it "does not show the new project button" do
+        get project_path(project)
+        expect(response.body).not_to include("Edit")
+      end
+
+      it "redirects to the root path and displays a not authorized message" do
+        get edit_project_path(project)
+        expect(response).not_to render_template(:edit)
+        expect(response).to redirect_to(root_path)
+        follow_redirect!
+        expect(flash.alert).to eq I18n.t("unauthorised_action.message")
+      end
+    end
+
+    context "when the user is a regional delivery officer" do
+      let(:user) { create(:user, :regional_delivery_officer) }
+
+      it "does not show the new project button" do
+        get project_path(project)
+        expect(response.body).not_to include("Edit")
+      end
+
+      it "redirects to the root path and displays a not authorized message" do
+        get edit_project_path(project)
+        expect(response).not_to render_template(:edit)
+        expect(response).to redirect_to(root_path)
+        follow_redirect!
+        expect(flash.alert).to eq I18n.t("unauthorised_action.message")
+      end
+    end
+  end
+
+  def create_unassigned_project(urn: 123456, trust_ukprn: 12345678)
+    project = build(:project, urn: urn, trust_ukprn: trust_ukprn, team_leader: nil)
+    mock_successful_api_responses(urn: project.urn, ukprn: project.trust_ukprn)
+    project.save!
+    project
+  end
+end

--- a/spec/requests/project_assignment_spec.rb
+++ b/spec/requests/project_assignment_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe "Project assignment" do
       end
     end
 
-    context "when a user is not a team lead or regional delivery officer" do
-      let(:user) { create(:user) }
+    context "when a user is a caseworker" do
+      let(:user) { create(:user, :caseworker) }
 
       it "does not show the new project button" do
         get project_path(project)
@@ -66,12 +66,5 @@ RSpec.describe "Project assignment" do
         expect(flash.alert).to eq I18n.t("unauthorised_action.message")
       end
     end
-  end
-
-  def create_unassigned_project(urn: 123456, trust_ukprn: 12345678)
-    project = build(:project, urn: urn, trust_ukprn: trust_ukprn, team_leader: nil)
-    mock_successful_api_responses(urn: project.urn, ukprn: project.trust_ukprn)
-    project.save!
-    project
   end
 end

--- a/spec/requests/project_management_spec.rb
+++ b/spec/requests/project_management_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe "Project management" do
       end
     end
 
-    context "when a user is not a team lead or regional delivery officer" do
-      let(:user) { create(:user) }
+    context "when a user is a caseworker" do
+      let(:user) { create(:user, :caseworker) }
 
       it "redirects to the root path and displays a not authorized message" do
         get new_project_path

--- a/spec/requests/project_management_spec.rb
+++ b/spec/requests/project_management_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe "Project management" do
   end
 
   describe "creating a new project" do
-    context "when the user is a team lead" do
-      let(:user) { create(:user, :team_leader) }
-
+    context "when the user is a regional delivery officer" do
+      let(:user) { create(:user, :regional_delivery_officer) }
       it "allows the action and renders the new template" do
         get new_project_path
         expect(response).to have_http_status(:success)
@@ -39,8 +38,8 @@ RSpec.describe "Project management" do
       end
     end
 
-    context "when the user is a regional delivery officer" do
-      let(:user) { create(:user, :regional_delivery_officer) }
+    context "when the user is a team lead" do
+      let(:user) { create(:user, :team_leader) }
 
       it "redirects to the root path and displays a not authorized message" do
         get new_project_path

--- a/spec/requests/project_management_spec.rb
+++ b/spec/requests/project_management_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe "Project management" do
+  before do
+    mock_successful_authentication(user.email)
+    allow_any_instance_of(ProjectsController).to receive(:user_id).and_return(user.id)
+  end
+
+  describe "creating a new project" do
+    context "when the user is a team lead" do
+      let(:user) { create(:user, :team_leader) }
+
+      it "allows the action and renders the new template" do
+        get new_project_path
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:new)
+      end
+
+      it "shows the new project button" do
+        get projects_path
+        expect(response.body).to include("Add a new project")
+      end
+    end
+
+    context "when a user is not a team lead or regional delivery officer" do
+      let(:user) { create(:user) }
+
+      it "redirects to the root path and displays a not authorized message" do
+        get new_project_path
+        expect(response).not_to render_template(:new)
+        expect(response).to redirect_to(root_path)
+        follow_redirect!
+        expect(flash.alert).to eq I18n.t("unauthorised_action.message")
+      end
+
+      it "does not show the new project button" do
+        get projects_path
+        expect(response.body).not_to include(I18n.t("project.new.title"))
+      end
+    end
+
+    context "when the user is a regional delivery officer" do
+      let(:user) { create(:user, :regional_delivery_officer) }
+
+      it "redirects to the root path and displays a not authorized message" do
+        get new_project_path
+        expect(response).not_to render_template(:new)
+        expect(response).to redirect_to(root_path)
+        follow_redirect!
+        expect(flash.alert).to eq I18n.t("unauthorised_action.message")
+      end
+
+      it "does not show the new project button" do
+        get projects_path
+        expect(response.body).not_to include(I18n.t("project.new.title"))
+      end
+    end
+  end
+end

--- a/spec/requests/projects_controller_spec.rb
+++ b/spec/requests/projects_controller_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 RSpec.describe ProjectsController, type: :request do
-  let(:team_leader) { create(:user, :team_leader) }
+  let(:regional_delivery_officer) { create(:user, :regional_delivery_officer) }
 
   before do
-    mock_successful_authentication(team_leader.email)
-    allow_any_instance_of(ProjectsController).to receive(:user_id).and_return(team_leader.id)
+    mock_successful_authentication(regional_delivery_officer.email)
+    allow_any_instance_of(ProjectsController).to receive(:user_id).and_return(regional_delivery_officer.id)
   end
 
   describe "#create" do
@@ -39,7 +39,7 @@ RSpec.describe ProjectsController, type: :request do
       it "assigns the team leader, calls the TaskListCreator, and redirects to the project path" do
         expect_any_instance_of(TaskListCreator).to receive(:call).with(project)
         expect(perform_request).to redirect_to(project_path(project.id))
-        expect(project.team_leader_id).to eq team_leader.id
+        expect(project.regional_delivery_officer).to eq regional_delivery_officer
       end
     end
   end

--- a/spec/support/project_helpers.rb
+++ b/spec/support/project_helpers.rb
@@ -1,0 +1,8 @@
+module ProjectHelpers
+  def create_unassigned_project(urn: 123456, trust_ukprn: 12345678)
+    project = build(:project, urn: urn, trust_ukprn: trust_ukprn, team_leader: nil)
+    mock_successful_api_responses(urn: project.urn, ukprn: project.trust_ukprn)
+    project.save!
+    project
+  end
+end


### PR DESCRIPTION
## Changes

We decided that Regional delivery officers will create (aka Handover) projects from the prepare side of the service to us. For our MVP this will be a manual process with automating it coming later.

Originally we had the Team Lead creating projects and assigning them to Caseworkers, here we make the changes to move the responsibility for creating the project to Regional delivery officers.

In the spirit of 'leave the code better than you found it' I've made some changes to some specs to try and follow the general principle of features testing the happy path and tighter unit test for everything else.

I think we have some work to do to make the assignment jounrney more intuitive for Team Leads, but that will come later.

https://trello.com/c/90qSKSQt

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
