### PR TITLE
(412) Add organisations to contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added content for sending documents to grant payment team action
 - Added content for confirm grant payment date with schoo action
 - Added content for checking school has received grant action
+- Project contacts can be grouped by the institution they belong to
 
 ### Removed
 

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -49,6 +49,6 @@ class ContactsController < ApplicationController
   end
 
   private def contact_params
-    params.require(:contact).permit(:name, :title, :email, :phone)
+    params.require(:contact).permit(:name, :title, :category, :email, :phone)
   end
 end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,6 +1,6 @@
 class ContactsController < ApplicationController
   before_action :find_project
-  before_action :find_contacts, only: :index
+  before_action :find_grouped_contacts, only: :index
 
   def index
   end
@@ -44,8 +44,8 @@ class ContactsController < ApplicationController
     @project = Project.find(params[:project_id])
   end
 
-  private def find_contacts
-    @contacts = Contact.where(project: @project)
+  private def find_grouped_contacts
+    @contacts = Contact.where(project: @project).group_by(&:category)
   end
 
   private def contact_params

--- a/app/helpers/contacts_helper.rb
+++ b/app/helpers/contacts_helper.rb
@@ -2,4 +2,8 @@ module ContactsHelper
   def has_contacts?(contacts)
     contacts.present? && contacts.any?
   end
