### PR TITLE
(573) SharePoint link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The Handover/new project form collects an establishment SharePoint link.
 - The Project Details section of the Project Information shows the establishment
   SharePoint link.
+- The Project Summary shows the establishment SharePoint link.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Users can be assigned to projects roles via 'change' links on the project
   information page. Only users with the team lead role can assign users.
 - The Handover/new project form collects an establishment SharePoint link.
+- The Project Details section of the Project Information shows the establishment
+  SharePoint link.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   conditions.
 - Users can be assigned to projects roles via 'change' links on the project
   information page. Only users with the team lead role can assign users.
+- The Handover/new project form collects an establishment SharePoint link.
 
 ### Changed
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -41,7 +41,8 @@ class ProjectsController < ApplicationController
       :incoming_trust_ukprn,
       :target_completion_date,
       :advisory_board_date,
-      :advisory_board_conditions
+      :advisory_board_conditions,
+      :establishment_sharepoint_link
     )
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,11 @@ module ApplicationHelper
 
     sanitize(rendered_markdown, attributes: default_attributes.merge(additional_attributes))
   end
+
+  def safe_link_to(body, url)
+    allowed_attributes = %w[href target]
+
+    link = link_to(body, url, target: :_blank)
+    sanitize(link, attributes: allowed_attributes)
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -11,6 +11,7 @@ class Project < ApplicationRecord
   validates :incoming_trust_ukprn, ukprn: true
   validates :advisory_board_date, presence: true, on: :create
   validates :advisory_board_date, past_date: true
+  validates :establishment_sharepoint_link, presence: true, on: :create
 
   validate :first_day_of_month
   validate :target_completion_date_is_in_the_future, on: :create

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,6 @@
 class Project < ApplicationRecord
+  SHAREPOINT_URLS = %w[educationgovuk-my.sharepoint.com educationgovuk.sharepoint.com].freeze
+
   has_many :sections, dependent: :destroy
   has_many :notes, dependent: :destroy
   has_many :contacts, dependent: :destroy
@@ -11,7 +13,7 @@ class Project < ApplicationRecord
   validates :incoming_trust_ukprn, ukprn: true
   validates :advisory_board_date, presence: true, on: :create
   validates :advisory_board_date, past_date: true
-  validates :establishment_sharepoint_link, presence: true, on: :create
+  validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}, on: :create
 
   validate :first_day_of_month
   validate :target_completion_date_is_in_the_future, on: :create

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -25,7 +25,7 @@ class Project < ApplicationRecord
   end
 
   def incoming_trust
-    @incoming_rust ||= fetch_trust(incoming_trust_ukprn)
+    @incoming_trust ||= fetch_trust(incoming_trust_ukprn)
   end
 
   private def fetch_establishment(urn)

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -5,7 +5,7 @@ class UrlValidator < ActiveModel::EachValidator
     uri = URI.parse(value)
 
     record.errors.add(attribute, :https_only) unless uri.scheme == "https"
-    record.errors.add(attribute, :host_not_allowed) unless uri.hostname&.include?(options[:hostname])
+    record.errors.add(attribute, :host_not_allowed) unless options[:hostnames].any? { |hostname| uri.hostname&.include?(hostname) }
   rescue URI::InvalidURIError
     record.errors.add(attribute, :invalid)
   end

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -1,0 +1,12 @@
+class UrlValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    uri = URI.parse(value)
+
+    record.errors.add(attribute, :https_only) unless uri.scheme == "https"
+    record.errors.add(attribute, :host_not_allowed) unless uri.hostname&.include?(options[:hostname])
+  rescue URI::InvalidURIError
+    record.errors.add(attribute, :invalid)
+  end
+end

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -36,6 +36,10 @@
       row.value { @project.advisory_board_date }
     end
     summary_list.row do |row|
+      row.key { t('project_information.show.project_details.rows.establishment_sharepoint_link') }
+      row.value { link_to(@project.establishment_sharepoint_link, @project.establishment_sharepoint_link, target: :_blank) }
+    end
+    summary_list.row do |row|
       row.key { t('project_information.show.project_details.rows.advisory_board_conditions') }
       row.value { simple_format(@project.advisory_board_conditions, class: "govuk-body") }
     end

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -37,7 +37,7 @@
     end
     summary_list.row do |row|
       row.key { t('project_information.show.project_details.rows.establishment_sharepoint_link') }
-      row.value { link_to(@project.establishment_sharepoint_link, @project.establishment_sharepoint_link, target: :_blank) }
+      row.value { safe_link_to(@project.establishment_sharepoint_link, @project.establishment_sharepoint_link) }
     end
     summary_list.row do |row|
       row.key { t('project_information.show.project_details.rows.advisory_board_conditions') }

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -36,12 +36,12 @@
       row.value { @project.advisory_board_date }
     end
     summary_list.row do |row|
