### PR TITLE
(557) Chore: rename trust to incoming trust

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -61,7 +61,7 @@ class ProjectsController < ApplicationController
   private def project_params
     params.require(:project).permit(
       :urn,
-      :trust_ukprn,
+      :incoming_trust_ukprn,
       :target_completion_date
     )
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,7 +6,7 @@ class Project < ApplicationRecord
   accepts_nested_attributes_for :notes, reject_if: proc { |attributes| attributes[:body].blank? }
 
   validates :urn, presence: true, numericality: {only_integer: true}, length: {is: 6}
-  validates :trust_ukprn, presence: true, numericality: {only_integer: true}
+  validates :incoming_trust_ukprn, presence: true, numericality: {only_integer: true}
   validates :target_completion_date, presence: true
 
   validate :first_day_of_month, :trust_ukprn_is_correct_format
@@ -34,7 +34,7 @@ class Project < ApplicationRecord
   private def trust_exists
     retrieve_trust
   rescue AcademiesApi::Client::NotFoundError
-    errors.add(:trust_ukprn, :no_trust_found)
+    errors.add(:incoming_trust_ukprn, :no_trust_found)
   end
 
   private def retrieve_establishment
@@ -45,7 +45,7 @@ class Project < ApplicationRecord
   end
 
   private def retrieve_trust
-    result = AcademiesApi::Client.new.get_trust(trust_ukprn)
+    result = AcademiesApi::Client.new.get_trust(incoming_trust_ukprn)
     raise result.error if result.error.present?
 
     @trust = result.object
@@ -61,13 +61,13 @@ class Project < ApplicationRecord
   end
 
   private def trust_ukprn_is_correct_format
-    return if trust_ukprn.nil?
+    return if incoming_trust_ukprn.nil?
 
-    number_of_digits = trust_ukprn.digits.count
-    first_digit = trust_ukprn.to_s.first.to_i
+    number_of_digits = incoming_trust_ukprn.digits.count
+    first_digit = incoming_trust_ukprn.to_s.first.to_i
 
     if number_of_digits != 8 || first_digit != 1
-      errors.add(:trust_ukprn, :must_be_correct_format)
+      errors.add(:incoming_trust_ukprn, :must_be_correct_format)
     end
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -21,8 +21,19 @@ class Project < ApplicationRecord
     @establishment || retrieve_establishment
   end
 
-  def trust
-    @trust || retrieve_trust
+  def incoming_trust
+    @incoming_rust ||= fetch_trust(incoming_trust_ukprn)
+  end
+
+      result.object
+    end
+  end
+
+  private def fetch_trust(ukprn)
+    result = AcademiesApi::Client.new.get_trust(ukprn)
+    raise result.error if result.error.present?
+
+    result.object
   end
 
   private def establishment_exists
@@ -32,7 +43,7 @@ class Project < ApplicationRecord
   end
 
   private def trust_exists
-    retrieve_trust
+    incoming_trust
   rescue AcademiesApi::Client::NotFoundError
     errors.add(:incoming_trust_ukprn, :no_trust_found)
   end
@@ -42,13 +53,6 @@ class Project < ApplicationRecord
     raise result.error if result.error.present?
 
     @establishment = result.object
-  end
-
-  private def retrieve_trust
-    result = AcademiesApi::Client.new.get_trust(incoming_trust_ukprn)
-    raise result.error if result.error.present?
-
-    @trust = result.object
   end
 
   private def first_day_of_month

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,8 +8,9 @@ class Project < ApplicationRecord
   validates :urn, presence: true, numericality: {only_integer: true}, length: {is: 6}
   validates :incoming_trust_ukprn, presence: true, numericality: {only_integer: true}
   validates :target_completion_date, presence: true
+  validates :incoming_trust_ukprn, ukprn: true
 
-  validate :first_day_of_month, :trust_ukprn_is_correct_format
+  validate :first_day_of_month
   validate :target_completion_date_is_in_the_future, on: :create
   validate :establishment_exists, :trust_exists, on: :create
 
@@ -57,17 +58,6 @@ class Project < ApplicationRecord
     # Target completion date is always the 1st of the month.
     if target_completion_date.day != 1
       errors.add(:target_completion_date, :must_be_first_of_the_month)
