### PR TITLE
Add environment banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,7 @@ ACADEMIES_API_TIMEOUT=0.6
 # sentry.io
 # https://sentry.io/organizations/sdd-n7/projects/
 #
-SENTRY_ENV=SENTRY_ENV # the environment production, pre-production/staging or development
+SENTRY_ENV=SENTRY_ENV # the environment production, pre-production/staging or development. This is the variable which controls the environment banner
 SENTRY_DSN=SENTRY_DSN # the DSN for the project in Sentry see: https://docs.sentry.io/platforms/ruby/configuration/options/#environment-variables
 
 # Redis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Features
 
+#### Added
+
+- Add environment banner for local development, development and test
+  environments.
+
 #### Changed
 
 - Fine-tuned padding for actions in various type/state combinations to closer

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,21 @@ $govuk-global-styles: true;
   @include govuk-typography-common();
 }
 
+.environment-banner {
+  &.govuk-tag {
+    display: block;
+    padding-left: calc((100vw - #{$govuk-page-width}) / 2);
+
+    @include govuk-media-query($until: $govuk-page-width + $govuk-gutter * 2) {
+      padding-left: $govuk-gutter;
+    }
+
+    @include govuk-media-query($until: tablet) {
+      padding-left: $govuk-gutter-half;
+    }
+  }
+}
+
 .list-style-none {
   list-style: none;
   padding-left: 0;

--- a/app/helpers/environment_banner_helper.rb
+++ b/app/helpers/environment_banner_helper.rb
@@ -1,0 +1,21 @@
+module EnvironmentBannerHelper
+  ENVIRONMENT_COLOURS = {
+    local_development: "purple",
+    development: "turquoise",
+    test: "orange"
+  }.freeze.with_indifferent_access
+
+  def environment_banner
+    return if ENVIRONMENT_COLOURS.keys.none?(sentry_env)
+
+    govuk_tag(
+      text: "#{sentry_env.tr("_", " ").upcase} ENVIRONMENT",
+      colour: ENVIRONMENT_COLOURS[sentry_env],
+      classes: "environment-banner"
+    )
+  end
+
+  private def sentry_env
+    ENV.fetch("SENTRY_ENV")
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,8 @@
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
+    <%= render partial: "shared/environment_banner" %>
+
     <%= govuk_header(service_name: t("service_name")) %>
 
     <div class="govuk-width-container ">

--- a/app/views/shared/_environment_banner.html.erb
+++ b/app/views/shared/_environment_banner.html.erb
@@ -1,0 +1,1 @@
+<%= environment_banner %>

--- a/spec/features/user_can_see_environment_banner_spec.rb
+++ b/spec/features/user_can_see_environment_banner_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.feature "Environment banner" do
+  let(:user) { create(:user, :caseworker) }
+  let(:project) { create(:project, caseworker: user) }
+
+  before do
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    sign_in_with_user(user)
+  end
+
+  describe "environment banner" do
+    context "when SENTRY_ENV is production" do
+      before { allow(ENV).to receive(:fetch).with("SENTRY_ENV").and_return("production") }
+
+      scenario "cannot see the environment banner" do
+        visit root_path
+        expect(page).to_not have_css(".environment-banner")
+      end
+    end
+
+    context "when SENTRY_ENV is non-production" do
+      before { allow(ENV).to receive(:fetch).with("SENTRY_ENV").and_return("development") }
+
+      scenario "can see the environment banner" do
+        visit root_path
+        within(".environment-banner") do
+          expect(page).to have_content("DEVELOPMENT ENVIRONMENT")
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/environment_banner_helper_spec.rb
+++ b/spec/helpers/environment_banner_helper_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe EnvironmentBannerHelper, type: :helper do
+  describe "#environment_banner" do
+    subject { helper.environment_banner }
+
+    context "when SENTRY_ENV is production" do
+      before { allow(ENV).to receive(:fetch).with("SENTRY_ENV").and_return("production") }
+
+      it { expect(subject).to be_nil }
+    end
+
+    context "when SENTRY_ENV is development" do
+      before { allow(ENV).to receive(:fetch).with("SENTRY_ENV").and_return("development") }
+
+      it { expect(subject).to eql(environment_tag("turquoise", "DEVELOPMENT ENVIRONMENT")) }
+    end
+
+    context "when SENTRY_ENV is local_development" do
+      before { allow(ENV).to receive(:fetch).with("SENTRY_ENV").and_return("local_development") }
+
+      it { expect(subject).to eql(environment_tag("purple", "LOCAL DEVELOPMENT ENVIRONMENT")) }
+    end
+
+    context "when SENTRY_ENV is test" do
+      before { allow(ENV).to receive(:fetch).with("SENTRY_ENV").and_return("test") }
+
+      it { expect(subject).to eql(environment_tag("orange", "TEST ENVIRONMENT")) }
+    end
+  end
+
+  private def environment_tag(colour, environment_name)
+    "<strong class=\"govuk-tag govuk-tag--#{colour} environment-banner\">#{environment_name}</strong>"
+  end
+end


### PR DESCRIPTION
## Changes

We want to know which environment we are currently in to help with development purposes. 
We have added an environment banner which displays this. 
We are currently using the sentry environment to control this.

![Screenshot 2022-10-31 at 15 25 29](https://user-images.githubusercontent.com/59832893/199045439-af7de68f-0417-406f-b32c-8ac75cead7cc.png)

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
