### PR TITLE
(522) Add Clear legal documents template/Move not applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Change the project information page to a one-quarter three-quarter layout to
   allow more room for the project information.
 - Updated content for the tasks in the 'Get ready for opening' section.
+- The "Not applicable" checkbox now sits at the top of the Task view, underneath
+  the Task-level hint.
 
 ### Fixed
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,11 +20,13 @@ $govuk-global-styles: true;
 }
 
 .task-checkboxes {
-  .govuk-checkboxes__item,
-  .govuk-checkboxes__divider {
+  .govuk-checkboxes__item {
     margin-bottom: govuk-spacing(9);
   }
+}
 
+.task-checkboxes,
+.clear-legal-documents-task-checkboxes {
   .govuk-checkboxes__item {
     label {
       @extend .govuk-\!-font-weight-bold;

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,6 +2,7 @@ class TasksController < ApplicationController
   before_action :find_task
 
   def show
+    render "tasks/clear_legal_documents/show" if @task.clear_legal_documents_type?
   end
 
   def update

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -14,6 +14,10 @@ class Task < ApplicationRecord
     @completed_actions_count ||= actions.where(completed: true).count
   end
 
+  def clear_legal_documents_type?
+    section.title == "Clear legal documents"
+  end
+
   def status
     return :not_applicable if not_applicable? && optional?
 

--- a/app/views/tasks/clear_legal_documents/show.html.erb
+++ b/app/views/tasks/clear_legal_documents/show.html.erb
@@ -4,16 +4,14 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-!-margin-bottom-9">
-      <%= render partial: "tasks/shared/task_title", locals: {task: @task} %>
+    <%= render partial: "tasks/shared/task_title", locals: {task: @task} %>
 
-      <%= render partial: "tasks/shared/task_hint", locals: {task: @task} %>
-
-      <%= render partial: "tasks/shared/task_guidance_summary", locals: {task: @task} %>
-    </div>
+    <%= render partial: "tasks/shared/task_hint", locals: {task: @task} %>
 
     <%= form_for :task, url: project_task_path, method: :put do |form| %>
-      <%= form.govuk_check_boxes_fieldset :actions, legend: {hidden: true}, classes: "task-checkboxes" do %>
+      <%= form.govuk_check_boxes_fieldset :actions, legend: {hidden: true}, classes: "clear-legal-documents-task-checkboxes" do %>
+        <%= render partial: "tasks/shared/not_applicable_checkbox", locals: {task: @task, form: form} %>
+
         <% @task.actions.each do |action| %>
           <%= render layout: "tasks/shared/action_checkbox", locals: {action: action, form: form} do %>
 

--- a/app/views/tasks/shared/_action_checkbox.html.erb
+++ b/app/views/tasks/shared/_action_checkbox.html.erb
@@ -1,0 +1,8 @@
+<%= form.govuk_check_box :completed_action_ids,
+                         action.id,
+                         label: { text: action.title },
+                         link_errors: true,
+                         checked: action.completed?,
+                         hint: -> do %>
+  <%= yield %>
+<% end %>

--- a/app/views/tasks/shared/_action_guidance_summary.html.erb
+++ b/app/views/tasks/shared/_action_guidance_summary.html.erb
@@ -1,0 +1,5 @@
+<% if action.guidance_summary? %>
+  <%= govuk_details(summary_text: action.guidance_summary) do %>
+    <%= render_markdown(action.guidance_text) %>
+  <% end %>
+<% end %>

--- a/app/views/tasks/shared/_action_hint.html.erb
+++ b/app/views/tasks/shared/_action_hint.html.erb
@@ -1,0 +1,1 @@
+<%= render_markdown(action.hint, hint: true) unless action.hint.nil? %>

--- a/app/views/tasks/shared/_not_applicable_checkbox.html.erb
+++ b/app/views/tasks/shared/_not_applicable_checkbox.html.erb
@@ -1,0 +1,8 @@
+<% if task.optional? %>
+  <div class="govuk-!-margin-bottom-9">
+    <%= form.govuk_check_box :not_applicable,
+          true,
+          label: {text: t("tasks.not_applicable")},
+          checked: task.not_applicable? %>
+  </div>
+<% end %>

--- a/app/views/tasks/shared/_task_guidance_summary.html.erb
+++ b/app/views/tasks/shared/_task_guidance_summary.html.erb
@@ -1,0 +1,5 @@
+<% if task.guidance_summary? %>
+  <%= govuk_details(summary_text: task.guidance_summary) do %>
+    <%= render_markdown(task.guidance_text) %>
+  <% end %>
+<% end %>

--- a/app/views/tasks/shared/_task_hint.html.erb
+++ b/app/views/tasks/shared/_task_hint.html.erb
@@ -1,0 +1,3 @@
+<% if task.hint? %>
+  <p class="govuk-body"><%= render_markdown(task.hint, hint: true) %></p>
+<% end %>

--- a/app/views/tasks/shared/_task_hint.html.erb
+++ b/app/views/tasks/shared/_task_hint.html.erb
@@ -1,3 +1,3 @@
 <% if task.hint? %>
-  <p class="govuk-body"><%= render_markdown(task.hint, hint: true) %></p>
+  <%= render_markdown(task.hint, hint: true) %>
 <% end %>

--- a/app/views/tasks/shared/_task_title.html.erb
+++ b/app/views/tasks/shared/_task_title.html.erb
@@ -1,0 +1,2 @@
+<span class="govuk-caption-l"><%= task.project.establishment.name %></span>
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-2"><%= task.title %></h1>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -9,7 +9,7 @@
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-2"><%= @task.title %></h1>
 
       <% if @task.hint? %>
-        <p class="govuk-body"><%= render_markdown(@task.hint) %></p>
+        <p class="govuk-body"><%= render_markdown(@task.hint, hint: true) %></p>
       <% end %>
 
       <% if @task.guidance_summary? %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -5,37 +5,21 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-!-margin-bottom-9">
-      <span class="govuk-caption-l"><%= @task.project.establishment.name %></span>
-      <h1 class="govuk-heading-xl govuk-!-margin-bottom-2"><%= @task.title %></h1>
+      <%= render partial: "tasks/shared/task_title", locals: {task: @task} %>
 
-      <% if @task.hint? %>
-        <p class="govuk-body"><%= render_markdown(@task.hint, hint: true) %></p>
-      <% end %>
+      <%= render partial: "tasks/shared/task_hint", locals: {task: @task} %>
 
-      <% if @task.guidance_summary? %>
-        <%= govuk_details(summary_text: @task.guidance_summary) do %>
-          <%= render_markdown(@task.guidance_text) %>
-        <% end %>
-      <% end %>
+      <%= render partial: "tasks/shared/task_guidance_summary", locals: {task: @task} %>
     </div>
 
     <%= form_for :task, url: project_task_path, method: :put do |form| %>
       <%= form.govuk_check_boxes_fieldset :actions, legend: {hidden: true}, classes: "task-checkboxes" do %>
         <% @task.actions.each do |action| %>
-          <%= form.govuk_check_box :completed_action_ids,
-                                   action.id,
-                                   label: { text: action.title },
-                                   link_errors: true,
-                                   checked: action.completed?,
-                                   hint: -> do %>
+          <%= render layout: "tasks/shared/action_checkbox", locals: {action: action, form: form} do %>
 
-            <%= render_markdown(action.hint, hint: true) unless action.hint.nil? %>
+            <%= render partial: "tasks/shared/action_hint", locals: {action: action} %>
 
-            <% if action.guidance_summary? %>
-              <%= govuk_details(summary_text: action.guidance_summary) do %>
-                <%= render_markdown(action.guidance_text) %>
-              <% end %>
-            <% end %>
+            <%= render partial: "tasks/shared/action_guidance_summary", locals: {action: action} %>
 
           <% end %>
         <% end %>

--- a/spec/factories/section_factory.rb
+++ b/spec/factories/section_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :section, class: "Section" do
-    title { "Clear legal documents" }
+    title { "Project kick-off" }
     order { 0 }
     project
   end

--- a/spec/features/users_can_mark_optional_tasks_as_not_applicable_spec.rb
+++ b/spec/features/users_can_mark_optional_tasks_as_not_applicable_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Users can mark optional tasks as not applicable to a project" do
   end
 
   let(:project) { create(:project, urn: 123456, incoming_trust_ukprn: 12345678) }
-  let!(:section) { create(:section, project: project) }
+  let!(:section) { create(:section, project: project, title: "Clear legal documents") }
   let(:task) { create(:task, :not_applicable, title: "Not applicable task", section: section) }
   let!(:actions) { create_list(:action, 3, task: task, completed: true) }
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -54,6 +54,24 @@ RSpec.describe Task, type: :model do
     end
   end
 
+  describe "#clear_legal_documents_type?" do
+    let(:task) { build(:task, section: section) }
+
+    subject { task.clear_legal_documents_type? }
+
+    context "when section is 'Clear legal documents'" do
+      let(:section) { build(:section, title: "Clear legal documents") }
+
+      it { expect(subject).to be true }
+    end
+
+    context "when section is not 'Clear legal documents'" do
+      let(:section) { build(:section, title: "Project kick-off") }
+
+      it { expect(subject).to be false }
+    end
+  end
+
   describe "#status" do
     let(:task) { create(:task) }
 

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe TasksController, type: :request do
   end
 
   describe "#show" do
-    let(:task) { create(:task) }
+    let(:section) { create(:section, title: "Project kick-off") }
+    let(:task) { create(:task, section: section) }
     let(:project_id) { task.section.project.id }
     let(:task_id) { task.id }
 
@@ -26,9 +27,19 @@ RSpec.describe TasksController, type: :request do
       it { expect { perform_request }.to raise_error(ActiveRecord::RecordNotFound) }
     end
 
-    it "returns a successful response" do
+    it "returns a successful response and renders the default template" do
       expect(subject).to have_http_status :success
       expect(subject.body).to include("Have you cleared the Supplementary funding agreement?")
+      expect(subject).to render_template :show
+    end
+
+    context "when the task is not in the 'Clear legal documents' section" do
+      let(:section) { create(:section, title: "Clear legal documents") }
+
+      it "returns a successful response and renders the clear_legal_documents_show template" do
+        expect(subject).to have_http_status :success
+        expect(subject).to render_template "clear_legal_documents/show"
+      end
     end
 
     it "can render actions with and without hint text" do


### PR DESCRIPTION
## Changes
### Add method to determine whether a task is in "Clear legal documents"
Tasks in the "Clear legal documents" section have a significantly different appearance than the tasks in the "Project kick-off" section.

So that we can differentiate between the two types, add a simple method on the Task model that check the section title.

### Apply GOV.UK hint styling to Task-level hint
We have a helper which can be used to apply the `govuk-hint` class.

Apply this to the Task-level hint to match the prototype.

### Move common task view components into partials
We will be introducing a separate template for "Clear legal documents" tasks.

Move common view components into partials so that we can build the new view from them.

### Render `clear_legal_documents/show` template if Task is of that type
Introduce a new template for "Clear legal documents" type Tasks.

The styling for the "Not applicable" checkbox has been updated to sit at the top.

This introduces extra partials for the checkboxes to make controlling this easier.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
