### PR TITLE
(582) Required first name and last name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the Task-level hint.
 - User assignment drop-downs and autocomplete components show the user's full
   name and email address.
+- Users first name and last name are now required. Any fallbacks, which show the
+  user's email address when first name and last name are absent, have been
+  removed.
 
 ### Fixed
 

--- a/app/helpers/project_information_helper.rb
+++ b/app/helpers/project_information_helper.rb
@@ -8,8 +8,6 @@ module ProjectInformationHelper
   def display_name(user)
     return t("project_information.show.project_details.rows.unassigned") if user.nil?
 
-    return user.email if user.full_name.blank?
-
     user.full_name
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,9 @@ class User < ApplicationRecord
   scope :regional_delivery_officers, -> { where(regional_delivery_officer: true).order_by_first_name }
   scope :caseworkers, -> { where(caseworker: true).order_by_first_name }
 
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+
   def full_name
     "#{first_name} #{last_name}" if first_name.present? && last_name.present?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,6 @@ class User < ApplicationRecord
   validates :last_name, presence: true
 
   def full_name
-    "#{first_name} #{last_name}" if first_name.present? && last_name.present?
+    "#{first_name} #{last_name}"
   end
 end

--- a/app/views/notes/_notes.html.erb
+++ b/app/views/notes/_notes.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <span class="govuk-caption-m"><%= note.created_at.to_date.to_formatted_s(:govuk) %></span>
-  <h3 class="govuk-heading-m"><%= note.user.full_name || note.user.email %></h3>
+  <h3 class="govuk-heading-m"><%= note.user.full_name %></h3>
 
   <%= render_markdown(note.body) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,7 +47,7 @@ en:
     not_applicable: Not applicable
     users:
       create:
-        error: You must provide a users email address e.g. bin/rails users:create EMAIL_ADDRESS=name@example.com
+        error: You must provide all arguments
     user_importer:
       import:
         error: You must provide a path

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -53,9 +53,4 @@ tasks.
 
 ## Add yourself as a user
 
