### PR TITLE
Compose depends_on includes a condition WIP

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -13,8 +13,10 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - test-db
-      - test-redis
+      test-db-health:
+        condition: service_healthy
+      test-redis:
+        condition: service_started
     env_file:
        - .env.test
     environment:
@@ -32,6 +34,18 @@ services:
     environment:
       ACCEPT_EULA: Y
       SA_PASSWORD: strongPassword&
+    networks:
+      - test-ci
+
+  test-db-health:
+    image: mcr.microsoft.com/mssql-tools:latest
+    command: /bin/bash -c "touch /var/log/sqlcmd.log && tail -f /var/log/sqlcmd.log"
+    healthcheck:
+      test: /opt/mssql-tools/bin/sqlcmd -S test-db -U sa -P 'strongPassword&' -o /var/log/sqlcmd.log
+      interval: "2s"
+      retries: 10
+    depends_on:
+      - test-db
     networks:
       - test-ci
 


### PR DESCRIPTION
## Changes

We have seen lots of intermittent failures in CI that we believe are due
to the MSSQL server container not starting before the applications
attempts to utilise it.

This results in an error:

> TinyTds::Error: Unable to connect: Adaptive Server is unavailable or
does not exist (test-db)

To avoid this we want the applicaiton to start once the MSSQL server is
ready to accept connections.

We tried a number of ways to do this and settled on what is here.

`depends_on` can use a `healthcheck` to make sure the containers are
considered healthy before starting the dependent container.

We have to use a seperate container to run the `sqlcmd` tool to attach
to the running MSSQL server, if we can attach, it we consider ourselves
healthy and so achieve the goal. This is because the `sqlcmd` is not
included in the MSSQL server image.

With a way to confirm the database is ready, we make the applicaiton
container dependent on the health container.

https://trello.com/c/6iQ0fjMx

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
