### PR TITLE
(611) Change "Complete" status tag to "Completed"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Fixed worklow for the test deployment
+- "Complete" tag now reads "Completed"
 
 ## [Release 4][release-4]
 

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -15,7 +15,7 @@ module TaskListHelper
         colour: "orange"
       },
       completed: {
-        text: "Complete",
+        text: "Completed",
         colour: "turquoise"
       },
       not_applicable: {

--- a/spec/helpers/task_list_helper_spec.rb
+++ b/spec/helpers/task_list_helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TaskListHelper, type: :helper do
 
     it "returns a tag representing the task status when the status is known" do
       allow(task).to receive(:status).and_return(:completed)
-      expect(helper.task_status_tag(task)).to eq '<strong class="govuk-tag govuk-tag--turquoise app-task-list__tag" id="clear-land-questionnaire-status">Complete</strong>'
+      expect(helper.task_status_tag(task)).to eq '<strong class="govuk-tag govuk-tag--turquoise app-task-list__tag" id="clear-land-questionnaire-status">Completed</strong>'
     end
 
     it "returns a tag representing an unknown status where the status is not known" do


### PR DESCRIPTION
## Changes

The "Complete" status tag now reads "Completed", so that it matches the language of other tags.

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
