### PR TITLE
(chore) Enable force SSL

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
## Changes
We want a secure service, enabling this setting in production like environments means the applicaiton will only allow secure connections.

More information on this here:

https://guides.rubyonrails.org/security.html#session-hijacking

https://trello.com/c/ea1Hdf88
