### PR TITLE
(517) Feature: capture approvals board data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- The Handover/new project form collects the advisory board date and any
+  conditions.
+
+### Changed
+
+### Fixed
+
 ## [Release 3][release-3]
 
 ### Added

--- a/app/controllers/project_information_controller.rb
+++ b/app/controllers/project_information_controller.rb
@@ -1,5 +1,5 @@
 class ProjectInformationController < ApplicationController
   def show
-    @project = Project.find(params[:project_id])
+    @project = ProjectPresenter.new(Project.find(params[:project_id]))
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -62,7 +62,9 @@ class ProjectsController < ApplicationController
     params.require(:project).permit(
       :urn,
       :incoming_trust_ukprn,
-      :target_completion_date
+      :target_completion_date,
+      :advisory_board_date,
+      :advisory_board_conditions
     )
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -9,6 +9,7 @@ class Project < ApplicationRecord
   validates :incoming_trust_ukprn, presence: true, numericality: {only_integer: true}
   validates :target_completion_date, presence: true
   validates :incoming_trust_ukprn, ukprn: true
+  validates :advisory_board_date, presence: true, on: :create
 
   validate :first_day_of_month
   validate :target_completion_date_is_in_the_future, on: :create

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -10,6 +10,7 @@ class Project < ApplicationRecord
   validates :target_completion_date, presence: true
   validates :incoming_trust_ukprn, ukprn: true
   validates :advisory_board_date, presence: true, on: :create
+  validates :advisory_board_date, past_date: true
 
   validate :first_day_of_month
   validate :target_completion_date_is_in_the_future, on: :create

--- a/app/presenters/project_presenter.rb
+++ b/app/presenters/project_presenter.rb
@@ -1,0 +1,7 @@
+class ProjectPresenter < SimpleDelegator
+  def advisory_board_date
+    return if super.blank?
+
+    super.to_date.to_formatted_s(:govuk)
+  end
+end

--- a/app/validators/past_date_validator.rb
+++ b/app/validators/past_date_validator.rb
@@ -1,0 +1,9 @@
+class PastDateValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless value.present?
+
+    unless value.past?
+      record.errors.add(attribute, :must_be_in_the_past)
+    end
+  end
+end

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -13,6 +13,14 @@
       row.key { t('project_information.show.project_details.rows.regional_delivery_officer') }
       row.value { display_name(@project.regional_delivery_officer) }
     end
+    summary_list.row do |row|
+      row.key { t('project_information.show.project_details.rows.advisory_board_date') }
+      row.value { @project.advisory_board_date }
+    end
+    summary_list.row do |row|
+      row.key { t('project_information.show.project_details.rows.advisory_board_conditions') }
+      row.value { simple_format(@project.advisory_board_conditions, class: "govuk-body") }
+    end
   end %>
 </div>
 

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -11,7 +11,9 @@
 
       <%= form.govuk_text_field :urn, label: {size: "m"}, width: 10 %>
       <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m"}, width: 10 %>
-      <%= form.govuk_date_field :target_completion_date, omit_day: true %>
+      <%= form.govuk_date_field :target_completion_date, omit_day: true, form_group: {id: "target-completion-date"} %>
+      <%= form.govuk_date_field :advisory_board_date, form_group: {id: "advisory-board-date"} %>
+      <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m"} %>
 
       <%= form.fields_for :note, @note do |note_form| %>
         <%= note_form.govuk_text_area :body,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,6 +221,9 @@ en:
               must_be_in_the_future: Target conversion date must be in the future.
             regional_delivery_officer_id:
               blank: Choose a regional delivery officer
+            advisory_board_date:
+              blank: Enter the advisory board date
+              must_be_in_the_past: The advisory board date must be in the past
         note:
           attributes:
             body:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,6 +94,8 @@ en:
           team_lead: Team lead
           regional_delivery_officer: Regional delivery officer
           unassigned: Not yet assigned
+          advisory_board_date: Date of advisory board
+          advisory_board_conditions: Conditions from advisory board
       school_details:
         title: School details
         rows:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -222,7 +222,7 @@ en:
             regional_delivery_officer_id:
               blank: Choose a regional delivery officer
             advisory_board_date:
-              blank: Enter the advisory board date
+              blank: Enter a date of advisory board
               must_be_in_the_past: The advisory board date must be in the past
         note:
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -177,6 +177,7 @@ en:
         incoming_trust_ukprn: Incoming trust UK Provider Reference Number (UKPRN)
         caseworker_id: Caseworker
         regional_delivery_officer_id: Regional delivery officer
