### PR TITLE
(708) Feature: add a by target completion date scope to project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - the service name has been removed from the Projects page
+- the Projects are listed in target completion date order, soonest first
 
 ## [Release 6][release-6]
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -23,6 +23,8 @@ class Project < ApplicationRecord
   belongs_to :team_leader, class_name: "User", optional: true
   belongs_to :regional_delivery_officer, class_name: "User", optional: true
 
+  scope :by_target_completion_date, -> { order(target_completion_date: :asc) }
+
   def establishment
     @establishment ||= fetch_establishment(urn)
   end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -30,11 +30,11 @@ class ProjectPolicy
 
     def resolve
       if user.team_leader?
-        scope.all
+        scope.all.by_target_completion_date
       elsif user.regional_delivery_officer?
-        scope.where(regional_delivery_officer: user)
+        scope.by_target_completion_date.where(regional_delivery_officer: user)
       else
-        scope.where(caseworker: user)
+        scope.by_target_completion_date.where(caseworker: user)
       end
     end
 

--- a/spec/features/users_can_view_projects_spec.rb
+++ b/spec/features/users_can_view_projects_spec.rb
@@ -11,9 +11,30 @@ RSpec.feature "Users can view a list of projects" do
   let(:regional_delivery_officer) { create(:user, :regional_delivery_officer, email: "regionaldeliveryofficer@education.gov.uk") }
   let(:user_1) { create(:user, email: "user1@education.gov.uk") }
   let(:user_2) { create(:user, email: "user2@education.gov.uk") }
-  let!(:unassigned_project) { create(:project, urn: 100001) }
-  let!(:user_1_project) { create(:project, urn: 100002, caseworker: user_1) }
-  let!(:user_2_project) { create(:project, urn: 100003, caseworker: user_2, regional_delivery_officer: regional_delivery_officer) }
+  let!(:unassigned_project) {
+    create(
+      :project,
+      urn: 100001,
+      target_completion_date: Date.today.beginning_of_month + 3.years
+    )
+  }
+  let!(:user_1_project) {
+    create(
+      :project,
+      urn: 100002,
+      caseworker: user_1,
+      target_completion_date: Date.today.beginning_of_month + 2.year
+    )
+  }
+  let!(:user_2_project) {
+    create(
+      :project,
+      urn: 100003,
+      caseworker: user_2,
+      regional_delivery_officer: regional_delivery_officer,
+      target_completion_date: Date.today.beginning_of_month + 1.years
+    )
+  }
 
   context "when the user is a team leader" do
     before do
@@ -26,6 +47,14 @@ RSpec.feature "Users can view a list of projects" do
       page_has_project(unassigned_project)
       page_has_project(user_1_project)
       page_has_project(user_2_project)
+    end
+
+    scenario "the projects are sorted by target completion date" do
+      visit projects_path
+
+      expect(page.find("ul.projects-list > li:nth-of-type(1)")).to have_content("100003")
+      expect(page.find("ul.projects-list > li:nth-of-type(2)")).to have_content("100002")
+      expect(page.find("ul.projects-list > li:nth-of-type(3)")).to have_content("100001")
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -266,6 +266,22 @@ RSpec.describe Project, type: :model do
     end
   end
 
+  describe "by_target_completion_date scope" do
+    before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+    it "shows the project that complete earliest first" do
+      last_project = create(:project, target_completion_date: Date.today.beginning_of_month + 3.years)
+      middle_project = create(:project, target_completion_date: Date.today.beginning_of_month + 2.years)
+      first_project = create(:project, target_completion_date: Date.today.beginning_of_month + 1.year)
+
+      ordered_projects = Project.by_target_completion_date
+
+      expect(ordered_projects[0]).to eq first_project
+      expect(ordered_projects[1]).to eq middle_project
+      expect(ordered_projects[2]).to eq last_project
+    end
+  end
+
   describe "#closed?" do
     context "when the closed_at is nil, i.e. the project is active" do
       it "returns false" do


### PR DESCRIPTION
## Changes

By target completion date seems the most reasonable sort order in a lot of situations and is
certainly an improvement over a random order from the database, which is
what we have now.

https://trello.com/c/h71w1gvi

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
