### PR TITLE
Fix: default rake task error in production

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,8 @@
 require_relative "config/application"
 
 Rails.application.load_tasks
-Rake::Task["default"].clear
-task default: %i[standard spec]
+
+if defined?(RSpec::Rails)
+  Rake::Task[:default].clear
+  task default: %i[standard spec]
+end


### PR DESCRIPTION
## Changes
The default rake task is the one that runs when you call `bin/rails`
without anything.

It's actually set to the `spec` task by the rspec-rails gem [1]. We like
our linter to run first so we cleared the task and set it to `standard`
then `spec`, however in production the rpec-rails gem is not loaded so
the default rake task is never set and trying to clear it results in an
error.

Here we check for the presence of the rspec-rails gem (via the RSpec::Rails
module) before we try to clear the default task.

[1] https://github.com/rspec/rspec-rails/blob/21731ed0aba404a46a63db32136b0756d2cb1060/lib/rspec/rails/tasks/rspec.rake#L6

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
