### PR TITLE
(739) Projects are no longer created if task list creation fails

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -26,8 +26,11 @@ class ProjectsController < ApplicationController
     authorize @project
 
     if @project.valid?
-      @project.save
-      TaskListCreator.new.call(@project, workflow_root: DEFAULT_WORKFLOW_ROOT)
+      ActiveRecord::Base.transaction do
+        @project.save
+        TaskListCreator.new.call(@project, workflow_root: DEFAULT_WORKFLOW_ROOT)
+      end
+
       notify_team_leaders
 
       redirect_to project_path(@project), notice: I18n.t("project.create.success")

--- a/spec/requests/projects_controller_spec.rb
+++ b/spec/requests/projects_controller_spec.rb
@@ -69,5 +69,21 @@ RSpec.describe ProjectsController, type: :request do
         end
       end
     end
+
+    context "when the task list cannot be created" do
+      let(:task_list_creator) { TaskListCreator.new }
+
+      before do
+        mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+
+        allow(TaskListCreator).to receive(:new).and_return(task_list_creator)
+        allow(task_list_creator).to receive(:call).and_raise(RuntimeError)
+      end
+
+      it "does not create a project" do
+        expect { perform_request }.to raise_error(RuntimeError)
+        expect(Project.count).to be 0
+      end
+    end
   end
 end


### PR DESCRIPTION
TRELLO-xPjY0AZI

## Changes

Previously, since we created projects before attempting to populate the task list, it was possible to reach a condition (if task list creation failed for any reason) where there would be a project with no tasks, or only part of the task list.

This change wraps the entire project creation process in a database transaction, so it either succeeds or fails as an entirety.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
