### PR TITLE
(612) Add privacy notice and link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Users can add, edit, and delete task level notes. These are displayed on the
   task page.
+- Added a privacy notice and link to the notice in the footer
 
 ### Changed
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,6 @@
+class StaticPagesController < ApplicationController
+  skip_before_action :redirect_unauthenticated_user
+
+  def privacy
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,7 @@
       </main>
     </div>
 
-    <%= govuk_footer %>
+    <%= govuk_footer(meta_items_title: "Helpful links", meta_items: {"Privacy notice" => privacy_path}) %>
 
   </body>
   <%= javascript_include_tag "application" %>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,103 @@
+<div class="govuk-grid-row govuk-body">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Privacy Notice:
+      Complete conversions, transfers and changes</h1>
+    <h2 class="govuk-heading-l">Who we are</h2>
+    <p class="govuk-body">The 'Complete conversions, transfers and changes'
+      service is available for employees of the Department for Education
+      (DfE) to help with the conversion of schools to academies. It is run
+      by and on behalf of the DfE. For the purpose of data protection
+      legislation, DfE is the data controller for the personal data
+      collected and further processed as part of Complete conversion and
+      transfers.</p>
+    <p class="govuk-body">DfE<br>
+      Sanctuary Buildings<br>
+      20 Great Smith St<br>
+      London<br>
+      SW1P 3BT</p>
+    <h2 class="govuk-heading-l">When we collect personal information</h2>
+    <p class="govuk-body">We receive your personal data when you:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>contact us for support using the service</li>
+      <li>leave feedback or for any other matters</li>
+      <li>respond to our evaluations of the effectiveness of the service</li>
+    </ul>
+    <h2 class="govuk-heading-l">What personal information we will collect</h2>
+    <p class="govuk-body">If you contact us for support or leave feedback
+      then we will collect your:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>name</li>
+      <li>phone number</li>
+      <li>your email address, if you include it in feedback on the service
+        or agree to be contacted for user research</li>
+    </ul>
+    <h2 class="govuk-heading-l">How we will use your information</h2>
+    <p class="govuk-body">If you contact us, DFE will use your name and
+      personal information to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>provide support</li>
+      <li>evaluate the effectiveness of the service and the policy</li>
+    </ul>
+    <p class="govuk-body">We will not share this information with any
+      other parties. </p>
+    <h2 class="govuk-heading-l">Why our use of your personal data is
+      lawful</h2>
+    <p class="govuk-body">In order for our use of your personal data to be
+      lawful, we need to meet one or more conditions in the data
+      protection legislation. For the purpose of 'Complete conversions,
+      transfers and changes', the Department processes your data where it
+      is necessary for the performance of a task carried out in the public
+      interest or in the exercise of official authority (Article 6(1)(e)
+      of the UK General Data Protection Regulation).</p>
+    <h2 class="govuk-heading-l">Who we will make your personal data
+      available to</h2>
+    <p class="govuk-body">The Department for Education use your data for
+      security purposes.</p>
+    <p class="govuk-body">We collect the IP addresses of people visiting
+      the Complete conversions and transfers website.</p>
+    <p class="govuk-body">This is for reasons for security, for example,
+      if we were receiving continuous direct denial of service attacks
+      from an IP address range then we could block it.</p>
+    <p class="govuk-body">The Department for Education also use your data
+      to enable users to use the service and receive updates.</p>
+    <h2 class="govuk-heading-l">How long we will keep your personal data</h2>
+    <p class="govuk-body">The DfE or its delivery partners will never keep
+      your personal data longer than we need it.</p>
+    <h2 class="govuk-heading-l">Your data protection rights</h2>
+    <p class="govuk-body">You have the right:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>to ask us for access to information about you that we hold</li>
+      <li>to have your personal data rectified, if it is inaccurate or
+        incomplete</li>
+      <li>to restrict our processing of your personal data (i.e.
+        permitting its storage but no further processing</li>
+      <li>to object to direct marketing (including profiling) and
+        processing for the purposes of scientific/historical research and
+        statistics</li>
+      <li>not to be subject to decisions based purely on automated
+        processing where it produces a legal or similarly significant
+        effect on you</li>
+    </ul>
+    <p class="govuk-body">If you need to contact us regarding any of the
+      above, or have any other questions about how your personal
+      information will be used, please <a href="https://www.gov.uk/contact-dfe" class="govuk-link" rel="noreferrer noopener" target="_blank">
+        contact the DfE (opens in new tab)</a>
+      stating Complete conversions, transfers and changes.</p>
+    <p class="govuk-body">The <a href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter" class="govuk-link" rel="noreferrer noopener" target="_blank">
+      DfE's Personal Information Charter</a> contains more
+      information about how the DfE handles personal information.</p>
+    <p class="govuk-body">The Information Commissioner's Office makes
+      further information about your data protection rights available in
+      their <a href="https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/" class="govuk-link" rel="noreferrer noopener" target="_blank">
+        Guide to the General Data Protection Regulation (GDPR)</a>.
+    </p>
+    <h2 class="govuk-heading-l">The right to lodge a complaint</h2>
+    <p class="govuk-body">You have the right to raise any concerns with
+      the <a href="https://ico.org.uk/make-a-complaint/" class="govuk-link" rel="noreferrer noopener" target="_blank">
+        Information Commissioner's Office (ICO)</a>. </p>
+    <h2 class="govuk-heading-l">Last updated</h2>
+    <p class="govuk-body">We may need to update this privacy notice
+      periodically, so we recommend that you revisit this information from
+      time to time. This version was last updated on 6 October 2022.</p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "projects#index"
 
+  # Static pages
+  get "/privacy", to: "static_pages#privacy"
+
   # Sign in
   get "/sign-in", to: "sessions#new"
   # Sign out

--- a/spec/features/users_can_view_static_pages_spec.rb
+++ b/spec/features/users_can_view_static_pages_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.feature "Users can view a list of projects" do
+  scenario "can see the privacy notice" do
+    visit privacy_path
+
+    expect(page).to have_content("Privacy Notice") # This string appears all over the site in the footer, so also test:
+    expect(page).to have_content("When we collect personal information")
+  end
+end


### PR DESCRIPTION
## Changes

This adds the text of the privacy notice from the prototype to a new static page (accessible without signing in), updates the content date in the notice, and adds a link to the site footer.

## Screenshot

![localhost_3000_privacy](https://user-images.githubusercontent.com/619082/194277202-ba388af1-f541-416b-8e0f-9dcf5c1ee967.png)

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
