### PR TITLE
Allow installation of `az containerapp` command

### DIFF
--- a/.github/workflows/build-and-push-image-development.yml
+++ b/.github/workflows/build-and-push-image-development.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           azcliversion: 2.40.0
           inlineScript: |
+            az config set extension.use_dynamic_install=yes_without_prompt
             az containerapp update \
               --name ${{ secrets.DEVELOPMENT_ACA_CONTAINERAPP_NAME }} \
               --resource-group ${{ secrets.DEVELOPMENT_ACA_RESOURCE_GROUP }} \


### PR DESCRIPTION
## Changes

Fixes error:
```
Starting script execution via docker image mcr.microsoft.com/azure-cli:2.40.0
ERROR: The command requires the extension containerapp. Unable to prompt for extension install confirmation as no tty available. Run 'az config set extension.use_dynamic_install=yes_without_prompt' to allow installing extensions without prompt.
Error: Error: az cli script failed.
```

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
