### PR TITLE
(481) Fix: Guard against an Action hint being nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Tasks that have actions without hint text can now be rendered.
+
 ## [Release 2][release-2]
 
 ### Added
@@ -106,4 +110,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/commits/develop/compare/release-1...release-2
 [release-1]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/releases/tag/release-1
-

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -20,7 +20,9 @@
       <%= form.govuk_check_box :completed_action_ids,
                                action.id,
                                label: { text: action.title },
-                               hint: -> { sanitize GovukMarkdown.render(action.hint).gsub!('govuk-body-m', 'govuk-hint') },
+                               hint: -> {
+                                 sanitize GovukMarkdown.render(action.hint).gsub!('govuk-body-m', 'govuk-hint') unless action.hint.nil?
+                               },
                                link_errors: true,
                                checked: action.completed? %>
 

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe TasksController, type: :request do
       expect(subject).to have_http_status :success
       expect(subject.body).to include("Have you cleared the Supplementary funding agreement?")
     end
+
+    it "can render actions with and without hint text" do
+      _action_with_hint = create(:action, hint: "A hint.", task: task)
+      _action_without_hint = create(:action, hint: nil, task: task)
+
+      expect { perform_request }.not_to raise_error
+    end
   end
 
   describe "#update" do


### PR DESCRIPTION
## Changes

The GovukMarkdown.render method expects a string and cannot handle nil.

Action hints are optional so we have lots of instances where the
`Action.hint` is nil.

Adding this guard clause means the view can still be rendered where
there are actions without a hint.

https://trello.com/c/FJaXxrXz

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
