### PR TITLE
(553) Chore: add phase banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- the phase banner and link to general feedback form
+
 ## [Release 6][release-6]
 
 ### Added

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require_relative "config/application"
+require "standard/rake"
 
 Rails.application.load_tasks
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,13 @@
     <%= govuk_header(service_name: t("service_name")) %>
 
     <div class="govuk-width-container ">
+      <%= govuk_phase_banner(
+            tag: {text: t("phase_banner.phase")},
+            text: t("phase_banner.phase_notice.html")
+          ) %>
+    </div>
+
+    <div class="govuk-width-container ">
       <%= yield :pre_content_nav %>
       <main class="govuk-main-wrapper " id="main-content" role="main">
         <%= render partial: "shared/flash" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,10 @@
 
 en:
   service_name: Complete conversions, transfers and changes
+  phase_banner:
+    phase: Beta
+    phase_notice:
+      html: This is a new service – your <a href="https://forms.office.com/r/47n7Q6nynQ" class="govuk-link">feeback</a> will help us improve it.
   sign_in:
     button: Sign in with your DfE Microsoft account
     message:

--- a/spec/features/users_can_view_the_home_page_spec.rb
+++ b/spec/features/users_can_view_the_home_page_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.feature "Users can view the home page" do
+  let(:user) { create(:user, :caseworker) }
+  before do
+    sign_in_with_user(user)
+  end
+
+  scenario "they see the phase banner and a link to the feedback form" do
+    visit root_path
+
+    within(".govuk-phase-banner") do
+      expect(page).to have_content(I18n.t("phase_banner.phase"))
+      expect(page.html).to include(I18n.t("phase_banner.phase_notice.html"))
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Phase banners help users to understand a product in context - they are also used to collect general feedback on every page of the product.
    
As we are entering our private beta, here we add the phase banner and link to a generic feedback form.

## Screen shot

![image](https://user-images.githubusercontent.com/480578/195327872-f49e2334-c87c-4e73-8f47-bfb12b13e729.png)

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
