### PR TITLE
(495) Exclude terraform folder from Prettier checks

### DIFF
--- a/.github/workflows/continuous-integration-terraform.yml
+++ b/.github/workflows/continuous-integration-terraform.yml
@@ -10,39 +10,39 @@ jobs:
     name: Terraform Validate
     runs-on: ubuntu-latest
     steps:
-    - name: Check out code
-      uses: actions/checkout@v3
+      - name: Check out code
+        uses: actions/checkout@v3
 
-    - name: Check for terraform version mismatch
-      run: |
-        DOTFILE_VERSION=$(cat terraform/.terraform-version)
-        TERRAFORM_IMAGE_REFERENCES=$(grep "uses: docker://hashicorp/terraform" .github/workflows/terraform-ci.yml | grep -v TERRAFORM_IMAGE_REFERENCES | wc -l | tr -d ' ')
-        if [ "$(grep "docker://hashicorp/terraform:${DOTFILE_VERSION}" .github/workflows/terraform-ci.yml | wc -l | tr -d ' ')" != "$TERRAFORM_IMAGE_REFERENCES" ]
-        then
-          echo -e "\033[1;31mError: terraform version in .terraform-version file does not match docker://hashicorp/terraform versions in .github/workflows/main.yml"
-          exit 1
-        fi
+      - name: Check for terraform version mismatch
+        run: |
+          DOTFILE_VERSION=$(cat terraform/.terraform-version)
+          TERRAFORM_IMAGE_REFERENCES=$(grep "uses: docker://hashicorp/terraform" .github/workflows/terraform-ci.yml | grep -v TERRAFORM_IMAGE_REFERENCES | wc -l | tr -d ' ')
+          if [ "$(grep "docker://hashicorp/terraform:${DOTFILE_VERSION}" .github/workflows/terraform-ci.yml | wc -l | tr -d ' ')" != "$TERRAFORM_IMAGE_REFERENCES" ]
+          then
+            echo -e "\033[1;31mError: terraform version in .terraform-version file does not match docker://hashicorp/terraform versions in .github/workflows/main.yml"
+            exit 1
+          fi
 
-    - name: Remove azure backend
-      run: rm ./terraform/backend.tf
+      - name: Remove azure backend
+        run: rm ./terraform/backend.tf
 
-    - name: Run a Terraform init
-      uses: docker://hashicorp/terraform:1.2.8
-      with:
-        entrypoint: terraform
-        args: -chdir=terraform init
+      - name: Run a Terraform init
+        uses: docker://hashicorp/terraform:1.2.8
+        with:
+          entrypoint: terraform
+          args: -chdir=terraform init
 
-    - name: Run a Terraform validate
-      uses: docker://hashicorp/terraform:1.2.8
-      with:
-        entrypoint: terraform
-        args: -chdir=terraform validate
+      - name: Run a Terraform validate
+        uses: docker://hashicorp/terraform:1.2.8
+        with:
+          entrypoint: terraform
+          args: -chdir=terraform validate
 
-    - name: Run a Terraform format check
-      uses: docker://hashicorp/terraform:1.2.8
-      with:
-        entrypoint: terraform
-        args: -chdir=terraform fmt -check=true -diff=true
+      - name: Run a Terraform format check
+        uses: docker://hashicorp/terraform:1.2.8
+        with:
+          entrypoint: terraform
+          args: -chdir=terraform fmt -check=true -diff=true
   terraform-docs-validation:
     name: Terraform Docs validation
     needs: terraform-validate

--- a/.prettierignore
+++ b/.prettierignore
@@ -27,3 +27,4 @@
 *.gz
 /public/assets/*
 /coverage
+/terraform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add a bulk user import Rake task.
 - Collect Azure Active Directory User ID on sign in.
 - The school diocese name is shown on project details or not applicable.
-- Selecting a caseworker will now offer to autocomplete if the user has Javascript enabled
+- Selecting a caseworker will now offer to autocomplete if the user has
+  Javascript enabled
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ to monitor errors and the performance of the application.
 We use infrastructure as code ([Terraform](https://www.terraform.io/)) to deploy and manage resources hosting the app.
 This is stored in the `terraform` directory.
 
-Documentation: [terraform/README.md](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/blob/main/terraform/README.md)
+Documentation: [terraform/README.md](/terraform/README.md)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ to monitor errors and the performance of the application.
 
 ## Infrastructure
 
-We use infrastructure as code ([Terraform](https://www.terraform.io/)) to deploy and manage resources hosting the app.
-This is stored in the `terraform` directory.
+We use infrastructure as code ([Terraform](https://www.terraform.io/)) to deploy
+and manage resources hosting the app. This is stored in the `terraform`
+directory.
 
 Documentation: [terraform/README.md](/terraform/README.md)


### PR DESCRIPTION
## Changes

Files in `/terraform` were being checked by Prettier locally, but not in CI, leading to unexpected local failures and introducing a chance of unintended changes being committed.

This now excludes this folder from all Prettier checks.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
