### PR TITLE
After opening redact funding docs becomes redact documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 #### Changed
 
-- After opening => redact and send task and actions no longer explicitly mention
-  funding documents only as other documents may need to be sent and publised on
-  GOV.UK
 - Fine-tuned padding for actions in various type/state combinations to closer
   match the prototype.
 - The support email has been swapped out for a complete team shared inbox.
@@ -36,6 +33,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Content
 
+- After opening => redact and send task and actions no longer explicitly mention
+  funding documents only as other documents may need to be sent and publised on
+  GOV.UK
 - Tenancy at will adds action to explicitly indicate that the email from the
   school has been received.
 - Subleases adds action to explicitly indicate that the email from the school

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 #### Changed
 
+- After opening => redact and send task and actions no longer explicitly mention
+  funding documents only as other documents may need to be sent and publised on
+  GOV.UK
 - Fine-tuned padding for actions in various type/state combinations to closer
   match the prototype.
 - The support email has been swapped out for a complete team shared inbox.

--- a/app/workflows/lists/conversion/sections/after-opening.yml
+++ b/app/workflows/lists/conversion/sections/after-opening.yml
@@ -11,7 +11,7 @@ tasks:
 
   - slug: redact-and-send-documents-to-be-published-on-gov-uk
     title: Redact and send documents to be published on GOV.UK
-    hint: |
+    hint:
       Documents relating to the conversion will be added to GOV.UK. These must
       be redacted to remove sensitive information.
     actions:

--- a/app/workflows/lists/conversion/sections/after-opening.yml
+++ b/app/workflows/lists/conversion/sections/after-opening.yml
@@ -9,7 +9,7 @@ tasks:
     actions:
       - title: Email the regional delivery officer
 
-  - slug: redact-and-send-documents-to-be-published-on-GOV.UK
+  - slug: redact-and-send-documents-to-be-published-on-gov-uk
     title: Redact and send documents to be published on GOV.UK
     hint: |
       Documents relating to the conversion will be added to GOV.UK. These must

--- a/app/workflows/lists/conversion/sections/after-opening.yml
+++ b/app/workflows/lists/conversion/sections/after-opening.yml
@@ -9,12 +9,11 @@ tasks:
     actions:
       - title: Email the regional delivery officer
 
-  - slug: redact-and-send-funding-agreement-documents
-    title: Redact and send funding agreement documents
+  - slug: redact-and-send-documents-to-be-published-on-GOV.UK
+    title: Redact and send documents to be published on GOV.UK
     hint: |
-      Funding agreement documents relating to the conversion will be added to
-      GOV.UK. These must be redacted to remove sensitive information.
-
+      Documents relating to the conversion will be added to GOV.UK. These must
+      be redacted to remove sensitive information.
     actions:
       - title: Redact all relevant documents
         guidance_summary: Help redacting the documents
@@ -37,7 +36,7 @@ tasks:
       - title: Send relevant documents to the funding team
         guidance_summary: Help sending documents
         guidance_text: |
-          Send the redacted funding agreement documents to the funding team at [FundingAgreements.CONVERTERS@education.gov.uk](mailto:FundingAgreements.CONVERTERS@education.gov.uk).
+          Send the redacted documents to the funding team at [FundingAgreements.CONVERTERS@education.gov.uk](mailto:FundingAgreements.CONVERTERS@education.gov.uk).
 
   - slug: update-esfa-data-in-kim
     title: Update ESFA data in KIM


### PR DESCRIPTION
Change copy as it is not only funding documents that can be redacted and set for publishing on GOV.UK

## Changes

- Title and slug change to be Redact and send documents to be published on GOV.UK
- guidance no longer mentions funding docs only
- guidance indicates that documents may end up published on GOV.UK
- I also changed the slug and it did not seem to break anything but I thought I'd better highlight that

![localhost_3000_projects_CAEF0ED1-E49A-4D9E-8529-FBEB9DF51418_tasks_B2362B81-C138-4DE0-B12B-55F64DB308D6](https://user-images.githubusercontent.com/13239597/201326820-44ae87c5-3356-4079-b5b9-15d8c7378424.png)

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
