### PR TITLE
Show a specific timeout error when the Academies API times out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 #### Added
 
+- If the Academies API times out, show a custom error page to the user
 - Rename the "Target completion date" on a project to "Provisional conversion
   date"
 - Set up accessibility tool

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,11 +6,16 @@ class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+  rescue_from AcademiesApi::Client::Error, with: :client_error
 
   private
 
   def user_not_authorized
     flash[:alert] = I18n.t("unauthorised_action.message")
     redirect_back(fallback_location: root_path)
+  end
+
+  def client_error
+    render "pages/api_client_timeout", status: 500
   end
 end

--- a/app/views/pages/api_client_timeout.html.erb
+++ b/app/views/pages/api_client_timeout.html.erb
@@ -1,0 +1,14 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t("pages.api_client_timeout.title") %></h1>
+    <p class="govuk-body">
+      <%= t("pages.api_client_timeout.body_text") %>
+    </p>
+
+    <p class="govuk-body">
+      <%= t("pages.api_client_timeout.email_help",
+            team_name: t("service_name"),
+            email: support_email(Rails.application.config.support_email)).html_safe %>
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,3 +73,8 @@ en:
     in_progress_projects: In progress
     notes: Notes
     contacts: Contacts
+  pages:
+    api_client_timeout:
+      title: Sorry, there was a problem
+      body_text: There was an error getting the details for the school or trust. Refresh the page to try again.
+      email_help: Email the %{team_name} team at %{email} if this error continues.

--- a/spec/features/users_can_view_static_pages_spec.rb
+++ b/spec/features/users_can_view_static_pages_spec.rb
@@ -30,4 +30,11 @@ RSpec.feature "Users can view static pages" do
     expect(page).to have_current_path("/internal_server_error")
     expect(page).to have_content("Sorry, there is a problem with the service")
   end
+
+  scenario "can see the `API timeout` error page" do
+    visit page_path(id: "api_client_timeout")
+
+    expect(page).to have_current_path("/api_client_timeout")
+    expect(page).to have_content("Sorry, there was a problem")
+  end
 end

--- a/spec/requests/projects_controller_spec.rb
+++ b/spec/requests/projects_controller_spec.rb
@@ -85,5 +85,15 @@ RSpec.describe ProjectsController, type: :request do
         expect(Project.count).to be 0
       end
     end
+
+    context "when the Academies API times out" do
+      before do
+        mock_timeout_api_responses(urn: 123456, ukprn: 10061021)
+      end
+
+      it "redirects to an informational client timeout page" do
+        expect(perform_request).to render_template("pages/api_client_timeout")
+      end
+    end
   end
 end

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -23,4 +23,23 @@ module AcademiesApiHelpers
     allow(test_client).to receive(:get_trust).with(ukprn).and_return(fake_result)
     allow(AcademiesApi::Client).to receive(:new).and_return(test_client)
   end
+
+  def mock_timeout_api_responses(urn:, ukprn:)
+    mock_timeout_api_establishment_response(urn:)
+    mock_timeout_api_trust_response(ukprn:)
+  end
+
+  def mock_timeout_api_establishment_response(urn:)
+    test_client = AcademiesApi::Client.new
+
+    allow(test_client).to receive(:get_establishment).with(urn).and_raise(AcademiesApi::Client::Error)
+    allow(AcademiesApi::Client).to receive(:new).and_return(test_client)
+  end
+
+  def mock_timeout_api_trust_response(ukprn:)
+    test_client = AcademiesApi::Client.new
+
+    allow(test_client).to receive(:get_trust).with(ukprn).and_raise(AcademiesApi::Client::Error)
+    allow(AcademiesApi::Client).to receive(:new).and_return(test_client)
+  end
 end


### PR DESCRIPTION
## Changes

If the Academies API times out, show an error page to the user, indicating they might be able to try again.

Previously, the users were being shown a less user-friendly error.

<img width="976" alt="Screenshot 2022-11-17 at 16 50 37" src="https://user-images.githubusercontent.com/1089521/202510810-3b9afc52-5b42-4cd7-a92c-7aceb16a2a6d.png">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