+
+  def format_category_name(category)
+    category.tr("_", " ").capitalize
+  end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -5,4 +5,12 @@ class Contact < ApplicationRecord
   validates :title, presence: true, allow_blank: false
 
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}, allow_blank: true
+
+  enum category: {
+    other: 0,
+    establishment: 1,
+    trust: 2,
+    local_authority: 3,
+    diocese: 4
+  }
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -8,7 +8,7 @@ class Contact < ApplicationRecord
 
   enum category: {
     other: 0,
-    establishment: 1,
+    school: 1,
     trust: 2,
     local_authority: 3,
     diocese: 4

--- a/app/views/contacts/_contacts.html.erb
+++ b/app/views/contacts/_contacts.html.erb
@@ -1,25 +1,40 @@
-<% @contacts.each_with_index do |contact, index| %>
+<% @contacts.each do |category, contacts| %>
+
+  <h3 class="govuk-heading-m"><%= category %></h3>
+
+  <% contacts.each_with_index do |contact, index| %>
+
   <% unless index == 0 %>
     <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
   <% end %>
 
-  <span class="govuk-caption-m"><%= contact.title %></span>
-  <h3 class="govuk-heading-m"><%= contact.name %></h3>
-
-  <%= govuk_summary_list(actions: false) do |summary_list|
+  <%= govuk_summary_list do |summary_list|
+    summary_list.row do |row|
+      row.key { t('contact.details.title') }
+      row.value { contact.title }
+      row.action(
+        text: t('contact.details.edit_link'),
+        href: edit_project_contact_path(@project, contact),
+        visually_hidden_text: contact.name
+      )
+    end
+    summary_list.row do |row|
+      row.key { t('contact.details.name') }
+      row.value { contact.name }
+    end
     if contact.email.present?
       summary_list.row do |row|
-        row.key { t('contact.details.long.email') }
+        row.key { t('contact.details.email') }
         row.value { contact.email }
       end
     end
     if contact.phone.present?
       summary_list.row do |row|
-        row.key { t('contact.details.long.phone') }
+        row.key { t('contact.details.phone') }
         row.value { contact.phone }
       end
     end
   end %>
 
-  <p class="govuk-body"><%= link_to t('contact.details.edit_link', contact_name: contact.name), edit_project_contact_path(@project, contact), class: "govuk-link" %></p>
+  <% end %>
 <% end %>

--- a/app/views/contacts/_contacts.html.erb
+++ b/app/views/contacts/_contacts.html.erb
@@ -1,6 +1,6 @@
 <% @contacts.each do |category, contacts| %>
 
-  <h3 class="govuk-heading-m"><%= category %></h3>
+  <h3 class="govuk-heading-m"><%= t('contact.index.category_heading', category_name: format_category_name(category)) %></h3>
 
   <% contacts.each_with_index do |contact, index| %>
 

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -10,17 +10,14 @@
       <%= form.govuk_error_summary %>
 
       <%= form.govuk_collection_select :category,
-        Contact.categories.map { |k, v| OpenStruct.new(id: k, name: format_category_name(k)) },
-        :id, :name,
-        label: { tag: 'h3', size: 'm' } %>
+        Contact.categories.keys,
+        :to_s,
+        ->(category_name) {format_category_name(category_name) } %>
 
-      <%= form.govuk_text_field :name, label: { tag: 'h3', size: 'm' } %>
-      <%= form.govuk_text_field :title, label: { tag: 'h3', size: 'm' } %>
-
-      <%= form.govuk_fieldset legend: { text: 'Contact details' } do %>
-        <%= form.govuk_email_field :email, label: { tag: 'h4', size: 's' } %>
-        <%= form.govuk_phone_field :phone, label: { tag: 'h4', size: 's' } %>
-      <% end %>
+      <%= form.govuk_text_field :title, width: 20 %>
+      <%= form.govuk_text_field :name %>
+      <%= form.govuk_email_field :email %>
+      <%= form.govuk_phone_field :phone, width: 10 %>
 
       <%= form.govuk_submit t("contact.edit.save_contact_button") do %>
         <%= govuk_link_to "Cancel", project_contacts_path(@project) %>

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @contact, url: project_contact_path(@project, @contact) do |form| %>
+    <%= form_for [@project, @contact] do |form| %>
       <%= form.govuk_error_summary %>
 
       <%= form.govuk_collection_select :category,

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -9,6 +9,11 @@
     <%= form_for @contact, url: project_contact_path(@project, @contact) do |form| %>
       <%= form.govuk_error_summary %>
 
+      <%= form.govuk_collection_select :category,
+        Contact.categories.map { |k, v| OpenStruct.new(id: k, name: format_category_name(k)) },
+        :id, :name,
+        label: { tag: 'h3', size: 'm' } %>
+
       <%= form.govuk_text_field :name, label: { tag: 'h3', size: 'm' } %>
       <%= form.govuk_text_field :title, label: { tag: 'h3', size: 'm' } %>
 

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -10,17 +10,14 @@
       <%= form.govuk_error_summary %>
 
       <%= form.govuk_collection_select :category,
-        Contact.categories.map { |k, v| OpenStruct.new(id: k, name: format_category_name(k)) },
-        :id, :name,
-        label: { tag: 'h3', size: 'm' } %>
+        Contact.categories.keys,
+        :to_s,
+        ->(category_name) {format_category_name(category_name) } %>
 
-      <%= form.govuk_text_field :name, label: { tag: 'h3', size: 'm' } %>
-      <%= form.govuk_text_field :title, label: { tag: 'h3', size: 'm' } %>
-
-      <%= form.govuk_fieldset legend: { text: 'Contact details' } do %>
-        <%= form.govuk_email_field :email, label: { tag: 'h4', size: 's' } %>
-        <%= form.govuk_phone_field :phone, label: { tag: 'h4', size: 's' } %>
-      <% end %>
+      <%= form.govuk_text_field :title, width: 20 %>
+      <%= form.govuk_text_field :name %>
+      <%= form.govuk_email_field :email %>
+      <%= form.govuk_phone_field :phone, width: 10 %>
 
       <%= form.govuk_submit t("contact.new.save_contact_button") do %>
         <%= govuk_link_to "Cancel", project_contacts_path(@project) %>

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @contact, url: project_contacts_path, method: :post do |form| %>
+    <%= form_for [@project, @contact] do |form| %>
       <%= form.govuk_error_summary %>
 
       <%= form.govuk_collection_select :category,

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -9,6 +9,11 @@
     <%= form_for @contact, url: project_contacts_path, method: :post do |form| %>
       <%= form.govuk_error_summary %>
 
+      <%= form.govuk_collection_select :category,
+        Contact.categories.map { |k, v| OpenStruct.new(id: k, name: format_category_name(k)) },
+        :id, :name,
+        label: { tag: 'h3', size: 'm' } %>
+
       <%= form.govuk_text_field :name, label: { tag: 'h3', size: 'm' } %>
       <%= form.govuk_text_field :title, label: { tag: 'h3', size: 'm' } %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,10 +130,11 @@ en:
     update:
       success: Contact has been updated successfully
     details:
-      long:
-        email: Email address
-        phone: Telephone number
-      edit_link: Edit %{contact_name}
+      name: Name
+      title: Role
+      email: Email
+      phone: Phone
+      edit_link: Change
   subnavigation:
     project_task_list: Task list
     project_information: Project information

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,6 +117,7 @@ en:
   contact:
     index:
       contacts: Contacts
+      category_heading: "%{category_name} contacts"
       add_contact_button: Add contact
       no_contacts_yet: There aren't any contacts for this project yet.
     new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,8 +121,8 @@ en:
       add_contact_button: Add contact
       no_contacts_yet: There aren't any contacts for this project yet.
     new:
-      title: Add a new contact
-      save_contact_button: Save contact
+      title: Add contact
+      save_contact_button: Add contact
     create:
       success: Contact has been added successfully
     edit:
@@ -151,8 +151,11 @@ en:
       note:
         body: Enter note
       contact:
-        email: Email address
-        phone: Telephone number
+        category: Contact for
+        title: Role
+        name: Name
+        email: Email
+        phone: Phone
     legend:
       project:
         target_completion_date: Target conversion date

--- a/db/migrate/20220826124914_add_category_to_contacts.rb
+++ b/db/migrate/20220826124914_add_category_to_contacts.rb
@@ -1,0 +1,6 @@
+class AddCategoryToContacts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :contacts, :category, :integer, null: false, default: 0
+    add_index :contacts, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_23_081934) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_26_124914) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -32,6 +32,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_23_081934) do
     t.string "phone"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "category", default: 0, null: false