-    end
-  end
-
-  private def trust_ukprn_is_correct_format
-    return if incoming_trust_ukprn.nil?
-
-    number_of_digits = incoming_trust_ukprn.digits.count
-    first_digit = incoming_trust_ukprn.to_s.first.to_i
-
-    if number_of_digits != 8 || first_digit != 1
-      errors.add(:incoming_trust_ukprn, :must_be_correct_format)
     end
   end
 

--- a/app/validators/ukprn_validator.rb
+++ b/app/validators/ukprn_validator.rb
@@ -1,0 +1,7 @@
+class UkprnValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    unless value.to_s.match?("^1[0-9]{7}$")
+      record.errors.add(attribute, :must_be_correct_format)
+    end
+  end
+end

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -55,7 +55,7 @@
     end
     summary_list.row do |row|
       row.key { t('project_information.show.trust_details.rows.ukprn') }
-      row.value { @project.trust_ukprn.to_s }
+      row.value { @project.incoming_trust_ukprn.to_s }
     end
     summary_list.row do |row|
       row.key { t('project_information.show.trust_details.rows.companies_house_number') }

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -51,7 +51,7 @@
   <%= govuk_summary_list(actions: false) do |summary_list|
     summary_list.row do |row|
       row.key { t('project_information.show.trust_details.rows.incoming_trust_name') }
-      row.value { @project.trust.name }
+      row.value { @project.incoming_trust.name }
     end
     summary_list.row do |row|
       row.key { t('project_information.show.trust_details.rows.ukprn') }
@@ -59,8 +59,7 @@
     end
     summary_list.row do |row|
       row.key { t('project_information.show.trust_details.rows.companies_house_number') }
-      row.value { @project.trust.companies_house_number }
-    end
+      row.value { @project.incoming_trust.companies_house_number } end
   end %>
 </div>
 

--- a/app/views/projects/index/_project_summary.html.erb
+++ b/app/views/projects/index/_project_summary.html.erb
@@ -12,7 +12,7 @@
 
   <div class="govuk-grid-row govuk-!-margin-top-2">
     <p class="govuk-grid-column-one-half govuk-body govuk-!-margin-bottom-2">
-      <span class="govuk-!-font-weight-bold"><%= t("project.summary.incoming_trust.title") %>: </span><%= project.trust.name %>
+      <span class="govuk-!-font-weight-bold"><%= t("project.summary.incoming_trust.title") %>: </span><%= project.incoming_trust.name %>
     </p>
     <p class="govuk-grid-column-one-half govuk-body govuk-!-margin-bottom-2 govuk-!-text-align-right">
       <span class="govuk-!-font-weight-bold"><%= t("project.summary.local_authority.title") %>: </span><%= project.establishment.local_authority %>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -10,7 +10,7 @@
       <h1 class="govuk-heading-l"><%= t("project.new.title") %></h1>
 
       <%= form.govuk_text_field :urn, label: {size: "m"}, width: 10 %>
-      <%= form.govuk_text_field :trust_ukprn, label: {size: "m"}, width: 10 %>
+      <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m"}, width: 10 %>
       <%= form.govuk_date_field :target_completion_date, omit_day: true %>
 
       <%= form.fields_for :note, @note do |note_form| %>

--- a/app/views/shared/_project_summary.html.erb
+++ b/app/views/shared/_project_summary.html.erb
@@ -7,7 +7,7 @@
     <%= govuk_summary_list(actions: false, html_attributes: {id: "project-summary"}) do |summary_list|
           summary_list.row do |row|
             row.key { t("project.summary.incoming_trust.title") }
-            row.value { @project.trust.name }
+            row.value { @project.incoming_trust.name }
           end
           summary_list.row do |row|
             row.key { t("project.summary.target_completion_date.title") }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -172,7 +172,7 @@ en:
     label:
       project:
         urn: School URN
-        trust_ukprn: Incoming trust UK Provider Reference Number (UKPRN)
+        incoming_trust_ukprn: Incoming trust UK Provider Reference Number (UKPRN)
         caseworker_id: Caseworker
         regional_delivery_officer_id: Regional delivery officer
       note:
