### PR TITLE
Add artefacts created by Intellij IDEs to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -29,3 +29,4 @@
 /coverage
 /terraform
 /doc/workflows/*
+/.idea/


### PR DESCRIPTION
## Changes

Add artefacts created by Intellij IDEs to .prettierignore. This ensures a test run with `AUTO_FIX_FORMATTING` enabled doesn't fail because prettier can't figure out what to do with these artefacts. 

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
