### PR TITLE
(386) Make projects index summary responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The back link destination is the task page for task level notes, or the notes
   page for project level notes.
 - Moved task notes to a more pleasing vertical alignment
+- The styling of the projects index summary component is fully responsive.
 
 ## [Release 5][release-5]
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,3 +34,29 @@ $govuk-global-styles: true;
     }
   }
 }
+
+.govuk-section-break--s {
+  @include govuk-responsive-margin(2, "top");
+  @include govuk-responsive-margin(2, "bottom");
+}
+
+.projects-list {
+  .project-summary {
+    p {
+      margin-block-end: 0;
+    }
+
+    @include govuk-media-query($from: desktop) {
+      .row-container {
+        display: flex;
+        justify-content: space-between;
+      }
+    }
+
+    @include govuk-media-query($until: desktop) {
+      .govuk-section-break:not(:last-child) {
+        display: none;
+      }
+    }
+  }
+}

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -16,7 +16,7 @@
                data: {module: "govuk-button"} %></p>
     <% end %>
 
-    <ul class="list-style-none govuk-!-padding-0">
+    <ul class="projects-list list-style-none govuk-!-padding-0">
       <% @projects.each do |project| %>
         <li>
           <span class="govuk-caption-m">URN <%= project.urn %></span>

--- a/app/views/projects/index/_project_summary.html.erb
+++ b/app/views/projects/index/_project_summary.html.erb
@@ -1,23 +1,23 @@
-<div class="govuk-!-margin-bottom-9">
-  <div class="govuk-grid-row govuk-!-margin-top-2">
-    <p class="govuk-grid-column-one-half govuk-body govuk-!-margin-bottom-2">
-      <span class="govuk-!-font-weight-bold"><%= t("project_information.show.school_details.rows.school_type") %>: </span><%= project.establishment.type %>
-    </p>
-    <p class="govuk-grid-column-one-half govuk-body govuk-!-margin-bottom-2 govuk-!-text-align-right">
-      <span class="govuk-!-font-weight-bold"><%= t("project.summary.target_completion_date.title") %>: </span><%= project.target_completion_date.to_formatted_s(:govuk) %>
-    </p>
+<div class="project-summary govuk-!-margin-bottom-9">
+
+  <div class="row-container">
+    <%= render partial: "projects/index/project_summary_item",
+          locals: {label: t("project_information.show.school_details.rows.school_type"), content: project.establishment.type} %>
+
+    <%= render partial: "projects/index/project_summary_item",
+          locals: {label: t("project.summary.target_completion_date.title"), content: project.target_completion_date.to_formatted_s(:govuk)} %>
   </div>
 
-  <hr class="govuk-section-break govuk-section-break govuk-section-break--visible">
+  <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
 
-  <div class="govuk-grid-row govuk-!-margin-top-2">
-    <p class="govuk-grid-column-one-half govuk-body govuk-!-margin-bottom-2">
-      <span class="govuk-!-font-weight-bold"><%= t("project.summary.incoming_trust.title") %>: </span><%= project.incoming_trust.name %>
-    </p>
-    <p class="govuk-grid-column-one-half govuk-body govuk-!-margin-bottom-2 govuk-!-text-align-right">
-      <span class="govuk-!-font-weight-bold"><%= t("project.summary.local_authority.title") %>: </span><%= project.establishment.local_authority %>
-    </p>
+  <div class="row-container">
+    <%= render partial: "projects/index/project_summary_item",
+          locals: {label: t("project.summary.incoming_trust.title"), content: project.incoming_trust.name} %>
+
+    <%= render partial: "projects/index/project_summary_item",
+          locals: {label: t("project.summary.local_authority.title"), content: project.establishment.local_authority} %>
   </div>
 
-  <hr class="govuk-section-break govuk-section-break govuk-section-break--visible">
+  <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
+
 </div>

--- a/app/views/projects/index/_project_summary_item.html.erb
+++ b/app/views/projects/index/_project_summary_item.html.erb
@@ -1,0 +1,3 @@
+<p>
+  <span class="govuk-!-font-weight-bold"><%= label %>: </span><%= content %>
+</p>


### PR DESCRIPTION
## Changes

Currently, the projects index summary wraps onto two lines when overlaps occur on small viewports and doesn't look great. We want to ensure the summary looks good on any screen size.

This applies responsive styling to the summary when the viewport is smaller than desktop size. Unfortunately, this was difficult to achieve with the GOV.UK grid system, so instead uses flexbox.

This includes a general tidy up of the component, which defines a `govuk-section-break--s` class that is absent from the GOV.UK Frontend styles.

[screen-capture (3).webm](https://user-images.githubusercontent.com/47089130/195080921-158d8f40-79b5-4ff5-bdc3-20983ad76feb.webm)

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
