### PR TITLE
Added extra action to Commercial transfer agreement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Content
 
+- Commercial transfer agreement adds action to explicitly indicate that the
+  email from the school has been received.
 - Swap out the link to the previous version of the single worksheet for a link
   to an updated version.
 

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -389,11 +389,9 @@ tasks:
       projects.
     actions:
       - title:
-          Email the school to confirm all relevant parties have signed the
-          Commercial transfer agreement
+          Email the school to ask if they have agreed and signed the Commercial transfer agreement
       - title:
-          Email received confirming the Commercial transfer agreement has been
-          agreed and signed
+          Receive email from the school confirming the Commercial transfer agreement has relevant signatures
       - title:
           Save a copy of the confirmation email in school's SharePoint folder
 

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -392,6 +392,9 @@ tasks:
           Email the school to confirm all relevant parties have signed the
           Commercial transfer agreement
       - title:
+          Email received confirming the Commercial transfer agreement has been
+          agreed and signed
+      - title:
           Save a copy of the confirmation email in school's SharePoint folder
 
   - slug: 125-year-lease

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -389,9 +389,11 @@ tasks:
       projects.
     actions:
       - title:
-          Email the school to ask if they have agreed and signed the Commercial transfer agreement
+          Email the school to ask if they have agreed and signed the Commercial
+          transfer agreement
       - title:
-          Receive email from the school confirming the Commercial transfer agreement has relevant signatures
+          Receive email from the school confirming the Commercial transfer
+          agreement has relevant signatures
       - title:
           Save a copy of the confirmation email in school's SharePoint folder
 


### PR DESCRIPTION
Based on user research we have added in an extra action to explicitly indicate if they have received the email from the school/trust that shows the CTA has been signed and agreed.

## Changes

Added extra action to Commercial transfer agreement

Based on user research we have added in an extra action to explicitly
indicate if they have received the email from the school/trust
that shows the CTA has been signed and agreed.

![image](https://user-images.githubusercontent.com/13239597/200011749-ac0f4390-5aff-4828-a2e2-4a32610ebb40.png)


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