+    t.index ["category"], name: "index_contacts_on_category"
     t.index ["project_id"], name: "index_contacts_on_project_id"
   end
 

--- a/spec/features/users_can_create_and_view_contacts_spec.rb
+++ b/spec/features/users_can_create_and_view_contacts_spec.rb
@@ -28,13 +28,13 @@ RSpec.feature "Users can view contacts" do
 
     expect(page).to have_current_path(new_project_contact_path(project))
 
-    select "Trust", from: "Category"
+    select "Trust", from: "Contact for"
     fill_in "Name", with: "Some One"
-    fill_in "Title", with: "Chief of Knowledge"
-    fill_in "Email address", with: "some@example.com"
-    fill_in "Telephone number", with: "01632 960456"
+    fill_in "Role", with: "Chief of Knowledge"
+    fill_in "Email", with: "some@example.com"
+    fill_in "Phone", with: "01632 960456"
 
-    click_button("Save contact")
+    click_button("Add contact")
 
     expect(page).to have_current_path(project_contacts_path(project_id))
 

--- a/spec/features/users_can_create_and_view_contacts_spec.rb
+++ b/spec/features/users_can_create_and_view_contacts_spec.rb
@@ -15,6 +15,8 @@ RSpec.feature "Users can view contacts" do
   scenario "User views contacts" do
     visit project_contacts_path(project_id)
 
+    expect(page).to have_content("Other contacts")
+
     expect_page_to_have_contact(
       name: "Jo Example",
       title: "CEO of Learning",
@@ -26,6 +28,7 @@ RSpec.feature "Users can view contacts" do
 
     expect(page).to have_current_path(new_project_contact_path(project))
 
+    select "Trust", from: "Category"
     fill_in "Name", with: "Some One"
     fill_in "Title", with: "Chief of Knowledge"
     fill_in "Email address", with: "some@example.com"
@@ -34,6 +37,9 @@ RSpec.feature "Users can view contacts" do
     click_button("Save contact")
 
     expect(page).to have_current_path(project_contacts_path(project_id))
+
+    expect(page).to have_content("Trust contacts")
+
     expect_page_to_have_contact(
       name: "Some One",
       title: "Chief of Knowledge",

--- a/spec/helpers/contacts_helper_spec.rb
+++ b/spec/helpers/contacts_helper_spec.rb
@@ -26,4 +26,14 @@ RSpec.describe ContactsHelper, type: :helper do
       end
     end
   end
+
+  describe "#format_category_name" do
+    context "given a category name" do
+      let(:category_name) { "test_category_with_spaces" }
+
+      it "formats the category name as expected" do
+        expect(helper.format_category_name(category_name)).to eq "Test category with spaces"
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes

Contacts can now be assigned to an organisation, and will be grouped accordingly.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
