### PR TITLE
(452) Feature: Add diocese details to project information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add a bulk user import Rake task.
 - Collect Azure Active Directory User ID on sign in.
+- The school diocese name is shown on project details or not applicable.
 
 ### Changed
 

--- a/app/models/academies_api/establishment.rb
+++ b/app/models/academies_api/establishment.rb
@@ -5,7 +5,8 @@ class AcademiesApi::Establishment < AcademiesApi::BaseApiModel
     :type,
     :age_range_lower,
     :age_range_upper,
-    :phase
+    :phase,
+    :diocese_name
   )
 
   def self.attribute_map
@@ -15,7 +16,8 @@ class AcademiesApi::Establishment < AcademiesApi::BaseApiModel
       type: "establishmentType.name",
       age_range_lower: "statutoryLowAge",
       age_range_upper: "statutoryHighAge",
-      phase: "phaseOfEducation.name"
+      phase: "phaseOfEducation.name",
+      diocese_name: "diocese.name"
     }
   end
 end

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -61,3 +61,11 @@ end %>
     row.value { @project.establishment.local_authority }
   end
 end %>
+
+<h2 class="govuk-heading-l" id="dioceseDetails"><%= t('project_information.show.diocese_details.title') %></h2>
+<%= govuk_summary_list(actions: false) do |summary_list|
+  summary_list.row do |row|
+    row.key { t('project_information.show.diocese_details.rows.diocese') }
+    row.value { @project.establishment.diocese_name }
+  end
+end %>

--- a/app/views/project_information/show/_side_navigation.html.erb
+++ b/app/views/project_information/show/_side_navigation.html.erb
@@ -5,5 +5,6 @@
     <%= render partial: "shared/side_navigation_item", locals: { name: t("project_information.show.school_details.title"), path: "#schoolDetails" } %>
     <%= render partial: "shared/side_navigation_item", locals: { name: t("project_information.show.trust_details.title"), path: "#trustDetails" } %>
     <%= render partial: "shared/side_navigation_item", locals: { name: t("project_information.show.local_authority_details.title"), path: "#localAuthorityDetails" } %>
+    <%= render partial: "shared/side_navigation_item", locals: { name: t("project_information.show.diocese_details.title"), path: "#dioceseDetails" } %>
   </ul>
 </nav>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,6 +108,10 @@ en:
         title: Local authority details
         rows:
           local_authority: Local authority
+      diocese_details:
+        title: Diocese details
+        rows:
+          diocese: Diocese
   note:
     index:
       notes: Notes

--- a/spec/factories/academies_api/establishment.rb
+++ b/spec/factories/academies_api/establishment.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     age_range_lower { 11 }
     age_range_upper { 18 }
     phase { "Secondary" }
+    diocese_name { "Diocese of West Placefield" }
   end
 end

--- a/spec/features/users_can_view_project_information_spec.rb
+++ b/spec/features/users_can_view_project_information_spec.rb
@@ -32,6 +32,12 @@ RSpec.feature "Users can view project information" do
 
     expect(page).to have_content("Local authority details")
     page_has_project_information_list_row(label: "Local authority", information: "West Placefield Council")
+
+    expect(page).to have_content(I18n.t("project_information.show.diocese_details.title"))
+    page_has_project_information_list_row(
+      label: I18n.t("project_information.show.diocese_details.rows.diocese"),
+      information: project.establishment.diocese_name
+    )
   end
 
   private def page_has_project_information_list_row(label:, information:, link: nil)


### PR DESCRIPTION
## Changes
A diocese is available only on certain types of faith schools.

Here we add the diocese name to the attributes we get on an
establishment from the Academies API and show that on the project
information view.

The default behaviour of showing 'not applicable' may not be the best
for this attribute, but it is good enough for this version.

https://trello.com/c/T83NT5uu

## Screenshots
![Screenshot 2022-09-05 at 14-05-12 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/188456399-3165c3bd-9e8a-4eb1-b150-8e4948ae264b.png)
![Screenshot 2022-09-05 at 14-04-54 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/188456411-9d96dea0-ea1f-4478-b01d-f36d2d244dd8.png)

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
