### PR TITLE
Show the conversion project route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - First version of a task list for involuntary conversions.
 - Renamed the new project button to 'new voluntary conversion project' and added
   the 'new involuntary conversion project' button
+- Show the conversion route on projects
 
 #### Changed
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -4,7 +4,7 @@ class ProjectsController < ApplicationController
 
   def index
     authorize Project
-    @pagy, @projects = pagy(policy_scope(Project.open))
+    @pagy, @projects = pagy(policy_scope(Project.open.includes(:details)))
 
     EstablishmentsFetcher.new.call(@projects)
     IncomingTrustsFetcher.new.call(@projects)
@@ -12,7 +12,7 @@ class ProjectsController < ApplicationController
 
   def completed
     authorize Project
-    @pagy, @projects = pagy(policy_scope(Project.completed))
+    @pagy, @projects = pagy(policy_scope(Project.completed.includes(:details)))
   end
 
   def show

--- a/app/models/conversion/involuntary/details.rb
+++ b/app/models/conversion/involuntary/details.rb
@@ -1,3 +1,7 @@
 class Conversion::Involuntary::Details < Conversion::Details
   WORKFLOW_PATH = Rails.root.join("app", "workflows", "lists", "conversion", "involuntary").freeze
+
+  def route
+    I18n.t("conversion_project.involuntary.route")
+  end
 end

--- a/app/models/conversion/voluntary/details.rb
+++ b/app/models/conversion/voluntary/details.rb
@@ -1,3 +1,7 @@
 class Conversion::Voluntary::Details < Conversion::Details
   WORKFLOW_PATH = Rails.root.join("app", "workflows", "lists", "conversion", "voluntary").freeze
+
+  def route
+    I18n.t("conversion_project.voluntary.route")
+  end
 end

--- a/app/views/projects/index/_project_summary.html.erb
+++ b/app/views/projects/index/_project_summary.html.erb
@@ -20,6 +20,13 @@
 
   <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
 
+  <div class="row-container">
+    <%= render partial: "projects/index/project_summary_item",
+          locals: {label: t("conversion_project.summary.route.title"), content: project.details.route} %>
+  </div>
+
+  <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
+
   <% if project.completed? %>
     <%= render partial: "projects/index/project_summary_item",
           locals: {label: t("project.summary.completed_at"), content: project.completed_at.to_formatted_s(:govuk_date_time_date_only)} %>

--- a/app/views/shared/_project_summary.html.erb
+++ b/app/views/shared/_project_summary.html.erb
@@ -29,6 +29,10 @@
             row.key { t("project.summary.trust_sharepoint_link.title") }
             row.value { safe_link_to(t("project.summary.trust_sharepoint_link.value"), @project.trust_sharepoint_link) }
           end
+          summary_list.row do |row|
+            row.key { t("conversion_project.summary.route.title") }
+            row.value { @project.details.route }
+          end
           if @project.completed?
             summary_list.row do |row|
               row.key { t("project.summary.completed_at") }

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -10,6 +10,9 @@ en:
       new:
         title: Add a new voluntary conversion project
         hint_html: <p>Enter the school and trust information.</p><p>This will create a conversion project for a school that has been granted an Academy order.</p>
+    summary:
+      route:
+        title: Route
   helpers:
     label:
       conversion_project:

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -1,10 +1,12 @@
 en:
   conversion_project:
     involuntary:
+      route: Involuntary
       new:
         title: Add a new involuntary conversion project
         hint_html: <p>Enter the school and trust information.</p><p>This will create a conversion project for a school that has been issued a Directive academy order.</p>
     voluntary:
+      route: Voluntary
       new:
         title: Add a new voluntary conversion project
         hint_html: <p>Enter the school and trust information.</p><p>This will create a conversion project for a school that has been granted an Academy order.</p>

--- a/spec/factories/conversion/involuntary/details_factory.rb
+++ b/spec/factories/conversion/involuntary/details_factory.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :involuntary_conversion_project_details, class: "Conversion::Involuntary::Details" do
+  end
+end

