### PR TITLE
Use mcr.microsoft.com/azure-sql-edge image instead of mssql

### DIFF
--- a/.env.database.example
+++ b/.env.database.example
@@ -3,4 +3,4 @@
 #
 # SA_PASSWORD must be at least 8 characters including uppercase, lowercase letters, base-10 digits and/or non-alphanumeric symbols
 ACCEPT_EULA=Y
-SA_PASSWORD=
+MSSQL_SA_PASSWORD=

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -30,10 +30,10 @@ services:
       - test-ci
 
   test-db:
-    image: mcr.microsoft.com/mssql/server:2019-latest
+    image: mcr.microsoft.com/azure-sql-edge:latest
     environment:
       ACCEPT_EULA: Y
-      SA_PASSWORD: strongPassword&
+      MSSQL_SA_PASSWORD: strongPassword&
     networks:
       - test-ci
 

--- a/docker-compose.database.local.yml
+++ b/docker-compose.database.local.yml
@@ -2,7 +2,7 @@ version: "2.8"
 services:
   db:
     container_name: dfe-complete-sql-server
-    image: mcr.microsoft.com/mssql/server:2019-latest
+    image: mcr.microsoft.com/azure-sql-edge:latest
     env_file: .env.database
     ports:
       - 1433:1433

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -2,7 +2,7 @@ version: "2.8"
 services:
   db:
     container_name: dfe-complete-sql-server
-    image: mcr.microsoft.com/mssql/server:2019-latest
+    image: docker-compose.local.yml
     env_file: .env.database
     ports:
       - 1433:1433


### PR DESCRIPTION
## Changes

* The mssql image isn't compatible with M1 Macs (ARM infrastructure)
* We're currently using Azure sql, so this may be preferable

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
