### PR TITLE
(451) Add optional handover comment field to the new project form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   show email only.
 - Show the full name of the note author if available. If it is not available,
   fall back to showing the email address.
+- Add an optional "Handover comments" input to the new project form. This will
+  create the first project note.
 
 ### Fixed
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -19,9 +19,10 @@ class ProjectsController < ApplicationController
   end
 
   def create
-    @project = Project.new(project_params)
+    @note = Note.new(**note_params, user_id: user_id)
+    @project = Project.new(**project_params, regional_delivery_officer_id: user_id, notes_attributes: [@note.attributes])
+
     authorize @project
-    assign_regional_delivery_officer
 
     if @project.valid?
       @project.save
@@ -59,9 +60,12 @@ class ProjectsController < ApplicationController
     params.require(:project).permit(
       :urn,
       :trust_ukprn,
-      :target_completion_date,
-      :regional_delivery_officer_id
+      :target_completion_date
     )
+  end
+
+  private def note_params
+    params.require(:project).require(:note).permit(:body)
   end
 
   private def case_worker_id
@@ -70,9 +74,5 @@ class ProjectsController < ApplicationController
 
   private def assign_team_leader
     @project.team_leader_id = user_id
-  end
-
-  private def assign_regional_delivery_officer
-    @project.regional_delivery_officer_id = user_id
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,6 +3,8 @@ class Project < ApplicationRecord
   has_many :notes, dependent: :destroy
   has_many :contacts, dependent: :destroy
 
+  accepts_nested_attributes_for :notes, reject_if: proc { |attributes| attributes[:body].blank? }
+
   validates :urn, presence: true, numericality: {only_integer: true}, length: {is: 6}
   validates :trust_ukprn, presence: true, numericality: {only_integer: true}
   validates :target_completion_date, presence: true

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -11,5 +11,10 @@
   <%= form.govuk_text_field :urn, label: { size: 'm' }, width: 10 %>
   <%= form.govuk_text_field :trust_ukprn, label: { size: 'm' }, width: 10 %>
   <%= form.govuk_date_field :target_completion_date, omit_day: true %>
+
+  <%= form.fields_for :note, @note do |note_form| %>
+    <%= note_form.govuk_text_area :body, label: {text: t("project.new.handover_comments_label"), size: 'm'} %>
+  <% end %>
+
   <%= form.govuk_submit %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,7 @@ en:
         text: Edit
     new:
       title: Add a new project
+      handover_comments_label: Handover comments
     create:
       success: Project has been created successfully
     edit:

--- a/spec/features/users_can_create_projects_spec.rb
+++ b/spec/features/users_can_create_projects_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature "Users can create new projects" do
       fill_in "Incoming trust UK Provider Reference Number (UKPRN)", with: ukprn
       fill_in "Month", with: 12
       fill_in "Year", with: 2025
+      fill_in "Handover comments", with: "A new handover comment"
 
       click_button("Continue")
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -17,6 +17,31 @@ RSpec.describe Project, type: :model do
     it { is_expected.to belong_to(:caseworker).required(false) }
     it { is_expected.to belong_to(:team_leader).required(false) }
 
+    describe "accept nested attributes for note" do
+      let(:user) { create(:user) }
+      let(:note_attributes) { attributes_for(:note, body: note_body, project: nil, user: user) }
+      let(:project_attributes) { attributes_for(:project) }
+
+      before { Project.create!(**project_attributes, notes_attributes: [note_attributes]) }
+
+      context "when the note body is blank" do
+        let(:note_body) { nil }
+
+        it "does not save the note" do
+          expect(Note.count).to be 0
+        end
+      end
+
+      context "when the note body is not blank" do
+        let(:note_body) { "A new note" }
+
+        it "saves the note" do
+          expect(Note.count).to be 1
+          expect(Note.last.body).to eq note_body
+        end
+      end
+    end
+
     describe "delete related entities" do
       context "when the project is deleted" do
         it "destroys all the related notes, contacts, sections leaving nothing orphaned" do

--- a/spec/requests/projects_controller_spec.rb
+++ b/spec/requests/projects_controller_spec.rb
@@ -9,14 +9,16 @@ RSpec.describe ProjectsController, type: :request do
   end
 
   describe "#create" do
+    let(:project) { build(:project) }
+    let(:project_params) { attributes_for(:project, regional_delivery_officer: nil) }
+    let(:note_params) { {body: "new note"} }
+
     subject(:perform_request) do
-      post projects_path, params: {project: {urn: 123456}}
+      post projects_path, params: {project: {**project_params, note: note_params}}
       response
     end
 
     context "when the project is not valid" do
-      let(:project) { build(:project, team_leader: nil) }
-
       before do
         allow(Project).to receive(:new).and_return(project)
         allow(project).to receive(:valid?).and_return false
@@ -28,18 +30,37 @@ RSpec.describe ProjectsController, type: :request do
     end
 
     context "when the project is valid" do
-      let(:project) { build(:project, team_leader: nil) }
+      let(:task_list_creator) { TaskListCreator.new }
 
       before do
         mock_successful_api_responses(urn: 123456, ukprn: 10061021)
-        allow(Project).to receive(:new).and_return(project)
-        allow(project).to receive(:valid?).and_return(true)
+
+        allow(TaskListCreator).to receive(:new).and_return(task_list_creator)
+        allow(task_list_creator).to receive(:call).and_return true
+
+        perform_request
       end
 
-      it "assigns the team leader, calls the TaskListCreator, and redirects to the project path" do
-        expect_any_instance_of(TaskListCreator).to receive(:call).with(project)
-        expect(perform_request).to redirect_to(project_path(project.id))
-        expect(project.regional_delivery_officer).to eq regional_delivery_officer
+      it "assigns the regional delivery officer, calls the TaskListCreator, and redirects to the project path" do
+        new_project_record = Project.last
+
+        expect(response).to redirect_to(project_path(Project.first.id))
+        expect(task_list_creator).to have_received(:call).with(new_project_record)
+        expect(new_project_record.regional_delivery_officer).to eq regional_delivery_officer
+      end
+
+      it "creates a new project and note" do
+        expect(Project.count).to be 1
+        expect(Note.count).to be 1
+        expect(Note.last.user).to eq regional_delivery_officer
+      end
+
+      context "when the note body is empty" do
+        let(:note_params) { {body: ""} }
+
+        it "does not create a new note" do
+          expect(Note.count).to be 0
+        end
       end
     end
   end


### PR DESCRIPTION
## Changes

The handover proforma and KIM allow users to add a handover note. We want to replicate this by adding an optional "handover comment" field to the new project form. This will create a new `Note` record for the `Project`.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
