### PR TITLE
(417) Add accessible-autocomplete to caseworker dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add a bulk user import Rake task.
 - Collect Azure Active Directory User ID on sign in.
 - The school diocese name is shown on project details or not applicable.
+- Selecting a caseworker will now offer to autocomplete if the user has Javascript enabled
 
 ### Changed
 

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -10,3 +10,4 @@
 //= link govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-152x152.png
 //= link govuk-frontend/govuk/assets/images/govuk-apple-touch-icon.png
 //= link govuk-frontend/govuk/assets/images/govuk-opengraph-image.png
+//= link accessible-autocomplete/dist/accessible-autocomplete.min.js

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,7 @@ $govuk-global-styles: true;
 
 @import "govuk-frontend/govuk/all";
 @import "@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";
+@import "accessible-autocomplete/src/autocomplete";
 
 @import "components/task-list";
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,4 +44,5 @@
     
   </body>
   <%= javascript_include_tag "application" %>
+  <%= yield :footer_post_js %>
 </html>

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -23,3 +23,12 @@
 
   </div>
 </div>
+
+<% content_for :footer_post_js do %>
+  <%= javascript_include_tag "accessible-autocomplete/dist/accessible-autocomplete.min" %>
+  <script>
+    accessibleAutocomplete.enhanceSelectElement({
+      selectElement: document.querySelector('#project-caseworker-id-field')
+    })
+  </script>
+<% end %>

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prettier": "^2.7.1"
   },
   "dependencies": {
-    "@ministryofjustice/frontend": "^1.4.2"
+    "@ministryofjustice/frontend": "^1.4.2",
+    "accessible-autocomplete": "^2.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,6 +70,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+accessible-autocomplete@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz#e295256c8d268b97c5ab456a1cb084b553ed3eb0"
+  integrity sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==
+  dependencies:
+    preact "^8.3.1"
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
@@ -714,6 +721,11 @@ picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+preact@^8.3.1:
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.3.tgz#78c2a5562fcecb1fed1d0055fa4ac1e27bde17c1"
+  integrity sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Changes

When selecting a caseworker, if the user has Javascript enabled the default select dropdown is replaced with an accessible autocomplete input.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