+        advisory_board_conditions: Advisory board conditions
       note:
         body: Enter note
       contact:
@@ -188,12 +189,14 @@ en:
     legend:
       project:
         target_completion_date: Target conversion date
+        advisory_board_date: Date of advisory board
     hint:
       project:
         urn: This is the URN of the existing school which is converting to an academy. URN is a 6-digit number.
         incoming_trust_ukprn: UKPRN is an 8-digit number that always starts with a 1.
         caseworker_id: The caseworker responsible for this project
         target_completion_date: The target conversion date is always the 1st of the month.
+        advisory_board_conditions: If there are conditions to be met as a result of the advisory board.
       note:
         body: Do not include personal or financial information.
 

--- a/db/migrate/20220915130100_add_advisory_board_attributes_to_project.rb
+++ b/db/migrate/20220915130100_add_advisory_board_attributes_to_project.rb
@@ -1,0 +1,6 @@
+class AddAdvisoryBoardAttributesToProject < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :advisory_board_date, :date
+    add_column :projects, :advisory_board_conditions, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_15_130012) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_15_130100) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -57,6 +57,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_15_130012) do
     t.uuid "regional_delivery_officer_id"
     t.uuid "caseworker_id"
     t.datetime "caseworker_assigned_at"
+    t.date "advisory_board_date"
+    t.text "advisory_board_conditions"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"
     t.index ["team_leader_id"], name: "index_projects_on_team_leader_id"

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     target_completion_date { (Date.today + 2.years).at_beginning_of_month }
     team_leader { association :user, :team_leader, email: "team-leader-#{SecureRandom.uuid}@education.gov.uk" }
     regional_delivery_officer { association :user, :regional_delivery_officer, email: "regional-delivery-officer-#{SecureRandom.uuid}@education.gov.uk" }
+    advisory_board_date { (Date.today - 2.weeks) }
   end
 end

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     team_leader { association :user, :team_leader, email: "team-leader-#{SecureRandom.uuid}@education.gov.uk" }
     regional_delivery_officer { association :user, :regional_delivery_officer, email: "regional-delivery-officer-#{SecureRandom.uuid}@education.gov.uk" }
     advisory_board_date { (Date.today - 2.weeks) }
+
+    trait :with_conditions do
+      advisory_board_conditions { "The following must be met:\n 1. Must be red\n2. Must be blue\n" }
+    end
   end
 end

--- a/spec/features/users_can_create_projects_spec.rb
+++ b/spec/features/users_can_create_projects_spec.rb
@@ -11,14 +11,27 @@ RSpec.feature "Users can create new projects" do
   context "when the URN and UKPRN are valid" do
     let(:urn) { 123456 }
     let(:ukprn) { 10061021 }
+    let(:two_weeks_ago) { Date.today - 2.weeks }
 
     before { mock_successful_api_responses(urn: urn, ukprn: ukprn) }
 
     scenario "a new project is created" do
       fill_in "School URN", with: urn
       fill_in "Incoming trust UK Provider Reference Number (UKPRN)", with: ukprn
-      fill_in "Month", with: 12
-      fill_in "Year", with: 2025
+
+      within("#target-completion-date") do
+        fill_in "Month", with: 12
+        fill_in "Year", with: 2025
+      end
+
+      within("#advisory-board-date") do
+        fill_in "Day", with: two_weeks_ago.day
+        fill_in "Month", with: two_weeks_ago.month
+        fill_in "Year", with: two_weeks_ago.year
+      end
+
+      fill_in "project-advisory-board-conditions-field", with: "This school must:\n1. Do this\n2. And that"
+
       fill_in "Handover comments", with: "A new handover comment"
 
       click_button("Continue")
@@ -26,6 +39,10 @@ RSpec.feature "Users can create new projects" do
       expect(page).to have_content(I18n.t("project.show.title"))
       expect(page).to have_content("Project kick-off")
       expect(page).to have_content("Handover with regional delivery officer")
+
+      click_on("Project information")
+
+      expect(page).to have_content(two_weeks_ago.to_formatted_s(:govuk))
     end
   end
 end

--- a/spec/features/users_can_create_projects_spec.rb
+++ b/spec/features/users_can_create_projects_spec.rb
@@ -20,8 +20,9 @@ RSpec.feature "Users can create new projects" do
       fill_in "Incoming trust UK Provider Reference Number (UKPRN)", with: ukprn
 
       within("#target-completion-date") do
-        fill_in "Month", with: 12
-        fill_in "Year", with: 2025
+        completion_date = Date.today + 1.year
+        fill_in "Month", with: completion_date.month
+        fill_in "Year", with: completion_date.year
       end
 
       within("#advisory-board-date") do

