### PR TITLE
(443) Chore: automate container image build in ci

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,0 +1,45 @@
+name: Continuous delivery
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build-and-push-image:
+    name: Build and push image
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Azure Container Registry login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DEVELOPMENT_AZURE_ACR_CLIENTID }}
+          password: ${{ secrets.DEVELOPMENT_AZURE_ACR_SECRET }}
+          registry: ${{ secrets.DEVELOPMENT_ACR_URL }}
+
+      - name: Prepare tags
+        id: prepare-tags
+        run: |
+          DOCKER_IMAGE=${{ secrets.DEVELOPMENT_ACR_URL }}/complete-app
+          VERSION=latest
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            VERSION=sha-${GITHUB_SHA}
+            TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
+          fi
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=deploy-version::${VERSION}
+
+      - name: Push image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: |
+            RAILS_ENV=development
+          push: true
+          tags: ${{ steps.prepare-tags.outputs.tags }}


### PR DESCRIPTION
## Changes
This gets us on the road to deployments, we build our application docker image and push it to the Azure container registry we created with the new Terraform.

There is still plenty to do, but this work let's us confirm the basics are working.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
