### PR TITLE
Spike parallel requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem "govuk_design_system_formbuilder", "~> 3.1"
 gem "govuk_markdown"
 
 gem "faraday"
+gem "typhoeus"
 
 # sentry.io error reporting 
 gem "sentry-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,8 @@ GEM
       rubocop
       smart_properties
     erubi (1.10.0)
+    ethon (0.15.0)
+      ffi (>= 1.15.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -357,6 +359,8 @@ GEM
     tilt (2.0.10)
     timeout (0.3.0)
     tiny_tds (2.1.5)
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.2.0)
@@ -421,6 +425,7 @@ DEPENDENCIES
   simplecov (~> 0.21.2)
   sprockets-rails
   standard
+  typhoeus
   tzinfo-data
   web-console
   webmock (~> 3.17)

--- a/app/models/academies_api/client.rb
+++ b/app/models/academies_api/client.rb
@@ -1,63 +1,77 @@
 class AcademiesApi::Client
-  ACADEMIES_API_TIMEOUT = ENV.fetch("ACADEMIES_API_TIMEOUT", 0.6).to_f
-
   class Error < StandardError; end
 
   class NotFoundError < StandardError; end
 
   class MultipleResultsError < StandardError; end
 
-  attr_reader :connection
-
-  def initialize(connection: nil)
-    @connection = connection || default_connection
+  def initialize(immediate_execution: false)
+    @hydra = Typhoeus::Hydra.new
+    @immediate_execution = immediate_execution
   end
 
-  def get_establishment(urn)
-    begin
-      response = @connection.get("/establishment/urn/#{urn}")
-    rescue Faraday::Error => error
-      raise Error.new(error)
+  def self.with_immediate_execution
+    new(immediate_execution: true)
+  end
+
+  def get_establishment(urn, &callback)
+    request = build_request(path: "/establishment/urn/#{urn}")
+    request.on_complete do |response|
+      response = handle_establishment_response(response, urn)
+      callback.call(response)
     end
 
-    case response.status
-    when 200
+    @hydra.queue(request)
+    execute if @immediate_execution
+  end
+
+  def get_trust(ukprn, &callback)
+    request = build_request(path: "/v2/trust/#{ukprn}")
+    request.on_complete do |response|
+      response = handle_trust_response(response, ukprn)
+      callback.call(response)
+    end
+
+    @hydra.queue request
+    execute if @immediate_execution
+  end
+
+  def execute
+    @hydra.run
+  end
+
+  private def handle_establishment_response(response, urn)
+    if response.success?
       Result.new(AcademiesApi::Establishment.new.from_json(response.body), nil)
-    when 404
+    elsif response.code == 404
       Result.new(nil, NotFoundError.new(I18n.t("academies_api.get_establishment.errors.not_found", urn: urn)))
     else
       Result.new(nil, Error.new(I18n.t("academies_api.get_establishment.errors.other", urn: urn)))
     end
   end
 
-  def get_trust(ukprn)
-    begin
-      response = @connection.get("/v2/trust/#{ukprn}")
-    rescue Faraday::Error => error
-      raise Error.new(error)
-    end
-
-    case response.status
-    when 200
+  private def handle_trust_response(response, ukprn)
+    if response.success?
       Result.new(AcademiesApi::Trust.new.from_json(response.body), nil)
-    when 404
+    elsif response.code == 404
       Result.new(nil, NotFoundError.new(I18n.t("academies_api.get_trust.errors.not_found", ukprn: ukprn)))
     else
       Result.new(nil, Error.new(I18n.t("academies_api.get_trust.errors.other", ukprn: ukprn)))
     end
   end
 
-  private def default_connection
-    Faraday.new(
-      url: ENV["ACADEMIES_API_HOST"],
-      request: {
-        timeout: ACADEMIES_API_TIMEOUT
-      },
-      headers: {
-        "Content-Type": "application/json",
-        ApiKey: ENV["ACADEMIES_API_KEY"]
-      }
+  private def build_request(path:)
+    Typhoeus::Request.new(
+      "#{ENV["ACADEMIES_API_HOST"]}#{path}",
+      headers: default_headers
     )
+  end
+
+  private def default_headers
+    {
+      "Content-Type": "application/json",
+      ApiKey: ENV["ACADEMIES_API_KEY"]
+    }
   end
 
   class Result

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,6 +3,8 @@ class Project < ApplicationRecord
 
   before_validation :add_invalid_date_errors
 
+  attr_accessor :establishment, :incoming_trust
+
   has_many :sections, dependent: :destroy
   has_many :notes, dependent: :destroy
   has_many :contacts, dependent: :destroy
@@ -72,17 +74,19 @@ class Project < ApplicationRecord
   end
 
   private def fetch_establishment(urn)
-    result = AcademiesApi::Client.new.get_establishment(urn)
-    raise result.error if result.error.present?
+    AcademiesApi::Client.with_immediate_execution.get_establishment(urn) do |result|
+      raise result.error if result.error.present?
 
-    result.object
+      return result.object
+    end
   end
 
   private def fetch_trust(ukprn)
-    result = AcademiesApi::Client.new.get_trust(ukprn)
-    raise result.error if result.error.present?
+    AcademiesApi::Client.with_immediate_execution.get_trust(ukprn) do |result|
+      raise result.error if result.error.present?
 
-    result.object
+      return result.object
+    end
   end
 
   private def establishment_exists


### PR DESCRIPTION
## Changes
Spike to parallelise the requests on the project index page to make the page load faster. 

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
