### PR TITLE
339 write an accessibility statement for our service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 #### Added
 
+- add in accessibility page
+- footer now have link to accessibility page
+- standardise the email the team link based on GOV.UK guidance
+- privacy policy page uses service name helper rather than explicit text
 - Add environment banner for local development, development and test
   environments.
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,7 +49,7 @@
       </main>
     </div>
 
-    <%= govuk_footer(meta_items_title: "Helpful links", meta_items: {"Privacy notice" => page_path(id: "privacy")}) %>
+    <%= govuk_footer(meta_items_title: "Helpful links", meta_items: {"Privacy notice" => page_path(id: "privacy"), "Accessibility Statement" => page_path(id: "accessibility")}) %>
 
   </body>
   <%= javascript_include_tag "application" %>

--- a/app/views/pages/accessibility.erb
+++ b/app/views/pages/accessibility.erb
@@ -54,7 +54,7 @@
     <p class="govuk-body">We're always looking to improve the accessibility of
       this website. If you find any problems not listed on this page or think
       we're not meeting accessibility requirements, email the <%= t("service_name") %>
-      team at <%= support_email("rsd.complete@dfe.com") %>.
+      team at <%= support_email(Rails.application.config.support_email) %>.
       </p>
     <h2 class="govuk-heading-l">Enforcement procedure</h2>
     <p class="govuk-body">The Equality and Human Rights Commission is

