### PR TITLE
Fix: Remove unnecessary dependabot config to try address intermittent test failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,12 +18,11 @@ updates:
     open-pull-requests-limit: 10
     versioning-strategy: auto
     target-branch: main
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
       time: "11:00"
       timezone: Europe/London
     open-pull-requests-limit: 10
-    versioning-strategy: auto
     target-branch: main


### PR DESCRIPTION
## Changes

We were seeing some internittent issues that linked to this, but are not
100% confident this is the fix.

We do know that github-actions for dependabot does not use
versioning-strategy[1] so we remove it.

Also removed the quotes for consistency with the rest of the file.

[1] https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy
## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