-The service will need to recognise you as a user, use the `users:create` task to
-add your DfE email address.
-
-```bash
-bin/rails users:create EMAIL_ADDRESS=you@education.gov.uk
-```
+[See 'Creating a new user'](/doc/users-accounts.md#creating-a-new-user)

--- a/doc/users-accounts.md
+++ b/doc/users-accounts.md
@@ -46,11 +46,18 @@ Caseworkers can:
 
 ## Creating a new user
 
-A basic user with no authorisation can be created:
+The service will need to recognise you as a user, use the `users:create` task to
+add your DfE email address. This will create a basic user with no assigned
+roles.
+
+You must pass your email address, first name, and last name as comma separated
+arguments. For example:
 
 ```bash
-bin/rails users:create EMAIL_ADDRESS=user.name@education.gov.uk
+bin/rails users:create["john.doe@education.gov.uk","John","Doe"]
 ```
+
+> **NOTE:** In some shells, such as Zsh, square brackets must be escaped.
 
 At least the `caseworker` role will need to be assigned to the new user on the
 Rails console:
@@ -58,7 +65,7 @@ Rails console:
 ```bash
 bin/rails console
 
-User.find_by(email: "user.name@education.gov.uk").update(caseworker: true)
+User.find_by(email: "john.doe@education.gov.uk").update(caseworker: true)
 ```
 
 ## Importing users in bulk

--- a/lib/tasks/users/create.rake
+++ b/lib/tasks/users/create.rake
@@ -1,10 +1,8 @@
 namespace :users do
   desc ">> Import a list of users email addresses who can sign in to the service"
-  task create: :environment do
-    email_address = ENV["EMAIL_ADDRESS"]
+  task :create, [:email, :first_name, :last_name] => :environment do |_task, args|
+    abort I18n.t("tasks.users.create.error") if args.names.any? { |name| args[name].nil? }
 
-    abort I18n.t("tasks.users.create.error") if email_address.nil?
-
-    User.create!(email: email_address.downcase)
+    User.create!(args.to_h)
   end
 end

--- a/spec/features/users_can_create_and_view_and_delete_contacts_spec.rb
+++ b/spec/features/users_can_create_and_view_and_delete_contacts_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Users can create and view and delete contacts" do
   end
 
   let!(:contact) { create(:contact, project: project) }
-  let(:user) { User.create!(email: "user@education.gov.uk") }
+  let(:user) { create(:user) }
   let(:project) { create(:project) }
   let(:project_id) { project.id }
 

--- a/spec/helpers/project_information_helper_spec.rb
+++ b/spec/helpers/project_information_helper_spec.rb
@@ -38,14 +38,6 @@ RSpec.describe ProjectInformationHelper, type: :helper do
       end
     end
 
-    context "when full name is nil" do
-      let(:user) { build(:user, first_name: nil, last_name: nil) }
-
-      it "returns the email address" do
-        expect(subject).to eq "user@education.gov.uk"
-      end
-    end
-
     context "when full name is present" do
       let(:user) { build(:user) }
 

--- a/spec/lib/tasks/users/create_spec.rb
+++ b/spec/lib/tasks/users/create_spec.rb
@@ -1,24 +1,36 @@
 require "rails_helper"
 
 RSpec.describe "rake users:create", type: :task do
+  let(:email) { "john.doe@education.gov.uk" }
+  let(:first_name) { "John" }
+  let(:last_name) { "Doe" }
+
+  subject { Rake::Task["users:create"] }
+
+  after { subject.reenable }
+
+  describe "missing arguments" do
+    %w[email first_name last_name].each do |attribute|
+      context "when #{attribute} is not provided" do
+        let(:"#{attribute}") { nil }
+
+        it "aborts the task" do
+          expect { subject.invoke(email, first_name, last_name) }.to raise_error(SystemExit, I18n.t("tasks.users.create.error"))
+        end
+      end
+    end
+  end
+
   it "creates a user in the service" do
-    ClimateControl.modify(EMAIL_ADDRESS: "name@example.com") do
-      expect { Rake::Task["users:create"].execute }.to change { User.count }.by(1)
-      expect(User.last.email).to eq "name@example.com"
-    end
+    expect { subject.invoke(email, first_name, last_name) }.to change { User.count }.by(1)
+    expect(User.last).to have_attributes(first_name:, last_name:, email:)
   end
 
-  it "does not create duplicates" do
-    User.create(email: "name@example.com")
+  context "when the user already exists" do
+    let!(:user) { create(:user, email: email) }
 
-    ClimateControl.modify(EMAIL_ADDRESS: "name@example.com") do
-      expect { Rake::Task["users:create"].execute }
-        .to raise_error(ActiveRecord::RecordNotUnique)
+    it "does not create a duplicate" do
+      expect { subject.invoke(email, first_name, last_name) }.to raise_error(ActiveRecord::RecordNotUnique)
     end
-  end
-
-  it "errors if no email address is supplied" do
-    expect { Rake::Task["users:create"].invoke }
-      .to raise_error(SystemExit, I18n.t("tasks.users.create.error"))
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -51,6 +51,16 @@ RSpec.describe User do
     end
   end
 
+  describe "Validations" do
+    describe "#first_name" do
+      it { is_expected.to validate_presence_of(:first_name) }
+    end
+
+    describe "#last_name" do
+      it { is_expected.to validate_presence_of(:first_name) }
+    end
+  end
+
   describe "#full_name" do
     subject { user.full_name }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -62,30 +62,12 @@ RSpec.describe User do
   end
 
   describe "#full_name" do
+    let(:user) { build(:user) }
+
     subject { user.full_name }
 
-    context "when first name is nil" do
-      let(:user) { build(:user, first_name: nil) }
-
-      it "returns nil" do
-        expect(subject).to be_nil
-      end
-    end
-
-    context "when last name is nil" do
-      let(:user) { build(:user, last_name: nil) }
-
-      it "returns nil" do
-        expect(subject).to be_nil
-      end
-    end
-
-    context "when first name and last name are present" do
-      let(:user) { build(:user) }
-
-      it "returns full name" do
-        expect(subject).to eq "John Doe"
-      end
+    it "returns full name" do
+      expect(subject).to eq "John Doe"
     end
   end
 end

--- a/spec/requests/contacts_controller_spec.rb
+++ b/spec/requests/contacts_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ContactsController, type: :request do
-  let(:user) { User.create!(email: "user@education.gov.uk") }
+  let(:user) { create(:user) }
 
   before do
     mock_successful_authentication(user.email)

--- a/spec/requests/sign_in_spec.rb
+++ b/spec/requests/sign_in_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Sign in" do
-  let(:user) { User.create!(email: "user@education.gov.uk") }
+  let(:user) { create(:user) }
 
   context "when the user is signed out" do
     it "redirects them to the sign in page and shows a helpful message" do
@@ -27,10 +27,7 @@ RSpec.describe "Sign in" do
   end
 
   context "when the users is not known by the application" do
-    before do
-      User.create!(email: "another.user@education.gov.uk")
-      mock_successful_authentication("user@education.gov.uk")
-    end
+    before { mock_successful_authentication("user@education.gov.uk") }
 
     it "redirects to the sign in page and shows a helpful message" do
       get "/auth/azure_activedirectory_v2/callback"

--- a/spec/requests/sign_out_spec.rb
+++ b/spec/requests/sign_out_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Sign out" do
     let(:user_email_address) { "user@education.gov.uk" }
 
     before do
-      User.create!(email: user_email_address)
+      create(:user)
       OmniAuth.config.mock_auth[:azure_activedirectory_v2] = OmniAuth::AuthHash.new({
         info: {
           email: user_email_address

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe TasksController, type: :request do
-  let(:user) { User.create!(email: "user@education.gov.uk") }
+  let(:user) { create(:user) }
 
   before do
     mock_successful_authentication(user.email)


### PR DESCRIPTION
## Changes
### Update the `users:create` Task to accept name attributes
Users now have a `first_name` and `last_name`. 

This updates the `users:create` Task, so that they can be passed as Task arguments, and updates the relevant documentation.

### Validate presence of name attributes on User
Currently, the `first_name` and `last_name` properties of the User model are optional.

This adds validation to check that all users do have `first_name` and `last_name`. 

There is no need for any data migrations as we don't yet have a deployed application.

### Remove fallbacks for when the name attributes of User are absent
We have various bit of logic dotted around to handle users that don’t have `first_name` and `last_name`.

Now that these are required, we can safely remove any fallbacks.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
