### PR TITLE
Accessibility tests for remaining groups

### DIFF
--- a/.github/workflows/continuous-integration-tests.yml
+++ b/.github/workflows/continuous-integration-tests.yml
@@ -36,7 +36,6 @@ jobs:
 
       - name: Run checks
         run: script/ci/accessibility
-        continue-on-error: true
 
       - if: always() && steps.cache-docker.outputs.cache-hit != 'true'
         name: Prepare Docker cache

--- a/app/views/conversion/involuntary/projects/new.html.erb
+++ b/app/views/conversion/involuntary/projects/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :pre_content_nav do %>
-  <%= govuk_back_link(href: root_path) %>
+  <% render partial: "shared/back_link", locals: {href: root_path} %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/conversion/voluntary/projects/new.html.erb
+++ b/app/views/conversion/voluntary/projects/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :pre_content_nav do %>
-  <%= govuk_back_link(href: root_path) %>
+  <% render partial: "shared/back_link", locals: {href: root_path} %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/project_information/show/_side_navigation.html.erb
+++ b/app/views/project_information/show/_side_navigation.html.erb
@@ -1,5 +1,5 @@
 <nav>
-  <h3 class="govuk-heading-m"><%= t("project_information.show.side_navigation.title") %></h3>
+  <h2 class="govuk-heading-m"><%= t("project_information.show.side_navigation.title") %></h2>
   <ul class="list-style-none govuk-!-padding-0">
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.project_details.title"), path: "#projectDetails"} %>
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.school_details.title"), path: "#schoolDetails"} %>

--- a/script/all/test-accessibility
+++ b/script/all/test-accessibility
@@ -3,4 +3,4 @@
 set -e
 
 echo "==> Running accessibility checks..."
-bundle exec rspec --tag accessibility
+NO_COVERAGE=true bundle exec rspec --tag accessibility

--- a/spec/accessibility/assignments_spec.rb
+++ b/spec/accessibility/assignments_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+require "axe-rspec"
+
+RSpec.feature "Test assignment accessibility", driver: :headless_firefox, accessibility: true do
+  let(:user) { create(:user, :team_leader) }
+  let(:project) { create(:project) }
+
+  before do
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    sign_in_with_user(user)
+  end
+
+  scenario "test change team lead for project page" do
+    visit project_assign_team_lead_path(project)
+
+    expect(page).to have_content("Change team lead")
+    expect(page).to be_axe_clean
+  end
+
+  scenario "test change caseworker for project page" do
+    visit project_assign_caseworker_path(project)
+
+    expect(page).to have_content("Change caseworker")
+    expect(page).to be_axe_clean
+  end
+
+  scenario "test change regional delivery officer for project page" do
+    visit project_assign_regional_delivery_officer_path(project)
+
+    expect(page).to have_content("Change regional delivery officer")
+    expect(page).to be_axe_clean
+  end
+end

--- a/spec/accessibility/authentication_spec.rb
+++ b/spec/accessibility/authentication_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+require "axe-rspec"
+
+RSpec.feature "Test authentication accessibility", driver: :headless_firefox, accessibility: true do
+  scenario "sign in page" do
+    visit sign_in_path
+
+    expect(page).to have_content("Sign in")
+    expect(page).to be_axe_clean
+  end
+
+  scenario "sign out page" do
+    visit sign_out_path
+
+    expect(page).to have_content("You have signed out")
+    expect(page).to be_axe_clean
+  end
+
+  scenario "authentication failed page" do
+    visit auth_failure_path
+
+    expect(page).to have_content("Authentication failed.")
+    expect(page).to be_axe_clean
+  end
+end

--- a/spec/accessibility/contacts_spec.rb
+++ b/spec/accessibility/contacts_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+require "axe-rspec"
+
+RSpec.feature "Test contacts accessibility", driver: :headless_firefox, accessibility: true do
+  let(:user) { create(:user, email: "user1@education.gov.uk") }
+  let(:project) { create(:project, caseworker: user) }
+
+  before do
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    sign_in_with_user(user)
+  end
+
+  scenario "show contacts page" do
+    contact = create(:contact, project: project)
+    visit project_contacts_path(project)
+
+    expect(page).to have_content(contact.name)
+    expect(page).to be_axe_clean
+  end
+
+  scenario "new page" do
+    visit new_project_contact_path(project)
+
+    expect(page).to have_content("Add contact")
+    expect(page).to be_axe_clean
+  end
+
+  scenario "edit page" do
+    contact = create(:contact, project: project)
+    visit edit_project_contact_path(project, contact)
+
+    expect(page).to have_content("Edit contact")
+    expect(page).to be_axe_clean
+  end
+
+  scenario "deleted page" do
+    contact = create(:contact, project: project)
+    visit project_contact_delete_path(project, contact)
+
+    expect(page).to have_content(contact.name)
+    expect(page).to be_axe_clean
+  end
+end

