### PR TITLE
Added extra action to 125 year lease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Content
 
+- 125 year lease adds action to explicitly indicate that the email from the
+  school has been received.
 - Swap out the link to the previous version of the single worksheet for a link
   to an updated version.
 

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -407,6 +407,9 @@ tasks:
         title:
           Email the school to confirm all relevant parties have signed the 125
           year lease
+      - title:
+          Email received confirming the 125 year lease has been agreed and
+          signed
       - type: single-checkbox
         title:
           Save a copy of the confirmation email in school's SharePoint folder

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -408,8 +408,8 @@ tasks:
           Email the school to confirm all relevant parties have signed the 125
           year lease
       - title:
-          Email received confirming the 125 year lease has been agreed and
-          signed
+          Receive email from the school confirming the 125 year lease has
+          relevant signatures
       - type: single-checkbox
         title:
           Save a copy of the confirmation email in school's SharePoint folder

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -408,8 +408,8 @@ tasks:
           Email the school to check all relevant parties have signed the 125
           year lease
       - title:
-          Receive email from the school confirming the 125 year lease is 
-          agreed and signed
+          Receive email from the school confirming the 125 year lease is agreed
+          and signed
       - type: single-checkbox
         title:
           Save a copy of the confirmation email in school's SharePoint folder

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -405,11 +405,11 @@ tasks:
         title: Confirm the 125 year lease has been signed
       - type: single-checkbox
         title:
-          Email the school to confirm all relevant parties have signed the 125
+          Email the school to check all relevant parties have signed the 125
           year lease
       - title:
-          Receive email from the school confirming the 125 year lease has
-          relevant signatures
+          Receive email from the school confirming the 125 year lease is 
+          agreed and signed
       - type: single-checkbox
         title:
           Save a copy of the confirmation email in school's SharePoint folder


### PR DESCRIPTION
Based on user research we have added in an extra action to explicitly indicate if they have received the email from the school/trust that shows the 125 year lease has been signed and agreed.

## Changes

125 year lease adds action to explicitly indicate that the email from the school has been received.

![image](https://user-images.githubusercontent.com/13239597/200271790-2bfedc30-5add-4a51-90ce-241106bb8b89.png)


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
