### PR TITLE
Make `Not applicable` checkbox text bold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The "Cancel" link on the new note page takes the user back to the task page if
   the note is a task-level note.
+- The text of the "Not applicable" checkboxes is bold to match the other task
+  checkboxes.
 
-## Content
+### Content
 
 ## [Release 8][release-8]
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,16 +35,14 @@ $govuk-global-styles: true;
   padding-left: 0;
 }
 
-.task-checkboxes {
+.task-actions__wrapper {
+  margin-bottom: govuk-spacing(9);
+
   .govuk-checkboxes__item {
     label {
       @extend .govuk-\!-font-weight-bold;
     }
   }
-}
-
-.task-actions__wrapper {
-  margin-bottom: govuk-spacing(9);
 }
 
 .task-action__wrapper {

--- a/app/views/tasks/shared/_action_single-checkbox.html.erb
+++ b/app/views/tasks/shared/_action_single-checkbox.html.erb
@@ -2,8 +2,7 @@
 
   <%= form.govuk_check_boxes_fieldset "action-#{action.id}",
         multiple: false,
-        legend: {text: action.title, hidden: true},
-        classes: "task-checkboxes" do %>
+        legend: {text: action.title, hidden: true} do %>
     <%= form.govuk_check_box "action-#{action.id}",
                             1,
                             0,


### PR DESCRIPTION
## Changes

The `Not applicable` checkboxes should have bold text to match the other task checkboxes.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
