### PR TITLE
(687) Remove duplicate service name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - the phase banner and link to general feedback form
 
+### Changed
+
+- the service name has been removed from the Projects page
+
 ## [Release 6][release-6]
 
 ### Added

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,5 +1,3 @@
-<h1 class="govuk-heading-l"><%= t("service_name") %></h1>
-
 <p>You are signed in with the email address <%= current_user.email %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
## Changes

Previously we showed the service name on the Project index.

As the service name is in the header, this was duplication.

We also used an h1 for two elements, which I don't believe is good practice.

## Screen shot

![image](https://user-images.githubusercontent.com/480578/195331200-bc28e9a6-2871-40d5-baf6-f3593ea29ead.png)

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