--- a/spec/accessibility/notes_spec.rb
+++ b/spec/accessibility/notes_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+require "axe-rspec"
+
+RSpec.feature "Test note accessibility", driver: :headless_firefox, accessibility: true do
+  let(:user) { create(:user, email: "user1@education.gov.uk") }
+  let(:project) { create(:project, caseworker: user) }
+  let(:section) { create(:section, project: project) }
+  let(:task) { create(:task, section: section) }
+
+  before do
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    sign_in_with_user(user)
+  end
+
+  describe "Project level notes" do
+    let!(:note) { create(:note, user: user, project: project) }
+    scenario "show notes page" do
+      visit project_notes_path(project)
+
+      expect(page).to have_content(note.body)
+      expect(page).to be_axe_clean
+    end
+
+    scenario "new page" do
+      visit new_project_note_path(project)
+
+      expect(page).to have_content("Enter note")
+      expect(page).to be_axe_clean
+    end
+
+    scenario "edit page" do
+      visit edit_project_note_path(project, note)
+
+      expect(page).to have_content(note.body)
+      expect(page).to be_axe_clean
+    end
+
+    scenario "deleted page" do
+      visit project_note_delete_path(project, note)
+
+      expect(page).to have_content("Are you sure you want to delete this note?")
+      expect(page).to be_axe_clean
+    end
+  end
+
+  describe "Task notes" do
+    let!(:task_note) { create(:note, project: project, task: task) }
+    scenario "new page" do
+      visit new_project_note_path(project, task)
+
+      expect(page).to have_content("Enter note")
+      expect(page).to be_axe_clean
+    end
+
+    scenario "show page" do
+      visit project_task_path(project, task)
+
+      expect(page).to have_content(task_note.body)
+      expect(page).to be_axe_clean
+    end
+  end
+end

--- a/spec/accessibility/project_information_spec.rb
+++ b/spec/accessibility/project_information_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+require "axe-rspec"
+
+RSpec.feature "Test project information accessibility", driver: :headless_firefox, accessibility: true do
+  let(:user) { create(:user, email: "user1@education.gov.uk") }
+  let(:project) { create(:project, caseworker: user) }
+
+  before do
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    sign_in_with_user(user)
+  end
+
+  scenario "project information page" do
+    visit project_information_path(project)
+
+    expect(page).to have_content("Project details")
+    expect(page).to be_axe_clean
+  end
+end

--- a/spec/accessibility/projects_spec.rb
+++ b/spec/accessibility/projects_spec.rb
@@ -25,10 +25,17 @@ RSpec.feature "Test projects accessibility", driver: :headless_firefox, accessib
     expect(page).to be_axe_clean
   end
 
-  scenario "new projects page" do
-    visit new_project_path
+  scenario "new voluntary conversion projects page" do
+    visit conversion_voluntary_new_path
 
     expect(page).to have_content("Add a new project")
+    expect(page).to be_axe_clean
+  end
+
+  scenario "new involuntary conversion projects page" do
+    visit conversion_involuntary_new_path
+
+    expect(page).to have_content("Add a new involuntary conversion project")
     expect(page).to be_axe_clean
   end
 

--- a/spec/accessibility/task_spec.rb
+++ b/spec/accessibility/task_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+require "axe-rspec"
+
+RSpec.feature "Test tasks accessibility", driver: :headless_firefox, accessibility: true do
+  let(:user) { create(:user, email: "user1@education.gov.uk") }
+  let(:project) { create(:project, caseworker: user) }
+
+  before do
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    sign_in_with_user(user)
+  end
+
+  scenario "show tasks page" do
+    section = create(:section, project: project)
+    task = create(:task, section: section)
+
+    visit project_path(project)
+
+    expect(page).to have_content(task.title)
+    expect(page).to be_axe_clean
+  end
+
+  scenario "individual task page" do
+    section = create(:section, project: project)
+    task = create(:task, section: section)
+
+    visit project_task_path(project, task)
+
+    expect(page).to have_content(task.title)
+    expect(page).to be_axe_clean
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@
 
 require "simplecov"
 SimpleCov.minimum_coverage 100
-SimpleCov.start "rails"
+SimpleCov.start "rails" unless ENV.fetch("NO_COVERAGE", false) == "true"
 
 # Add Capybara
 require "capybara/rspec"


### PR DESCRIPTION
## Changes

This PR is part 2 for accessibility tests (part 1: [https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/350](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/350))

The accessibility tests are based per page so we decided to group them together into seperate spec files.

The groupings include:

- tasks
- project information
- notes
- contacts
- assignments
- authentication

### Running accessibility tests locally

run `bundle exec rspec --tag accessibility spec/accessibility`


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
