### PR TITLE
(765) Allow test suite to use real browser for capybara tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 #### Added
 
+- Set up selenium to work within CI
 - add in accessibility page
 - footer now have link to accessibility page
 - standardise the email the team link based on GOV.UK guidance

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,8 +134,17 @@ FROM web as test
 RUN \
   apt-get update && \
   apt-get install -y \
+  firefox-esr \
   shellcheck \
   yarn
+
+ARG gecko_driver_version=0.32.0
+
+RUN wget https://github.com/mozilla/geckodriver/releases/download/v$gecko_driver_version/geckodriver-v$gecko_driver_version-linux64.tar.gz
+RUN tar -xvzf  geckodriver-v$gecko_driver_version-linux64.tar.gz
+RUN rm geckodriver-v$gecko_driver_version-linux64.tar.gz
+RUN chmod +x geckodriver
+RUN mv geckodriver* /usr/local/bin
 
 COPY .eslintignore ${APP_HOME}/.eslintignore
 COPY .eslintrc.json ${APP_HOME}/.eslintrc.json

--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ group :test do
   gem "capybara"
   gem "climate_control"
   gem "simplecov", "~> 0.21.2"
+  gem "selenium-webdriver"
   gem "shoulda-matchers", "~> 5.1"
   gem "webmock", "~> 3.17"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (4.1.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
@@ -314,6 +315,7 @@ GEM
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -324,6 +326,11 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    selenium-webdriver (4.5.0)
+      childprocess (>= 0.5, < 5.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     sentry-rails (5.4.2)
       railties (>= 5.0)
       sentry-ruby (~> 5.4.2)
@@ -373,6 +380,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -414,6 +422,7 @@ DEPENDENCIES
   rails-controller-testing
   rspec-rails
   sass-rails
+  selenium-webdriver
   sentry-rails
   sentry-ruby
   shoulda-matchers (~> 5.1)

--- a/spec/features/test_for_ci_spec.rb
+++ b/spec/features/test_for_ci_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.feature "Test that selenium works in CI" do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in_with_user(user)
+  end
+
+  scenario "the test runs", driver: :headless_firefox do
+    visit root_path
+
+    expect(page).to have_content("Projects (0)")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,13 @@ require "support/factory_bot"
 #
 Dir[Rails.root.join("spec", "support", "**", "*.rb")].sort.each { |f| require f }
 
+Capybara.register_driver :headless_firefox do |app|
+  options = Selenium::WebDriver::Firefox::Options.new
+  options.headless!
+
+  Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
+end
+
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
 begin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ require "capybara/rspec"
 
 # Add Webmock
 require "webmock/rspec"
+WebMock.disable_net_connect!(allow_localhost: true)
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
## Changes

Set up selenium to work within CI

This is our first step in automating our accessibilty tests.
The next step is to make our test feature test be more specific for an accessibility test and to install axe-core-selenium gem as the accessibility tool.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
