### PR TITLE
(714) Add project closed date to the project index view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The Handover/new project form collects a trust SharePoint link.
 - The trust SharePoint link is shown on the project information.
 - The trust SharePoint link is shown on the project summary.
+- Closed projects display their closed date on the project list
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The trust SharePoint link is shown on the project information.
 - The trust SharePoint link is shown on the project summary.
 - Closed projects display their closed date on the project list
+- Closed projects are sorted to the back of the project list
 
 #### Changed
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -26,6 +26,12 @@ class Project < ApplicationRecord
 
   scope :by_target_completion_date, -> { order(target_completion_date: :asc) }
 
+  # This works under MSSQL because it puts NULL at the front, and we can't make it more robust because TinyTDS won't
+  # play nicely with things like IS NULL and NULLS LAST. If you're running this under a different database and the
+  # order is suddenly inverted, go check out https://michaeljherold.com/articles/null-based-ordering-in-activerecord/
+  # and see if you can use Arel to build a proper query.
+  scope :by_closed_state, -> { order(:closed_at) }
+
   def establishment
     @establishment ||= fetch_establishment(urn)
   end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -30,11 +30,11 @@ class ProjectPolicy
 
     def resolve
       if user.team_leader?
-        scope.all.by_target_completion_date
+        scope.by_closed_state.by_target_completion_date
       elsif user.regional_delivery_officer?
-        scope.by_target_completion_date.where(regional_delivery_officer: user)
+        scope.by_closed_state.by_target_completion_date.where(regional_delivery_officer: user)
       else
-        scope.by_target_completion_date.where(caseworker: user)
+        scope.by_closed_state.by_target_completion_date.where(caseworker: user)
       end
     end
 

--- a/app/views/projects/index/_project_summary.html.erb
+++ b/app/views/projects/index/_project_summary.html.erb
@@ -20,4 +20,11 @@
 
   <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
 
+  <% if project.closed? %>
+    <%= render partial: "projects/index/project_summary_item",
+          locals: {label: t("project.summary.closed_at"), content: project.closed_at.to_formatted_s(:govuk_date_time_date_only)} %>
+
+    <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
+  <% end %>
+
 </div>

--- a/spec/features/users_can_view_projects_spec.rb
+++ b/spec/features/users_can_view_projects_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "Users can view a list of projects" do
     mock_successful_api_responses(urn: 100001, ukprn: 10061021)
     mock_successful_api_responses(urn: 100002, ukprn: 10061021)
     mock_successful_api_responses(urn: 100003, ukprn: 10061021)
+    mock_successful_api_responses(urn: 100004, ukprn: 10061021)
   end
 
   let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
@@ -24,6 +25,16 @@ RSpec.feature "Users can view a list of projects" do
       urn: 100002,
       caseworker: user_1,
       target_completion_date: Date.today.beginning_of_month + 2.year
+    )
+  }
+  let!(:user_2_closed_project) {
+    create(
+      :project,
+      urn: 100004,
+      caseworker: user_2,
+      regional_delivery_officer: regional_delivery_officer,
+      target_completion_date: Date.today.beginning_of_month + 6.months,
+      closed_at: Date.today.beginning_of_month + 7.months
     )
   }
   let!(:user_2_project) {
@@ -47,14 +58,18 @@ RSpec.feature "Users can view a list of projects" do
       page_has_project(unassigned_project)
       page_has_project(user_1_project)
       page_has_project(user_2_project)
+      page_has_project(user_2_closed_project)
     end
 
-    scenario "the projects are sorted by target completion date" do
+    # If this is unexpectedly failing due to sorting closed projects first, see the by_closed_state scope in the
+    # projects model for an explanation of the likely culprit.
+    scenario "the projects are sorted by closed state, then by target completion date" do
       visit projects_path
 
       expect(page.find("ul.projects-list > li:nth-of-type(1)")).to have_content("100003")
       expect(page.find("ul.projects-list > li:nth-of-type(2)")).to have_content("100002")
       expect(page.find("ul.projects-list > li:nth-of-type(3)")).to have_content("100001")
+      expect(page.find("ul.projects-list > li:nth-of-type(4)")).to have_content("100004")
     end
   end
 


### PR DESCRIPTION
TRELLO-oebBbkgX

## Changes

- To surface the fact that a project has been closed whilst in the list view, display the closed date where it exists.
- Since it's unlikely for people to want access to closed projects as often, sort them to the bottom of the list view.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
