### PR TITLE
Use `bulk` API endpoints for Trust and Establishment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 #### Changed
 
+- Page load speed has been improved on pages that fetch project data from the
+  API.
+
 #### Fixed
 
 - The "Cancel" link on the new note page takes the user back to the task page if

--- a/app/models/academies_api/client.rb
+++ b/app/models/academies_api/client.rb
@@ -15,14 +15,14 @@ class AcademiesApi::Client
 
   def get_establishment(urn)
     begin
-      response = @connection.get("/establishment/urn/#{urn}")
+      response = @connection.get("/establishments/bulk", {urn:})
     rescue Faraday::Error => error
       raise Error.new(error)
     end
 
     case response.status
     when 200
-      Result.new(AcademiesApi::Establishment.new.from_json(response.body), nil)
+      Result.new(AcademiesApi::Establishment.new.from_hash(JSON.parse(response.body)[0]), nil)
     when 404
       Result.new(nil, NotFoundError.new(I18n.t("academies_api.get_establishment.errors.not_found", urn: urn)))
     else
@@ -32,14 +32,14 @@ class AcademiesApi::Client
 
   def get_trust(ukprn)
     begin
-      response = @connection.get("/v2/trust/#{ukprn}")
+      response = @connection.get("/v2/trusts/bulk", {ukprn:, establishments: false})
     rescue Faraday::Error => error
       raise Error.new(error)
     end
 
     case response.status
     when 200
-      Result.new(AcademiesApi::Trust.new.from_json(response.body), nil)
+      Result.new(AcademiesApi::Trust.new.from_hash(JSON.parse(response.body)["data"][0]), nil)
     when 404
       Result.new(nil, NotFoundError.new(I18n.t("academies_api.get_trust.errors.not_found", ukprn: ukprn)))
     else

--- a/app/models/academies_api/trust.rb
+++ b/app/models/academies_api/trust.rb
@@ -10,8 +10,8 @@ class AcademiesApi::Trust < AcademiesApi::BaseApiModel
 
   def self.attribute_map
     {
-      original_name: "data.giasData.groupName",
-      companies_house_number: "data.giasData.companiesHouseNumber"
+      original_name: "giasData.groupName",
+      companies_house_number: "giasData.companiesHouseNumber"
     }
   end
 end

--- a/spec/models/academies_api/client_spec.rb
+++ b/spec/models/academies_api/client_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe AcademiesApi::Client do
     let(:client) { described_class.new(connection: fake_successful_establishment_connection(12345678, fake_response)) }
 
     context "when the establishment can be found" do
-      let(:fake_response) { [200, nil, {establishmentName: "Establishment Name"}.to_json] }
+      let(:fake_response) { [200, nil, [{establishmentName: "Establishment Name"}].to_json] }
 
       it "returns a Result with the establishment and no error" do
         result = client.get_establishment(12345678)
@@ -63,7 +63,7 @@ RSpec.describe AcademiesApi::Client do
   def fake_successful_establishment_connection(urn, response)
     Faraday.new do |builder|
       builder.adapter :test do |stub|
-        stub.get("/establishment/urn/#{urn}") do |env|
+        stub.get("/establishments/bulk?urn=#{urn}") do |_env|
           response
         end
       end
@@ -73,7 +73,7 @@ RSpec.describe AcademiesApi::Client do
   def fake_failed_establishment_connection(urn)
     Faraday.new do |builder|
       builder.adapter :test do |stub|
-        stub.get("/establishment/urn/#{urn}") do |env|
+        stub.get("/establishments/bulk?urn=#{urn}") do |_env|
           raise Faraday::Error
         end
       end
@@ -84,7 +84,7 @@ RSpec.describe AcademiesApi::Client do
     let(:client) { described_class.new(connection: fake_successful_trust_connection(10061021, fake_response)) }
 
     context "when the trust can be found" do
-      let(:fake_response) { [200, nil, {data: {giasData: {groupName: "THE ROMERO CATHOLIC ACADEMY"}}}.to_json] }
+      let(:fake_response) { [200, nil, {data: [{giasData: {groupName: "THE ROMERO CATHOLIC ACADEMY"}}]}.to_json] }
 
       it "returns a Result with the establishment and no error" do
         result = client.get_trust(10061021)
@@ -134,7 +134,7 @@ RSpec.describe AcademiesApi::Client do
   def fake_successful_trust_connection(ukprn, response)
     Faraday.new do |builder|
       builder.adapter :test do |stub|
-        stub.get("/v2/trust/#{ukprn}") do |env|
+        stub.get("/v2/trusts/bulk?ukprn=#{ukprn}&establishments=false") do |_env|
           response
         end
       end
@@ -144,7 +144,7 @@ RSpec.describe AcademiesApi::Client do
   def fake_failed_trust_connection(ukprn)
     Faraday.new do |builder|
       builder.adapter :test do |stub|
-        stub.get("/v2/trust/#{ukprn}") do |env|
+        stub.get("/v2/trusts/bulk?ukprn=#{ukprn}&establishments=false") do |_env|
           raise Faraday::Error
         end
       end


### PR DESCRIPTION
## Changes

Currently, our pages load very slowly as we send an API request for each Trust and Establishment related to a project. To help with this, we have added `bulk` endpoints to the API so that we can retrieve multiple Trusts and Establishments in a single request.

These new endpoints are significantly faster than the single resource endpoints. For now, this swaps out the API requests, but keeps them separate. We will see if this has a big enough impact on page load before doing the work to fetch all of the Trusts and Establishments in one go.

---

Note: this takes about 4 seconds now for 10 projects. We can get this down to less than a second if we get all at once.


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
