### PR TITLE
(712) Trust SharePoint link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - An email is sent via GOV.UK Notify to all team leads when a project is
   created.
 - The Handover/new project form collects a trust SharePoint link.
+- The trust SharePoint link is shown on the project information.
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   created.
 - The Handover/new project form collects a trust SharePoint link.
 - The trust SharePoint link is shown on the project information.
+- The trust SharePoint link is shown on the project summary.
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Projects can be closed.
 - An email is sent via GOV.UK Notify to all team leads when a project is
   created.
+- The Handover/new project form collects a trust SharePoint link.
 
 #### Changed
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -49,7 +49,8 @@ class ProjectsController < ApplicationController
       :target_completion_date,
       :advisory_board_date,
       :advisory_board_conditions,
-      :establishment_sharepoint_link
+      :establishment_sharepoint_link,
+      :trust_sharepoint_link
     )
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -14,6 +14,7 @@ class Project < ApplicationRecord
   validates :advisory_board_date, presence: true, on: :create
   validates :advisory_board_date, past_date: true
   validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}, on: :create
+  validates :trust_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}, on: :create
 
   validate :first_day_of_month
   validate :target_completion_date_is_in_the_future, on: :create

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -43,6 +43,10 @@
       row.key { t('project_information.show.project_details.rows.establishment_sharepoint_link') }
       row.value { safe_link_to(t("project.summary.establishment_sharepoint_link.value"), @project.establishment_sharepoint_link) }
     end
+    summary_list.row do |row|
+      row.key { t('project_information.show.project_details.rows.trust_sharepoint_link') }
+      row.value { safe_link_to(t("project.summary.trust_sharepoint_link.value"), @project.trust_sharepoint_link) }
+    end
   end %>
 </div>
 

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -13,6 +13,7 @@
       <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m"}, width: 10 %>
       <%= form.govuk_date_field :target_completion_date, omit_day: true, form_group: {id: "target-completion-date"} %>
       <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m"} %>
+      <%= form.govuk_text_field :trust_sharepoint_link, label: {size: "m"} %>
       <%= form.govuk_date_field :advisory_board_date, form_group: {id: "advisory-board-date"} %>
       <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m"} %>
 

--- a/app/views/shared/_project_summary.html.erb
+++ b/app/views/shared/_project_summary.html.erb
@@ -25,6 +25,10 @@
             row.key { t("project.summary.establishment_sharepoint_link.title") }
             row.value { safe_link_to(t("project.summary.establishment_sharepoint_link.value"), @project.establishment_sharepoint_link) }
           end
+          summary_list.row do |row|
+            row.key { t("project.summary.trust_sharepoint_link.title") }
+            row.value { safe_link_to(t("project.summary.trust_sharepoint_link.value"), @project.trust_sharepoint_link) }
+          end
           if @project.closed?
             summary_list.row do |row|
               row.key { t("project.summary.closed_at") }

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -94,6 +94,7 @@ en:
         regional_delivery_officer_id: Regional delivery officer
         advisory_board_conditions: Advisory board conditions
         establishment_sharepoint_link: School SharePoint link
+        trust_sharepoint_link: Trust SharePoint link
     legend:
       project:
         target_completion_date: Target conversion date
@@ -105,7 +106,8 @@ en:
         caseworker_id: The caseworker responsible for this project
         target_completion_date: The target conversion date is always the 1st of the month.
         advisory_board_conditions: If there are conditions to be met as a result of the advisory board.
-        establishment_sharepoint_link: Provide a link to the SharePoint folder for this project. This is where you save all the relevant documents.
+        establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant documents.
+        trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant documents.
   activerecord:
     errors:
       models:
@@ -131,7 +133,12 @@ en:
               blank: Enter a date of advisory board
               must_be_in_the_past: The advisory board date must be in the past
             establishment_sharepoint_link:
-              blank: Enter a SharePoint link
-              invalid: Enter a SharePoint link in the correct format
-              https_only: The SharePoint link must have the https scheme
-              host_not_allowed: enter a sharepoint link in the correct format. sharepoint links start with 'https://educationgovuk.sharepoint.com' or 'https://educationgovuk-my.sharepoint.com/'
+              blank: Enter a school SharePoint link
+              invalid: Enter a school SharePoint link in the correct format
+              https_only: The school SharePoint link must have the https scheme
+              host_not_allowed: Enter a school sharepoint link in the correct format. SharePoint links start with 'https://educationgovuk.sharepoint.com' or 'https://educationgovuk-my.sharepoint.com/'
+            trust_sharepoint_link:
+              blank: Enter a trust SharePoint link
+              invalid: Enter a trust SharePoint link in the correct format
+              https_only: The trust SharePoint link must have the https scheme
+              host_not_allowed: Enter a trust sharepoint link in the correct format. SharePoint links start with 'https://educationgovuk.sharepoint.com' or 'https://educationgovuk-my.sharepoint.com/'

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -39,7 +39,9 @@ en:
         title: Region
       establishment_sharepoint_link:
         title: School SharePoint link
-        value: Open the School Sharepoint folder in a new tab
+        value: Open the school Sharepoint folder in a new tab
+      trust_sharepoint_link:
+        value: Open the trust Sharepoint folder in a new tab
       closed_at: Project closed
     assign:
       team_leader:
@@ -60,7 +62,8 @@ en:
           regional_delivery_officer: Regional delivery officer
           unassigned: Not yet assigned
           advisory_board_date: Date of advisory board
