### PR TITLE
Chore: Configure ActionMailer in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,6 +83,16 @@ Rails.application.configure do
   config.active_record.schema_migrations_table_name = "#{ENV["SQL_SERVER_SCHEMA_NAME"]}.schema_migrations"
   config.active_record.internal_metadata_table_name = "#{ENV["SQL_SERVER_SCHEMA_NAME"]}.ar_internal_metadata"
 
-  # confugure the host name
+  # configure the host name
   config.hosts << ENV["HOSTNAME"]
+
+  # configure ActionMailer
+  # set the host so links in emails work
+  # https://guides.rubyonrails.org/action_mailer_basics.html#generating-urls-in-action-mailer-views
+  config.action_mailer.default_url_options = {host: ENV["HOSTNAME"]}
+
+  # Use GOV.UK Notify to send email
+  # https://github.com/dxw/mail-notify
+  config.action_mailer.delivery_method = :notify
+  config.action_mailer.notify_settings = {api_key: ENV["GOV_NOTIFY_API_KEY"]}
 end


### PR DESCRIPTION
## Changes
Sending emails will not work without being configured.

Here we add the default hostname so links to the application in emails work and configure ActionMailer to use GOV.UK Notify to actually send emails - this is already configured in local development.

We don't have Sidekiq configured in production environments just yet, so for now, these emails are sent asynhronusly, see:

https://guides.rubyonrails.org/action_mailer_basics.html#calling-the-mailer

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
