### PR TITLE
(750) Fine-tune padding for actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Features
+
+#### Changed
+
+- Fine-tuned padding for actions in various type/state combinations to closer
+  match the prototype.
+
 ## [Release 7][release-7]
 
 ### Features

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,17 +28,31 @@ $govuk-global-styles: true;
   }
 }
 
+.task-actions__wrapper {
+  margin-bottom: govuk-spacing(9);
+}
+
 .task-action__wrapper {
   &:first-of-type {
     margin-top: 0;
   }
 
   &__padding-normal {
-    margin-top: govuk-spacing(9);
+    margin-top: govuk-spacing(4);
   }
 
   &__padding-reduced {
-    margin-top: govuk-spacing(0);
+    margin-top: govuk-spacing(2);
+  }
+
+  .govuk-form-group {
+    margin-bottom: 0;
+  }
+}
+
+.task-action {
+  &__subheading:not(:first-of-type) {
+    margin-top: govuk-spacing(9);
   }
 }
 

--- a/app/views/tasks/shared/_action_wrapper.html.erb
+++ b/app/views/tasks/shared/_action_wrapper.html.erb
@@ -1,3 +1,3 @@
-<div class="task-action__wrapper task-action__wrapper__padding-<%= action.padding || "normal" %>">
+<div class="task-action__wrapper task-action__<%= action.action_type %> task-action__wrapper__padding-<%= action.padding || "normal" %>">
 <%= yield %>
 </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -18,16 +18,20 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for :task, url: project_task_path, method: :put do |form| %>
 
-      <%= render partial: "tasks/shared/not_applicable_checkbox", locals: {task: @task, form: form} %>
+    <div class="task-actions__wrapper">
 
-      <% @task.actions.each do |action| %>
-        <%= render layout: "tasks/shared/action_#{action.action_type}", locals: {action: action, form: form} do %>
+        <%= render partial: "tasks/shared/not_applicable_checkbox", locals: {task: @task, form: form} %>
 
-          <%= render partial: "tasks/shared/action_hint", locals: {action: action} %>
+        <% @task.actions.each do |action| %>
+          <%= render layout: "tasks/shared/action_#{action.action_type}", locals: {action: action, form: form} do %>
 
-          <%= render partial: "tasks/shared/action_guidance_summary", locals: {action: action} %>
+            <%= render partial: "tasks/shared/action_hint", locals: {action: action} %>
+
+            <%= render partial: "tasks/shared/action_guidance_summary", locals: {action: action} %>
+          <% end %>
         <% end %>
-      <% end %>
+
+      </div>
 
       <%= form.govuk_submit %>
 


### PR DESCRIPTION
TRELLO-hGeYurIn

## Changes

This commit fine-tunes the padding for actions, actions with reduced padding, actions of the subtitle type, and between the list of actions and the submit task button to more closely match the prototype.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