-      row.key { t('project_information.show.project_details.rows.establishment_sharepoint_link') }
-      row.value { safe_link_to(@project.establishment_sharepoint_link, @project.establishment_sharepoint_link) }
-    end
-    summary_list.row do |row|
       row.key { t('project_information.show.project_details.rows.advisory_board_conditions') }
       row.value { simple_format(@project.advisory_board_conditions, class: "govuk-body") }
+    end
+    summary_list.row do |row|
+      row.key { t('project_information.show.project_details.rows.establishment_sharepoint_link') }
+      row.value { safe_link_to(t("project.summary.establishment_sharepoint_link.value"), @project.establishment_sharepoint_link) }
     end
   end %>
 </div>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -12,6 +12,7 @@
       <%= form.govuk_text_field :urn, label: {size: "m"}, width: 10 %>
       <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m"}, width: 10 %>
       <%= form.govuk_date_field :target_completion_date, omit_day: true, form_group: {id: "target-completion-date"} %>
+      <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m"} %>
       <%= form.govuk_date_field :advisory_board_date, form_group: {id: "advisory-board-date"} %>
       <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m"} %>
 

--- a/app/views/shared/_project_summary.html.erb
+++ b/app/views/shared/_project_summary.html.erb
@@ -22,8 +22,8 @@
             row.value { @project.establishment.region_name }
           end
           summary_list.row do |row|
-            row.key { t("project.summary.sharepoint_link.title") }
-            row.value { link_to(@project.establishment_sharepoint_link, @project.establishment_sharepoint_link, target: :_blank) }
+            row.key { t("project.summary.establishment_sharepoint_link.title") }
+            row.value { safe_link_to(@project.establishment_sharepoint_link, @project.establishment_sharepoint_link) }
           end
         end %>
 

--- a/app/views/shared/_project_summary.html.erb
+++ b/app/views/shared/_project_summary.html.erb
@@ -21,6 +21,10 @@
             row.key { t("project.summary.region.title") }
             row.value { @project.establishment.region_name }
           end
+          summary_list.row do |row|
+            row.key { t("project.summary.sharepoint_link.title") }
+            row.value { link_to(@project.establishment_sharepoint_link, @project.establishment_sharepoint_link, target: :_blank) }
+          end
         end %>
 
   </div>

--- a/app/views/shared/_project_summary.html.erb
+++ b/app/views/shared/_project_summary.html.erb
@@ -23,7 +23,7 @@
           end
           summary_list.row do |row|
             row.key { t("project.summary.establishment_sharepoint_link.title") }
-            row.value { safe_link_to(@project.establishment_sharepoint_link, @project.establishment_sharepoint_link) }
+            row.value { safe_link_to(t("project.summary.establishment_sharepoint_link.value"), @project.establishment_sharepoint_link) }
           end
         end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -246,6 +246,9 @@ en:
               must_be_in_the_past: The advisory board date must be in the past
             establishment_sharepoint_link:
               blank: Enter a SharePoint link
+              invalid: Enter a SharePoint link in the correct format
+              https_only: The SharePoint link must have the https scheme
+              host_not_allowed: Enter a SharePoint link in the correct format. SharePoint links start with 'https://educationgovuk.sharepoint.com' or 'https://educationgovuk-my.sharepoint.com/'
         note:
           attributes:
             body:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,6 +83,8 @@ en:
         title: Target conversion date
       region:
         title: Region
+      establishment_sharepoint_link:
+        title: School SharePoint link
     assign:
       team_leader:
         success: Team leader has been assigned successfully

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,7 @@ en:
         title: Region
       establishment_sharepoint_link:
         title: School SharePoint link
+        value: Open the School Sharepoint folder in a new tab
     assign:
       team_leader:
         success: Team leader has been assigned successfully

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,6 +193,7 @@ en:
         caseworker_id: Caseworker
         regional_delivery_officer_id: Regional delivery officer
         advisory_board_conditions: Advisory board conditions
+        establishment_sharepoint_link: School SharePoint link
       note:
         body: Enter note
       contact:
@@ -212,6 +213,7 @@ en:
         caseworker_id: The caseworker responsible for this project
         target_completion_date: The target conversion date is always the 1st of the month.
         advisory_board_conditions: If there are conditions to be met as a result of the advisory board.
+        establishment_sharepoint_link: Provide a link to the SharePoint folder for this project. This is where you save all the relevant documents.
       note:
         body: Do not include personal or financial information.
 
