### PR TITLE
Add email received step to subleases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Content
 
+- Subleases adds action to explicitly indicate that the email from the school
+  has been received.
 - Commercial transfer agreement adds action to explicitly indicate that the
   email from the school has been received.
 - 125 year lease adds action to explicitly indicate that the email from the

--- a/app/workflows/lists/conversion/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/sections/clear-legal-docs.yml
@@ -440,8 +440,12 @@ tasks:
         title: Confirm any subleases have been signed
       - type: single-checkbox
         title:
-          Email the school to confirm all relevant parties have signed any
+          Email the school to check all relevant parties have signed any
           subleases
+      - type: single-checkbox
+        title:
+          Receive email from the school confirming any subleases are agreed and
+          signed
       - type: single-checkbox
         title:
           Save a copy of the confirmation email in school's SharePoint folder


### PR DESCRIPTION

## Changes

Subleases adds action to explicitly indicate that the email from the school has been received.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.


![localhost_3000_projects_9874BD59-598D-496A-A23C-95557686E2F7_tasks_B9594439-38B4-4DCE-8B38-341262BF971E](https://user-images.githubusercontent.com/13239597/200303665-2a74a5d9-c80b-41f5-b244-abeeee81d3bd.png)
