### PR TITLE
849 update guidance for school urn and ukprn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 #### Changed
 
+- Add project now include links to GIAS to help find URN and UKPRN
 - Fine-tuned padding for actions in various type/state combinations to closer
   match the prototype.
 - The support email has been swapped out for a complete team shared inbox.

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -9,8 +9,8 @@
 
       <h1 class="govuk-heading-l"><%= t("project.new.title") %></h1>
 
-      <%= form.govuk_text_field :urn, label: {size: "m"}, width: 10 %>
-      <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m"}, width: 10 %>
+      <%= form.govuk_text_field :urn, label: {size: "m"}, hint: {text: t("helpers.hint.project.urn").html_safe}, width: 10 %>
+      <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m"}, hint: {text: t("helpers.hint.project.incoming_trust_ukprn").html_safe}, width: 10 %>
       <%= form.govuk_date_field :provisional_conversion_date, omit_day: true, form_group: {id: "provisional-conversion-date"} %>
       <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m"} %>
       <%= form.govuk_text_field :trust_sharepoint_link, label: {size: "m"} %>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -104,8 +104,10 @@ en:
         advisory_board_date: Date of advisory board
     hint:
       project:
-        urn: This is the URN of the existing school which is converting to an academy. URN is a 6-digit number.
-        incoming_trust_ukprn: UKPRN is an 8-digit number that always starts with a 1.
+        urn: <a href="https://www.get-information-schools.service.gov.uk/Search" class="govuk-link" rel="noreferrer noopener" target="_blank">Search Get Information About Schools (GIAS) to find the school's URN (opens in a new tab)</a>.
+          This is the URN of the existing school which is converting to an academy. A URN is a 6-digit number.
+        incoming_trust_ukprn: <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in a new tab)</a>.
+          A UKPRN is an 8-digit number that always starts with a 1.
         caseworker_id: The caseworker responsible for this project
         provisional_conversion_date: The provisional conversion date is always the 1st of the month.
         advisory_board_conditions: If there are conditions to be met as a result of the advisory board.


### PR DESCRIPTION
## Changes

- include guidance on how to find the UKPRN, link to GIAS establishment
  search and explain what a UKPRN is.
- include guidance on how to find the URN, link to GIAS school search
  and explain what a URN is.

This does mean we now have html links in the yml file and sanitise the link when we put it in the hint.

![localhost_3000_projects_new](https://user-images.githubusercontent.com/13239597/203302320-a8fd2ada-8f26-4728-b5d0-d98cde084fed.png)


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