--- a/spec/features/users_can_view_project_information_spec.rb
+++ b/spec/features/users_can_view_project_information_spec.rb
@@ -1,8 +1,10 @@
 require "rails_helper"
 
 RSpec.feature "Users can view project information" do
+  include ActionView::Helpers::TextHelper
+
   let(:user) { create(:user, :caseworker) }
-  let(:project) { create(:project, caseworker: user) }
+  let(:project) { create(:project, :with_conditions, caseworker: user) }
   let(:project_id) { project.id }
 
   before do
@@ -21,6 +23,13 @@ RSpec.feature "Users can view project information" do
 
       expect(page).to have_content(project.regional_delivery_officer.full_name)
       expect(page).to have_link(project.regional_delivery_officer.email)
+    end
+  end
+
+  scenario "they can view the advisory board details" do
+    within("#projectDetails") do
+      expect(page).to have_content(project.advisory_board_date.to_formatted_s(:govuk))
+      expect(page.html).to include(simple_format(project.advisory_board_conditions, class: "govuk-body"))
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_db_column(:caseworker_id).of_type :uuid }
     it { is_expected.to have_db_column(:team_leader_id).of_type :uuid }
     it { is_expected.to have_db_column(:caseworker_assigned_at).of_type :datetime }
+    it { is_expected.to have_db_column(:advisory_board_date).of_type :date }
+    it { is_expected.to have_db_column(:advisory_board_conditions).of_type :text }
   end
 
   describe "Relationships" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -73,6 +73,8 @@ RSpec.describe Project, type: :model do
   describe "Validations" do
     before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 
+    it { is_expected.to validate_presence_of(:advisory_board_date).on(:create) }
+
     describe "#urn" do
       it { is_expected.to validate_presence_of(:urn) }
       it { is_expected.to validate_numericality_of(:urn).only_integer }

--- a/spec/presenters/project_presenter_spec.rb
+++ b/spec/presenters/project_presenter_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe ProjectPresenter do
+  describe "#advisory_board_date" do
+    it "returns the formatted date" do
+      project = build(:project)
+      expect(described_class.new(project).advisory_board_date)
+        .to eq(project.advisory_board_date.to_formatted_s(:govuk))
+    end
+
+    it "can be empty when there is no advisory board date" do
+      project = build(:project, advisory_board_date: nil)
+      expect(described_class.new(project).advisory_board_date)
+        .to be_nil
+    end
+  end
+end

--- a/spec/validators/past_date_validator_spec.rb
+++ b/spec/validators/past_date_validator_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe PastDateValidator do
+  subject do
+    Class.new {
+      include ActiveModel::Validations
+      attr_accessor :date
+      validates :date, past_date: true
+    }.new
+  end
+
+  context "when the date is in the past" do
+    it "is valid" do
+      subject.date = Date.today - 1.month
+      expect(subject).to be_valid
+    end
+  end
+
+  context "when the date is in the future" do
+    it "is invalid" do
+      subject.date = Date.today + 1.month
+      expect(subject).to be_invalid
+    end
+  end
+
+  context "when the date is today" do
+    it "is invalid" do
+      subject.date = Date.today
+      expect(subject).to be_invalid
+    end
+  end
+end


### PR DESCRIPTION
## Depends on
#171 

## Changes

The advisory board is where the decsion is made to allow a school to convert. Whilst we are not sure how the date this board met and any conditions that arise from it are useful, we have plenty of evidence they will be needed.

This works introduces capturing these details during the handover of a project. As with most data that makes up the handover, we could get it from the prepare system, but in order to get to a working MVP we will keep this step manual for now and have a Regional delivery officer provide them, automating this step away will come later.

The advisory board date is required as it must have taken place and must be in the past for the same reason.

The conditions are optional, as there may be none, although we may want to think about what none vs forgot to add them might look like at some point later, for this version we assume that submitting none = there were none.

https://trello.com/c/CpPDtrpy

## Screenshots
![Screenshot 2022-09-16 at 13-56-00 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/190644498-323b8a2b-4d25-4b30-ad7e-2639505ef2c9.png)
![Screenshot 2022-09-16 at 13-56-30 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/190644508-b2e311ee-0c32-4150-83a7-a422d4db5bd5.png)
![Screenshot 2022-09-16 at 13-56-44 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/190644519-45bbb2ec-ed5e-4605-b617-1dc6445ff94f.png)
![Screenshot 2022-09-16 at 13-57-44 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/190644530-6a28490e-d9d0-4a11-b365-3f21d0307f3a.png)



## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