--- a/app/views/pages/accessibility.erb
+++ b/app/views/pages/accessibility.erb
@@ -1,0 +1,85 @@
+<div class="govuk-grid-row govuk-body">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Accessibility statement</h1>
+    <p class="govuk-body">This accessibility statement applies to Complete
+      conversions, transfers and changes.</p>
+    <p class="govuk-body">This website is run by the Department for Education
+      (DfE). We want as many people as possible to be able to use this website.
+      For example, that means you should be able to:</p>
+    <ul>
+      <li>change colours, contrast levels and fonts</li>
+      <li>zoom in up to 300% without the text spilling off the screen</li>
+      <li>navigate most of the website using just a keyboard</li>
+      <li>navigate most of the website using speech recognition software</li>
+      <li>listen to most of the website using a screen reader (including the
+        most recent versions of JAWS, NVDA and VoiceOver)</li>
+    </ul>
+    <p class="govuk-body">We've also made the website text as simple as possible
+      to understand.</p>
+    <p class="govuk-body"><a href="https://mcmw.abilitynet.org.uk/" target="_blank" rel="noopner noreferrer">
+      AbilityNet (opens in a new tab)</a> has advice on making your device
+      easier to use if you have a disability.
+    <h2 class="govuk-heading-l">How accessible this website is</h2>
+    <p class="govuk-body">This website is partially compliant with the
+      <abbr title="Web Content Accessibility Guidelines">WCAG</abbr> version 2.1
+      AA standard, due to the following non-compliance:</p>
+    <ul>
+        <li>
+          <p class="govuk-body">Some links are coded to visually appear as
+            buttons so they may not have the expected behaviour for keyboard
+            only users. A work around is to try the interacting with them as if
+            they were links.</p>
+          <p class="govuk-body">We expect to have this resolved by 28 February
+            2023.</p>
+        </li>
+        <li>
+          <p class="govuk-body">Some buttons are coded to visually appear as
+            links so they may not have the expected behaviour for keyboard
+            only users. A work around is to try the interacting with them as if
+            they were buttons.</p>
+          <p class="govuk-body">We expect to have this resolved by 28 February
+            2023.</p>
+        </li>
+    </ul>
+    <h2 class="govuk-heading-l">What to do if you can not access parts of this
+      website</h2>
+    <p class="govuk-body">If you need information on this website in a differnt
+      format or cannot use the serivce, email the <%= t("service_name") %> team
+      at <%= support_email("rsd.complete@dfe.com") %>.
+      </p>
+    <p class="govuk-body">We'll consider your request and get back to you within
+      20 working days.</p>
+    <h2 class="govuk-heading-l">Reporting accessibility problems with this
+      website</h2>
+    <p class="govuk-body">We're always looking to improve the accessibility of
+      this website. If you find any problems not listed on this page or think
+      we're not meeting accessibility requirements, email the <%= t("service_name") %>
+      team at <%= support_email("rsd.complete@dfe.com") %>.
+      </p>
+    <h2 class="govuk-heading-l">Enforcement procedure</h2>
+    <p class="govuk-body">The Equality and Human Rights Commission is
+      responsible for enforcing the Public Sector Bodies (Websites and Mobile
+      Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility
+      regulations'). If you're not happy with how we respond to your complaint,
+      <a rel="noopner noreferrer" href="https://www.equalityadvisoryservice.com/" target="_blank">
+      contact the Equality Advisory and Support Service</a>.</p>
+    <h2 class="govuk-heading-l">Technical information about this website's
+      accessibility</h2>
+    <p class="govuk-body">The Department for Education is committed to making
+      its websites accessible, in accordance with the Public Sector Bodies
+      (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
+    <h2 class="govuk-heading-l">What we're doing to improve accessibility</h2>
+    <p class="govuk-body">We have a plan to fix the current accessibility
+      issues. We will also schedule regular accessibility audits as we continue
+      to expand the website and its functionality.</p>
+    <p class="govuk-body">Future audits will cover untested and the most
+      frequently used pages.</p>
+    <h2 class="govuk-heading-l">Preparation of this accessibility statement</h2>
+    <p class="govuk-body">This statement was prepared on 3 November 2022. It was
+      last reviewed on 3 Novevember 2022.</p>
+    <p class="govuk-body">This website was last tested on 1 November 2022. The
+      test was carried out by a Senior Accessibility Specialist Advisor at DfE.</p>
+    <p class="govuk-body">They tested the most frequently used pages within the
+      website.</p>
+  </div>
+</div>

--- a/app/views/pages/accessibility.erb
+++ b/app/views/pages/accessibility.erb
@@ -16,7 +16,7 @@
     </ul>
     <p class="govuk-body">We've also made the website text as simple as possible
       to understand.</p>
-    <p class="govuk-body"><a href="https://mcmw.abilitynet.org.uk/" target="_blank" rel="noopner noreferrer">
+    <p class="govuk-body"><a href="https://mcmw.abilitynet.org.uk/" target="_blank" rel="noopener noreferrer">
       AbilityNet (opens in a new tab)</a> has advice on making your device
       easier to use if you have a disability.
     <h2 class="govuk-heading-l">How accessible this website is</h2>

--- a/app/views/pages/accessibility.erb
+++ b/app/views/pages/accessibility.erb
@@ -61,7 +61,7 @@
       responsible for enforcing the Public Sector Bodies (Websites and Mobile
       Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility
       regulations'). If you're not happy with how we respond to your complaint,
-      <a rel="noopner noreferrer" href="https://www.equalityadvisoryservice.com/" target="_blank">
+      <a rel="noopener noreferrer" href="https://www.equalityadvisoryservice.com/" target="_blank">
       contact the Equality Advisory and Support Service</a>.</p>
     <h2 class="govuk-heading-l">Technical information about this website's
       accessibility</h2>

--- a/app/views/pages/internal_server_error.html.erb
+++ b/app/views/pages/internal_server_error.html.erb
@@ -4,7 +4,7 @@
     <p class="govuk-body">Try again later.</p>
 
     <p class="govuk-body">
-      <%= support_email("Contact the #{t("service_name").downcase} team") %> if you have any questions.
+      <%= support_email("Contact the #{t("service_name")} team") %> if you have any questions.
     </p>
   </div>
 </div>

--- a/app/views/pages/page_not_found.html.erb
+++ b/app/views/pages/page_not_found.html.erb
@@ -8,7 +8,8 @@
       If you pasted the web address, check you copied the entire address.
     </p>
     <p class="govuk-body">
-      If the web address is correct or you selected a link or button, <%= support_email("contact the #{t("service_name").downcase} team") %>.
+      If the web address is correct or you selected a link or button, email the
+      <%= t("service_name") %> team at <%= support_email("rsd.complete@dfe.com") %>.
     </p>
   </div>
 </div>

--- a/app/views/pages/page_not_found.html.erb
+++ b/app/views/pages/page_not_found.html.erb
@@ -9,7 +9,7 @@
     </p>
     <p class="govuk-body">
       If the web address is correct or you selected a link or button, email the
-      <%= t("service_name") %> team at <%= support_email("rsd.complete@dfe.com") %>.
+      <%= t("service_name") %> team at <%= support_email(Rails.application.config.support_email) %>.
     </p>
   </div>
 </div>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,15 +1,12 @@
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Privacy Notice:
-      Complete conversions, transfers and changes</h1>
+    <h1 class="govuk-heading-xl">Privacy Notice: <%= t("service_name") %></h1>
     <h2 class="govuk-heading-l">Who we are</h2>
-    <p class="govuk-body">The 'Complete conversions, transfers and changes'
-      service is available for employees of the Department for Education
-      (DfE) to help with the conversion of schools to academies. It is run
-      by and on behalf of the DfE. For the purpose of data protection
-      legislation, DfE is the data controller for the personal data
-      collected and further processed as part of Complete conversion and
-      transfers.</p>
+    <p class="govuk-body">The '<%= t("service_name") %>' service is available
+      for employees of the Department for Education (DfE) to help with the
+      conversion of schools to academies. It is run by and on behalf of the DfE.
+      For the purpose of data protection legislation, DfE is the data controller
+      for the personal data collected and further processed as part of <%= t("service_name") %>.</p>
     <p class="govuk-body">DfE<br>
       Sanctuary Buildings<br>
       20 Great Smith St<br>
@@ -44,17 +41,17 @@
       lawful</h2>
     <p class="govuk-body">In order for our use of your personal data to be
       lawful, we need to meet one or more conditions in the data
-      protection legislation. For the purpose of 'Complete conversions,
-      transfers and changes', the Department processes your data where it
-      is necessary for the performance of a task carried out in the public
-      interest or in the exercise of official authority (Article 6(1)(e)
-      of the UK General Data Protection Regulation).</p>
+      protection legislation. For the purpose of '<%= t("service_name") %>',
+      the Department processes your data where it is necessary for the
+      performance of a task carried out in the public interest or in the
+      exercise of official authority (Article 6(1)(e) of the UK General Data
+      Protection Regulation).</p>
     <h2 class="govuk-heading-l">Who we will make your personal data
       available to</h2>
     <p class="govuk-body">The Department for Education use your data for
       security purposes.</p>
     <p class="govuk-body">We collect the IP addresses of people visiting
-      the Complete conversions and transfers website.</p>
+      the <%= t("service_name") %> website.</p>
     <p class="govuk-body">This is for reasons for security, for example,
       if we were receiving continuous direct denial of service attacks
       from an IP address range then we could block it.</p>
@@ -82,7 +79,7 @@
       above, or have any other questions about how your personal
       information will be used, please <a href="https://www.gov.uk/contact-dfe" class="govuk-link" rel="noreferrer noopener" target="_blank">
         contact the DfE (opens in new tab)</a>
-      stating Complete conversions, transfers and changes.</p>
+      stating <%= t("service_name") %>.</p>
     <p class="govuk-body">The <a href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter" class="govuk-link" rel="noreferrer noopener" target="_blank">
       DfE's Personal Information Charter</a> contains more
       information about how the DfE handles personal information.</p>

--- a/spec/features/users_can_view_static_pages_spec.rb
+++ b/spec/features/users_can_view_static_pages_spec.rb
@@ -9,6 +9,14 @@ RSpec.feature "Users can view static pages" do
     expect(page).to have_content("When we collect personal information")
   end
 
+  scenario "can see the accessibility page" do
+    visit page_path(id: "accessibility")
+
+    expect(page).to have_current_path("/accessibility")
+    expect(page).to have_content("Accessibility statement") # This string appears all over the site in the footer, so also test:
+    expect(page).to have_content("This accessibility statement applies to Complete conversions, transfers and changes.")
+  end
+
   scenario "can see the `404 page not found` error page" do
     visit page_path(id: "page_not_found")
 


### PR DESCRIPTION
## Changes

For ticket https://trello.com/c/MzrMzefK/339-write-an-accessibility-statement-for-our-service

- add in accessibility page
- footer now have link to accessibility page
- standardise the email the team link based on GOV.UK guidance
- privacy policy page uses service name helper rather than explicit text

Footer 
![image](https://user-images.githubusercontent.com/13239597/199731630-9b7d8aa6-4db4-4be5-827d-864c1375d625.png)

Example of how we ask users to contact us
![image](https://user-images.githubusercontent.com/13239597/199731708-b78b50d7-92e0-4aea-8eee-6d8518c85d6d.png)


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
