### PR TITLE
(760) - Legal documents private beta changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The checkbox label in the "Land questionnaire" task says "Signed by
   solicitor", updated from "Signed by school or trust".
 - The "Articles of association" task is now optional.
+- Change the guidance link in the "Articles of association" task.
 
 ## [Release 7][release-7]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Change the guidance link in the "Articles of association" task.
 - The "Signed by secretary of state" section has been removed from the "Trust
   modification order" task.
+- The "Signed by secretary of state" section has been removed from the
+  "Direction to transfer" task.
 
 ## [Release 7][release-7]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   school has been received.
 - Swap out the link to the previous version of the single worksheet for a link
   to an updated version.
+- The checkbox label in the "Land questionnaire" task says "Signed by
+  solicitor", updated from "Signed by school or trust".
 
 ## [Release 7][release-7]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   to an updated version.
 - The checkbox label in the "Land questionnaire" task says "Signed by
   solicitor", updated from "Signed by school or trust".
+- The "Articles of association" task is now optional.
 
 ## [Release 7][release-7]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   modification order" task.
 - The "Signed by secretary of state" section has been removed from the
   "Direction to transfer" task.
+- The "Commercial transfer agreement" task has been moved to the bottom of the
+  "Clear and sign legal documents" section
 
 ## [Release 7][release-7]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   solicitor", updated from "Signed by school or trust".
 - The "Articles of association" task is now optional.
 - Change the guidance link in the "Articles of association" task.
+- The "Signed by secretary of state" section has been removed from the "Trust
+  modification order" task.
 
 ## [Release 7][release-7]
 

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -28,7 +28,7 @@ tasks:
         title: Cleared
       - type: single-checkbox
         padding: reduced
-        title: Signed by school or trust
+        title: Signed by solicitor
       - type: single-checkbox
         padding: reduced
         title: Saved in the school's SharePoint folder

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -207,8 +207,10 @@ tasks:
 
   - slug: clear-and-sign-articles-of-association
     title: Articles of association
-    hint: |
-      The Articles of association must be updated if the trust currently uses a version from February 2016 or earlier.
+    hint:
+      The Articles of association must be updated if the trust currently uses a
+      version from February 2016 or earlier.
+    optional: true
     actions:
       - type: subheading
         title: Check and clear the Articles of association

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -342,25 +342,6 @@ tasks:
       - type: single-checkbox
         padding: reduced
         title: Saved in the school's SharePoint folder
-      - type: subheading
-        title: Signed by the Secretary of State
-        hint: |
-          Send the Direction to transfer to the Academies Operational Practice Unit.
-        guidance_summary: How to get the Direction to transfer signed
-        guidance_text: |
-          The Academies Operational Practice Unit will arrange for the Direction to transfer to be signed by the deputy director or a grade 6 team member, on behalf of the Secretary of State.
-
-          You can email the Academies Operational Practice Unit at
-          [academiesdelivery.operations@education.gov.uk](mailto:academiesdelivery.operations@education.gov.uk).
-
-          It can take several weeks to hear back from the Academies Operational
-          Practice Unit.
-      - type: single-checkbox
-        padding: reduced
-        title: Sent to Academies Operational Practice Unit
-      - type: single-checkbox
-        padding: reduced
-        title: Document signed on behalf of the Secretary of State
 
   - slug: commercial-transfer-agreement
     title: Commercial transfer agreement

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -217,7 +217,7 @@ tasks:
         hint:
           You can use the [land transfer advice and guidance to check for common
           problems (opens in new
-          tab)](https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Land-Transfer-and-shared-land-use.aspx).
+          tab)](https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Academy-Governance-(includes-clearing-Articles-of-Association).aspx).
         guidance_summary: Help checking for changes
         guidance_text: |
           Changes that personalise the model documents to a school or trust, and remove or add optional clauses, are expected. The wording of clauses should not change.

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -343,21 +343,6 @@ tasks:
         padding: reduced
         title: Saved in the school's SharePoint folder
 
-  - slug: commercial-transfer-agreement
-    title: Commercial transfer agreement
-    hint:
-      The Commercial transfer agreement is essential for all conversion
-      projects.
-    actions:
-      - title:
-          Email the school to ask if they have agreed and signed the Commercial
-          transfer agreement
-      - title:
-          Receive email from the school confirming the Commercial transfer
-          agreement has relevant signatures
-      - title:
-          Save a copy of the confirmation email in school's SharePoint folder
-
   - slug: 125-year-lease
     title: 125 year lease
     hint:
@@ -422,4 +407,19 @@ tasks:
           Tenancy at will
       - type: single-checkbox
         title:
+          Save a copy of the confirmation email in school's SharePoint folder
+
+  - slug: commercial-transfer-agreement
+    title: Commercial transfer agreement
+    hint:
+      The Commercial transfer agreement is essential for all conversion
+      projects.
+    actions:
+      - title:
+          Email the school to ask if they have agreed and signed the Commercial
+          transfer agreement
+      - title:
+          Receive email from the school confirming the Commercial transfer
+          agreement has relevant signatures
+      - title:
           Save a copy of the confirmation email in school's SharePoint folder

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -310,28 +310,6 @@ tasks:
       - type: single-checkbox
         padding: reduced
         title: Saved in the school's SharePoint folder
-      - type: subheading
-        title: Signed by the Secretary of State
-        hint: |
-          Send the Trust modification order to the Academies Operational
-          Practice Unit.
-        guidance_summary: How to get the Trust modification order signed
-        guidance_text: |
-          The Academies Operational Practice Unit will arrange for
-          the Trust modification order to be signed by the deputy director or a
-          grade 6 team member, on behalf of the Secretary of State.
-
-          You can email the Academies Operational Practice Unit at
-          [academiesdelivery.operations@education.gov.uk](mailto:academiesdelivery.operations@education.gov.uk).
-
-          It can take several weeks to hear back from the Academies Operational
-          Practice Unit.
-      - type: single-checkbox
-        padding: reduced
-        title: Sent to Academies Operational Practice Unit
-      - type: single-checkbox
-        padding: reduced
-        title: Document signed on behalf of the Secretary of State
 
   - slug: clear-and-sign-direction-to-transfer
     title: Direction to transfer


### PR DESCRIPTION
## Changes

### Update content for `Land questionnaire`
The checkbox should say "Signed by solicitor" not "Signed by school or trust".

### Make `Articles of association` optional
We have had some feedback that `Articles of association` should be optional. 

We generally show optional tasks last in the "Clear and sign legal documents"
section. but as `Articles of association` is the last non-optional task, there is no to
change its order. 

### Update the guidance link in the `Articles of association` task
We have had some feedback that this link is incorrect and should be swapped.

### Remove `Signed by secretary of state` from `Trust modification order`
We have had some feedback that the `Signed by secretary of state` section is not
needed in the `Trust modification order` task.

The caseworker doesn't need to arrange for these documents to be signed by
secretary of state - academy operations does this for them, after they send
these documents to them with the single worksheet.

### Remove `Signed by secretary of state` from `Direction to transfer `
We have had some feedback that the `Signed by secretary of state` section is not
needed in the `Direction to transfer` task.

The caseworker doesn't need to arrange for these documents to be signed by
secretary of state - academy operations does this for them, after they send
these documents to them with the single worksheet.

### Move `Commercial transfer agreement` to make it the last legal docs task
We have had some feedback that the `Commercial transfer agreement` should be
moved to the bottom of the `Clear legal documents` section.

It is the last document that's received, often in the final month before the
school converts.


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
