### PR TITLE
Set database `Azure` flag

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -21,4 +21,5 @@ test:
 
 production:
   <<: *default
+  azure: true
   database: sip


### PR DESCRIPTION
## Changes

* We are using an Azure SQL database
* This setting is needed to specify the default database name in the login packet since Azure has no notion of `USE [database]`
* https://github.com/rails-sqlserver/tiny_tds#using-tinytds-with-azure

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