@@ -239,6 +241,8 @@ en:
             advisory_board_date:
               blank: Enter a date of advisory board
               must_be_in_the_past: The advisory board date must be in the past
+            establishment_sharepoint_link:
+              blank: Enter a SharePoint link
         note:
           attributes:
             body:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,7 @@ en:
           regional_delivery_officer: Regional delivery officer
           unassigned: Not yet assigned
           advisory_board_date: Date of advisory board
+          establishment_sharepoint_link: School SharePoint link
           advisory_board_conditions: Conditions from advisory board
       school_details:
         title: School details

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
     get "/delete", action: :confirm_destroy
   end
 
-  resources :projects do
+  resources :projects, only: %i[index show new create] do
     get "information", to: "project_information#show"
 
     resources :tasks, only: %i[show update]

--- a/db/migrate/20220921141636_add_establishment_sharepoint_link_to_project.rb
+++ b/db/migrate/20220921141636_add_establishment_sharepoint_link_to_project.rb
@@ -1,0 +1,5 @@
+class AddEstablishmentSharepointLinkToProject < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :establishment_sharepoint_link, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_15_130100) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_21_141636) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -59,6 +59,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_15_130100) do
     t.datetime "caseworker_assigned_at"
     t.date "advisory_board_date"
     t.text "advisory_board_conditions"
+    t.text "establishment_sharepoint_link"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"
     t.index ["team_leader_id"], name: "index_projects_on_team_leader_id"

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     team_leader { association :user, :team_leader, email: "team-leader-#{SecureRandom.uuid}@education.gov.uk" }
     regional_delivery_officer { association :user, :regional_delivery_officer, email: "regional-delivery-officer-#{SecureRandom.uuid}@education.gov.uk" }
     advisory_board_date { (Date.today - 2.weeks) }
+    establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/project/information" }
 
     trait :with_conditions do
       advisory_board_conditions { "The following must be met:\n 1. Must be red\n2. Must be blue\n" }

--- a/spec/features/users_can_create_projects_spec.rb
+++ b/spec/features/users_can_create_projects_spec.rb
@@ -25,6 +25,8 @@ RSpec.feature "Users can create new projects" do
         fill_in "Year", with: completion_date.year
       end
 
+      fill_in "School SharePoint link", with: "https://educationgovuk-my.sharepoint.com/project/information"
+
       within("#advisory-board-date") do
         fill_in "Day", with: two_weeks_ago.day
         fill_in "Month", with: two_weeks_ago.month

--- a/spec/features/users_can_view_a_project_spec.rb
+++ b/spec/features/users_can_view_a_project_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Users can view a project" do
       expect(page).to have_content(project.establishment.local_authority)
       expect(page).to have_content(project.incoming_trust.name)
       expect(page).to have_content(project.establishment.region_name)
-      expect(page).to have_link(project.establishment_sharepoint_link, href: project.establishment_sharepoint_link)
+      expect(page).to have_link(I18n.t("project.summary.establishment_sharepoint_link.value"), href: project.establishment_sharepoint_link)
     end
   end
 end

--- a/spec/features/users_can_view_a_project_spec.rb
+++ b/spec/features/users_can_view_a_project_spec.rb
@@ -18,6 +18,7 @@ RSpec.feature "Users can view a project" do
       expect(page).to have_content(project.establishment.local_authority)
       expect(page).to have_content(project.incoming_trust.name)
       expect(page).to have_content(project.establishment.region_name)
+      expect(page).to have_link(project.establishment_sharepoint_link, href: project.establishment_sharepoint_link)
     end
   end
 end

--- a/spec/features/users_can_view_project_information_spec.rb
+++ b/spec/features/users_can_view_project_information_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Users can view project information" do
 
   scenario "they can view the School SharePoint link" do
     within("#projectDetails") do
-      expect(page).to have_link(project.establishment_sharepoint_link, href: project.establishment_sharepoint_link)
+      expect(page).to have_link(I18n.t("project.summary.establishment_sharepoint_link.value"), href: project.establishment_sharepoint_link)
     end
   end
 

--- a/spec/features/users_can_view_project_information_spec.rb
+++ b/spec/features/users_can_view_project_information_spec.rb
@@ -33,6 +33,12 @@ RSpec.feature "Users can view project information" do
     end
   end
 
+  scenario "they can view the School SharePoint link" do
+    within("#projectDetails") do
+      expect(page).to have_link(project.establishment_sharepoint_link, href: project.establishment_sharepoint_link)
+    end
+  end
+
   scenario "they can view the school details" do
     within("#schoolDetails") do
       expect(page).to have_content(project.establishment.name)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -30,4 +30,23 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#safe_link_to" do
