### PR TITLE
(542) Show full name and email on assignment pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated content for the tasks in the 'Get ready for opening' section.
 - The "Not applicable" checkbox now sits at the top of the Task view, underneath
   the Task-level hint.
+- User assignment drop-downs and autocomplete components show the user's full
+  name and email address.
 
 ### Fixed
 

--- a/app/helpers/assignments_helper.rb
+++ b/app/helpers/assignments_helper.rb
@@ -1,0 +1,5 @@
+module AssignmentsHelper
+  def full_name_and_email(user)
+    "#{user.full_name} (#{user.email})"
+  end
+end

--- a/app/views/assignments/assign_caseworker.html.erb
+++ b/app/views/assignments/assign_caseworker.html.erb
@@ -4,7 +4,10 @@
       <%= form.govuk_error_summary %>
 
       <span class="govuk-caption-m">URN <%= @project.urn %></span>
-      <%= form.govuk_collection_select :caseworker_id, @caseworkers, :id, :full_name,
+      <%= form.govuk_collection_select :caseworker_id,
+            @caseworkers,
+            :id,
+            ->(user) { full_name_and_email(user) },
             label: {text: t("assignment.assign_caseworker.title", school_name: @project.establishment.name),
                     tag: "h1",
                     size: "l"},

--- a/app/views/assignments/assign_regional_delivery_officer.html.erb
+++ b/app/views/assignments/assign_regional_delivery_officer.html.erb
@@ -4,7 +4,10 @@
       <%= form.govuk_error_summary %>
 
       <span class="govuk-caption-m">URN <%= @project.urn %></span>
-      <%= form.govuk_collection_select :regional_delivery_officer_id, @regional_delivery_officers, :id, :full_name,
+      <%= form.govuk_collection_select :regional_delivery_officer_id,
+            @regional_delivery_officers,
+            :id,
+            ->(user) { full_name_and_email(user) },
             label: {text: t("assignment.assign_regional_delivery_officer.title", school_name: @project.establishment.name),
                     tag: "h1",
                     size: "l"},

--- a/app/views/assignments/assign_team_leader.html.erb
+++ b/app/views/assignments/assign_team_leader.html.erb
@@ -4,7 +4,10 @@
       <%= form.govuk_error_summary %>
 
       <span class="govuk-caption-m">URN <%= @project.urn %></span>
-      <%= form.govuk_collection_select :team_leader_id, @team_leaders, :id, :full_name,
+      <%= form.govuk_collection_select :team_leader_id,
+            @team_leaders,
+            :id,
+            ->(user) { full_name_and_email(user) },
             label: {text: t("assignment.assign_team_leader.title", school_name: @project.establishment.name),
                     tag: "h1",
                     size: "l"},

--- a/spec/helpers/assignments_helper_spec.rb
+++ b/spec/helpers/assignments_helper_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe AssignmentsHelper, type: :helper do
+  describe "#full_name_and_email" do
+    let(:user) { create(:user) }
+
+    subject { helper.full_name_and_email(user) }
+
+    it "returns the users full name followed by their parenthesised email" do
+      expect(subject).to eq "John Doe (user@education.gov.uk)"
+    end
+  end
+end


### PR DESCRIPTION
## Changes
### Show full name and email on assignment pages
We want to show the full name and email of users in the autocomplete on the assignment pages so users can be confident that they are selecting the right person.

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/47089130/191996258-6267d86a-d065-4faa-865e-cb40a5b648da.png">

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
