### PR TITLE
(447) Change migration adding RDOs to work with existing data

### DIFF
--- a/db/migrate/20220815100605_add_regional_delivery_officer_to_users.rb
+++ b/db/migrate/20220815100605_add_regional_delivery_officer_to_users.rb
@@ -1,6 +1,6 @@
 class AddRegionalDeliveryOfficerToUsers < ActiveRecord::Migration[7.0]
   def change
     add_column :users, :regional_delivery_officer, :boolean, null: false, default: false
-    add_reference :projects, :regional_delivery_officer, null: false, foreign_key: {to_table: :users}, type: :uuid
+    add_reference :projects, :regional_delivery_officer, foreign_key: {to_table: :users}, type: :uuid
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,7 +52,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_22_104025) do
     t.uuid "team_leader_id", null: false
     t.integer "trust_ukprn", null: false
     t.date "target_completion_date", null: false
-    t.uuid "regional_delivery_officer_id", null: false
+    t.uuid "regional_delivery_officer_id"
     t.uuid "caseworker_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"


### PR DESCRIPTION
## Changes

The previous form of this migration tried to add a non-nullable `regional_delivery_officer_id` column, which fails in databases where there is existing data.

Making this relationship nullable allows migrations to be performed.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
