### PR TITLE
(643) Separate linting/formatting and application tests under CI

### DIFF
--- a/.github/workflows/continuous-integration-tests.yml
+++ b/.github/workflows/continuous-integration-tests.yml
@@ -8,12 +8,32 @@ on:
       - develop
 
 jobs:
-  rails-test:
-    name: Rails test
+  linting-and-formatting:
+    name: Linting and formatting tests
     runs-on: ubuntu-latest
 
     env:
       RAILS_ENV: test
+      ONLY_LINTING: "true"
+      BUNDLE_ONLY: "linting"
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - uses: ruby/setup-ruby@v1
+      - uses: actions/setup-node@v3
+
+      - name: Test
+        run: script/no-docker/test
+
+  application:
+    name: Application tests
+    runs-on: ubuntu-latest
+
+    env:
+      RAILS_ENV: test
+      ONLY_APP_TESTS: "true"
 
     steps:
       - name: Check out code

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY Gemfile ${DEPS_HOME}/Gemfile
 COPY Gemfile.lock ${DEPS_HOME}/Gemfile.lock
 
 RUN gem update --system 3.3.15
-RUN gem install bundler -v 2.3.7
+RUN gem install bundler -v 2.3.23
 RUN bundle config set frozen "true"
 RUN bundle config set no-cache "true"
 RUN bundle config set with "${BUNDLE_GEM_GROUPS}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,6 @@ COPY bin ${APP_HOME}/bin
 COPY config ${APP_HOME}/config
 COPY lib ${APP_HOME}/lib
 COPY db ${APP_HOME}/db
-COPY doc ${APP_HOME}/doc
 COPY app ${APP_HOME}/app
 # End
 

--- a/Gemfile
+++ b/Gemfile
@@ -63,11 +63,9 @@ group :development, :test do
   gem "rspec-rails"
   gem "brakeman"
   gem "bullet"
-  gem "standard"
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "rails-controller-testing"
-  gem "erb_lint", require: false
 end
 
 group :test do
@@ -76,6 +74,11 @@ group :test do
   gem "simplecov", "~> 0.21.2"
   gem "shoulda-matchers", "~> 5.1"
   gem "webmock", "~> 3.17"
+end
+
+group :linting do
+  gem "standard"
+  gem "erb_lint", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,4 +417,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.3.7
+   2.3.23

