### PR TITLE
(519) Fix task list links

### DIFF
--- a/app/views/projects/show/_task_list.html.erb
+++ b/app/views/projects/show/_task_list.html.erb
@@ -8,10 +8,11 @@
         <% section.tasks.each do |task| %>
           <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="#" aria-describedby="<%= task_status_id(task) %>>"
-                  <%= link_to(task.title, project_task_path(@project.id, task.id), class: "govuk-link") %>>
+                <a href="#" aria-describedby="<%= task_status_id(task) %>">
+                  <%= link_to(task.title, project_task_path(@project.id, task.id), class: "govuk-link") %>
+                </a>
               </span>
-              <%= task_status_tag(task) %>
+            <%= task_status_tag(task) %>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
## Changes

A slight syntax error caused the ERB linter to remove the closing tag for the task list anchors.

Fix the syntax error, then run the linter again to make sure it now works fine.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