--- a/spec/factories/conversion/involuntary/project_factory.rb
+++ b/spec/factories/conversion/involuntary/project_factory.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :involuntary_conversion_project, class: "Conversion::Project" do
+    type { "Conversion::Project" }
+    urn { 123456 }
+    incoming_trust_ukprn { 10061021 }
+    provisional_conversion_date { (Date.today + 2.years).at_beginning_of_month }
+    advisory_board_date { (Date.today - 2.weeks) }
+    establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/establishment-folder" }
+    trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }
+
+    after :create do |project|
+      create :involuntary_conversion_project_details, project: project
+    end
+  end
+end

--- a/spec/factories/conversion/voluntary/details_factory.rb
+++ b/spec/factories/conversion/voluntary/details_factory.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :voluntary_conversion_project_details, class: "Conversion::Voluntary::Details" do
+  end
+end

--- a/spec/factories/conversion/voluntary/project_factory.rb
+++ b/spec/factories/conversion/voluntary/project_factory.rb
@@ -1,14 +1,16 @@
 FactoryBot.define do
-  factory :conversion_project, class: "Project" do
+  factory :voluntary_conversion_project, class: "Conversion::Project", aliases: [:conversion_project] do
     type { "Conversion::Project" }
     urn { 123456 }
     incoming_trust_ukprn { 10061021 }
     provisional_conversion_date { (Date.today + 2.years).at_beginning_of_month }
-    team_leader { association :user, :team_leader, email: "team-leader-#{SecureRandom.uuid}@education.gov.uk" }
-    regional_delivery_officer { association :user, :regional_delivery_officer, email: "regional-delivery-officer-#{SecureRandom.uuid}@education.gov.uk" }
     advisory_board_date { (Date.today - 2.weeks) }
     establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/establishment-folder" }
     trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }
+
+    after :create do |project|
+      create :voluntary_conversion_project_details, project: project
+    end
 
     trait :with_conditions do
       advisory_board_conditions { "The following must be met:\n 1. Must be red\n2. Must be blue\n" }
@@ -18,6 +20,11 @@ FactoryBot.define do
       team_leader { nil }
       regional_delivery_officer { nil }
       caseworker { nil }
+    end
+
+    trait :with_team_lead_and_regional_delivery_officer_assigned do
+      team_leader { association :user, :team_leader }
+      regional_delivery_officer { association :user, :regional_delivery_officer }
     end
   end
 end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     caseworker { false }
 
     trait :caseworker do
-      email { "caseworker@education.gov.uk" }
+      email { "caseworker-#{SecureRandom.uuid}@education.gov.uk" }
       caseworker { true }
     end
 
@@ -16,14 +16,14 @@ FactoryBot.define do
       first_name { "Team" }
       last_name { "Leader" }
       team_leader { true }
-      email { "team.lead@education.gov.uk" }
+      email { "team-leader-#{SecureRandom.uuid}@education.gov.uk" }
     end
 
     trait :regional_delivery_officer do
       first_name { "Regional" }
       last_name { "Delivery-Officer" }
       regional_delivery_officer { true }
-      email { "regional.delivery.officer@education.gov.uk" }
+      email { "regional-delivery-officer-#{SecureRandom.uuid}@education.gov.uk" }
     end
   end
 end

--- a/spec/features/users_can_view_a_project_summary_spec.rb
+++ b/spec/features/users_can_view_a_project_summary_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.feature "Users can view a project summary" do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in_with_user(user)
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+  end
+
+  context "when they view a single voluntary conversion project" do
+    scenario "they see the route" do
+      project = create(:voluntary_conversion_project, caseworker: user)
+
+      visit project_path(project)
+
+      within("#project-summary") do
+        expect(page).to have_content("Voluntary")
+      end
+    end
+  end
+
+  context "when they view a single involuntary conversion project" do
+    scenario "they see the route" do
+      project = create(:involuntary_conversion_project, caseworker: user)
+      visit project_path(project)
+
+      within("#project-summary") do
+        expect(page).to have_content("Involuntary")
+      end
+    end
+  end
+end

--- a/spec/features/users_can_view_project_information_spec.rb
+++ b/spec/features/users_can_view_project_information_spec.rb
@@ -13,26 +13,6 @@ RSpec.feature "Users can view project information" do
     visit project_information_path(project_id)
   end
 
