### PR TITLE
Fix: missing not applicable options

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,6 +3,8 @@ class Task < ApplicationRecord
   has_many :actions, dependent: :destroy
   has_many :notes, dependent: :destroy
 
+  LEGAL_DOCUMENT_SECTION_TITLE = "Clear and sign legal documents"
+
   default_scope { order(order: "asc") }
 
   delegate :project, to: :section
@@ -16,7 +18,7 @@ class Task < ApplicationRecord
   end
 
   def clear_legal_documents_type?
-    section.title == "Clear legal documents"
+    section.title == LEGAL_DOCUMENT_SECTION_TITLE
   end
 
   def status

--- a/spec/features/users_can_mark_optional_tasks_as_not_applicable_spec.rb
+++ b/spec/features/users_can_mark_optional_tasks_as_not_applicable_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Users can mark optional tasks as not applicable to a project" do
   end
 
   let(:project) { create(:project, urn: 123456, incoming_trust_ukprn: 12345678) }
-  let!(:section) { create(:section, project: project, title: "Clear legal documents") }
+  let!(:section) { create(:section, project: project, title: Task::LEGAL_DOCUMENT_SECTION_TITLE) }
   let(:task) { create(:task, :not_applicable, title: "Not applicable task", section: section) }
   let!(:actions) { create_list(:action, 3, task: task, completed: true) }
 

--- a/spec/fixtures/files/workflows/conversion/sections/clearing.yml
+++ b/spec/fixtures/files/workflows/conversion/sections/clearing.yml
@@ -1,4 +1,4 @@
-title: Clear legal documents
+title: Clear and sign legal documents
 tasks:
   - title: Clear land questionnaire
     actions:

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Task, type: :model do
     subject { task.clear_legal_documents_type? }
 
     context "when section is 'Clear legal documents'" do
-      let(:section) { build(:section, title: "Clear legal documents") }
+      let(:section) { build(:section, title: "Clear and sign legal documents") }
 
       it { expect(subject).to be true }
     end

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe TasksController, type: :request do
     end
 
     context "when the task is not in the 'Clear legal documents' section" do
-      let(:section) { create(:section, title: "Clear legal documents") }
+      let(:section) { create(:section, title: "Clear and sign legal documents") }
 
       it "returns a successful response and renders the clear_legal_documents_show template" do
         expect(subject).to have_http_status :success

--- a/spec/services/task_list_creator_spec.rb
+++ b/spec/services/task_list_creator_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe TaskListCreator do
 
     context "when the workflow's optional fields are empty" do
       it "creates tasks from the workflow" do
-        section = Section.find_by(title: "Clear legal documents")
+        section = Section.find_by(title: "Clear and sign legal documents")
 
         expect(Task.count).to be 3
         expect(
@@ -73,7 +73,7 @@ RSpec.describe TaskListCreator do
       end
 
       it "creates actions from the workflow" do
-        section = Section.find_by(title: "Clear legal documents")
+        section = Section.find_by(title: "Clear and sign legal documents")
         task = section.tasks.find_by(title: "Clear land questionnaire")
 
         expect(


### PR DESCRIPTION
## Changes

Our "legal documents' section renders a different view which includes the ability to show the 'not applicable' option.

We really don't like this and have work planned to change this very (very) soon, however, we use the section title to identify when to render a legal document task over a generic task.

Recently we changed the title of this section to:

Clear and sign legal documents

and did not update the condition.

Here we do that, even though it is horrific.
