### PR TITLE
Add Commercial transfer agreement to legal docs section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 #### Added
 
-- Commercial transfer agreement added to legal docs
 - The phase banner and link to general feedback form
 - Projects can be closed.
 - An email is sent via GOV.UK Notify to all team leads when a project is
@@ -25,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Content
 
+- Commercial transfer agreement added to legal docs
 - Content changes to EFSA in KIM to combine 2 bullet points
 - Remove the Handback with regional delivery officer task
 - Tell regional delivery that the academy has opened task to Project close

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 #### Added
 
+- Commercial transfer agreement added to legal docs
 - The phase banner and link to general feedback form
 - Projects can be closed.
 - An email is sent via GOV.UK Notify to all team leads when a project is

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -334,7 +334,6 @@ tasks:
       - type: single-checkbox
         title: Document signed on behalf of the Secretary of State
 
-
   - slug: commercial-transfer-agreement
     title: Commercial transfer agreement
     hint:

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -333,3 +333,16 @@ tasks:
         title: Sent to Academies Operational Practice Unit
       - type: single-checkbox
         title: Document signed on behalf of the Secretary of State
+
+  - slug: commercial-transfer-agreement
+    title: Commercial transfer agreement
+    hint:
+      The Commercial transfer agreement is essential for all conversion
+      projects.
+    actions:
+      - title:
+          Email the school to confirm all relevant parties have signed the
+          Commercial Transfer agreement
+
+      - title:
+          Save a copy of the confirmation email in school's SharePoint folder

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -342,7 +342,7 @@ tasks:
     actions:
       - title:
           Email the school to confirm all relevant parties have signed the
-          Commercial Transfer agreement
+          Commercial transfer agreement
 
       - title:
           Save a copy of the confirmation email in school's SharePoint folder


### PR DESCRIPTION
## Changes

Adds the commercial transfer agreement to the legal docs section.

This needs a content check from @SteveMilnes and code check from a dev.

![image](https://user-images.githubusercontent.com/13239597/196925771-f9506593-2e75-462f-8197-f71e562c6af6.png)


## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
