### PR TITLE
Chore: Set the host name in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,4 +82,7 @@ Rails.application.configure do
   # tell Rails to look for it's internal tables there.
   config.active_record.schema_migrations_table_name = "#{ENV["SQL_SERVER_SCHEMA_NAME"]}.schema_migrations"
   config.active_record.internal_metadata_table_name = "#{ENV["SQL_SERVER_SCHEMA_NAME"]}.ar_internal_metadata"
+
+  # confugure the host name
+  config.hosts << ENV["HOSTNAME"]
 end

--- a/doc/environment-variables.md
+++ b/doc/environment-variables.md
@@ -1,8 +1,25 @@
 # Environment variables
 
+We have three production environment si.e. where Rails is running in
+'production' with RAILS_ENV="production":
+
+- development
+- test
+- production
+
+These environments require extra variables to function, these are stored in the
+Terraform tfvar files.
+
 `SQL_SERVER_SCHEMA_NAME`
 
-This is the SQL Server schema name used in production and
-pre-production/staging. Must be set in those environments, not used locally, see
+This is the SQL Server schema name used in production environments and must be
+set in those, not used locally, see
 [SQL Server documentation](./microsoft-sql-server.md) for more information on
 schema in this context.
+
+`HOSTNAME`
+
+This is the host name for the running application in production environments, we
+set this into the `Rails.application.config.hosts` array, see:
+
+https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization


### PR DESCRIPTION
## Changes
We want to prevent DNS rebinding and other Host header attacks so we set a allow list of host names, which for now is only one.

We'll get the host name from the environment the deployment is in.

https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
