### PR TITLE
(486) Create Azure Container Registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@
 terraform.rc*
 *.tfstate*
 *.tfvars*
+!terraform.tfvars.example
 .terraform/
 backend.vars
 ### XML data

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -88,10 +88,9 @@ to use the settings you specified in the previous step.
 
 ##### Create a Terraform variables file
 
-Copy the `terraform.tfvars.example` to `terraform.tfvars` and modify the contents as required
+Each environment will need it's own `tfvars` file.
 
-If you do not wish to create the file, Terraform will ask you to provide the variables
-when you run it.
+Copy the `terraform.tfvars.example` to `environment-name.tfvars` and modify the contents as required
 
 ##### Create the infrastructure
 
@@ -109,12 +108,12 @@ Switch to the new or existing workspace:
 
 Plan the changes:
 
-`$ terraform plan`
+`$ terraform plan -var-file=staging.tfvars`
 
 Terraform will ask you to provide any variables not specified in an `*.auto.tfvars` file.
 Now you can run:
 
-`$ terraform apply`
+`$ terraform apply -var-file=staging.tfvars`
 
 If everything looks good, answer `yes` and wait for the new infrastructure to be created.
 
@@ -130,15 +129,24 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.20.0 |
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry) | resource |
+| [azurerm_resource_group.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Will be used along with `project_name` as a prefix for all resources. | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
+| <a name="input_resource_group"></a> [resource\_group](#input\_resource\_group) | Resource group name in which to launch resources. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/terraform/container-registry.tf
+++ b/terraform/container-registry.tf
@@ -1,0 +1,13 @@
+resource "azurerm_container_registry" "acr" {
+  name                = local.resource_prefix
+  resource_group_name = data.azurerm_resource_group.default.name
+  location            = local.azure_region
+  sku                 = "Standard"
+  admin_enabled       = true
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,3 @@
+data "azurerm_resource_group" "default" {
+  name = local.resource_group
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  environment     = var.environment
+  project_name    = var.project_name
+  resource_prefix = "${local.environment}${local.project_name}"
+  resource_group  = var.resource_group
+  azure_region    = data.azurerm_resource_group.default.location
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,3 +1,4 @@
 provider "azurerm" {
   features {}
+  skip_provider_registration = true
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,3 @@
+environment    = "test"
+project_name   = "my-project"
+resource_group = "resource-group-name"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,14 @@
+variable "environment" {
+  description = "Environment name. Will be used along with `project_name` as a prefix for all resources."
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name. Will be used along with `environment` as a prefix for all resources."
+  type        = string
+}
+
+variable "resource_group" {
+  description = "Resource group name in which to launch resources."
+  type        = string
+}


### PR DESCRIPTION
## Changes

* We need somewhere to store the image that will be created by Github
  actions
* This uses terraform to launch an Azure Container Registry within a
  given resource group
* `skip_provider_registration` has been set, as we will be using
    accounts that do not have the permissions to register new Azure
    resource providers. https://github.com/hashicorp/terraform-provider-azurerm/issues/7206

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
