### PR TITLE
(478) Contacts can be deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Javascript enabled
 - The date and time that a caseworker is first assigned to a project is
   recorded. Any subsequent assignments will not be recorded.
+- Contacts can be deleted via a button on the edit contact page.
 
 ### Changed
 

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -47,6 +47,10 @@ class ContactsController < ApplicationController
     redirect_to project_contacts_path(@project), notice: I18n.t("contact.destroy.success")
   end
 
+  def confirm_destroy
+    @contact = Contact.find(params[:contact_id])
+  end
+
   private def find_project
     @project = Project.find(params[:project_id])
   end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -40,6 +40,13 @@ class ContactsController < ApplicationController
     end
   end
 
+  def destroy
+    @contact = Contact.find(params[:id])
+    @contact.destroy
+
+    redirect_to project_contacts_path(@project), notice: I18n.t("contact.destroy.success")
+  end
+
   private def find_project
     @project = Project.find(params[:project_id])
   end

--- a/app/views/contacts/confirm_destroy.html.erb
+++ b/app/views/contacts/confirm_destroy.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-grid-row govuk-body">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for [@project, @contact], path: project_contact_path(@project, @contact), method: :delete do |form| %>
+      <h1 class="govuk-heading-l"><%= t("contact.confirm_destroy.title", contact_name: @contact.name) %></h1>
+      <p><%= t("contact.confirm_destroy.guidance", contact_title: @contact.title, contact_name: @contact.name) %></p>
+
+      <%= form.govuk_submit "Delete", warning: true do %>
+        <%= govuk_link_to "Cancel", edit_project_contact_path(@project, @contact) %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -20,6 +20,7 @@
       <%= form.govuk_phone_field :phone, width: 10 %>
 
       <%= form.govuk_submit t("contact.edit.save_contact_button") do %>
+        <%= govuk_button_link_to "Delete", project_contact_delete_path(@project, @contact), warning: true %>
         <%= govuk_link_to "Cancel", project_contacts_path(@project) %>
       <% end %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,6 +140,10 @@ en:
       success: Contact has been updated successfully
     destroy:
       success: Contact has been deleted successfully
+    confirm_destroy:
+      title:
+        Are you sure you want to delete %{contact_name}?
+      guidance: This will remove the contact for %{contact_title} called %{contact_name} from the contacts list.
     details:
       name: Name
       title: Role

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,6 +138,8 @@ en:
       save_contact_button: Save contact
     update:
       success: Contact has been updated successfully
+    destroy:
+      success: Contact has been deleted successfully
     details:
       name: Name
       title: Role

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,9 @@ Rails.application.routes.draw do
   resources :projects do
     resources :tasks
     resources :notes
-    resources :contacts
+    resources :contacts do
+      get "/delete", action: :confirm_destroy
+    end
   end
 
   get "/projects/:id/information", to: "project_information#show", as: :project_information

--- a/spec/requests/contacts_controller_spec.rb
+++ b/spec/requests/contacts_controller_spec.rb
@@ -183,4 +183,20 @@ RSpec.describe ContactsController, type: :request do
       expect(Contact.where(id: contact_id)).to_not exist
     end
   end
+
+  describe "#confirm_destroy" do
+    let(:project) { create(:project) }
+    let(:project_id) { project.id }
+    let(:contact) { create(:contact) }
+    let(:contact_id) { contact.id }
+
+    subject(:perform_request) do
+      get project_contact_delete_path(project_id, contact_id)
+      response
+    end
+
+    it "returns a successful response" do
+      expect(subject).to have_http_status :success
+    end
+  end
 end

--- a/spec/requests/contacts_controller_spec.rb
+++ b/spec/requests/contacts_controller_spec.rb
@@ -164,4 +164,23 @@ RSpec.describe ContactsController, type: :request do
       end
     end
   end
+
+  describe "#destroy" do
+    let(:project) { create(:project) }
+    let(:project_id) { project.id }
+    let(:contact) { create(:contact) }
+    let(:contact_id) { contact.id }
+
+    subject(:perform_request) do
+      delete project_contact_path(project_id, contact_id)
+      response
+    end
+
+    it "deletes the contact and redirects to the index view with a success message" do
+      expect(perform_request).to redirect_to(project_contacts_path(project.id))
+      expect(request.flash[:notice]).to eq(I18n.t("contact.destroy.success"))
+
+      expect(Contact.where(id: contact_id)).to_not exist
+    end
+  end
 end


### PR DESCRIPTION
## Changes
### Add destroy action to the ContactsController
We want users to be able to delete contacts. Add the destroy action to the ContactsController

### Add `confirm_destroy` action to the ContactsController
We want to show an "Are you sure?" page when a user selects to delete a contact.

Add a `confirm_destroy` action to the ContactsController that will be used to show the "Are you sure?" page.

### Enable user to delete contacts
This adds a delete contact confirmation page, which is accessed through a link on the edit contacts page.

## Screenshots
![image](https://user-images.githubusercontent.com/47089130/188857499-2b676590-e32f-4ba6-9bad-2829950e7100.png)

![image](https://user-images.githubusercontent.com/47089130/188857542-5fd145f4-02a0-45a7-8718-51a957c91aa4.png)

![image](https://user-images.githubusercontent.com/47089130/188857571-0d7d5dd8-e813-4c59-a821-f3697d0a7d64.png)


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
