### PR TITLE
(500) Update task list content and layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Instead, users must be explicitly given the caseworker role.
 - Improved the layout of the new project page.
 - Improve the layout of the task page.
+- Update the content for the "Project kick-off" section of the task list.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Tasks that have actions without hint text can now be rendered.
+- Links on the task list now open in a new tab.
 
 ## [Release 2][release-2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The caseworker role is no longer implied from the lack of any other roles.
   Instead, users must be explicitly given the caseworker role.
 - Improved the layout of the new project page.
+- Improve the layout of the task page.
 
 ### Fixed
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,11 @@ $govuk-global-styles: true;
 }
 
 .task-checkboxes {
+  .govuk-checkboxes__item,
+  .govuk-checkboxes__divider {
+    margin-bottom: govuk-spacing(9);
+  }
+
   .govuk-checkboxes__item {
     label {
       @extend .govuk-\!-font-weight-bold;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,3 +12,11 @@ $govuk-global-styles: true;
 .list-style-none {
   list-style: none;
 }
+
+.task-checkboxes {
+  .govuk-checkboxes__item {
+    label {
+      @extend .govuk-\!-font-weight-bold;
+    }
+  }
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+  def render_markdown(markdown, hint: false)
+    additional_attributes = ["target"]
+    default_attributes = Loofah::HTML5::WhiteList::ALLOWED_ATTRIBUTES
+
+    rendered_markdown = GovukMarkdown.render(markdown)
+    rendered_markdown.gsub!("govuk-body-m", "govuk-hint") if hint
+
+    sanitize(rendered_markdown, attributes: default_attributes.merge(additional_attributes))
+  end
 end

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -24,16 +24,18 @@
           <%= form.govuk_check_box :completed_action_ids,
                                    action.id,
                                    label: { text: action.title },
-                                   hint: -> {
-                                     sanitize GovukMarkdown.render(action.hint).gsub!('govuk-body-m', 'govuk-hint') unless action.hint.nil?
-                                   },
                                    link_errors: true,
-                                   checked: action.completed? %>
+                                   checked: action.completed?,
+                                   hint: -> do %>
 
-          <% if action.guidance_summary? %>
-            <%= govuk_details(summary_text: action.guidance_summary) do %>
-              <%= sanitize GovukMarkdown.render(action.guidance_text) %>
+            <%= sanitize GovukMarkdown.render(action.hint).gsub!('govuk-body-m', 'govuk-hint') unless action.hint.nil? %>
+
+            <% if action.guidance_summary? %>
+              <%= govuk_details(summary_text: action.guidance_summary) do %>
+                <%= sanitize GovukMarkdown.render(action.guidance_text) %>
+              <% end %>
             <% end %>
+
           <% end %>
         <% end %>
 

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -2,44 +2,48 @@
   <%= govuk_back_link(href: project_path(@task.project)) %>
 <% end %>
 
-<h1 class="govuk-heading-l"><%= @task.title %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= @task.title %></h1>
 
-<% if @task.hint? %>
-  <p class="govuk-body"><%= sanitize GovukMarkdown.render(@task.hint) %></p>
-<% end %>
+    <% if @task.hint? %>
+      <p class="govuk-body"><%= sanitize GovukMarkdown.render(@task.hint) %></p>
+    <% end %>
 
-<% if @task.guidance_summary? %>
-  <%= govuk_details(summary_text: @task.guidance_summary) do %>
-    <%= sanitize GovukMarkdown.render(@task.guidance_text) %>
-  <% end %>
-<% end %>
-
-<%= form_for :task, url: project_task_path, method: :put do |form| %>
-  <%= form.govuk_check_boxes_fieldset :actions, legend: {text: "Actions", size: "m"} do %>
-    <% @task.actions.each do |action| %>
-      <%= form.govuk_check_box :completed_action_ids,
-            action.id,
-            label: {text: action.title},
-            hint: -> {
-              sanitize GovukMarkdown.render(action.hint).gsub!("govuk-body-m", "govuk-hint") unless action.hint.nil?
-            },
-            link_errors: true,
-            checked: action.completed? %>
-
-      <% if action.guidance_summary? %>
-        <%= govuk_details(summary_text: action.guidance_summary) do %>
-          <%= sanitize GovukMarkdown.render(action.guidance_text) %>
-        <% end %>
+    <% if @task.guidance_summary? %>
+      <%= govuk_details(summary_text: @task.guidance_summary) do %>
+        <%= sanitize GovukMarkdown.render(@task.guidance_text) %>
       <% end %>
     <% end %>
 
-    <% if @task.optional? %>
-      <%= form.govuk_check_box_divider %>
-      <%= form.govuk_check_box :not_applicable,
-            true,
-            label: {text: t("tasks.not_applicable")},
-            checked: @task.not_applicable? %>
+    <%= form_for :task, url: project_task_path, method: :put do |form| %>
+      <%= form.govuk_check_boxes_fieldset :actions, legend: { text: "Actions", size: "m" } do %>
+        <% @task.actions.each do |action| %>
+          <%= form.govuk_check_box :completed_action_ids,
+                                   action.id,
+                                   label: { text: action.title },
+                                   hint: -> {
+                                     sanitize GovukMarkdown.render(action.hint).gsub!('govuk-body-m', 'govuk-hint') unless action.hint.nil?
+                                   },
+                                   link_errors: true,
+                                   checked: action.completed? %>
+
+          <% if action.guidance_summary? %>
+            <%= govuk_details(summary_text: action.guidance_summary) do %>
+              <%= sanitize GovukMarkdown.render(action.guidance_text) %>
+            <% end %>
+          <% end %>
+        <% end %>
+
+        <% if @task.optional? %>
+          <%= form.govuk_check_box_divider %>
+          <%= form.govuk_check_box :not_applicable,
+                                   true,
+                                   label: { text: t("tasks.not_applicable") },
+                                   checked: @task.not_applicable? %>
+        <% end %>
+      <% end %>
+      <%= form.govuk_submit %>
     <% end %>
-  <% end %>
-  <%= form.govuk_submit %>
-<% end %>
+  </div>
+</div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -4,20 +4,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= @task.title %></h1>
+    <div class="govuk-!-margin-bottom-9">
+      <h1 class="govuk-heading-l"><%= @task.title %></h1>
 
-    <% if @task.hint? %>
-      <p class="govuk-body"><%= sanitize GovukMarkdown.render(@task.hint) %></p>
-    <% end %>
-
-    <% if @task.guidance_summary? %>
-      <%= govuk_details(summary_text: @task.guidance_summary) do %>
-        <%= sanitize GovukMarkdown.render(@task.guidance_text) %>
+      <% if @task.hint? %>
+        <p class="govuk-body"><%= sanitize GovukMarkdown.render(@task.hint) %></p>
       <% end %>
-    <% end %>
+
+      <% if @task.guidance_summary? %>
+        <%= govuk_details(summary_text: @task.guidance_summary) do %>
+          <%= sanitize GovukMarkdown.render(@task.guidance_text) %>
+        <% end %>
+      <% end %>
+    </div>
 
     <%= form_for :task, url: project_task_path, method: :put do |form| %>
-      <%= form.govuk_check_boxes_fieldset :actions, legend: { text: "Actions", size: "m" } do %>
+      <%= form.govuk_check_boxes_fieldset :actions, legend: { hidden: true } do %>
         <% @task.actions.each do |action| %>
           <%= form.govuk_check_box :completed_action_ids,
                                    action.id,

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -9,18 +9,18 @@
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-2"><%= @task.title %></h1>
 
       <% if @task.hint? %>
-        <p class="govuk-body"><%= sanitize GovukMarkdown.render(@task.hint) %></p>
+        <p class="govuk-body"><%= render_markdown(@task.hint) %></p>
       <% end %>
 
       <% if @task.guidance_summary? %>
         <%= govuk_details(summary_text: @task.guidance_summary) do %>
-          <%= sanitize GovukMarkdown.render(@task.guidance_text) %>
+          <%= render_markdown(@task.guidance_text) %>
         <% end %>
       <% end %>
     </div>
 
     <%= form_for :task, url: project_task_path, method: :put do |form| %>
-      <%= form.govuk_check_boxes_fieldset :actions, legend: { hidden: true }, classes: "task-checkboxes" do %>
+      <%= form.govuk_check_boxes_fieldset :actions, legend: {hidden: true}, classes: "task-checkboxes" do %>
         <% @task.actions.each do |action| %>
           <%= form.govuk_check_box :completed_action_ids,
                                    action.id,
@@ -29,11 +29,11 @@
                                    checked: action.completed?,
                                    hint: -> do %>
 
-            <%= sanitize GovukMarkdown.render(action.hint).gsub!('govuk-body-m', 'govuk-hint') unless action.hint.nil? %>
+            <%= render_markdown(action.hint, hint: true) unless action.hint.nil? %>
 
             <% if action.guidance_summary? %>
               <%= govuk_details(summary_text: action.guidance_summary) do %>
-                <%= sanitize GovukMarkdown.render(action.guidance_text) %>
+                <%= render_markdown(action.guidance_text) %>
               <% end %>
             <% end %>
 
@@ -43,9 +43,9 @@
         <% if @task.optional? %>
           <%= form.govuk_check_box_divider %>
           <%= form.govuk_check_box :not_applicable,
-                                   true,
-                                   label: { text: t("tasks.not_applicable") },
-                                   checked: @task.not_applicable? %>
+                true,
+                label: {text: t("tasks.not_applicable")},
+                checked: @task.not_applicable? %>
         <% end %>
       <% end %>
       <%= form.govuk_submit %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -19,7 +19,7 @@
     </div>
 
     <%= form_for :task, url: project_task_path, method: :put do |form| %>
-      <%= form.govuk_check_boxes_fieldset :actions, legend: { hidden: true } do %>
+      <%= form.govuk_check_boxes_fieldset :actions, legend: { hidden: true }, classes: "task-checkboxes" do %>
         <% @task.actions.each do |action| %>
           <%= form.govuk_check_box :completed_action_ids,
                                    action.id,

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -5,7 +5,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-!-margin-bottom-9">
-      <h1 class="govuk-heading-l"><%= @task.title %></h1>
+      <span class="govuk-caption-l"><%= @task.project.establishment.name %></span>
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-2"><%= @task.title %></h1>
 
       <% if @task.hint? %>
         <p class="govuk-body"><%= sanitize GovukMarkdown.render(@task.hint) %></p>

--- a/app/workflows/conversion.yml
+++ b/app/workflows/conversion.yml
@@ -4,53 +4,52 @@ sections:
   - title: Project kick-off
     tasks:
       - title: Handover with regional delivery officer
-        hint: |
-          How to make sure the handover with the regional delivery officer
-          is completed, and you can begin work on the project.
         actions:
           - title:
               Review the project information, check the documents and carry out
               research
-            hint: |
-              Check that no information is missing from the existing project documents and there are no errors.
+            hint:
+              Check that no information is missing from the existing project
+              documents and there are no errors.
+            guidance_summary: What to check for
+            guidance_text: |
+              You should check existing project documents, including:
+
+              * Academy order
+              * Application to convert
+
+              Check that no information is missing and there are no errors.
 
               You should also research the background of the project before you meet with the regional delivery officer.
-            guidance_summary: What to review, research and check
-            guidance_text: |
+
               Things to check during your background research include:
 
               * Project information, such as advisory board conditions
               * School or trust website for more information about the school
               * Google maps for potential land issues
 
-              You should also check existing project documents, including:
-
-              * Academy order
-              * Application to convert
           - title:
-              Make notes and write questions to as the regional delivery officer
-            hint: |
+              Make notes and write questions to ask the regional delivery
+              officer
+            guidance_summary: What to make notes about
+            guidance_text: |
               Note down things you want to ask and talk about with the regional delivery officer at the handover meeting.
 
               This is an opportunity to clarify anything that you're unsure about after reviewing the project and doing your background research.
+
           - title: Attend handover meeting with regional delivery officer
-            hint: |
-              You should have made a note of things you like to ask and talk about with the Regional deliver officer at the handover meeting.
-
-              Go through those talking points with them at the meeting.
-
-              This will prepare you to begin the project.
+            hint:
+              Discuss any questions you have about the project in the meeting.
 
       - title: External stakeholder kick-off
         hint:
-          You should complete these actions after you've had the handover with
-          the regional delivery officer.
+          You should start this work after you've had the handover with the
+          regional delivery officer.
         actions:
           - title: Send introductory emails
-            hint: |
-              Introduce yourself to the school, trust and their solicitors and organise a kick-off meeting.
-
-              You should also contact the local authority separately.
+            hint:
+              Introduce yourself to the school, trust and their solicitors. You
+              should also contact the local authority, but do this separately.
             guidance_summary: What to include in introductory emails
             guidance_text: |
               You can [choose an email template (opens in new tab)](https://educationgovuk.sharepoint.com/:f:/r/sites/ServiceDeliveryDirectorate/Shared%20Documents/Operational%20Delivery/Training%20and%20Resources/Resources/Project%20templates?csf=1&web=1&e=Hf4exC) to help you write your introductory emails. There are templates for the school or trust, their solicitors and the local authority.
@@ -66,10 +65,7 @@ sections:
               You should aim to do this in the first week of picking up the project.
               Ideally the kick-off meeting should take place within the first couple of weeks.
 
-          - title: Check you have the Local authority proforma
-            hint:
-              Make sure the local authority has completed and returned their
-              proforma, then save it in SharePoint.
+          - title: Check and save the Local authority proforma in SharePoint
             guidance_summary: Help with the Local authority proforma
             guidance_text: |
               The regional delivery officer should have sent the Local authority proforma to the local authority to complete.
@@ -87,31 +83,31 @@ sections:
 
               Tell them if the local authority cannot complete the conversion by the target date.
 
-              You'll need to work with the school, trust and local authority to agree a new conversion date.
+              If the local authority cannot complete the conversion by the target date, you'll need to work with the school, trust and local authority to agree a new date.
 
           - title: Send invites to the kick-off meeting or call
             hint:
               Check who the school and trust would like to attend the kick-off
-              meeting and send out invites.
-            guidance_summary: Advice for arranging the kick-off meeting
+              meeting.
+            guidance_summary: How to arrange the kick-off meeting
             guidance_text: |
               Your introductory email should have included some possible dates for a kick-off meeting.
 
-              Once the school have got back to you with a suitable date and list of attendees, send out invites to arrange the time, date and location of the meeting. It’s likely to be a video call over Microsoft Teams.
+              Once the school have got back to you with a suitable date and list of attendees, send out invites to arrange the time, date and location of the meeting. It's likely to be a video call over Microsoft Teams.
 
               Some schools and trusts may prefer to have a 1-to-1 call with you, rather than a meeting involving all stakeholders.
 
           - title: Host the kick-off meeting or call
             hint:
               Make sure all attendees understand what they need to do, and when
-              they need to do it by, to complete the conversion on time.
-            guidance_summary: What to talk about in the kick-off meeting
+              they need to do it by.
+            guidance_summary: What to talk about in the meeting
             guidance_text: |
               You should discuss and record issues that might complicate or delay the project.
 
-              You can [use the conversion checklist to guide the conversation](https://educationgovuk.sharepoint.com/:w:/s/ServiceDeliveryDirectorate/EZx-RuHD_JxEuaCF68ZXpe8BvSQ3ITlysjfNJ28t0_xzfQ?e=hxRZxt) and make sure you talk about everything you need to.
+              You can use the [conversion checklist (opens in a new tab)](https://educationgovuk.sharepoint.com/:w:/s/ServiceDeliveryDirectorate/EU-dQwiXf3NFmiPoiRABB_MBhO02xGbkBlhSifmDGiAnGA?e=Q9XOkA) to guide the conversation and make sure you talk about everything you need to.
 
-          - title: Update and share the conversion checklist
+          - title: Share the conversion checklist
             hint:
               Update the conversion checklist with any agreed actions, dates and
               comments from the kick-off meeting or call.
@@ -121,18 +117,20 @@ sections:
               the kick-off meeting or call.
 
       - title: Process conversion grant
-        hint: |
-          Check the grant payment form is ready, the school or trust has a vendor account and send the correct information to the Grant payments team.
+        guidance_summary: How to process a conversion grant
+        guidance_text: |
+          Check the grant claim form is ready, the school or trust has a vendor account and send the correct information to the Grant payments team.
 
-          Start this as soon as possible. Schools and trusts can start incurring solicitor and local authority fees early in the process.
+          Start this as soon as possible. Schools and trusts can start getting charged by solicitors and the local authority early in the process.
+
         actions:
           - title: Check the school or trust have a vendor account
             hint: |
-              The school or trust receiving the conversion grant must have a vendor account.
-
               You can [check if the school or trust has a vendor account (opens in new tab)](https://educationgovuk.sharepoint.com/sites/lvedfe00083/SitePages/Set-up-and-mainta.aspx) on SharePoint.
             guidance_summary: How to set up a vendor account
             guidance_text: |
+              The school or trust receiving the conversion grant must have a vendor account.
+
               Schools and trusts can [set up a vendor account (opens in new tab)](https://www.gov.uk/guidance/provide-information-about-your-banking-and-payments-to-dfe) when they provide information about their banking and payments to DfE.
 
               Share the link with them so they can register if needed.
@@ -140,40 +138,38 @@ sections:
               It can take 15 to 20 days for an account to be created.
 
           - title: Check and confirm the school's grant eligibility
-            hint: |
-              You need to confirm the amount of money the school can receive.
-
-              This information must be included in your email to the Grant payments team later.
-            guidance_summary: How check grant eligibility
+            hint:
+              A school may have already had some of the grant if they've tried
+              to become an academy before.
+            guidance_summary: How to check grant eligibility
             guidance_text: |
               Usually, a converting school will be eligible for a £25,000 grant to help with the costs of becoming an academy.
 
-              However, if the school has applied to become an academy in the past but not completed the process, they may have received some of the money then.
+              If the school has applied to become an academy in the past but not completed the process, they may already have been given some of the money.
 
-              Check in the school SharePoint folder to see if a Grant claim form has been submitted already.
+              Check in the school's SharePoint folder to see if a Grant claim form has been submitted before.
 
               You can also email the Grant payments team at [CFUGrantPayments.REGIONSGROUP@education.gov.uk](mailto:CFUGrantPayments.REGIONSGROUP@education.gov.uk) to check if the school has previously received any money, and how much they’re still eligible for.
 
-          - title: Receive, check and save the Grant payment form
-            hint: |
-              The school or trust must send you the Grant payment form.
+              You must include this information in your email to the Grant payments team later.
 
-              Once they have, check the Grant payment form is complete. Make sure there's no missing information.
-
-              Save the completed form in the SharePoint folder for that school.
-
-          - title: Send the grant information to the payments team
-            hint: |
-              You need to send the following documents and information to the Grant payments team:
-
-              * Application to convert
-              * Academy order
-              * Grant claim form
-
-              You'll find the Academy order, Application to convert and Grant claim form in the school's SharePoint folder.
-            guidance_summary: How to contact the Grant payments team
+          - title: Receive, check and save the grant claim form
+            hint: Make sure there's no missing information.
+            guidance_summary: How to check and save the form
             guidance_text: |
-              You should send the documents to the Grant payments team by email.
+              The school or trust must send you the grant claim form.
+
+              Check it's complete and save it in the school's SharePoint folder.
+
+          - title: Send the grant information form to the payments team
+            hint:
+              Send them the Application to convert, Academy order and Grant
+              claim form.
+            guidance_summary: Guidance on what information to send
+            guidance_text: |
+              You'll find the Academy order, Application to convert and Grant claim form in the school's SharePoint folder.
+
+              You should send the documents to the Grant payments team by email at [CFUGrantPayments.REGIONSGROUP@education.gov.uk](mailto:CFUGrantPayments.REGIONSGROUP@education.gov.uk).
 
               The subject line of the email must include the:
 
@@ -191,21 +187,16 @@ sections:
 
               It's helpful to include the school or trust's vendor account number too. The Grant payments team will need this to be able to send the money to whoever will receive it.
 
-              Send the email to [GrantPayments.RDD@education.gov.uk](GrantPayments.RDD@education.gov.uk).
-
           - title: Give the school and trust the grant payment date
-            hint:
-              When the Grant payments team have confirmed the date they'll
-              transfer the funds, let the school and trust know when the grant
-              will be paid.
+            hint: The Grant payments team will confirm the date with you first.
 
           - title: Check the school or trust have received the grant
             hint:
-              Check in with the school or trust, whichever was going to receive
-              the payment, to make sure they have the money.
+              Get in touch with the school or trust the month after you contact
+              the Grant payments team.
             guidance_summary: When to check the funds have been received
             guidance_text: |
-              It can take several weeks to process the grant payment once you've submitted the request.
+              It can take several weeks to process the grant payment.
 
               Get in touch with the school or trust the month after you contact the Grant payments team.
 

--- a/config/initializers/govuk_markdown.rb
+++ b/config/initializers/govuk_markdown.rb
@@ -1,0 +1,6 @@
+module GovukMarkdown
+  def self.render(markdown)
+    renderer = GovukMarkdown::Renderer.new(with_toc_data: true, link_attributes: {class: "govuk-link", target: "_blank"})
+    Redcarpet::Markdown.new(renderer, tables: true, no_intra_emphasis: true).render(markdown).strip
+  end
+end

--- a/spec/features/users_can_view_the_actions_for_a_task_spec.rb
+++ b/spec/features/users_can_view_the_actions_for_a_task_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Users can view the Actions for a Task" do
     visit project_task_path(project_id, task_id)
 
     # Task
-    expect(page).to have_css(".govuk-heading-l", text: "Have you cleared the Supplementary funding agreement?")
+    expect(page).to have_css(".govuk-heading-xl", text: "Have you cleared the Supplementary funding agreement?")
 
     # Task hint
     expect(page).to have_link("View the model documents (opens in new tab)", href: "https://www.gov.uk/government/collections/convert-to-an-academy-documents-for-schools")

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe "#render_markdown" do
+    let(:markdown) { "[link](https://some-path.com)" }
+
+    before { allow(GovukMarkdown).to receive(:render).and_call_original }
+
+    subject! { helper.render_markdown(markdown) }
+
+    it "calls the GovukMarkdown renderer" do
+      expect(GovukMarkdown).to have_received(:render).with(markdown)
+    end
+
+    it "sets html_safe" do
+      expect(subject.html_safe?).to be true
+    end
+
+    it "does not strip out target attributes" do
+      expect(subject).to eq "<p class=\"govuk-body-m\"><a href=\"https://some-path.com\" class=\"govuk-link\" target=\"_blank\">link</a></p>"
+    end
+
+    context "when the hint option is true" do
+      let(:markdown) { "Content" }
+
+      subject! { helper.render_markdown(markdown, hint: true) }
+
+      it "replaces the 'govuk-body-m' class with 'govuk-hint'" do
+        expect(subject).to eq "<p class=\"govuk-hint\">Content</p>"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes
### Use two thirds layout for task list
We want to use the GOV.UK two-thirds layout for the task list. This is recommended to stop lines of text getting so long that they are difficult to read.

### Hide "Actions" legend and update spacing
This removes the "Actions" legend for the checklist, and increases the whitespace beneath the task title and guidance to maintain the separation.

### Align the Action checkbox guidance with the checkbox hint
Include the guidance details component in the Proc that is passed into the Action hint in order to align them.

### Bold the labels of the action checkboxes
The labels of the action checkboxes are becoming lost amongst the content that has been added to the task page as hint text and guidance.

Bold the labels so that they stand out.

### Add spacing below each checkbox
So that each checkbox is distinct and easy to visually separate, add some additional spacing between each. 

This makes the legal documents section in its current form (with the divider) look a bit odd, but this will be tackled in the future.

### Update task title styling
Update the styling of the task title to match the prototype. This includes a caption with the establishment name.

### Update the content for the task list Project kick-off section
The content for this section has been reviewed.

### Make sure "Opens in new tab" links open in a new tab
Currently, any links we pass through the renderer do not open in a new tab (despite saying that they do). 

We use a custom Markdown renderer with GOV.UK styling (GovukMarkdown) that is derived from Redcarpet. Redcarpet allow us to configure what attributes their renderer adds to links.

This monkey patches the GovukMarkdown library to adds `target: "_blank"` option for link attributes.

This also swaps DRYs up any calls to `sanitize` into a `render_markdown` helper. `sanitize` strips out `target` attributes, so we need to explicitly allow these. The previous fix for enabling hint styling no longer works, so move this into the helper as well.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
