### PR TITLE
Launch Redis Cache

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -139,7 +139,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | 0.5.2 |
+| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v0.6.0 |
 
 ## Resources
 
@@ -159,6 +159,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 | <a name="input_container_secret_environment_variables"></a> [container\_secret\_environment\_variables](#input\_container\_secret\_environment\_variables) | Container secret environment variables | `map(string)` | n/a | yes |
 | <a name="input_enable_container_registry"></a> [enable\_container\_registry](#input\_enable\_container\_registry) | Set to true to create a container registry | `bool` | n/a | yes |
 | <a name="input_enable_mssql_database"></a> [enable\_mssql\_database](#input\_enable\_mssql\_database) | Set to true to create an Azure SQL server/database, with aprivate endpoint within the virtual network | `bool` | n/a | yes |
+| <a name="input_enable_redis_cache"></a> [enable\_redis\_cache](#input\_enable\_redis\_cache) | Set to true to create a Redis Cache | `bool` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Will be used along with `project_name` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | Image name | `string` | n/a | yes |
 | <a name="input_key_vault_access_users"></a> [key\_vault\_access\_users](#input\_key\_vault\_access\_users) | List of users that require access to the Key Vault where tfvars are stored. This should be a list of User Principle Names (Found in Active Directory) that need to run terraform | `list(string)` | n/a | yes |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -1,5 +1,5 @@
 module "azure_container_apps_hosting" {
-  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=0.5.2"
+  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v0.6.0"
 
   environment    = local.environment
   project_name   = local.project_name
@@ -15,4 +15,6 @@ module "azure_container_apps_hosting" {
   container_secret_environment_variables = local.container_secret_environment_variables
 
   enable_mssql_database = local.enable_mssql_database
+
+  enable_redis_cache = local.enable_redis_cache
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -9,6 +9,7 @@ locals {
   container_command                      = var.container_command
   container_secret_environment_variables = var.container_secret_environment_variables
   enable_mssql_database                  = var.enable_mssql_database
+  enable_redis_cache                     = var.enable_redis_cache
   key_vault_access_users                 = toset(var.key_vault_access_users)
   tfvars_filename                        = var.tfvars_filename
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,3 +58,8 @@ variable "enable_mssql_database" {
   description = "Set to true to create an Azure SQL server/database, with aprivate endpoint within the virtual network"
   type        = bool
 }
+
+variable "enable_redis_cache" {
+  description = "Set to true to create a Redis Cache"
+  type        = bool
+}


### PR DESCRIPTION
## Changes

* Redis is used along with Sidekiq to run tasks asynchronously
* This is the first step, which allows the tasks to be sent to Redis
* Once this is up and running, we will configure the worker (Sidekiq) app to run the queued tasks

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