@@ -189,7 +189,7 @@ en:
     hint:
       project:
         urn: This is the URN of the existing school which is converting to an academy. URN is a 6-digit number.
-        trust_ukprn: UKPRN is an 8-digit number that always starts with a 1.
+        incoming_trust_ukprn: UKPRN is an 8-digit number that always starts with a 1.
         caseworker_id: The caseworker responsible for this project
         target_completion_date: The target conversion date is always the 1st of the month.
       note:
@@ -205,7 +205,7 @@ en:
               no_establishment_found: There’s no school with that URN. Check the number you entered is correct.
               not_a_number: School URN can only contain numbers. No letters or special characters.
               wrong_length: URN must be 6 digits long. For example, 123456.
-            trust_ukprn:
+            incoming_trust_ukprn:
               blank: Enter a UKPRN
               no_trust_found: There’s no trust with that UKPRN. Check the number you entered is correct.
               not_a_number: UKPRN can only contain numbers. No letters or special characters.

--- a/db/migrate/20220915130012_rename_project_trust_to_incoming_trust.rb
+++ b/db/migrate/20220915130012_rename_project_trust_to_incoming_trust.rb
@@ -1,0 +1,5 @@
+class RenameProjectTrustToIncomingTrust < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :projects, :trust_ukprn, :incoming_trust_ukprn
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_06_151837) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_15_130012) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -52,7 +52,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_06_151837) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "team_leader_id"
-    t.integer "trust_ukprn", null: false
+    t.integer "incoming_trust_ukprn", null: false
     t.date "target_completion_date", null: false
     t.uuid "regional_delivery_officer_id"
     t.uuid "caseworker_id"

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :project, class: "Project" do
     urn { 123456 }
-    trust_ukprn { 10061021 }
+    incoming_trust_ukprn { 10061021 }
     target_completion_date { (Date.today + 2.years).at_beginning_of_month }
     team_leader { association :user, :team_leader, email: "team-leader-#{SecureRandom.uuid}@education.gov.uk" }
     regional_delivery_officer { association :user, :regional_delivery_officer, email: "regional-delivery-officer-#{SecureRandom.uuid}@education.gov.uk" }

--- a/spec/features/users_can_assign_users_to_projects_spec.rb
+++ b/spec/features/users_can_assign_users_to_projects_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Users can assign users to projects" do
   before do
-    mock_successful_api_responses(urn: project.urn, ukprn: project.trust_ukprn)
+    mock_successful_api_responses(urn: project.urn, ukprn: project.incoming_trust_ukprn)
     sign_in_with_user(user)
   end
 

--- a/spec/features/users_can_mark_optional_tasks_as_not_applicable_spec.rb
+++ b/spec/features/users_can_mark_optional_tasks_as_not_applicable_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Users can mark optional tasks as not applicable to a project" do
     sign_in_with_user(user_one)
   end
 
-  let(:project) { create(:project, urn: 123456, trust_ukprn: 12345678) }
+  let(:project) { create(:project, urn: 123456, incoming_trust_ukprn: 12345678) }
   let!(:section) { create(:section, project: project) }
   let(:task) { create(:task, :not_applicable, title: "Not applicable task", section: section) }
   let!(:actions) { create_list(:action, 3, task: task, completed: true) }

--- a/spec/features/users_can_view_a_project_spec.rb
+++ b/spec/features/users_can_view_a_project_spec.rb
@@ -13,10 +13,10 @@ RSpec.feature "Users can view a project" do
     visit project_path(project)
 
     within("#project-summary") do
-      expect(page).to have_content(project.trust.name)
+      expect(page).to have_content(project.incoming_trust.name)
       expect(page).to have_content(project.target_completion_date.to_formatted_s(:govuk))
       expect(page).to have_content(project.establishment.local_authority)
-      expect(page).to have_content(project.trust.name)
+      expect(page).to have_content(project.incoming_trust.name)
       expect(page).to have_content(project.establishment.region_name)
     end
   end

--- a/spec/features/users_can_view_project_information_spec.rb
+++ b/spec/features/users_can_view_project_information_spec.rb
@@ -36,9 +36,9 @@ RSpec.feature "Users can view project information" do
 
   scenario "they can view the trust details" do
     within("#trustDetails") do
