### PR TITLE
Allow database name to be specified via env

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -22,4 +22,4 @@ test:
 production:
   <<: *default
   azure: true
-  database: sip
+  database: <%= ENV["DATABASE_NAME"] || "sip" %>


### PR DESCRIPTION
## Changes

* Modifies database.yml production environment, so that the database name can be set via an environment variable. Defaults to 'sip'

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
