### PR TITLE
(768) Create project form object

### DIFF
--- a/app/forms/create_project_form.rb
+++ b/app/forms/create_project_form.rb
@@ -1,0 +1,81 @@
+class CreateProjectForm
+  include ActiveModel::Model
+  include ActiveRecord::AttributeAssignment
+
+  include ::MultiparameterDate
+
+  attr_accessor :urn,
+    :incoming_trust_ukprn,
+    :establishment_sharepoint_link,
+    :trust_sharepoint_link,
+    :advisory_board_conditions,
+    :note_body,
+    :user,
+    :attributes_with_empty_values,
+    :attributes_with_invalid_values
+
+  attr_reader :target_conversion_date,
+    :advisory_board_date
+
+  validates :urn,
+    :incoming_trust_ukprn,
+    :establishment_sharepoint_link,
+    :trust_sharepoint_link, presence: true
+
+  validates :urn, urn: true
+  validates :incoming_trust_ukprn, ukprn: true
+
+  validates :target_conversion_date, date_in_the_future: true
+  validates :advisory_board_date, date_in_the_past: true
+
+  validate :multiparameter_date_attributes_values
+  validate :multiparameter_date_attributes_empty
+
+  def initialize(params = {})
+    @attributes_with_empty_values = []
+    @attributes_with_invalid_values = []
+    super(params)
+  end
+
+  def target_conversion_date=(value)
+    if month_for(value).nil? && year_for(value).nil?
+      @attributes_with_empty_values << :target_conversion_date
+      return
+    end
+
+    if date_parameter_valid?(value)
+      @target_conversion_date = date_from_multiparameter_hash(value)
+    else
+      @attributes_with_invalid_values << :target_conversion_date
+    end
+  end
+
+  def advisory_board_date=(value)
+    if value.nil? || (day_for(value).nil? && month_for(value).nil? && year_for(value).nil?)
+      @attributes_with_empty_values << :advisory_board_date
+      return
+    end
+
+    if date_parameter_valid?(value)
+      @advisory_board_date = date_from_multiparameter_hash(value)
+    else
+      @attributes_with_invalid_values << :advisory_board_date
+    end
+  end
+
+  def save
+    if valid?
+      true
+    end
+  end
+
+  private def multiparameter_date_attributes_values
+    return if @attributes_with_invalid_values.empty?
+    @attributes_with_invalid_values.each { |attribute| errors.add(attribute, :invalid) }
+  end
+
+  private def multiparameter_date_attributes_empty
+    return if @attributes_with_empty_values.empty?
+    @attributes_with_empty_values.each { |attribute| errors.add(attribute, :blank) }
+  end
+end

--- a/app/forms/multiparameter_date.rb
+++ b/app/forms/multiparameter_date.rb
@@ -1,0 +1,39 @@
+module MultiparameterDate
+  ACCEPTABLE_YEAR_RANGE = 2000..3000
+
+  private def date_from_multiparameter_hash(hash)
+    Date.new(year_for(hash), month_for(hash), day_for(hash))
+  rescue ArgumentError
+    hash
+  end
+
+  private def date_parameter_valid?(param)
+    day_parameter_valid?(day_for(param)) &&
+      month_parameter_valid?(month_for(param)) &&
+      year_parameter_valid?(year_for(param))
+  end
+
+  private def day_parameter_valid?(param)
+    (1..31).to_a.include?(param)
+  end
+
+  private def month_parameter_valid?(param)
+    (1..12).to_a.include?(param)
+  end
+
+  private def year_parameter_valid?(param)
+    ACCEPTABLE_YEAR_RANGE.to_a.include?(param)
+  end
+
+  private def day_for(value)
+    value[3]
+  end
+
+  private def month_for(value)
+    value[2]
+  end
+
+  private def year_for(value)
+    value[1]
+  end
+end

--- a/spec/factories/create_project_form_factory.rb
+++ b/spec/factories/create_project_form_factory.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :create_project_form do
+    urn { 123456 }
+    incoming_trust_ukprn { 10061021 }
+    target_conversion_date { {3 => 1, 2 => 1, 1 => 2025} }
+    advisory_board_date { {3 => 1, 2 => 10, 1 => 2022} }
+    establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/establishment-folder" }
+    trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }
+    user { association :user, :regional_delivery_officer }
+  end
+end

