### PR TITLE
Refactor `support_email` helper to not need a display name

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,7 +16,8 @@ module ApplicationHelper
     sanitize(link, attributes: allowed_attributes)
   end
 
-  def support_email(name)
+  def support_email(name = nil)
+    name = Rails.application.config.support_email if name.nil?
     govuk_mail_to(Rails.application.config.support_email, name)
   end
 end

--- a/app/views/pages/accessibility.erb
+++ b/app/views/pages/accessibility.erb
@@ -45,7 +45,7 @@
       website</h2>
     <p class="govuk-body">If you need information on this website in a differnt
       format or cannot use the serivce, email the <%= t("service_name") %> team
-      at <%= support_email("rsd.complete@dfe.com") %>.
+      at <%= support_email %>.
       </p>
     <p class="govuk-body">We'll consider your request and get back to you within
       20 working days.</p>
@@ -54,7 +54,7 @@
     <p class="govuk-body">We're always looking to improve the accessibility of
       this website. If you find any problems not listed on this page or think
       we're not meeting accessibility requirements, email the <%= t("service_name") %>
-      team at <%= support_email(Rails.application.config.support_email) %>.
+      team at <%= support_email %>.
       </p>
     <h2 class="govuk-heading-l">Enforcement procedure</h2>
     <p class="govuk-body">The Equality and Human Rights Commission is

--- a/app/views/pages/api_client_timeout.html.erb
+++ b/app/views/pages/api_client_timeout.html.erb
@@ -8,7 +8,7 @@
     <p class="govuk-body">
       <%= t("pages.api_client_timeout.email_help",
             team_name: t("service_name"),
-            email: support_email(Rails.application.config.support_email)).html_safe %>
+            email: support_email).html_safe %>
     </p>
   </div>
 </div>

--- a/app/views/pages/page_not_found.html.erb
+++ b/app/views/pages/page_not_found.html.erb
@@ -9,7 +9,7 @@
     </p>
     <p class="govuk-body">
       If the web address is correct or you selected a link or button, email the
-      <%= t("service_name") %> team at <%= support_email(Rails.application.config.support_email) %>.
+      <%= t("service_name") %> team at <%= support_email %>.
     </p>
   </div>
 </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -51,12 +51,22 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#support_email" do
-    let(:name) { "contact the complete conversions, transfers and changes team" }
+    context "when the display name is nil" do
+      subject { helper.support_email }
 
-    subject { helper.support_email(name) }
+      it "returns a mailto link to the support email with the email as the display name" do
+        expect(subject).to eq "<a class=\"govuk-link\" href=\"mailto:complete.rsd@education.gov.uk\">complete.rsd@education.gov.uk</a>"
+      end
+    end
 
-    it "returns a mailto link to the support email" do
-      expect(subject).to eq "<a class=\"govuk-link\" href=\"mailto:complete.rsd@education.gov.uk\">#{name}</a>"
+    context "when the display name is not nil" do
+      let(:name) { "contact the complete conversions, transfers and changes team" }
+
+      subject { helper.support_email(name) }
+
+      it "returns a mailto link to the support email with the supplied name" do
+        expect(subject).to eq "<a class=\"govuk-link\" href=\"mailto:complete.rsd@education.gov.uk\">#{name}</a>"
+      end
     end
   end
 end


### PR DESCRIPTION
## Changes

You can now call `ApplicationHelpers#support_email` without a display name
and it will show the support email mailto: link with the support email itself
as the display text.

Requires https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/325 to be merged first. 

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
