### PR TITLE
(449) Process action hint text through markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added content for confirm grant payment date with schoo action
 - Added content for checking school has received grant action
 - Project contacts can be grouped by the institution they belong to
+- Action hint text is parsed via Markdown to allow rich formatting
 
 ### Removed
 

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -20,7 +20,7 @@
       <%= form.govuk_check_box :completed_action_ids,
                                action.id,
                                label: { text: action.title },
-                               hint: { text: action.hint },
+                               hint: -> { sanitize GovukMarkdown.render(action.hint).gsub!('govuk-body-m', 'govuk-hint') },
                                link_errors: true,
                                checked: action.completed? %>
 


### PR DESCRIPTION
## Changes

This allows for rich formatting such as paragraphs, links and lists in hint text.

### Screenshots

#### Before

![localhost_3000_projects_7893AA86-C623-4CE6-B32D-3C7F318E5E14_tasks_4A639CC0-441C-4BEC-8243-50D48BFE0000 (1)](https://user-images.githubusercontent.com/619082/187875560-f6e2784e-6217-4fac-a802-7309825d42f6.png)


#### After

![localhost_3000_projects_7893AA86-C623-4CE6-B32D-3C7F318E5E14_tasks_4A639CC0-441C-4BEC-8243-50D48BFE0000](https://user-images.githubusercontent.com/619082/187875552-dbfbd026-fada-4f7d-9ea7-d539b57be180.png)


## Next steps

There are some open questions about if this is the best way to provide richer hints and if it introduces too much complexity in the page, but this will be addressed separately.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
