### PR TITLE
(483) Store assignment timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The school diocese name is shown on project details or not applicable.
 - Selecting a caseworker will now offer to autocomplete if the user has
   Javascript enabled
+- The date and time that a caseworker is first assigned to a project is
+  recorded. Any subsequent assignments will not be recorded.
 
 ### Changed
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -45,7 +45,7 @@ class ProjectsController < ApplicationController
     @project = Project.find(params[:id])
     authorize @project
 
-    @project.assign_attributes(case_worker_id)
+    assign_caseworker(caseworker_id)
     assign_team_leader
 
     @project.save
@@ -68,11 +68,16 @@ class ProjectsController < ApplicationController
     params.require(:project).require(:note).permit(:body)
   end
 
-  private def case_worker_id
+  private def caseworker_id
     params.require(:project).permit(:caseworker_id)
   end
 
   private def assign_team_leader
     @project.team_leader_id = user_id
+  end
+
+  private def assign_caseworker(caseworker_id)
+    @project.assign_attributes(caseworker_id)
+    @project.assign_attributes(caseworker_assigned_at: DateTime.now) if @project.caseworker_assigned_at.nil?
   end
 end

--- a/db/migrate/20220906094506_add_caseworker_assigned_at_to_project.rb
+++ b/db/migrate/20220906094506_add_caseworker_assigned_at_to_project.rb
@@ -1,0 +1,5 @@
+class AddCaseworkerAssignedAtToProject < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :caseworker_assigned_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_01_125956) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_06_094506) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -56,6 +56,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_01_125956) do
     t.date "target_completion_date", null: false
     t.uuid "regional_delivery_officer_id"
     t.uuid "caseworker_id"
+    t.datetime "caseworker_assigned_at"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"
     t.index ["team_leader_id"], name: "index_projects_on_team_leader_id"

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_db_column(:target_completion_date).of_type :date }
     it { is_expected.to have_db_column(:caseworker_id).of_type :uuid }
     it { is_expected.to have_db_column(:team_leader_id).of_type :uuid }
+    it { is_expected.to have_db_column(:caseworker_assigned_at).of_type :datetime }
   end
 
   describe "Relationships" do


### PR DESCRIPTION
## Changes
### Add caseworker_assigned_at field to Project that can only be set once
We want to record the time that a project has been assigned to a caseworker. This will represent the start point when measuring how long it takes a project in the service to reach completion.

This adds a `caseworker_assigned_at` timestamp to the `Project`. Because we should not update this value once it has been set, we override the setter to raise an error if this is attempted (this seems like it will more useful to future devs than just an early return).

### Set `caseworker_assigned_at` timestamp when caseworker first assigned
We only want to set the `caseworker_assigned_at` timestamp once.

This assigns the timestamp in the controller conditionally on whether the timestamp has been previously set.

This also contains very small tidy-up to update any instances of "case_worker" to "caseworker" for consistency.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
