### PR TITLE
(chore) Configure simple cov to output json

### DIFF
--- a/config/initializers/simplecov.rb
+++ b/config/initializers/simplecov.rb
@@ -1,0 +1,3 @@
+require "simplecov_json_formatter"
+
+SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter


### PR DESCRIPTION
## Changes
We would like Sonarcloud to pick up our coverage, according to this:

https://docs.sonarcloud.io/enriching/test-coverage/test-coverage-parameters/

Outputting json is required so this configures simple cov.

At this point, I have not idea how sonarcloud can read the file, but this might be a 'it just works' things so we are happy to try as this has no other impact that we can see.
