### PR TITLE
(523) Titleise the trust name for display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Note bodies are parsed via Markdown to allow rich formatting.
 - Workflow definition files are now split by section, rather than being
   monolithic.
+- Trust names are now displayed in title case, rather than all caps.
 
 ### Fixed
 

--- a/app/models/academies_api/trust.rb
+++ b/app/models/academies_api/trust.rb
@@ -1,12 +1,16 @@
 class AcademiesApi::Trust < AcademiesApi::BaseApiModel
   attr_accessor(
-    :name,
+    :original_name,
     :companies_house_number
   )
 
+  def name
+    original_name.titleize
+  end
+
   def self.attribute_map
     {
-      name: "data.giasData.groupName",
+      original_name: "data.giasData.groupName",
       companies_house_number: "data.giasData.companiesHouseNumber"
     }
   end

--- a/spec/factories/academies_api/trust.rb
+++ b/spec/factories/academies_api/trust.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :academies_api_trust, class: "AcademiesApi::Trust" do
-    name { "THE ROMERO CATHOLIC ACADEMY" }
+    original_name { "THE ROMERO CATHOLIC ACADEMY" }
     companies_house_number { "09702162" }
   end
 end

--- a/spec/models/academies_api/client_spec.rb
+++ b/spec/models/academies_api/client_spec.rb
@@ -89,8 +89,14 @@ RSpec.describe AcademiesApi::Client do
       it "returns a Result with the establishment and no error" do
         result = client.get_trust(10061021)
 
-        expect(result.object.name).to eql("THE ROMERO CATHOLIC ACADEMY")
+        expect(result.object.original_name).to eql("THE ROMERO CATHOLIC ACADEMY")
         expect(result.error).to be_nil
+      end
+
+      it "correctly titleises the trust name" do
+        result = client.get_trust(10061021)
+
+        expect(result.object.name).to eql("The Romero Catholic Academy")
       end
     end
 


### PR DESCRIPTION
## Changes

Previously trust names would display in ALL CAPS, since this is how they arrive from upstream APIs. They are now run through `titleize` before display, which converts them to title case.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
