### PR TITLE
Fix: do not use a css compressor in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,8 +24,11 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
-  # Compress CSS using a preprocessor.
-  # config.assets.css_compressor = :sass
+  # explicitly disable the CSS compressor
+  config.assets.css_compressor = nil
+
+  # compress the sass with sassc
+  config.sass.style = :compressed
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
## Changes
This known issue with sassc and the GOV.UK kit [1] can be avoided by explicitally setting `config.assets.css_compressor` to nil and then enabling compression in sassc with:

`config.sass.style`

[1] https://github.com/alphagov/govuk-frontend/issues/1350#issuecomment-493129270

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
