### PR TITLE
Fixes and improvements for schema testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint:js": "eslint .",
     "lint:js:fix": "yarn run lint:js --fix",
     "workflows:validate:tasklists": "ajv -s app/workflows/schemas/tasklist.schema.json -d app/workflows/lists/**/tasklist.yml --spec=draft2020",
-    "workflows:validate:sections": "ajv -s app/workflows/schemas/section.schema.json -d 'app/workflows/sections/**/sections/*.yml' --spec=draft2020",
+    "workflows:validate:sections": "ajv -s app/workflows/schemas/section.schema.json -d 'app/workflows/lists/**/sections/*.yml' --spec=draft2020",
     "workflows:docs:generate": "jsonschema2md -d app/workflows/schemas/ -o doc/workflows -f yaml -x -"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint:js:fix": "yarn run lint:js --fix",
     "workflows:validate:tasklists": "ajv -s app/workflows/schemas/tasklist.schema.json -d app/workflows/lists/**/tasklist.yml --spec=draft2020",
     "workflows:validate:sections": "ajv -s app/workflows/schemas/section.schema.json -d 'app/workflows/lists/**/sections/*.yml' --spec=draft2020",
-    "workflows:docs:generate": "jsonschema2md -d app/workflows/schemas/ -o doc/workflows -f yaml -x -"
+    "workflows:docs:generate": "rm -r doc/workflows;jsonschema2md -d app/workflows/schemas/ -o doc/workflows -f yaml -x -"
   },
   "devDependencies": {
     "ajv-cli": "^5.0.0",


### PR DESCRIPTION
## Changes

- An incorrect path in the file glob meant that sections weren't being correctly validated against the schema. They now are.
- Schema documentation wasn't being generated into a clean folder, so files which were no longer relevant could still be kicking around. It now nukes the folder first.
