### PR TITLE
Fix error in Church supplemental agreement link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   funding agreement so it is accurate
 - Added content to Trust modification order
 - Removed duplicate Trust modification order
+- Removed word funding from Church supplemental agreement hint text link to make
+  sure naming is consistent and accurate
 
 ### Removed
 

--- a/app/workflows/conversion.yml
+++ b/app/workflows/conversion.yml
@@ -126,8 +126,7 @@ sections:
           If needed, check the Articles of association for changes from the model documents.
 
           You can [view the model documents (opens in new tab)](https://www.gov.uk/government/collections/convert-to-an-academy-documents-for-schools) to check for changes.
-        guidance_summary:
-          Help checking the Church supplemental funding agreement
+        guidance_summary: Help checking the Church supplemental agreement
         guidance_text: |
           Changes that personalise the model documents to a school or trust, and remove or add optional clauses, are expected. The wording of clauses should not change.
 


### PR DESCRIPTION
## Changes

_Steve spotted a naming error in the hint text link on Church supplemental agreement task during our desk review. Fixing this_

VS code seems to have added an app.code-workspace file. Not sure what that's for or where it's come from. Hopefully it makes sense to the more technically knowledgeable members of the team.

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
