### PR TITLE
(491) Make user `caseworker` role explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   fall back to showing the email address.
 - Add an optional "Handover comments" input to the new project form. This will
   create the first project note.
+- The caseworker role is no longer implied from the lack of any other roles.
+  Instead, users must be explicitly given the caseworker role.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ The headers of the CSV must be consistent with the attributes on the `user`
 model. Boolean values can be indicated by `0` and `1`, all values should be
 provided to avoid not-null constraint errors. For example:
 
-| email                     | first_name | last_name | team_leader | regional_delivery_officer |
-| ------------------------- | ---------- | --------- | ----------- | ------------------------- |
-| john.doe@education.gov.uk | John       | Doe       | 1           | 0                         |
-| jane.doe@education.gov.uk | Jane       | Doe       | 0           | 1                         |
+| email                       | first_name | last_name | team_leader | regional_delivery_officer | caseworker |
+| --------------------------- | ---------- | --------- | ----------- | ------------------------- | ---------- |
+| john.doe@education.gov.uk   | John       | Doe       | 1           | 0                         | 0          |
+| jane.doe@education.gov.uk   | Jane       | Doe       | 0           | 1                         | 0          |
+| joseph.doe@education.gov.uk | Joseph     | Doe       | 0           | 0                         | 1          |
 
 ## ADRs
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   has_many :projects, foreign_key: "caseworker"
   has_many :notes
 
-  scope :caseworkers, -> { where(team_leader: false).and(where(regional_delivery_officer: false)) }
+  scope :caseworkers, -> { where(caseworker: true) }
 
   def full_name
     "#{first_name} #{last_name}" if first_name.present? && last_name.present?

--- a/db/migrate/20220906151837_add_caseworker_to_user.rb
+++ b/db/migrate/20220906151837_add_caseworker_to_user.rb
@@ -1,0 +1,5 @@
+class AddCaseworkerToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :caseworker, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_06_094506) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_06_151837) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -96,6 +96,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_06_094506) do
     t.string "first_name"
     t.string "last_name"
     t.string "active_directory_user_id"
+    t.boolean "caseworker", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -5,9 +5,11 @@ FactoryBot.define do
     last_name { "Doe" }
     team_leader { false }
     regional_delivery_officer { false }
+    caseworker { false }
 
     trait :caseworker do
       email { "caseworker@education.gov.uk" }
+      caseworker { true }
     end
 
     trait :team_leader do

--- a/spec/features/users_can_update_projects_spec.rb
+++ b/spec/features/users_can_update_projects_spec.rb
@@ -48,8 +48,8 @@ end
 
 RSpec.feature "Users can update a project" do
   let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
-  let!(:caseworker) { create(:user, email: "user1@education.gov.uk") }
-  let!(:caseworker_2) { create(:user, email: "user2@education.gov.uk") }
+  let!(:caseworker) { create(:user, :caseworker, email: "user1@education.gov.uk") }
+  let!(:caseworker_2) { create(:user, :caseworker, email: "user2@education.gov.uk") }
 
   context "the user is a team leader" do
     before do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,20 +7,18 @@ RSpec.describe User do
     it { is_expected.to have_db_column(:last_name).of_type :string }
     it { is_expected.to have_db_column(:team_leader).of_type :boolean }
     it { is_expected.to have_db_column(:regional_delivery_officer).of_type :boolean }
+    it { is_expected.to have_db_column(:caseworker).of_type :boolean }
   end
 
   describe "scopes" do
     describe "caseworkers" do
-      it "only includes users that are not team lead or regional delivery officer" do
-        caseworker = create(:user, :caseworker)
-        team_lead = create(:user, :team_leader)
-        regional_delivery_officer = create(:user, :regional_delivery_officer)
+      let!(:caseworker) { create(:user, :caseworker) }
+      let!(:team_lead) { create(:user, :team_leader) }
+      let!(:regional_delivery_officer) { create(:user, :regional_delivery_officer) }
 
-        caseworkers = User.caseworkers
-
-        expect(caseworkers).not_to include team_lead
-        expect(caseworkers).not_to include regional_delivery_officer
-        expect(caseworkers).to include caseworker
+      it "only includes users that have the caseworker role" do
+        expect(User.caseworkers.count).to be 1
+        expect(User.caseworkers).to include caseworker
       end
     end
   end


### PR DESCRIPTION
## Changes
We want to make the `caseworker` role explicit rather than inferring it from the lack of any other role.

This adds a new column to the User model of `caseworker`,  and updates the existing code to use this.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