--- a/spec/forms/create_project_form_spec.rb
+++ b/spec/forms/create_project_form_spec.rb
@@ -1,0 +1,110 @@
+require "rails_helper"
+
+RSpec.describe CreateProjectForm, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:urn) }
+    it { is_expected.to validate_presence_of(:incoming_trust_ukprn) }
+    it { is_expected.to validate_presence_of(:establishment_sharepoint_link) }
+    it { is_expected.to validate_presence_of(:trust_sharepoint_link) }
+
+    describe "target conversion date" do
+      it "must be in the future" do
+        form = build(
+          :create_project_form,
+          target_conversion_date: date_to_multiparameter_hash((Date.today + 1.year).at_beginning_of_month)
+        )
+        expect(form).to be_valid
+
+        form.target_conversion_date = date_to_multiparameter_hash(Date.today - 1.year)
+        expect(form).to be_invalid
+      end
+
+      context "when the date params are partially complete" do
+        it "treats the date as invalid" do
+          form = build(:create_project_form, target_conversion_date: {3 => 1, 2 => 10, 1 => nil})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:target_conversion_date, :invalid)).to be true
+
+          form = build(:create_project_form, target_conversion_date: {3 => 1, 2 => nil, 1 => 2022})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:target_conversion_date, :invalid)).to be true
+        end
+      end
+
+      context "when the month and year are missing" do
+        it "treats the date as blank" do
+          form = build(:create_project_form, target_conversion_date: {3 => 1, 2 => nil, 1 => nil})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:target_conversion_date, :blank)).to be true
+        end
+      end
+    end
+
+    describe "advisory board date" do
+      it "must be in the past" do
+        form = build(
+          :create_project_form,
+          advisory_board_date: date_to_multiparameter_hash(Date.today - 1.week)
+        )
+        expect(form).to be_valid
+
+        form.advisory_board_date = date_to_multiparameter_hash(Date.today + 1.month)
+        expect(form).to be_invalid
+      end
+
+      context "when the date parameters are partially complete" do
+        it "treats the date as invalid" do
+          form = build(:create_project_form, advisory_board_date: {3 => nil, 2 => 10, 1 => 1})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :invalid)).to be true
+
+          form = build(:create_project_form, advisory_board_date: {3 => 2022, 2 => nil, 1 => 1})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :invalid)).to be true
+
+          form = build(:create_project_form, advisory_board_date: {3 => 2022, 2 => 10, 1 => nil})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :invalid)).to be true
+        end
+      end
+
+      context "when all the date parameters are missing" do
+        it "treats the date as blank" do
+          form = build(:create_project_form, advisory_board_date: {3 => nil, 2 => nil, 1 => nil})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :blank)).to be true
+        end
+      end
+
+      context "when no date value is set" do
+        it "treats the date as blank" do
+          form = build(:create_project_form, advisory_board_date: nil)
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :blank)).to be true
+        end
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when the form is valid" do
+      it "returns true" do
+        expect(build(:create_project_form).save).to be true
+      end
+    end
+
+    context "when the form is invalid" do
+      it "returns nil" do
+        expect(build(:create_project_form, urn: nil).save).to be_nil
+      end
+    end
+  end
+
+  def date_to_multiparameter_hash(date)
+    {
+      3 => date.day,
+      2 => date.month,
+      1 => date.year
+    }
+  end
+end