+    let(:body) { "Link" }
+    let(:url) { "https://example.com" }
+
+    subject { safe_link_to(body, url) }
+
+    context "when the url contains unsafe protocols" do
+      let(:url) { "javascript:alert('malicious')" }
+
+      it "removes unsafe protocols" do
+        expect(subject).to_not include("javascript")
+      end
+    end
+
+    it "adds the target blank attribute" do
+      expect(subject).to include("target=\"_blank\"")
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_db_column(:caseworker_assigned_at).of_type :datetime }
     it { is_expected.to have_db_column(:advisory_board_date).of_type :date }
     it { is_expected.to have_db_column(:advisory_board_conditions).of_type :text }
+    it { is_expected.to have_db_column(:establishment_sharepoint_link).of_type :text }
   end
 
   describe "Relationships" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -147,6 +147,10 @@ RSpec.describe Project, type: :model do
         end
       end
     end
+
+    describe "#establishment_sharepoint_link" do
+      it { is_expected.to validate_presence_of :establishment_sharepoint_link }
+    end
   end
 
   describe "#establishment" do

--- a/spec/validators/url_validator_spec.rb
+++ b/spec/validators/url_validator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe UrlValidator do
     Class.new do
       include ActiveModel::Model
       attr_accessor :link
-      validates :link, url: {hostname: "example"}
+      validates :link, url: {hostnames: %w[example another-example]}
     end
   end
 
@@ -40,8 +40,12 @@ RSpec.describe UrlValidator do
   end
 
   context "when the URL matches the hostname and scheme" do
-    it "is valid" do
-      expect(subject.valid?).to be true
+    %w[https://example.com https://another-example.com].each do |url|
+      let(:link) { url }
+
+      it "is valid" do
+        expect(subject.valid?).to be true
+      end
     end
   end
 end

--- a/spec/validators/url_validator_spec.rb
+++ b/spec/validators/url_validator_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe UrlValidator do
+  let(:link) { "https://example.com" }
+  let(:testing_model) do
+    Class.new do
+      include ActiveModel::Model
+      attr_accessor :link
+      validates :link, url: {hostname: "example"}
+    end
+  end
+
+  subject { testing_model.new(link: link) }
+
+  context "when the URL is an invalid URI" do
+    let(:link) { "/[invalid]" }
+
+    it "is invalid" do
+      expect(subject.valid?).to be false
+      expect(subject.errors.first.type).to be :invalid
+    end
+  end
+
+  context "when the URL scheme is not https" do
+    let(:link) { "http://example.com" }
+
+    it "is invalid" do
+      expect(subject.valid?).to be false
+      expect(subject.errors.first.type).to be :https_only
+    end
+  end
+
+  context "when the URL hostname does not match" do
+    let(:link) { "https://something-else.com" }
+
+    it "is invalid" do
+      expect(subject.valid?).to be false
+      expect(subject.errors.first.type).to be :host_not_allowed
+    end
+  end
+
+  context "when the URL matches the hostname and scheme" do
+    it "is valid" do
+      expect(subject.valid?).to be true
+    end
+  end
+end


### PR DESCRIPTION
## Changes
### Add SharePoint link to Project
We know that users collate documents in a SharePoint folder as part of the prepare journey, and that users of this service will need to update/add to them.

Add a SharePoint link property to the Project model.

### Fix typo of memoized instance variable

### Restrict project routes
We don't use all seven default routes, only create the ones we do use.

### Collect SharePoint link on Project creation
We want to collect the SharePoint link when the user creates a project.

### Show SharePoint link on Project Details

### Show SharePoint link on Project Summary

### Add URL validator
We want to check the hostname and scheme of the SharePoint link.

Add a generic validator.

### Validate that the SharePoint link follows the expected format
We believe all project SharePoint links will start with `https://educationgovuk-my.sharepoint.com/` or `educationgovuk.sharepoint.com`.

Validate this on project creation.

This also updates the UrlValidator to handle multiple URLs

### Add a safe_link_to helper
Currently, it's possible for a user to provide a malicious SharePoint link such as `"javascript:alert('malicious')"`, which is not escaped by the Rails `link_to` helper.

This was being flagged by Brakeman as a potential XSS issue.

Add a `safe_link_to` method that sanitizes links.

### Display a body for the SharePoint link
The SharePoint links can be long and not-very-nice to read.

Instead, we want to show a body for the link.

This also moves the SharePoint link to the bottom of the Project Information list so that the advisory board rows are together.

## Screenshots
<img width="1110" alt="image" src="https://user-images.githubusercontent.com/47089130/192825007-33cf81b4-99c1-4f15-b9ae-11ac254ac894.png">

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