--- a/README.md
+++ b/README.md
@@ -39,12 +39,31 @@ available at [`http://localhost:3000/`](http://localhost:3000/).
 
 To run the test suite, run `script/test`.
 
+### Reducing test scope
+
 You can optionally use `ONLY_LINTING` and `ONLY_APP_TESTS` environment variables
 to selectively run either linting/formatting/schema tests or application tests
 respectively, for example
 
 ```bash
 ONLY_LINTING=1 script/test
+```
+
+### Fixing formatting
+
+By default, linters will cause a test failure if there are formatting problems.
+However, you can automatically fix formatting in many cases by using the
+`AUTO_FIX_FORMATTING` environment variable:
+
+```bash
+AUTO_FIX_FORMATTING=1 script/test
+```
+
+This can also be combined with the reduced scopes for fast formatting fixes, for
+example:
+
+```bash
+AUTO_FIX_FORMATTING=1 ONLY_LINTING=1 script/test
 ```
 
 ## Environment variables

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ available at [`http://localhost:3000/`](http://localhost:3000/).
 
 To run the test suite, run `script/test`.
 
+You can optionally use `ONLY_LINTING` and `ONLY_APP_TESTS` environment variables
+to selectively run either linting/formatting/schema tests or application tests
+respectively, for example
+
+```bash
+ONLY_LINTING=1 script/test
+```
+
 ## Environment variables
 
 See [.env.example](./.env.example)

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -11,9 +11,9 @@
 
     <% if policy(:project).new? %>
       <p><%= link_to t("project.index.new_button.text"),
-                     new_project_path,
-                     class: "govuk-button",
-                     data: {module: "govuk-button"} %></p>
+               new_project_path,
+               class: "govuk-button",
+               data: {module: "govuk-button"} %></p>
     <% end %>
 
     <ul class="list-style-none govuk-!-padding-0">

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,7 +17,7 @@ services:
     environment:
       DATABASE_URL: postgres://postgres:password@test-db:5432/dfe-academies-test
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
-      AUTOMATICALLY_FIX_LINTING: "true"
+      AUTO_FIX_FORMATTING: "true"
       SENTRY_ENV: test
       REDIS_URL: redis://127.0.0.1:6379
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
        - .env.development.local
     environment:
       DATABASE_URL: postgres://postgres:password@db:5432/dfe-academies-development
-      AUTOMATICALLY_FIX_LINTING: "true"
+      AUTO_FIX_FORMATTING: "true"
       SENTRY_ENV: development
       REDIS_URL: redis://test-redis:6379
     volumes:

--- a/script/all/test
+++ b/script/all/test
@@ -13,50 +13,6 @@ if [ -n "$TEST_FILES" ]; then
   echo "==> Running the tests matching '$TEST_FILES'..."
   bundle exec rspec "$TEST_FILES"
 else
-  if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
-    echo "==> Formatting files..."
-    yarn run lint:format:fix
-  else
-    echo "==> Checking formatting..."
-    yarn run lint:format
-  fi
-
-  echo "==> Running ShellCheck..."
-  for file in $(git ls-files script/*)
-  do
-    shellcheck -x "$file"
-  done
-
-  if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
-    echo "==> Linting ERB in autocorrect mode..."
-    bundle exec erblint --lint-all --autocorrect
-  else
-    echo "==> Linting ERB..."
-    bundle exec erblint --lint-all
-  fi
-  if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
-    echo "==> Linting Ruby in fix mode..."
-    bundle exec standardrb --fix
-  else
-    echo "==> Linting Ruby..."
-    bundle exec standardrb
-  fi
-
-  if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
-    echo "==> Linting JS in fix mode..."
-    yarn run lint:js:fix
-  else
-    echo "==> Linting JS..."
-    yarn run lint:js
-  fi
-
-  echo "==> Validating workflows..."
-  yarn run workflows:validate:tasklists
-  yarn run workflows:validate:sections
-
-  echo "==> Running the tests..."
-  bundle exec rspec
-
-  echo "==> Running Brakeman..."
-  bundle exec brakeman -o /dev/stdout
+  script/all/test-linting
+  script/all/test-application
 fi

--- a/script/all/test
+++ b/script/all/test
@@ -13,6 +13,12 @@ if [ -n "$TEST_FILES" ]; then
   echo "==> Running the tests matching '$TEST_FILES'..."
   bundle exec rspec "$TEST_FILES"
 else
-  script/all/test-linting
-  script/all/test-application
+  if [ -n "$ONLY_LINTING" ]; then
+    script/all/test-linting
+  elif [ -n "$ONLY_APP_TESTS" ]; then
+    script/all/test-application
+  else
+    script/all/test-linting
+    script/all/test-application
+  fi
 fi

--- a/script/all/test
+++ b/script/all/test
@@ -3,7 +3,7 @@
 # Run the test suite for the application. Optionally pass in a path to an
 # individual test file to run a single test.
 #
-# Do not set AUTOMATICALLY_FIX_LINTING if you want to disable linter fixing
+# Do not set AUTO_FIX_FORMATTING if you want to disable linter fixing
 
 set -e
 

--- a/script/all/test-application
+++ b/script/all/test-application
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Run the test suite for the application.
+
+set -e
+
+echo "==> Running application tests..."
+bundle exec rspec
+
+echo "==> Running Brakeman..."
+bundle exec brakeman -o /dev/stdout

--- a/script/all/test-linting
+++ b/script/all/test-linting
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# Run linting, formatting and schema tests.
+#
+# Do not set AUTOMATICALLY_FIX_LINTING if you want to disable linter fixing
+
+set -e
+
+echo "==> Running linting/formatting tests..."
+
+if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
+  echo "==> Formatting files..."
+  yarn run lint:format:fix
+else
+  echo "==> Checking formatting..."
+  yarn run lint:format
+fi
+
+echo "==> Running ShellCheck..."
+for file in $(git ls-files script/*)
+do
+  shellcheck -x "$file"
+done
+
+if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
+  echo "==> Linting ERB in autocorrect mode..."
+  bundle exec erblint --lint-all --autocorrect
+else
+  echo "==> Linting ERB..."
+  bundle exec erblint --lint-all
+fi
+if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
+  echo "==> Linting Ruby in fix mode..."
+  bundle exec standardrb --fix
+else
+  echo "==> Linting Ruby..."
+  bundle exec standardrb
+fi
+
+if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
+  echo "==> Linting JS in fix mode..."
+  yarn run lint:js:fix
+else
+  echo "==> Linting JS..."
+  yarn run lint:js
+fi
+
+echo "==> Validating workflows..."
+yarn run workflows:validate:tasklists
+yarn run workflows:validate:sections

--- a/script/all/test-linting
+++ b/script/all/test-linting
@@ -2,13 +2,13 @@
 
 # Run linting, formatting and schema tests.
 #
-# Do not set AUTOMATICALLY_FIX_LINTING if you want to disable linter fixing
+# Do not set AUTO_FIX_FORMATTING if you want to disable linter fixing
 
 set -e
 
 echo "==> Running linting/formatting tests..."
 
-if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
+if [ -n "$AUTO_FIX_FORMATTING" ]; then
   echo "==> Formatting files..."
   yarn run lint:format:fix
 else
@@ -22,14 +22,14 @@ do
   shellcheck -x "$file"
 done
 
-if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
+if [ -n "$AUTO_FIX_FORMATTING" ]; then
   echo "==> Linting ERB in autocorrect mode..."
   bundle exec erblint --lint-all --autocorrect
 else
   echo "==> Linting ERB..."
   bundle exec erblint --lint-all
 fi
-if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
+if [ -n "$AUTO_FIX_FORMATTING" ]; then
   echo "==> Linting Ruby in fix mode..."
   bundle exec standardrb --fix
 else
@@ -37,7 +37,7 @@ else
   bundle exec standardrb
 fi
 
-if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
+if [ -n "$AUTO_FIX_FORMATTING" ]; then
   echo "==> Linting JS in fix mode..."
   yarn run lint:js:fix
 else

--- a/script/no-docker/test
+++ b/script/no-docker/test
@@ -15,4 +15,4 @@ fi
 echo "==> Updating..."
 script/no-docker/update
 
-AUTOMATICALLY_FIX_LINTING=true script/all/test "$@"
+script/all/test "$@"

--- a/script/no-docker/update
+++ b/script/no-docker/update
@@ -7,11 +7,14 @@ set -e
 echo "==> Bootstrapping..."
 script/no-docker/bootstrap
 
-echo "==> Starting SQL Server container..."
-script/no-docker/database
+# Only run database tasks if we are not in ONLY_LINTING mode
+if [ -z "$ONLY_LINTING" ]; then
+  echo "==> Starting SQL Server container..."
+  script/no-docker/database
 
-echo "==> Running database migrations..."
-bundle exec rails db:migrate
+  echo "==> Running database migrations..."
+  bundle exec rails db:migrate
 
-echo "==> Running test database migrations..."
-RAILS_ENV="test" bundle exec rails db:migrate
+  echo "==> Running test database migrations..."
+  RAILS_ENV="test" bundle exec rails db:migrate
+fi


### PR DESCRIPTION
## Changes

At the moment, our test suite under CI doesn't run linting and formatting checks on all files. This is because all our tests run in the Docker container, which only includes files we explicitly copy in to the image.

To solve this, this PR separates the linting/formatting/schema tests and the application tests into two distinct processes. The linting can run directly in a GitHub worker (which completes a lot faster, giving us a fail-fast error for the more mundane things like style issues), and then the application tests run in the full-blown Docker container for parity with production. It also gives us more immediate visibility over which part of the test suite has failed.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.

## Next steps

- [x] Change the GitHub required tests configuration