--- a/spec/forms/multiparameter_date_spec.rb
+++ b/spec/forms/multiparameter_date_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+class DummyClass
+  include MultiparameterDate
+end
+
+RSpec.describe MultiparameterDate do
+  subject = DummyClass.new
+
+  describe "#date_from_multiparameter_hash" do
+    it "creates a Date object from a hash" do
+      date_hash = {3 => 1, 2 => 12, 1 => 2022}
+
+      expect(subject.send(:date_from_multiparameter_hash, date_hash))
+        .to eq Date.new(2022, 12, 1)
+    end
+
+    it "returns the hash when there is a argument error" do
+      date_hash = {3 => 32, 2 => 12, 1 => 2022}
+
+      expect(subject.send(:date_from_multiparameter_hash, date_hash))
+        .to be date_hash
+    end
+  end
+
+  describe "#date_parameter_valid?" do
+    context "when the day is invalid" do
+      it "returns false" do
+        expect(subject.send(:date_parameter_valid?, {3 => 32, 2 => 12, 1 => 2022}))
+          .to be false
+
+        expect(subject.send(:date_parameter_valid?, {3 => 0, 2 => 12, 1 => 2022}))
+          .to be false
+      end
+    end
+
+    context "when the month is invalid" do
+      it "returns false" do
+        expect(subject.send(:date_parameter_valid?, {3 => 1, 2 => 24, 1 => 2022}))
+          .to be false
+
+        expect(subject.send(:date_parameter_valid?, {3 => 1, 2 => 0, 1 => 2022}))
+          .to be false
+      end
+    end
+
+    context "when the year is invalid" do
+      it "returns false" do
+        expect(subject.send(:date_parameter_valid?, {3 => 1, 2 => 12, 1 => 1945}))
+          .to be false
+
+        expect(subject.send(:date_parameter_valid?, {3 => 1, 2 => 12, 1 => 0}))
+          .to be false
+      end
+    end
+
+    context "when all values are valid" do
+      it "returns true" do
+        expect(subject.send(:date_parameter_valid?, {3 => 1, 2 => 12, 1 => 2022}))
+          .to be true
+      end
+    end
+  end
+
+  describe "#day_for" do
+    it "returns the day value at key 3" do
+      date_hash = {3 => 1, 2 => 12, 1 => 2022}
+      expect(subject.send(:day_for, date_hash)).to eq 1
+    end
+  end
+
+  describe "#month_for" do
+    it "returns the day value at key 2" do
+      date_hash = {3 => 1, 2 => 12, 1 => 2022}
+      expect(subject.send(:month_for, date_hash)).to eq 12
+    end
+  end
+
+  describe "#year_for" do
+    it "returns the day value at key 1" do
+      date_hash = {3 => 1, 2 => 12, 1 => 2022}
+      expect(subject.send(:year_for, date_hash)).to eq 2022
+    end
+  end
+end


### PR DESCRIPTION
## Changes

The motivation for this work is a bug we have where a user enters an invalid value into the three part date field, e.g. a month value as 31 or letters instead of numbers.

![Screenshot 2022-11-16 at 13 59 20](https://user-images.githubusercontent.com/480578/202200858-ffeb4565-65b3-4255-8c6f-c304d694f971.png)

![Screenshot 2022-11-16 at 13 59 28](https://user-images.githubusercontent.com/480578/202200824-546eb418-00d3-4ce4-a17e-6a2d0f7c382e.png)

This is a pattern from the [GOV.UK design system](https://design-system.service.gov.uk/components/date-input/) so it's surprising to have to deal with it ourselves rahter than being handled by the [GOV.UK formbuilder](https://govuk-form-builder.netlify.app/) that we use

It is also pretty hard to fix as the 3 param dates is handled by Rails magic™ the three params are cast into a Date object, but as we have learnt, if the params cannot be cast, the application crashes.

We think this is because in generic Rails a Date object exposed in a form is made up of select boxes which the user cannot submit incorrect params - but we are not 100% on this, it feels pretty brittle...

Whilst we had a previous [fix](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/306), this led us to crashes in development and whilst we are not clear on the issue, we have to assume this was the  cause as reverting the change fixed the problem.

Here we are introducing a form object, a design pattern that places a 'form object' between the form being submitted and the models being updated. This gives us a number of good things:

- a context to validate a new project in
- a place to deal with the multiparameters from dates in the form
 - a different option to handle creating multiple objects from one form, a Project and Note in this case
- a place to trigger any notifications
- a way to thin out the controller

At the cost of duplication.

I prefer this approach as it seperates the model, which should accept a date object for attributes representing dates from the form submission with has the three parameters - it seperates the concerns.

This work is proving to be large, so I want to open this PR now which introduces the form object, validation and multiparameter handling, but does not use it to save anything. 

We can follow up with more changes to actually use the new form object.

https://trello.com/c/GAI7lOH0

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
