### PR TITLE
(740) Add errors when project dates are invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fine-tuned padding for actions in various type/state combinations to closer
   match the prototype.
 
+#### Fixed
+
+- Invalid dates such as 42/01/2022, no longer cause the app to throw an
+  exception. We now rescue from the invalid date and show a validation message.
+
 ### Content
 
 - Swap out the link to the previous version of the single worksheet for a link

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,8 @@
 class Project < ApplicationRecord
   SHAREPOINT_URLS = %w[educationgovuk-my.sharepoint.com educationgovuk.sharepoint.com].freeze
 
+  before_validation :add_invalid_date_errors
+
   has_many :sections, dependent: :destroy
   has_many :notes, dependent: :destroy
   has_many :contacts, dependent: :destroy
@@ -40,8 +42,33 @@ class Project < ApplicationRecord
     @incoming_trust ||= fetch_trust(incoming_trust_ukprn)
   end
 
+  # Rescue argument error raised when value
+  # cannot be parsed as a `Date`. For example,
+  # `-1, -1, -2` or `42, 0, 2022`
+  def advisory_board_date=(value)
+    @advisory_board_date_invalid = false
+    super
+  rescue ArgumentError
+    @advisory_board_date_invalid = true
+  end
+
+  # Rescue argument error raised when value
+  # cannot be parsed as a `Date`. For example,
+  # `-1, -1, -2` or `42, 0, 2022`
+  def target_completion_date=(value)
+    @target_completion_date_invalid = false
+    super
+  rescue ArgumentError
+    @target_completion_date_invalid = true
+  end
+
   def closed?
     closed_at.present?
+  end
+
+  private def add_invalid_date_errors
+    errors.add(:advisory_board_date, :invalid) if @advisory_board_date_invalid
+    errors.add(:target_completion_date, :invalid) if @target_completion_date_invalid
   end
 
   private def fetch_establishment(urn)

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -131,11 +131,13 @@ en:
               blank: Enter a target conversion month and year
               must_be_first_of_the_month: Target completion date must be on the first day of the month
               must_be_in_the_future: Target conversion date must be in the future.
+              invalid: Enter a valid target conversion date.
             regional_delivery_officer_id:
               blank: Choose a regional delivery officer
             advisory_board_date:
               blank: Enter a date of advisory board
               must_be_in_the_past: The advisory board date must be in the past
+              invalid: Enter a valid advisory board date
             establishment_sharepoint_link:
               blank: Enter a school SharePoint link
               invalid: Enter a school SharePoint link in the correct format

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -76,7 +76,20 @@ RSpec.describe Project, type: :model do
   describe "Validations" do
     before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 
-    it { is_expected.to validate_presence_of(:advisory_board_date).on(:create) }
+    describe "#advisory_board_date" do
+      it { is_expected.to validate_presence_of(:advisory_board_date).on(:create) }
+
+      context "when the date is invalid" do
+        subject { create(:project) }
+
+        before { subject.advisory_board_date = {3 => -1, 2 => -1, 1 => -1} }
+
+        it "adds an error to the Project" do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:advisory_board_date]).to include(I18n.t("activerecord.errors.models.project.attributes.advisory_board_date.invalid"))
+        end
+      end
+    end
 
     describe "#urn" do
       it { is_expected.to validate_presence_of(:urn) }
@@ -121,6 +134,17 @@ RSpec.describe Project, type: :model do
 
     describe "#target_completion_date" do
       it { is_expected.to validate_presence_of(:target_completion_date) }
+
+      context "when the date is invalid" do
+        subject { create(:project) }
+
+        before { subject.target_completion_date = {3 => -1, 2 => -1, 1 => -1} }
+
+        it "adds an error to the Project" do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:target_completion_date]).to include(I18n.t("activerecord.errors.models.project.attributes.target_completion_date.invalid"))
+        end
+      end
 
       context "when the date is not on the first of the month" do
         subject { build(:project, target_completion_date: Date.new(2025, 12, 2)) }


### PR DESCRIPTION
## Changes

Currently, when an invalid date such as 42,01,2022 or -1,01,2022 is set, we see a MultiParameter error.

Unfortunately, there doesn't seem to be any particularly nice way to fix this.

This overrides the setter for the Project date attributes. We rescue from any invalid dates, and add a custom error. Simply setting the error in the `rescue` won't work as the date is nillfied and we will see the error associated with the `presence` validation. 

This solution does not show the user their previous incorrect input. However, to enable that does not seem worth the effort at this point.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
