### PR TITLE
(487) Feature: add region to project information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The date and time that a caseworker is first assigned to a project is
   recorded. Any subsequent assignments will not be recorded.
 - Contacts can be deleted via a button on the edit contact page.
-- Show the region on the project summary.
+- Show the region on the project summary and school details.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The date and time that a caseworker is first assigned to a project is
   recorded. Any subsequent assignments will not be recorded.
 - Contacts can be deleted via a button on the edit contact page.
+- Show the region on the project summary.
 
 ### Changed
 

--- a/app/models/academies_api/establishment.rb
+++ b/app/models/academies_api/establishment.rb
@@ -6,7 +6,8 @@ class AcademiesApi::Establishment < AcademiesApi::BaseApiModel
     :age_range_lower,
     :age_range_upper,
     :phase,
-    :diocese_name
+    :diocese_name,
+    :region_name
   )
 
   def self.attribute_map
@@ -17,7 +18,8 @@ class AcademiesApi::Establishment < AcademiesApi::BaseApiModel
       age_range_lower: "statutoryLowAge",
       age_range_upper: "statutoryHighAge",
       phase: "phaseOfEducation.name",
-      diocese_name: "diocese.name"
+      diocese_name: "diocese.name",
+      region_name: "gor.name"
     }
   end
 end

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -1,71 +1,81 @@
-<h2 class="govuk-heading-l" id="projectDetails"><%= t('project_information.show.project_details.title') %></h2>
-<%= govuk_summary_list(actions: false) do |summary_list|
-  summary_list.row do |row|
-    row.key { t('project_information.show.project_details.rows.caseworker') }
-    row.value { display_name(@project.caseworker) }
-  end
-  summary_list.row do |row|
-    row.key { t('project_information.show.project_details.rows.team_lead') }
-    row.value { display_name(@project.team_leader) }
-  end
-  summary_list.row do |row|
-    row.key { t('project_information.show.project_details.rows.regional_delivery_officer') }
-    row.value { display_name(@project.regional_delivery_officer) }
-  end
-end %>
+<div id="projectDetails">
+  <h2 class="govuk-heading-l"><%= t('project_information.show.project_details.title') %></h2>
+  <%= govuk_summary_list(actions: false) do |summary_list|
+    summary_list.row do |row|
+      row.key { t('project_information.show.project_details.rows.caseworker') }
+      row.value { @project.caseworker&.email or t('project_information.show.project_details.rows.unassigned') }
+    end
+    summary_list.row do |row|
+      row.key { t('project_information.show.project_details.rows.team_lead') }
+      row.value { @project.team_leader&.email or t('project_information.show.project_details.rows.unassigned') }
+    end
+    summary_list.row do |row|
+      row.key { t('project_information.show.project_details.rows.regional_delivery_officer') }
+      row.value { @project.regional_delivery_officer.email }
+    end
+  end %>
+</div>
 
-<h2 class="govuk-heading-l" id="schoolDetails"><%= t('project_information.show.school_details.title') %></h2>
-<%= govuk_summary_list(actions: false) do |summary_list|
-  summary_list.row do |row|
-    row.key { t('project_information.show.school_details.rows.original_school_name') }
-    row.value { @project.establishment.name }
-  end
-  summary_list.row do |row|
-    row.key { t('project_information.show.school_details.rows.old_urn') }
-    row.value { @project.urn.to_s }
-  end
-  summary_list.row do |row|
-    row.key { t('project_information.show.school_details.rows.school_type') }
-    row.value { @project.establishment.type }
-  end
-  summary_list.row do |row|
-    row.key { t('project_information.show.school_details.rows.age_range') }
-    row.value { age_range(@project.establishment) }
-  end
-  summary_list.row do |row|
-    row.key { t('project_information.show.school_details.rows.school_phase') }
-    row.value { @project.establishment.phase }
-  end
-end %>
+<div id="schoolDetails">
+  <h2 class="govuk-heading-l"><%= t('project_information.show.school_details.title') %></h2>
+  <%= govuk_summary_list(actions: false) do |summary_list|
+    summary_list.row do |row|
+      row.key { t('project_information.show.school_details.rows.original_school_name') }
+      row.value { @project.establishment.name }
+    end
+    summary_list.row do |row|
+      row.key { t('project_information.show.school_details.rows.old_urn') }
+      row.value { @project.urn.to_s }
+    end
+    summary_list.row do |row|
+      row.key { t('project_information.show.school_details.rows.school_type') }
+      row.value { @project.establishment.type }
+    end
+    summary_list.row do |row|
+      row.key { t('project_information.show.school_details.rows.age_range') }
+      row.value { age_range(@project.establishment) }
+    end
+    summary_list.row do |row|
+      row.key { t('project_information.show.school_details.rows.school_phase') }
+      row.value { @project.establishment.phase }
+    end
+  end %>
+</div>
 