-  scenario "they can view the users names and email addresses assigned to the project" do
-    within("#projectDetails") do
-      expect(page).to have_content(user.full_name)
-      expect(page).to have_link("Email caseworker", href: "mailto:#{user.email}")
-
-      expect(page).to have_content(project.team_leader.full_name)
-      expect(page).to have_link("Email team leader", href: "mailto:#{project.team_leader.email}")
-
-      expect(page).to have_content(project.regional_delivery_officer.full_name)
-      expect(page).to have_link("Email regional delivery officer", href: "mailto:#{project.regional_delivery_officer.email}")
-    end
-  end
-
-  scenario "they can view the advisory board details" do
-    within("#projectDetails") do
-      expect(page).to have_content(project.advisory_board_date.to_formatted_s(:govuk))
-      expect(page.html).to include(simple_format(project.advisory_board_conditions, class: "govuk-body"))
-    end
-  end
-
   scenario "they can view the School SharePoint link" do
     within("#projectDetails") do
       expect(page).to have_link(I18n.t("project.summary.establishment_sharepoint_link.value"), href: project.establishment_sharepoint_link)
@@ -72,6 +52,34 @@ RSpec.feature "Users can view project information" do
   scenario "the diocese details" do
     within("#dioceseDetails") do
       expect(page).to have_content(project.establishment.diocese_name)
+    end
+  end
+
+  context "when the caseworker, team lead and regional delivery officer have been assigned" do
+    let(:project) { create(:conversion_project, :with_team_lead_and_regional_delivery_officer_assigned, caseworker: user) }
+
+    scenario "they can view the users names and email addresses assigned to the project" do
+      within("#projectDetails") do
+        expect(page).to have_content(user.full_name)
+        expect(page).to have_link("Email caseworker", href: "mailto:#{user.email}")
+
+        expect(page).to have_content(project.team_leader.full_name)
+        expect(page).to have_link("Email team leader", href: "mailto:#{project.team_leader.email}")
+
+        expect(page).to have_content(project.regional_delivery_officer.full_name)
+        expect(page).to have_link("Email regional delivery officer", href: "mailto:#{project.regional_delivery_officer.email}")
+      end
+    end
+  end
+
+  context "when there are conditions from the advisory board" do
+    let(:project) { create(:conversion_project, :with_conditions, caseworker: user) }
+
+    scenario "they can view the advisory board details" do
+      within("#projectDetails") do
+        expect(page).to have_content(project.advisory_board_date.to_formatted_s(:govuk))
+        expect(page.html).to include(simple_format(project.advisory_board_conditions, class: "govuk-body"))
+      end
     end
   end
 end

--- a/spec/models/conversion/involuntary/details_spec.rb
+++ b/spec/models/conversion/involuntary/details_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Conversion::Involuntary::Details do
+  describe "#route" do
+    it "returns the locale for the involuntary route" do
+      details = described_class.new
+
+      expect(details.route).to eql I18n.t("conversion_project.involuntary.route")
+    end
+  end
+end

--- a/spec/models/conversion/voluntary/details_spec.rb
+++ b/spec/models/conversion/voluntary/details_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Conversion::Voluntary::Details do
+  describe "#route" do
+    it "returns the locale for the voluntary route" do
+      details = described_class.new
+
+      expect(details.route).to eql I18n.t("conversion_project.voluntary.route")
+    end
+  end
+end


### PR DESCRIPTION
## Changes

As we have two 'routes' for converison projects we want to show users which
project is which.

Here we introduce that behaviour, which is also our first time to reach for our
new voluntary and involuntary details objects.

Because of this we have to do a bunch of things to get a working set of
factories to help us.

https://trello.com/c/ZZLlHN7W

![Screenshot 2022-12-06 at 14-39-26 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/205941703-799b6429-9a59-4b4c-8e8b-926a1bed2a2b.png)
  
![Screenshot 2022-12-06 at 14-39-41 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/205941738-b2a2aacf-5bf5-47ec-bdc1-dc9678a3425b.png)



