### PR TITLE
(565) Projects pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Users can add, edit, and delete task level notes. These are displayed on the
   task page.
 - Added a privacy notice and link to the notice in the footer
+- Pagination has been added to the projects index page. 10 projects are shown
+  per page.
 
 ### Changed
 

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ gem "sentry-rails"
 
 gem "sidekiq"
 
+gem "pagy"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,6 +394,7 @@ DEPENDENCIES
   omniauth
   omniauth-azure-activedirectory-v2
   omniauth-rails_csrf_protection
+  pagy
   pry-rails
   puma (~> 5.0)
   pundit (~> 2.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include Authentication
   include Pundit::Authorization
+  include Pagy::Backend
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -6,7 +6,7 @@ class ProjectsController < ApplicationController
 
   def index
     authorize Project
-    @projects = policy_scope(Project)
+    @pagy, @projects = pagy(policy_scope(Project))
   end
 
   def show

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -9,6 +9,13 @@
       <%= t("project.index.title.all") %> (<%= @projects.count %>)
     </h1>
 
+    <% if policy(:project).new? %>
+      <p><%= link_to t("project.index.new_button.text"),
+                     new_project_path,
+                     class: "govuk-button",
+                     data: {module: "govuk-button"} %></p>
+    <% end %>
+
     <ul class="list-style-none govuk-!-padding-0">
       <% @projects.each do |project| %>
         <li>
@@ -22,12 +29,7 @@
       <% end %>
     </ul>
 
-    <% if policy(:project).new? %>
-      <p><%= link_to t("project.index.new_button.text"),
-               new_project_path,
-               class: "govuk-button",
-               data: {module: "govuk-button"} %></p>
-    <% end %>
+    <%= govuk_pagination(pagy: @pagy) %>
 
   </div>
 </div>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-grid-column-full">
 
     <h1 class="govuk-heading-l">
-      <%= t("project.index.title.all") %> (<%= @projects.count %>)
+      <%= t("project.index.title.all") %> (<%= @pagy.count %>)
     </h1>
 
     <% if policy(:project).new? %>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+# Pagy initializer file (5.10.1)
+# Customize only what you really need and notice that the core Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+# Pagy DEFAULT Variables
+# See https://ddnexus.github.io/pagy/api/pagy#variables
+# All the Pagy::DEFAULT are set for all the Pagy instances but can be overridden per instance by just passing them to
+# Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
+
+# Instance variables
+# See https://ddnexus.github.io/pagy/api/pagy#instance-variables
+# Pagy::DEFAULT[:page]   = 1                                  # default
+Pagy::DEFAULT[:items] = 10 # default
+# Pagy::DEFAULT[:outset] = 0                                  # default
+
+# Other Variables
+# See https://ddnexus.github.io/pagy/api/pagy#other-variables
+Pagy::DEFAULT[:size] = [1, 1, 1, 1]
+# Pagy::DEFAULT[:page_param] = :page                           # default
+# The :params can be also set as a lambda e.g ->(params){ params.exclude('useless').merge!('custom' => 'useful') }
+# Pagy::DEFAULT[:params]     = {}                              # default
+# Pagy::DEFAULT[:fragment]   = '#fragment'                     # example
+# Pagy::DEFAULT[:link_extra] = 'data-remote="true"'            # example
+# Pagy::DEFAULT[:i18n_key]   = 'pagy.item_name'                # default
+# Pagy::DEFAULT[:cycle]      = true                            # example
+
+# Extras
+# See https://ddnexus.github.io/pagy/extras
+
+# Backend Extras
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/extras/array
+# require 'pagy/extras/array'
+
+# Calendar extra: Add pagination filtering by calendar time unit (year, quarter, month, week, day)
+# See https://ddnexus.github.io/pagy/extras/calendar
+# require 'pagy/extras/calendar'
+# Default for each unit
+# Pagy::Calendar::Year::DEFAULT[:order]     = :asc        # Time direction of pagination
+# Pagy::Calendar::Year::DEFAULT[:format]    = '%Y'        # strftime format
+#
+# Pagy::Calendar::Quarter::DEFAULT[:order]  = :asc        # Time direction of pagination
+# Pagy::Calendar::Quarter::DEFAULT[:format] = '%Y-Q%q'    # strftime format
+#
+# Pagy::Calendar::Month::DEFAULT[:order]    = :asc        # Time direction of pagination
+# Pagy::Calendar::Month::DEFAULT[:format]   = '%Y-%m'     # strftime format
+#
+# Pagy::Calendar::Week::DEFAULT[:order]     = :asc        # Time direction of pagination
+# Pagy::Calendar::Week::DEFAULT[:format]    = '%Y-%W'     # strftime format
+#
+# Pagy::Calendar::Day::DEFAULT[:order]      = :asc        # Time direction of pagination
+# Pagy::Calendar::Day::DEFAULT[:format]     = '%Y-%m-%d'  # strftime format
+#
+# Uncomment the following lines, if you need calendar localization without using the I18n extra
+# module LocalizePagyCalendar
+#   def localize(time, opts)
+#     ::I18n.l(time, **opts)
+#   end
+# end
+# Pagy::Calendar.prepend LocalizePagyCalendar
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/extras/elasticsearch_rails
+# Default :pagy_search method: change only if you use also
+# the searchkick or meilisearch extra that defines the same
+# Pagy::DEFAULT[:elasticsearch_rails_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:elasticsearch_rails_search] = :search
+# require 'pagy/extras/elasticsearch_rails'
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See http://ddnexus.github.io/pagy/extras/headers
+# require 'pagy/extras/headers'
+# Pagy::DEFAULT[:headers] = { page: 'Current-Page',
+#                            items: 'Page-Items',
+#                            count: 'Total-Count',
+#                            pages: 'Total-Pages' }     # default
+
+# Meilisearch extra: Paginate `Meilisearch` result objects
+# See https://ddnexus.github.io/pagy/extras/meilisearch
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or searchkick extra that define the same method
+# Pagy::DEFAULT[:meilisearch_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:meilisearch_search] = :ms_search
+# require 'pagy/extras/meilisearch'
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/extras/metadata
+# you must require the frontend helpers internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/frontend_helpers'
+# require 'pagy/extras/metadata'
+# For performance reasons, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::DEFAULT[:metadata] = %i[scaffold_url page prev next last]   # example
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/extras/searchkick
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or meilisearch extra that defines the same
+# DEFAULT[:searchkick_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:searchkick_search] = :search
+# require 'pagy/extras/searchkick'
+# uncomment if you are going to use Searchkick.pagy_search
+# Searchkick.extend Pagy::Searchkick
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/extras/bootstrap
+# require 'pagy/extras/bootstrap'
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Foundation extra: Add nav, nav_js and combo_nav_js helpers and templates for Foundation pagination
+# See https://ddnexus.github.io/pagy/extras/foundation
+# require 'pagy/extras/foundation'
+
+# Materialize extra: Add nav, nav_js and combo_nav_js helpers for Materialize pagination
+# See https://ddnexus.github.io/pagy/extras/materialize
+# require 'pagy/extras/materialize'
+
+# Navs extra: Add nav_js and combo_nav_js javascript helpers
+# Notice: the other frontend extras add their own framework-styled versions,
+# so require this extra only if you need the unstyled version
+# See https://ddnexus.github.io/pagy/extras/navs
+# require 'pagy/extras/navs'
+
+# Semantic extra: Add nav, nav_js and combo_nav_js helpers for Semantic UI pagination
+# See https://ddnexus.github.io/pagy/extras/semantic
+# require 'pagy/extras/semantic'
+
+# UIkit extra: Add nav helper and templates for UIkit pagination
+# See https://ddnexus.github.io/pagy/extras/uikit
+# require 'pagy/extras/uikit'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/extras/navs#steps
+# Pagy::DEFAULT[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
+
+# Feature Extras
+
+# Gearbox extra: Automatically change the number of items per page depending on the page number
+# See https://ddnexus.github.io/pagy/extras/gearbox
+# require 'pagy/extras/gearbox'
+# set to false only if you want to make :gearbox_extra an opt-in variable
+# Pagy::DEFAULT[:gearbox_extra] = false               # default true
+# Pagy::DEFAULT[:gearbox_items] = [15, 30, 60, 100]   # default
+
+# Items extra: Allow the client to request a custom number of items per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/extras/items
+# require 'pagy/extras/items'
+# set to false only if you want to make :items_extra an opt-in variable
+# Pagy::DEFAULT[:items_extra] = false    # default true
+# Pagy::DEFAULT[:items_param] = :items   # default
+# Pagy::DEFAULT[:max_items]   = 100      # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/extras/overflow
+# require 'pagy/extras/overflow'
+# Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+
+# Support extra: Extra support for features like: incremental, infinite, auto-scroll pagination
+# See https://ddnexus.github.io/pagy/extras/support
+# require 'pagy/extras/support'
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/extras/trim
+# require 'pagy/extras/trim'
+# set to false only if you want to make :trim_extra an opt-in variable
+# Pagy::DEFAULT[:trim_extra] = false # default true
+
+# Standalone extra: Use pagy in non Rack environment/gem
+# See https://ddnexus.github.io/pagy/extras/standalone
+# require 'pagy/extras/standalone'
+# Pagy::DEFAULT[:url] = 'http://www.example.com/subdir'  # optional default
+
+# Rails
+# Enable the .js file required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_items_selector_js)
+# See https://ddnexus.github.io/pagy/extras#javascript
+
+# With the asset pipeline
+# Sprockets need to look into the pagy javascripts dir, so add it to the assets paths
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/api/frontend#i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'de' },
+#                 { locale: 'en' },
+#                 { locale: 'es' })
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'en' },
+#                 { locale: 'es', filepath: 'path/to/pagy-es.yml' },
+#                 { locale: 'xyz',  # not built-in
+#                   filepath: 'path/to/pagy-xyz.yml',
+#                   pluralize: lambda{ |count| ... } )
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/extras/i18n
+# require 'pagy/extras/i18n'
+
+# Default i18n key
+# Pagy::DEFAULT[:i18n_key] = 'pagy.item_name'   # default
+
+# When you are done setting your own default freeze it, so it will not get changed accidentally
+Pagy::DEFAULT.freeze


### PR DESCRIPTION
## Changes
### Add Pagy for pagination
We want to implement pagination using the GOV.UK components library, which is
compatible with Pagy.

This adds and configures Pagy. The default number of items per page is set to
10, and the default size parameter is set to match the Design System
documentation.

### Paginate the projects index page
For now, we send a request to the API for each project on the project index
page. These requests are very slow, resulting in a very, very slow page load time
when there are multiple projects. We want to paginate the projects in order to
reduce the load.

This paginates the projects index page. It also moves the `Add a new project`
button to the top of the page, because it was looking a bit odd next to the
pagination component.

### Fix the total number of projects shown in the heading
We need to update the way we calculate the total number of projects now that we
paginate them (else we are just showing the number of projects per page).

This uses the Pagy `count` method which returns the total number of records.

## Screenshot

![image](https://user-images.githubusercontent.com/47089130/194849849-cacd3b90-c85c-4869-bb71-0fb868ba6612.png)

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
