### PR TITLE
Bump azurerm container apps hosting version 0.2.0

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -136,7 +136,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v0.1.2 |
+| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v0.2.0 |
 
 ## Resources
 
@@ -148,7 +148,7 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Azure location in which to launch resources. | `string` | n/a | yes |
 | <a name="input_container_command"></a> [container\_command](#input\_container\_command) | Container command | `list(any)` | n/a | yes |
-| <a name="input_container_environment_variables"></a> [container\_environment\_variables](#input\_container\_environment\_variables) | Container environment variables | `map(string)` | n/a | yes |
+| <a name="input_container_secret_environment_variables"></a> [container\_secret\_environment\_variables](#input\_container\_secret\_environment\_variables) | Container secret environment variables | `map(string)` | n/a | yes |
 | <a name="input_enable_container_registry"></a> [enable\_container\_registry](#input\_enable\_container\_registry) | Set to true to create a container registry | `bool` | n/a | yes |
 | <a name="input_enable_mssql_database"></a> [enable\_mssql\_database](#input\_enable\_mssql\_database) | Set to true to create an Azure SQL server/database, with aprivate endpoint within the virtual network | `bool` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Will be used along with `project_name` as a prefix for all resources. | `string` | n/a | yes |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -1,5 +1,5 @@
 module "azure_container_apps_hosting" {
-  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v0.1.2"
+  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v0.2.0"
 
   environment    = local.environment
   project_name   = local.project_name
@@ -7,9 +7,9 @@ module "azure_container_apps_hosting" {
 
   enable_container_registry = local.enable_container_registry
 
-  image_name                      = local.image_name
-  container_command               = local.container_command
-  container_environment_variables = local.container_environment_variables
+  image_name                             = local.image_name
+  container_command                      = local.container_command
+  container_secret_environment_variables = local.container_secret_environment_variables
 
   enable_mssql_database       = local.enable_mssql_database
   mssql_server_admin_password = local.mssql_server_admin_password

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,12 +1,12 @@
 locals {
-  environment                     = var.environment
-  project_name                    = var.project_name
-  azure_location                  = var.azure_location
-  enable_container_registry       = var.enable_container_registry
-  image_name                      = var.image_name
-  container_command               = var.container_command
-  container_environment_variables = var.container_environment_variables
-  enable_mssql_database           = var.enable_mssql_database
-  mssql_server_admin_password     = var.mssql_server_admin_password
-  mssql_database_name             = var.mssql_database_name
+  environment                            = var.environment
+  project_name                           = var.project_name
+  azure_location                         = var.azure_location
+  enable_container_registry              = var.enable_container_registry
+  image_name                             = var.image_name
+  container_command                      = var.container_command
+  container_secret_environment_variables = var.container_secret_environment_variables
+  enable_mssql_database                  = var.enable_mssql_database
+  mssql_server_admin_password            = var.mssql_server_admin_password
+  mssql_database_name                    = var.mssql_database_name
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,9 +28,10 @@ variable "container_command" {
   type        = list(any)
 }
 
-variable "container_environment_variables" {
-  description = "Container environment variables"
+variable "container_secret_environment_variables" {
+  description = "Container secret environment variables"
   type        = map(string)
+  sensitive   = true
 }
 
 variable "enable_mssql_database" {


### PR DESCRIPTION
## Changes

* Bumps azurerm container apps hosting module to version 0.2.0
* Now has the option to set environment variables as secrets, so that they are not exposed via `az containerapp` commands

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
