### PR TITLE
(chore) Add allowed hosts to Rails hosts

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,8 +83,9 @@ Rails.application.configure do
   config.active_record.schema_migrations_table_name = "#{ENV["SQL_SERVER_SCHEMA_NAME"]}.schema_migrations"
   config.active_record.internal_metadata_table_name = "#{ENV["SQL_SERVER_SCHEMA_NAME"]}.ar_internal_metadata"
 
-  # configure the host name
+  # configure the host names
   config.hosts << ENV["HOSTNAME"]
+  config.hosts.concat ENV.fetch("ALLOWED_HOSTS", "").split(",")
 
   # configure ActionMailer
   # set the host so links in emails work

--- a/doc/environment-variables.md
+++ b/doc/environment-variables.md
@@ -24,6 +24,14 @@ set this into the `Rails.application.config.hosts` array, see:
 
 https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization
 
+`ALLOWED_HOSTS`
+
+This is a comma separated list of hostnames that the application will respond to
+behind the CDN, it usually includes the container host name and the cdn
+hostname, see:
+
+https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization
+
 `SENTRY_ENV`
 
 This is the environment name that will appear in Sentry, so one of development,


### PR DESCRIPTION
## Changes
Once we put the applicaiton behind a CDN we found that Rails built in host authorization kicked in, preventing the application from responding via the CDN.

Adding this, allows us to specify all of the possible hostnames the host authorization validation may encounter.

We retain the sepearate `HOSTNAME` to specify the external host name users use when accessing the application as this is used to build links.