-<h2 class="govuk-heading-l" id="trustDetails"><%= t('project_information.show.trust_details.title') %></h2>
-<%= govuk_summary_list(actions: false) do |summary_list|
-  summary_list.row do |row|
-    row.key { t('project_information.show.trust_details.rows.incoming_trust_name') }
-    row.value { @project.trust.name }
-  end
-  summary_list.row do |row|
-    row.key { t('project_information.show.trust_details.rows.ukprn') }
-    row.value { @project.trust_ukprn.to_s }
-  end
-  summary_list.row do |row|
-    row.key { t('project_information.show.trust_details.rows.companies_house_number') }
-    row.value { @project.trust.companies_house_number }
-  end
-end %>
+<div id="trustDetails">
+  <h2 class="govuk-heading-l"><%= t('project_information.show.trust_details.title') %></h2>
+  <%= govuk_summary_list(actions: false) do |summary_list|
+    summary_list.row do |row|
+      row.key { t('project_information.show.trust_details.rows.incoming_trust_name') }
+      row.value { @project.trust.name }
+    end
+    summary_list.row do |row|
+      row.key { t('project_information.show.trust_details.rows.ukprn') }
+      row.value { @project.trust_ukprn.to_s }
+    end
+    summary_list.row do |row|
+      row.key { t('project_information.show.trust_details.rows.companies_house_number') }
+      row.value { @project.trust.companies_house_number }
+    end
+  end %>
+</div>
 
-<h2 class="govuk-heading-l" id="localAuthorityDetails"><%= t('project_information.show.local_authority_details.title') %></h2>
-<%= govuk_summary_list(actions: false) do |summary_list|
-  summary_list.row do |row|
-    row.key { t('project_information.show.local_authority_details.rows.local_authority') }
-    row.value { @project.establishment.local_authority }
-  end
-end %>
+<div id="localAuthorityDetails">
+  <h2 class="govuk-heading-l"><%= t('project_information.show.local_authority_details.title') %></h2>
+  <%= govuk_summary_list(actions: false) do |summary_list|
+    summary_list.row do |row|
+      row.key { t('project_information.show.local_authority_details.rows.local_authority') }
+      row.value { @project.establishment.local_authority }
+    end
+  end %>
+</div>
 
-<h2 class="govuk-heading-l" id="dioceseDetails"><%= t('project_information.show.diocese_details.title') %></h2>
-<%= govuk_summary_list(actions: false) do |summary_list|
-  summary_list.row do |row|
-    row.key { t('project_information.show.diocese_details.rows.diocese') }
-    row.value { @project.establishment.diocese_name }
-  end
-end %>
+<div id="dioceseDetails">
+  <h2 class="govuk-heading-l"><%= t('project_information.show.diocese_details.title') %></h2>
+  <%= govuk_summary_list(actions: false) do |summary_list|
+    summary_list.row do |row|
+      row.key { t('project_information.show.diocese_details.rows.diocese') }
+      row.value { @project.establishment.diocese_name }
+    end
+  end %>
+</div>

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -39,6 +39,10 @@
       row.key { t('project_information.show.school_details.rows.school_phase') }
       row.value { @project.establishment.phase }
     end
