### PR TITLE
(550) Tidy up Rails routes

### DIFF
--- a/app/controllers/project_information_controller.rb
+++ b/app/controllers/project_information_controller.rb
@@ -1,5 +1,5 @@
 class ProjectInformationController < ApplicationController
   def show
-    @project = Project.find(params[:id])
+    @project = Project.find(params[:project_id])
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,15 +14,15 @@ Rails.application.routes.draw do
   # Omniauth callbacks
   get "auth/:provider/callback", to: "sessions#create"
 
-  resources :projects do
-    resources :tasks
-    resources :notes do
-      get "/delete", action: :confirm_destroy
-    end
-    resources :contacts do
-      get "/delete", action: :confirm_destroy
-    end
+  concern :has_destroy_confirmation do
+    get "/delete", action: :confirm_destroy
   end
 
-  get "/projects/:id/information", to: "project_information#show", as: :project_information
+  resources :projects do
+    get "information", to: "project_information#show"
+
+    resources :tasks, only: %i[show update]
+    resources :notes, except: %i[show], concerns: :has_destroy_confirmation
+    resources :contacts, except: %i[show], concerns: :has_destroy_confirmation
+  end
 end


### PR DESCRIPTION
## Changes
- Move the project information routes into the projects resources block (this also changes the params name, so update the controller to match).
- Restrict the routes created to the ones which we have defined.
- Use a concern to DRY up the repeated destroy confirmation page routes.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
