### PR TITLE
(fix) doc directory is included in ci tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,7 @@ COPY bin ${APP_HOME}/bin
 COPY config ${APP_HOME}/config
 COPY lib ${APP_HOME}/lib
 COPY db ${APP_HOME}/db
+COPY doc ${APP_HOME}/doc
 COPY app ${APP_HOME}/app
 # End
 

--- a/doc/decisions/0011-use-sentry-io-for-error-reporting-and-performance-monitoring.md
+++ b/doc/decisions/0011-use-sentry-io-for-error-reporting-and-performance-monitoring.md
@@ -8,8 +8,8 @@ Accepted
 
 ## Context
 
-Monitoring errors that occur an application is a vital troubleshooting tool
-both in development and later when live.
+Monitoring errors that occur an application is a vital troubleshooting tool both
+in development and later when live.
 
 Many services exist to make this process as friction free as possible.
 
@@ -23,5 +23,5 @@ We will use [Sentry](https://sentry.io) for error reporting.
 ## Consequences
 
 - Onboarding new developers will involved granting access to the appropriate
-Sentry team and project.
+  Sentry team and project.
 - There may be a cost associated with the service.


### PR DESCRIPTION
## Changes

The doc directory was not included in the CI Docker image and so any formating errors would not be flagged in CI. Running locally does include the doc directory and reports errors, this cause confusion.

We store our docs in the code so they should form part of the CI tests we run.

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