-      expect(page).to have_content(project.trust.name)
+      expect(page).to have_content(project.incoming_trust.name)
       expect(page).to have_content(project.incoming_trust_ukprn)
-      expect(page).to have_content(project.trust.companies_house_number)
+      expect(page).to have_content(project.incoming_trust.companies_house_number)
     end
   end
 

--- a/spec/features/users_can_view_project_information_spec.rb
+++ b/spec/features/users_can_view_project_information_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Users can view project information" do
   scenario "they can view the trust details" do
     within("#trustDetails") do
       expect(page).to have_content(project.trust.name)
-      expect(page).to have_content(project.trust_ukprn)
+      expect(page).to have_content(project.incoming_trust_ukprn)
       expect(page).to have_content(project.trust.companies_house_number)
     end
   end

--- a/spec/features/users_can_view_projects_spec.rb
+++ b/spec/features/users_can_view_projects_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature "Users can view a list of projects" do
     within urn.ancestor("li") do
       expect(page).to have_content("School type: #{project.establishment.type}")
       expect(page).to have_content("Target conversion date: #{project.target_completion_date.to_formatted_s(:govuk)}")
-      expect(page).to have_content("Incoming trust: #{project.trust.name}")
+      expect(page).to have_content("Incoming trust: #{project.incoming_trust.name}")
       expect(page).to have_content("Local authority: #{project.establishment.local_authority}")
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -164,6 +164,17 @@ RSpec.describe Project, type: :model do
       it "retreives establishment data from the Academies API" do
         expect(subject.establishment).to eq establishment
       end
+
+      it "caches the response" do
+        academies_api_client = double(AcademiesApi::Client, get_establishment: AcademiesApi::Client::Result.new(double, nil))
+        allow(AcademiesApi::Client).to receive(:new).and_return(academies_api_client)
+        project = described_class.new(urn: urn)
+
+        project.establishment
+        project.establishment
+
+        expect(academies_api_client).to have_received(:get_establishment).with(urn).once
+      end
     end
 
     context "when the Academies API client returns a #{AcademiesApi::Client::NotFoundError}" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Project, type: :model do
   describe "Columns" do
     it { is_expected.to have_db_column(:urn).of_type :integer }
-    it { is_expected.to have_db_column(:trust_ukprn).of_type :integer }
+    it { is_expected.to have_db_column(:incoming_trust_ukprn).of_type :integer }
     it { is_expected.to have_db_column(:target_completion_date).of_type :date }
     it { is_expected.to have_db_column(:caseworker_id).of_type :uuid }
     it { is_expected.to have_db_column(:team_leader_id).of_type :uuid }
@@ -94,11 +94,11 @@ RSpec.describe Project, type: :model do
       end
     end
 
-    describe "#trust_ukprn" do
-      it { is_expected.to validate_presence_of(:trust_ukprn) }
-      it { is_expected.to validate_numericality_of(:trust_ukprn).only_integer }
-      it { is_expected.to allow_value(12345678).for(:trust_ukprn) }
-      it { is_expected.not_to allow_values(1234567, 123456789, 23456789).for(:trust_ukprn) }
+    describe "#incoming_trust_ukprn" do
+      it { is_expected.to validate_presence_of(:incoming_trust_ukprn) }
+      it { is_expected.to validate_numericality_of(:incoming_trust_ukprn).only_integer }
+      it { is_expected.to allow_value(12345678).for(:incoming_trust_ukprn) }
+      it { is_expected.not_to allow_values(1234567, 123456789, 23456789).for(:incoming_trust_ukprn) }
 
       context "when no trust with that UKPRN exists in the API" do
         let(:no_trust_found_result) do
@@ -112,7 +112,7 @@ RSpec.describe Project, type: :model do
 
         it "is invalid" do
           expect(subject).to_not be_valid
-          expect(subject.errors[:trust_ukprn]).to include(I18n.t("activerecord.errors.models.project.attributes.trust_ukprn.no_trust_found"))
+          expect(subject.errors[:incoming_trust_ukprn]).to include(I18n.t("activerecord.errors.models.project.attributes.incoming_trust_ukprn.no_trust_found"))
         end
       end
     end
@@ -199,7 +199,7 @@ RSpec.describe Project, type: :model do
     let(:ukprn) { 10061021 }
     let(:trust) { build(:academies_api_trust) }
 