+    summary_list.row do |row|
+      row.key { t('project_information.show.school_details.rows.region') }
+      row.value { @project.establishment.region_name }
+    end
   end %>
 </div>
 

--- a/app/views/shared/_project_summary.html.erb
+++ b/app/views/shared/_project_summary.html.erb
@@ -4,7 +4,7 @@
     <span class="govuk-caption-l">URN <%= @project.urn %></span>
     <h1 class="govuk-heading-l"><%= @project.establishment.name %></h1>
 
-    <%= govuk_summary_list(actions: false) do |summary_list|
+    <%= govuk_summary_list(actions: false, html_attributes: {id: "project-summary"}) do |summary_list|
           summary_list.row do |row|
             row.key { t("project.summary.incoming_trust.title") }
             row.value { @project.trust.name }
@@ -16,6 +16,10 @@
           summary_list.row do |row|
             row.key { t("project.summary.local_authority.title") }
             row.value { @project.establishment.local_authority }
+          end
+          summary_list.row do |row|
+            row.key { t("project.summary.region.title") }
+            row.value { @project.establishment.region_name }
           end
         end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,8 @@ en:
         title: Local authority
       target_completion_date:
         title: Target conversion date
+      region:
+        title: Region
   project_information:
     show:
       side_navigation:
@@ -100,6 +102,7 @@ en:
           school_type: School type
           age_range: Age range
           school_phase: School phase
+          region: Region
       trust_details:
         title: Trust details
         rows:

--- a/spec/factories/academies_api/establishment.rb
+++ b/spec/factories/academies_api/establishment.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     age_range_upper { 18 }
     phase { "Secondary" }
     diocese_name { "Diocese of West Placefield" }
+    region_name { "West Midlands" }
   end
 end

--- a/spec/features/users_can_view_a_project_spec.rb
+++ b/spec/features/users_can_view_a_project_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.feature "Users can view a project" do
+  let(:user) { create(:user, :caseworker) }
+  let(:project) { create(:project, caseworker: user) }
+
+  before do
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    sign_in_with_user(user)
+  end
+
+  scenario "they can view a summary of the project details" do
+    visit project_path(project)
+
+    within("#project-summary") do
+      expect(page).to have_content(project.trust.name)
+      expect(page).to have_content(project.target_completion_date.to_formatted_s(:govuk))
+      expect(page).to have_content(project.establishment.local_authority)
+      expect(page).to have_content(project.trust.name)
+      expect(page).to have_content(project.establishment.region_name)
+    end
+  end
+end

--- a/spec/features/users_can_view_project_information_spec.rb
+++ b/spec/features/users_can_view_project_information_spec.rb
@@ -28,6 +28,11 @@ RSpec.feature "Users can view project information" do
       page_has_project_information_list_row(section: section, label: "School type", information: "Academy converter")
       page_has_project_information_list_row(section: section, label: "Age range", information: "11 to 18")
       page_has_project_information_list_row(section: section, label: "School phase", information: "Secondary")
+      page_has_project_information_list_row(
+        section: section,
+        label: I18n.t("project_information.show.school_details.rows.region"),
+        information: project.establishment.region_name
+      )
     end
   end
 

--- a/spec/features/users_can_view_project_information_spec.rb
+++ b/spec/features/users_can_view_project_information_spec.rb
@@ -8,47 +8,61 @@ RSpec.feature "Users can view project information" do
   before do
     mock_successful_api_responses(urn: 123456, ukprn: 10061021)
     sign_in_with_user(user)
-  end
-
-  scenario "User views project information" do
     visit project_information_path(project_id)
