### PR TITLE
Add sign in with helper

### DIFF
--- a/spec/requests/assignments_controller_spec.rb
+++ b/spec/requests/assignments_controller_spec.rb
@@ -4,9 +4,8 @@ RSpec.describe AssignmentsController, type: :request do
   let(:user) { create(:user, team_leader: true) }
 
   before do
-    mock_successful_authentication(user.email)
+    sign_in_with(user)
     mock_successful_api_responses(urn: 123456, ukprn: 10061021)
-    allow_any_instance_of(AssignmentsController).to receive(:user_id).and_return(user.id)
   end
 
   shared_examples_for "an action which redirects unauthorized users" do

--- a/spec/requests/contacts_controller_spec.rb
+++ b/spec/requests/contacts_controller_spec.rb
@@ -4,9 +4,8 @@ RSpec.describe ContactsController, type: :request do
   let(:user) { create(:user) }
 
   before do
-    mock_successful_authentication(user.email)
+    sign_in_with(user)
     mock_successful_api_responses(urn: 123456, ukprn: 10061021)
-    allow_any_instance_of(ContactsController).to receive(:user_id).and_return(user.id)
   end
 
   describe "#index" do

--- a/spec/requests/conversion/involuntary/projects_controller_spec.rb
+++ b/spec/requests/conversion/involuntary/projects_controller_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe Conversion::Involuntary::ProjectsController, type: :request do
   let(:this_controller) { Conversion::Involuntary::ProjectsController }
 
   before do
-    mock_successful_authentication(regional_delivery_officer.email)
-    allow_any_instance_of(Conversion::Involuntary::ProjectsController).to receive(:user_id).and_return(regional_delivery_officer.id)
+    sign_in_with(regional_delivery_officer)
   end
 
   it_behaves_like "a conversion project"

--- a/spec/requests/conversion/voluntary/projects_controller_spec.rb
+++ b/spec/requests/conversion/voluntary/projects_controller_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe Conversion::Voluntary::ProjectsController, type: :request do
   let(:this_controller) { Conversion::Voluntary::ProjectsController }
 
   before do
-    mock_successful_authentication(regional_delivery_officer.email)
-    allow_any_instance_of(Conversion::Voluntary::ProjectsController).to receive(:user_id).and_return(regional_delivery_officer.id)
+    sign_in_with(regional_delivery_officer)
   end
 
   it_behaves_like "a conversion project"

--- a/spec/requests/notes_controller_spec.rb
+++ b/spec/requests/notes_controller_spec.rb
@@ -4,9 +4,8 @@ RSpec.describe NotesController, type: :request do
   let(:user) { create(:user, :caseworker) }
 
   before do
-    mock_successful_authentication(user.email)
+    sign_in_with(user)
     mock_successful_api_responses(urn: 123456, ukprn: 10061021)
-    allow_any_instance_of(NotesController).to receive(:user_id).and_return(user.id)
   end
 
   describe "#index" do

--- a/spec/requests/project_complete_spec.rb
+++ b/spec/requests/project_complete_spec.rb
@@ -4,9 +4,8 @@ RSpec.describe "Completing projects", type: :request do
   let(:user) { create(:user, :caseworker) }
 
   before do
-    mock_successful_authentication(user.email)
+    sign_in_with(user)
     mock_successful_api_responses(urn: 123456, ukprn: 10061021)
-    allow_any_instance_of(ProjectsCompleteController).to receive(:user_id).and_return(user.id)
   end
 
   describe "the complete project button" do

--- a/spec/requests/project_information_controller_spec.rb
+++ b/spec/requests/project_information_controller_spec.rb
@@ -4,9 +4,8 @@ RSpec.describe ProjectInformationController, type: :request do
   let(:user) { create(:user, :team_leader) }
 
   before do
-    mock_successful_authentication(user.email)
+    sign_in_with(user)
     mock_successful_api_responses(urn: 123456, ukprn: 10061021)
-    allow_any_instance_of(ProjectInformationController).to receive(:user_id).and_return(user.id)
   end
 
   describe "#show" do

--- a/spec/requests/project_management_spec.rb
+++ b/spec/requests/project_management_spec.rb
@@ -2,8 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Project management" do
   before do
-    mock_successful_authentication(user.email)
-    allow_any_instance_of(ProjectsController).to receive(:user_id).and_return(user.id)
+    sign_in_with(user)
   end
 
   describe "creating a new project" do

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe TasksController, type: :request do
   let(:user) { create(:user) }
 
   before do
-    mock_successful_authentication(user.email)
-    allow_any_instance_of(TasksController).to receive(:user_id).and_return(user.id)
+    sign_in_with(user)
   end
 
   describe "#show" do

--- a/spec/support/shared_examples/conversion_project.rb
+++ b/spec/support/shared_examples/conversion_project.rb
@@ -93,8 +93,7 @@ RSpec.shared_examples "a conversion project" do
       let(:caseworker) { create(:user, :caseworker) }
 
       before do
-        mock_successful_authentication(caseworker.email)
-        allow_any_instance_of(this_controller).to receive(:user_id).and_return(caseworker.id)
+        sign_in_with(caseworker)
       end
 
       it "does not create the project and shows an error message" do

--- a/spec/support/sign_in_helpers.rb
+++ b/spec/support/sign_in_helpers.rb
@@ -1,4 +1,9 @@
 module SignInHelpers
+  def sign_in_with(user)
+    mock_successful_authentication(user.email)
+    allow_any_instance_of(ApplicationController).to receive(:user_id).and_return(user.id)
+  end
+
   def mock_successful_authentication(email_address)
     OmniAuth.config.mock_auth[:azure_activedirectory_v2] = OmniAuth::AuthHash.new({
       info: {


### PR DESCRIPTION
## Changes

We have something similar for feature specs, this just reduces noise in
our specs that are not focused on how we signed in, but need to behave
as a user who is signed in.

