### PR TITLE
(886) Fix accessible autocomplete on user assignment pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the note is a task-level note.
 - The text of the "Not applicable" checkboxes is bold to match the other task
   checkboxes.
+- The assign user select elements are enhanced with the accessible autocomplete
+  component.
 
 ### Content
 

--- a/app/views/assignments/assign_caseworker.html.erb
+++ b/app/views/assignments/assign_caseworker.html.erb
@@ -11,6 +11,7 @@
             label: {text: t("assignment.assign_caseworker.title", school_name: @project.establishment.name),
                     tag: "h1",
                     size: "l"},
+            class: "accessible-autocomplete-target",
             options: {include_blank: true, selected: @project.caseworker&.id} %>
 
       <%= form.govuk_submit do %>
@@ -20,4 +21,4 @@
   </div>
 </div>
 
-<%= render partial: "shared/autocomplete", locals: {field_id: "project-caseworker-id-field"} %>
+<%= render partial: "shared/autocomplete", locals: {selector: ".accessible-autocomplete-target"} %>

--- a/app/views/assignments/assign_regional_delivery_officer.html.erb
+++ b/app/views/assignments/assign_regional_delivery_officer.html.erb
@@ -11,6 +11,7 @@
             label: {text: t("assignment.assign_regional_delivery_officer.title", school_name: @project.establishment.name),
                     tag: "h1",
                     size: "l"},
+            class: "accessible-autocomplete-target",
             options: {include_blank: true, selected: @project.regional_delivery_officer&.id} %>
 
       <%= form.govuk_submit do %>
@@ -20,4 +21,4 @@
   </div>
 </div>
 
-<%= render partial: "shared/autocomplete", locals: {field_id: "project-regional-delivery-officer-id-field"} %>
+<%= render partial: "shared/autocomplete", locals: {selector: ".accessible-autocomplete-target"} %>

--- a/app/views/assignments/assign_team_leader.html.erb
+++ b/app/views/assignments/assign_team_leader.html.erb
@@ -11,6 +11,7 @@
             label: {text: t("assignment.assign_team_leader.title", school_name: @project.establishment.name),
                     tag: "h1",
                     size: "l"},
+            class: "accessible-autocomplete-target",
             options: {include_blank: true, selected: @project.team_leader&.id} %>
 
       <%= form.govuk_submit do %>
@@ -20,4 +21,4 @@
   </div>
 </div>
 
-<%= render partial: "shared/autocomplete", locals: {field_id: "project-team-leader-id-field"} %>
+<%= render partial: "shared/autocomplete", locals: {selector: ".accessible-autocomplete-target"} %>

--- a/app/views/shared/_autocomplete.html.erb
+++ b/app/views/shared/_autocomplete.html.erb
@@ -2,7 +2,7 @@
   <%= javascript_include_tag "accessible-autocomplete/dist/accessible-autocomplete.min" %>
   <script>
       accessibleAutocomplete.enhanceSelectElement({
-          selectElement: document.getElementById("<%= field_id %>")
+          selectElement: document.querySelector("<%= selector %>")
       })
   </script>
 <% end %>


### PR DESCRIPTION
## Changes

### Fix accessible autocomplete on user assignment pages
We enhance our select elements on the user assignment pages with the
accessible autocomplete component.

Currently, we use the ID of the select element to attach the component.
However, because this ID is generated from the form builder, it has changed
with a recent renaming of attributes.

This adds a "target" class to the select element so any further renames will
not break the autocomplete.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
