### PR TITLE
Improvements to erblint behaviour

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -10,3 +10,5 @@ linters:
       inherit_from: .erb-lint_rubocop.yml
       AllCops:
         DisabledByDefault: true
+exclude:
+  - 'vendor/**/*'

--- a/script/all/test
+++ b/script/all/test
@@ -28,8 +28,8 @@ else
   done
 
   if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
-    echo "==> Linting ERB in fix mode..."
-    bundle exec erblint --lint-all --fix
+    echo "==> Linting ERB in autocorrect mode..."
+    bundle exec erblint --lint-all --autocorrect
   else
     echo "==> Linting ERB..."
     bundle exec erblint --lint-all


### PR DESCRIPTION
## Changes

- erblint uses `--autocorrect` instead of `--fix` to automatically solve problems; change this in the test runner script
- Exclude the contents of the vendor folder from linting
