### PR TITLE
Add allowed hosts to list of hosts

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -85,6 +85,7 @@ Rails.application.configure do
 
   # configure the host name
   config.hosts << ENV["HOSTNAME"]
+  config.hosts.concat ENV.fetch("ALLOWED_HOSTS", "").split(',')
 
   # configure ActionMailer
   # set the host so links in emails work


### PR DESCRIPTION
## Changes

* `config.hosts` defines which hostnames are allowed to be used when accessing the app
* When going via a CDN, the hostnames get added to the forwarded header, but the HTTP_HOST is still also check to make sure it matches.
* Adding this, allows us to specify all of the possible hostnames the validation may encounter

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
