### PR TITLE
Move task notes below header block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Only project level notes are shown on the notes page.
 - The back link destination is the task page for task level notes, or the notes
   page for project level notes.
+- Moved task notes to a more pleasing vertical alignment
 
 ## [Release 5][release-5]
 

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -11,7 +11,11 @@
 
       <%= render partial: "tasks/shared/task_guidance_summary", locals: {task: @task} %>
     </div>
+  </div>
+</div>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= form_for :task, url: project_task_path, method: :put do |form| %>
       <%= form.govuk_check_boxes_fieldset :actions, legend: {hidden: true}, classes: "task-checkboxes" do %>
         <% @task.actions.each do |action| %>


### PR DESCRIPTION
## Changes

Move the task notes block down below the header, in line with the first action.

## Screenshots

### Before

![localhost_3000_projects_3F805EC1-E0ED-4A6A-A927-6556F87CD2F4_tasks_298D0AAF-CB2C-412B-ABCD-1EF54271E770 (1)](https://user-images.githubusercontent.com/619082/194335343-e3f30a09-b36e-4e21-af5a-69194920ad2f.png)

### After

![localhost_3000_projects_3F805EC1-E0ED-4A6A-A927-6556F87CD2F4_tasks_298D0AAF-CB2C-412B-ABCD-1EF54271E770](https://user-images.githubusercontent.com/619082/194335330-bb4bad54-ff2d-4982-8275-949c2220f4e7.png)

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
