### PR TITLE
Swap out the support email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fine-tuned padding for actions in various type/state combinations to closer
   match the prototype.
+- The support email has been swapped out for a complete team shared inbox.
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -300,7 +300,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 [unreleased]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-7...HEAD
-[release-6]:
+[release-7]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-6...release-7
 [release-6]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-5...release-6

--- a/app/views/pages/internal_server_error.html.erb
+++ b/app/views/pages/internal_server_error.html.erb
@@ -4,7 +4,7 @@
     <p class="govuk-body">Try again later.</p>
 
     <p class="govuk-body">
-      <%= support_email("Contact the Regional Services support team") %> if you have any questions.
+      <%= support_email("Contact the #{t("service_name").downcase} team") %> if you have any questions.
     </p>
   </div>
 </div>

--- a/app/views/pages/page_not_found.html.erb
+++ b/app/views/pages/page_not_found.html.erb
@@ -8,7 +8,7 @@
       If you pasted the web address, check you copied the entire address.
     </p>
     <p class="govuk-body">
-      If the web address is correct or you selected a link or button, <%= support_email("contact the Regional Services support team") %>.
+      If the web address is correct or you selected a link or button, <%= support_email("contact the #{t("service_name").downcase} team") %>.
     </p>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,6 @@ module DfeCompleteConversionsTransfersAndChanges
 
     config.exceptions_app = routes
 
-    config.support_email = "regionalservices.rg@education.gov.uk"
+    config.support_email = "complete.rsd@education.gov.uk"
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -51,12 +51,12 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#support_email" do
-    let(:name) { "contact the Regional Services support team" }
+    let(:name) { "contact the complete conversions, transfers and changes team" }
 
     subject { helper.support_email(name) }
 
     it "returns a mailto link to the support email" do
-      expect(subject).to eq "<a class=\"govuk-link\" href=\"mailto:regionalservices.rg@education.gov.uk\">#{name}</a>"
+      expect(subject).to eq "<a class=\"govuk-link\" href=\"mailto:complete.rsd@education.gov.uk\">#{name}</a>"
     end
   end
 end


### PR DESCRIPTION
## Changes
### Swap out the support email
We initially used the regional services email as our support email, but have since created a shared inbox for the complete team.

This swaps out the email and associated links.

### Fix the release 7 link in the CHANGELOG

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