-    subject { described_class.new(trust_ukprn: ukprn) }
+    subject { described_class.new(incoming_trust_ukprn: ukprn) }
 
     context "when the API returns a successful response" do
       before { mock_successful_api_trust_response(ukprn: ukprn, trust: trust) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -95,11 +95,6 @@ RSpec.describe Project, type: :model do
     end
 
     describe "#incoming_trust_ukprn" do
-      it { is_expected.to validate_presence_of(:incoming_trust_ukprn) }
-      it { is_expected.to validate_numericality_of(:incoming_trust_ukprn).only_integer }
-      it { is_expected.to allow_value(12345678).for(:incoming_trust_ukprn) }
-      it { is_expected.not_to allow_values(1234567, 123456789, 23456789).for(:incoming_trust_ukprn) }
-
       context "when no trust with that UKPRN exists in the API" do
         let(:no_trust_found_result) do
           AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError.new("No trust found with that UKPRN. Enter a valid UKPRN."))

--- a/spec/requests/project_assignment_spec.rb
+++ b/spec/requests/project_assignment_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Project assignment" do
 
     before do
       mock_successful_authentication(user.email)
-      mock_successful_api_responses(urn: project.urn, ukprn: project.trust_ukprn)
+      mock_successful_api_responses(urn: project.urn, ukprn: project.incoming_trust_ukprn)
       allow_any_instance_of(ProjectsController).to receive(:user_id).and_return(user.id)
     end
 

--- a/spec/support/project_helpers.rb
+++ b/spec/support/project_helpers.rb
@@ -1,7 +1,7 @@
 module ProjectHelpers
-  def create_unassigned_project(urn: 123456, trust_ukprn: 12345678)
-    project = build(:project, urn: urn, trust_ukprn: trust_ukprn, team_leader: nil)
-    mock_successful_api_responses(urn: project.urn, ukprn: project.trust_ukprn)
+  def create_unassigned_project(urn: 123456, incoming_trust_ukprn: 12345678)
+    project = build(:project, urn: urn, incoming_trust_ukprn: incoming_trust_ukprn, team_leader: nil)
+    mock_successful_api_responses(urn: project.urn, ukprn: project.incoming_trust_ukprn)
     project.save!
     project
   end

--- a/spec/validators/ukprn_validator_spec.rb
+++ b/spec/validators/ukprn_validator_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe UkprnValidator do
+  subject do
+    Class.new {
+      include ActiveModel::Validations
+      attr_accessor :ukprn_value
+      validates :ukprn_value, ukprn: true
+    }.new
+  end
+
+  context "with a valid UKPRN" do
+    it "is valid" do
+      subject.ukprn_value = 12345678
+      expect(subject.valid?).to be true
+    end
+  end
+
+  context "with a UKPRN that is longer than eight digits" do
+    it "is invalid" do
+      subject.ukprn_value = 123456789
+      expect(subject.valid?).to be false
+    end
+  end
+
+  context "with a UKPRN that is shorter than eight digits" do
+    it "is invalid" do
+      subject.ukprn_value = 1234567
+      expect(subject.valid?).to be false
+    end
+  end
+
+  context "with a UKPRN that does not start with a 1" do
+    it "is invalid" do
+      subject.ukprn_value = 21234567
+      expect(subject.valid?).to be false
+    end
+  end
+
+  context "with a UKPRN that contains letters" do
+    it "is invalid" do
+      subject.ukprn_value = "012LET3434"
+      expect(subject.valid?).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Changes

 When we modelled `trust` we kept the naming simple, we've since learnt
 that `trust` is a keyword in Ruby in certain conditions.
    
A conversion represents a school becoming an academy by joining a Trust,
we use the term 'incomming trust' to describe to which trust the school is
joining.
    
Later when adding transfers we will be storing both the
incomming and outgoing trust i.e the new trust and the trust the school
is leaving - changing this column name now solves the Ruby name clash and
sets us up nicely for a time when we introduce the concept of
`outgoing_trust_ukprn` as well.

This work also adds a new UKPN validator that decouples the validation from the speciific attribute.

https://trello.com/c/ma1FCLSP

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