-          establishment_sharepoint_link: School SharePoint link
+          establishment_sharepoint_link: School SharePoint folder
+          trust_sharepoint_link: Trust SharePoint folder
           advisory_board_conditions: Conditions from advisory board
       school_details:
         title: School details

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -38,9 +38,10 @@ en:
       region:
         title: Region
       establishment_sharepoint_link:
-        title: School SharePoint link
+        title: School SharePoint folder
         value: Open the school Sharepoint folder in a new tab
       trust_sharepoint_link:
+        title: Trust SharePoint folder
         value: Open the trust Sharepoint folder in a new tab
       closed_at: Project closed
     assign:

--- a/db/migrate/20221020124723_add_trust_sharepoint_link_to_project.rb
+++ b/db/migrate/20221020124723_add_trust_sharepoint_link_to_project.rb
@@ -1,0 +1,5 @@
+class AddTrustSharepointLinkToProject < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :trust_sharepoint_link, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_18_122208) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_20_124723) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -64,6 +64,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_18_122208) do
     t.text "advisory_board_conditions"
     t.text "establishment_sharepoint_link"
     t.datetime "closed_at"
+    t.text "trust_sharepoint_link"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"
     t.index ["team_leader_id"], name: "index_projects_on_team_leader_id"

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -6,7 +6,8 @@ FactoryBot.define do
     team_leader { association :user, :team_leader, email: "team-leader-#{SecureRandom.uuid}@education.gov.uk" }
     regional_delivery_officer { association :user, :regional_delivery_officer, email: "regional-delivery-officer-#{SecureRandom.uuid}@education.gov.uk" }
     advisory_board_date { (Date.today - 2.weeks) }
-    establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/project/information" }
+    establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/establishment-folder" }
+    trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }
 
     trait :with_conditions do
       advisory_board_conditions { "The following must be met:\n 1. Must be red\n2. Must be blue\n" }

--- a/spec/features/users_can_create_projects_spec.rb
+++ b/spec/features/users_can_create_projects_spec.rb
@@ -25,7 +25,8 @@ RSpec.feature "Users can create new projects" do
         fill_in "Year", with: completion_date.year
       end
 
-      fill_in "School SharePoint link", with: "https://educationgovuk-my.sharepoint.com/project/information"
+      fill_in "School SharePoint link", with: "https://educationgovuk-my.sharepoint.com/school-folder"
+      fill_in "Trust SharePoint link", with: "https://educationgovuk-my.sharepoint.com/trust-folder"
 
       within("#advisory-board-date") do
         fill_in "Day", with: two_weeks_ago.day

--- a/spec/features/users_can_view_a_project_spec.rb
+++ b/spec/features/users_can_view_a_project_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature "Users can view a project" do
       expect(page).to have_content(project.incoming_trust.name)
       expect(page).to have_content(project.establishment.region_name)
       expect(page).to have_link(I18n.t("project.summary.establishment_sharepoint_link.value"), href: project.establishment_sharepoint_link)
+      expect(page).to have_link(I18n.t("project.summary.trust_sharepoint_link.value"), href: project.trust_sharepoint_link)
     end
   end
 end

--- a/spec/features/users_can_view_project_information_spec.rb
+++ b/spec/features/users_can_view_project_information_spec.rb
@@ -39,6 +39,12 @@ RSpec.feature "Users can view project information" do
     end
   end
 
+  scenario "they can view the Trust SharePoint link" do
+    within("#projectDetails") do
+      expect(page).to have_link(I18n.t("project.summary.trust_sharepoint_link.value"), href: project.trust_sharepoint_link)
+    end
+  end
+
   scenario "they can view the school details" do
     within("#schoolDetails") do
       expect(page).to have_content(project.establishment.name)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -153,6 +153,10 @@ RSpec.describe Project, type: :model do
     describe "#establishment_sharepoint_link" do
       it { is_expected.to validate_presence_of :establishment_sharepoint_link }
     end
+
+    describe "#trust_sharepoint_link" do
+      it { is_expected.to validate_presence_of :trust_sharepoint_link }
+    end
   end
 
   describe "#establishment" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_db_column(:advisory_board_date).of_type :date }
     it { is_expected.to have_db_column(:advisory_board_conditions).of_type :text }
     it { is_expected.to have_db_column(:establishment_sharepoint_link).of_type :text }
+    it { is_expected.to have_db_column(:trust_sharepoint_link).of_type :text }
     it { is_expected.to have_db_column(:closed_at).of_type :datetime }
   end
 


### PR DESCRIPTION
## Changes
### Add trust SharePoint link to Project
The two main entities involved in a conversion are the School and the Trust it
is joining. We already collect the school SharePoint folder link, we should do
the same for the Trust.

### Collect trust SharePoint link on project creation
We want to collect the trust SharePoint link when the user creates a project.

This includes some minor changes to the validation messages for a school
SharePoint link, so that they can be distinguished from the new trust
SharePoint link.

### Add the trust SharePoint link to the project information tab
This also changes "link" to "folder" for the school SharePoint folder, so that
the description matches the header.

### Add the trust SharePoint link to the project summary
This also changes "link" to "folder" for the school SharePoint folder, so that
the description matches the header.

## Screenshots
![image](https://user-images.githubusercontent.com/47089130/196705445-b7da9f2c-4905-4db7-a2fb-3a639eec13d3.png)

![image](https://user-images.githubusercontent.com/47089130/196705044-3782429b-3d10-4864-a5b7-4e9269f364a0.png)

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
