### PR TITLE
Fix the destination of the new Note "Cancel" link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Features
+
+#### Added
+
+#### Changed
+
+#### Fixed
+
+- The "Cancel" link on the new note page takes the user back to the task page if
+  the note is a task-level note.
+
+## Content
+
 ## [Release 8][release-8]
 
 ### Features

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -12,7 +12,7 @@
       <%= form.govuk_text_area :body, label: {tag: "h1", size: "l"} %>
 
       <%= form.govuk_submit t("note.new.save_note_button") do %>
-        <%= govuk_link_to "Cancel", project_notes_path(@project) %>
+        <%= govuk_link_to "Cancel", back_link_destination(@note) %>
       <% end %>
     <% end %>
   </div>

--- a/spec/features/users_can_create_and_view_and_delete_notes_spec.rb
+++ b/spec/features/users_can_create_and_view_and_delete_notes_spec.rb
@@ -28,6 +28,7 @@ RSpec.feature "Users can create and view notes" do
 
     expect(page).to have_current_path(new_project_note_path(project))
     expect(page).to have_link("Back", href: project_notes_path(project_id))
+    expect(page).to have_link("Cancel", href: project_notes_path(project_id))
 
     fill_in "Enter note", with: new_note_body
 

--- a/spec/features/users_can_create_and_view_and_delete_task_level_notes_spec.rb
+++ b/spec/features/users_can_create_and_view_and_delete_task_level_notes_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature "Users can create and view task level notes" do
 
     expect(page).to have_current_path(new_project_note_path(project, task_id: task_id))
     expect(page).to have_field("note[task_id]", type: :hidden, with: task_id)
+    expect(page).to have_link("Cancel", href: project_task_path(project_id, task_id))
 
     fill_in "Enter note", with: new_note_body
 


### PR DESCRIPTION
## Changes

Currently, the "Cancel" link on the new note page always takes the user to the project notes path.

Instead, we want to take the user to the project task page if the note is a task-level note.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
