### PR TITLE
(763) Mark up links styled as buttons correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fine-tuned padding for actions in various type/state combinations to closer
   match the prototype.
 - The support email has been swapped out for a complete team shared inbox.
+- Links styled as buttons are now correctly marked up for accessibility
 
 #### Fixed
 

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -8,10 +8,7 @@
     </h1>
 
     <% if policy(:project).new? %>
-      <p><%= link_to t("project.index.new_button.text"),
-               new_project_path,
-               class: "govuk-button",
-               data: {module: "govuk-button"} %></p>
+      <p><%= govuk_button_link_to t("project.index.new_button.text"), new_project_path %></p>
     <% end %>
 
     <ul class="projects-list list-style-none govuk-!-padding-0">


### PR DESCRIPTION
TRELLO-z1U8cdt1

## Changes

Use the component helpers to make sure that a link styled as a button is marked up correctly for screen readers and browsers to implement the expected behaviour, improving accessibility.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
