### PR TITLE
(chore) Tidy GitHub action names and environments

### DIFF
--- a/.github/workflows/build-and-push-image-development.yml
+++ b/.github/workflows/build-and-push-image-development.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   build-and-push-image-development:
     name: Build and push image development
-    environment: development
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/build-and-push-image-development.yml
+++ b/.github/workflows/build-and-push-image-development.yml
@@ -1,4 +1,4 @@
-name: Continuous delivery
+name: Continuous Delivery / Development
 
 on:
   push:

--- a/.github/workflows/build-and-push-image-test.yml
+++ b/.github/workflows/build-and-push-image-test.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   set-test-release-version:
     name: Set Test Release Version
-    environment: test
     runs-on: ubuntu-latest
     outputs:
       version: ${{steps.release-version.outputs.version}}

--- a/.github/workflows/build-and-push-image-test.yml
+++ b/.github/workflows/build-and-push-image-test.yml
@@ -1,4 +1,4 @@
-name: Continuous delivery
+name: Continuous Delivery / Test
 
 on:
   push:

--- a/.github/workflows/continuous-integration-terraform.yml
+++ b/.github/workflows/continuous-integration-terraform.yml
@@ -1,4 +1,4 @@
-name: Continuous integration
+name: Continuous Integration / Terraform
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   terraform-validate:
-    name: Terraform Validate
+    name: Validate
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -44,7 +44,7 @@ jobs:
           entrypoint: terraform
           args: -chdir=terraform fmt -check=true -diff=true
   terraform-docs-validation:
-    name: Terraform Docs validation
+    name: Validate documentation
     needs: terraform-validate
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/continuous-integration-tests.yml
+++ b/.github/workflows/continuous-integration-tests.yml
@@ -1,4 +1,4 @@
-name: Continuous integration
+name: Continuous Integration / Application
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   linting-and-formatting:
-    name: Linting and formatting tests
+    name: Linting and formatting
     runs-on: ubuntu-latest
 
     env:
@@ -28,7 +28,7 @@ jobs:
         run: script/no-docker/test
 
   application:
-    name: Application tests
+    name: Specs
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/continuous-integration-tfsec.yml
+++ b/.github/workflows/continuous-integration-tfsec.yml
@@ -1,9 +1,9 @@
-name: Continuous integration
+name: Continuous Integration / Terraform
 on:
   pull_request:
 jobs:
   tfsec-pr-commenter:
-    name: tfsec PR commenter
+    name: Security PR commenter
     runs-on: ubuntu-latest
     steps:
       - name: Clone repo

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Continuous integration](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/actions/workflows/continuous-integration-rails.yml/badge.svg)](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/actions/workflows/continuous-integration-rails.yml)
+[![Continuous integration](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/actions/workflows/continuous-integration-tests.yml/badge.svg)](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/actions/workflows/continuous-integration-tests.yml)
 
 # DfE: Complete conversions, transfers and changes
 


### PR DESCRIPTION
Having the actions all have the same name wasn't helpful, for me at least.

Here we've renamed them to show their intention.

We've also removed the GitHub environment/deployments as they are not compatible with our deployment actions - once this is merged we can delete the GitHub environments so they are no longer shown in the GitHub UI.