### PR TITLE
Add GitHub Actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,12 @@ updates:
     open-pull-requests-limit: 10
     versioning-strategy: auto
     target-branch: main
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "11:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 10
+    versioning-strategy: auto
+    target-branch: main


### PR DESCRIPTION
## Changes

Some of our Github actions were running against older versions. This change allows dependabot to scan the `.github/workflows` folder and open pull requests when action versions change.

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
