### PR TITLE
(792) Add type to project model

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -4,6 +4,8 @@ class ProjectsController < ApplicationController
 
   DEFAULT_WORKFLOW_ROOT = Rails.root.join("app", "workflows", "lists", "conversion").freeze
 
+  DEFAULT_PROJECT_TYPE = 0
+
   def index
     authorize Project
     @pagy, @projects = pagy(policy_scope(Project))
@@ -21,7 +23,12 @@ class ProjectsController < ApplicationController
 
   def create
     @note = Note.new(**note_params, user_id: user_id)
-    @project = Project.new(**project_params, regional_delivery_officer_id: user_id, notes_attributes: [@note.attributes])
+    @project = Project.new(
+      **project_params,
+      project_type: DEFAULT_PROJECT_TYPE,
+      regional_delivery_officer_id: user_id,
+      notes_attributes: [@note.attributes]
+    )
 
     authorize @project
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -34,6 +34,10 @@ class Project < ApplicationRecord
   # and see if you can use Arel to build a proper query.
   scope :by_closed_state, -> { order(:closed_at) }
 
+  enum project_type: {
+    conversion: 0
+  }
+
   def establishment
     @establishment ||= fetch_establishment(urn)
   end

--- a/db/migrate/20221109113234_add_type_to_project.rb
+++ b/db/migrate/20221109113234_add_type_to_project.rb
@@ -1,0 +1,5 @@
+class AddTypeToProject < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :project_type, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20221109114622_remove_default_from_project_type.rb
+++ b/db/migrate/20221109114622_remove_default_from_project_type.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultFromProjectType < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :projects, :project_type, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_20_124723) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_09_113234) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -66,6 +66,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_20_124723) do
     t.text "establishment_sharepoint_link"
     t.datetime "closed_at"
     t.text "trust_sharepoint_link"
+    t.integer "project_type", default: 0, null: false
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"
     t.index ["team_leader_id"], name: "index_projects_on_team_leader_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_09_113234) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_09_114622) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -66,7 +66,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_09_113234) do
     t.text "establishment_sharepoint_link"
     t.datetime "closed_at"
     t.text "trust_sharepoint_link"
-    t.integer "project_type", default: 0, null: false
+    t.integer "project_type", null: false
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"
     t.index ["team_leader_id"], name: "index_projects_on_team_leader_id"

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :project, class: "Project" do
+    project_type { 0 }
     urn { 123456 }
     incoming_trust_ukprn { 10061021 }
     target_completion_date { (Date.today + 2.years).at_beginning_of_month }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_db_column(:establishment_sharepoint_link).of_type :text }
     it { is_expected.to have_db_column(:trust_sharepoint_link).of_type :text }
     it { is_expected.to have_db_column(:closed_at).of_type :datetime }
+    it { is_expected.to have_db_column(:project_type).of_type :integer }
   end
 
   describe "Relationships" do


### PR DESCRIPTION
TRELLO-jXNyxFiH

## Changes

The project model now stores a `project_type` to distinguish one workflow from another. All created projects default to `conversion` to keep the behaviour the same.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