-
-    expect(page).to have_content("Project details")
-    page_has_project_information_list_row(label: "Caseworker", information: "John Doe", link: "user@education.gov.uk")
-    page_has_project_information_list_row(label: "Team lead", information: "Team Leader", link: project.team_leader.email)
-    page_has_project_information_list_row(label: "Regional delivery officer", information: "Regional Delivery-Officer", link: project.regional_delivery_officer.email)
-
-    expect(page).to have_content("School details")
-    page_has_project_information_list_row(label: "Original school name", information: "Caludon Castle School")
-    page_has_project_information_list_row(label: "Old Unique Reference Number", information: "123456")
-    page_has_project_information_list_row(label: "School type", information: "Academy converter")
-    page_has_project_information_list_row(label: "Age range", information: "11 to 18")
-    page_has_project_information_list_row(label: "School phase", information: "Secondary")
-
-    expect(page).to have_content("Trust details")
-    page_has_project_information_list_row(label: "Incoming trust name", information: "THE ROMERO CATHOLIC ACADEMY")
-    page_has_project_information_list_row(label: "UK Provider Reference Number", information: "10061021")
-    page_has_project_information_list_row(label: "Companies House number", information: "09702162")
-
-    expect(page).to have_content("Local authority details")
-    page_has_project_information_list_row(label: "Local authority", information: "West Placefield Council")
-
-    expect(page).to have_content(I18n.t("project_information.show.diocese_details.title"))
-    page_has_project_information_list_row(
-      label: I18n.t("project_information.show.diocese_details.rows.diocese"),
-      information: project.establishment.diocese_name
-    )
   end
 
-  private def page_has_project_information_list_row(label:, information:, link: nil)
-    project_information_list = page.find("#projectInformationList")
-
-    within project_information_list do
-      label = find("dt", text: label)
-      row_value = label.ancestor(".govuk-summary-list__row").find("dd")
-
-      expect(row_value).to have_content(information)
-      expect(row_value).to have_link(link) if link.present?
+  describe "the project details" do
+    scenario "have the appropriate values" do
+      section = find("#projectDetails")
+      page_has_project_information_list_row(section: section, label: "Caseworker", information: "user@education.gov.uk")
+      page_has_project_information_list_row(section: section, label: "Team lead", information: project.team_leader.email)
+      page_has_project_information_list_row(section: section, label: "Regional delivery officer", information: project.regional_delivery_officer.email)
     end
+  end
+
+  describe "the school details" do
+    scenario "have the appropriate values" do
+      section = find("#schoolDetails")
+      page_has_project_information_list_row(section: section, label: "Original school name", information: "Caludon Castle School")
+      page_has_project_information_list_row(section: section, label: "Old Unique Reference Number", information: "123456")
+      page_has_project_information_list_row(section: section, label: "School type", information: "Academy converter")
+      page_has_project_information_list_row(section: section, label: "Age range", information: "11 to 18")
+      page_has_project_information_list_row(section: section, label: "School phase", information: "Secondary")
+    end
+  end
+
+  describe "the trust details" do
+    scenario "have the appropriate values" do
+      section = find("#trustDetails")
+      page_has_project_information_list_row(section: section, label: "Incoming trust name", information: "THE ROMERO CATHOLIC ACADEMY")
+      page_has_project_information_list_row(section: section, label: "UK Provider Reference Number", information: "10061021")
+      page_has_project_information_list_row(section: section, label: "Companies House number", information: "09702162")
+    end
+  end
+
+  describe "the local authority details" do
+    scenario "have the appropriate values" do
+      section = find("#localAuthorityDetails")
+      page_has_project_information_list_row(section: section, label: "Local authority", information: "West Placefield Council")
+    end
+  end
+
+  describe "the diocese details" do
+    scenario "have the appropriate values" do
+      section = find("#dioceseDetails")
+      page_has_project_information_list_row(
+        section: section,
+        label: I18n.t("project_information.show.diocese_details.rows.diocese"),
+        information: project.establishment.diocese_name
+      )
+    end
+  end
+
+  private def page_has_project_information_list_row(section:, label:, information:)
+    label = section.find("dt", text: label)
+    information = section.find("dd", text: information)
+
+    assert label
+    assert information
   end
 end


### PR DESCRIPTION
## Changes

Whilst not directly helpful right now, we are in Regional Services Division and have regional delivery officers and regional caseworkers - it seems likely that the concept of 'region' will be useful.

Here we are exposing the establishment (school) region which we get from get informatiion about schools via the academies API.

https://trello.com/c/x1coxpiz

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
