### PR TITLE
895 copy changes to project create fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 #### Changed
 
+- Content iterations to the add project pages including, copy, hints and errors
 - Page load speed has been improved on pages that fetch project data from the
   API. The project index page fetches establishments and trusts in bulk.
 

--- a/app/views/conversion/involuntary/projects/new.html.erb
+++ b/app/views/conversion/involuntary/projects/new.html.erb
@@ -12,11 +12,11 @@
 
       <%= form.govuk_text_field :urn, label: {size: "m"}, hint: {text: t("helpers.hint.project.urn").html_safe}, width: 10 %>
       <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m"}, hint: {text: t("helpers.hint.project.incoming_trust_ukprn").html_safe}, width: 10 %>
+      <%= form.govuk_date_field :advisory_board_date, form_group: {id: "advisory-board-date"} %>
+      <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m"} %>
       <%= form.govuk_date_field :provisional_conversion_date, omit_day: true, form_group: {id: "provisional-conversion-date"} %>
       <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m"} %>
       <%= form.govuk_text_field :trust_sharepoint_link, label: {size: "m"} %>
-      <%= form.govuk_date_field :advisory_board_date, form_group: {id: "advisory-board-date"} %>
-      <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m"} %>
 
       <%= form.fields_for :note, @note do |note_form| %>
         <%= note_form.govuk_text_area :body,

--- a/app/views/conversion/involuntary/projects/new.html.erb
+++ b/app/views/conversion/involuntary/projects/new.html.erb
@@ -21,7 +21,7 @@
       <%= form.fields_for :note, @note do |note_form| %>
         <%= note_form.govuk_text_area :body,
               label: {text: t("project.new.handover_comments_label"), size: "m"},
-              hint: {text: t("project.new.handover_comments_hint")} %>
+              hint: {text: t("project.new.handover_comments_hint").html_safe} %>
       <% end %>
 
       <%= form.govuk_submit %>

--- a/app/views/conversion/voluntary/projects/new.html.erb
+++ b/app/views/conversion/voluntary/projects/new.html.erb
@@ -12,11 +12,11 @@
 
       <%= form.govuk_text_field :urn, label: {size: "m"}, hint: {text: t("helpers.hint.project.urn").html_safe}, width: 10 %>
       <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m"}, hint: {text: t("helpers.hint.project.incoming_trust_ukprn").html_safe}, width: 10 %>
+      <%= form.govuk_date_field :advisory_board_date, form_group: {id: "advisory-board-date"} %>
+      <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m"} %>
       <%= form.govuk_date_field :provisional_conversion_date, omit_day: true, form_group: {id: "provisional-conversion-date"} %>
       <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m"} %>
       <%= form.govuk_text_field :trust_sharepoint_link, label: {size: "m"} %>
-      <%= form.govuk_date_field :advisory_board_date, form_group: {id: "advisory-board-date"} %>
-      <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m"} %>
 
       <%= form.fields_for :note, @note do |note_form| %>
         <%= note_form.govuk_text_area :body,

--- a/app/views/conversion/voluntary/projects/new.html.erb
+++ b/app/views/conversion/voluntary/projects/new.html.erb
@@ -21,7 +21,7 @@
       <%= form.fields_for :note, @note do |note_form| %>
         <%= note_form.govuk_text_area :body,
               label: {text: t("project.new.handover_comments_label"), size: "m"},
-              hint: {text: t("project.new.handover_comments_hint")} %>
+              hint: {text: t("project.new.handover_comments_hint").html_safe} %>
       <% end %>
 
       <%= form.govuk_submit %>

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -29,10 +29,14 @@ en:
         advisory_board_date: Date of advisory board
     hint:
       conversion_project:
-        urn: <a href="https://www.get-information-schools.service.gov.uk/Search" class="govuk-link" rel="noreferrer noopener" target="_blank">Search Get Information About Schools (GIAS) to find the school's URN (opens in a new tab)</a>.
+        urn: |
           This is the URN of the existing school which is converting to an academy. A URN is a 6-digit number.
-        incoming_trust_ukprn: <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in a new tab)</a>.
+          <br /><br />
+          <a href="https://www.get-information-schools.service.gov.uk/Search" class="govuk-link" rel="noreferrer noopener" target="_blank">Search Get Information About Schools (GIAS) to find the school's URN (opens in a new tab)</a>.
+        incoming_trust_ukprn: |
           A UKPRN is an 8-digit number that always starts with a 1.
+          <br /><br />
+          <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in a new tab)</a>.
         caseworker_id: The caseworker responsible for this project
         provisional_conversion_date: The provisional conversion date is always the 1st of the month.
         advisory_board_conditions: If there are conditions to be met as a result of the advisory board.

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -4,15 +4,12 @@ en:
       route: Involuntary
       new:
         title: Add a new involuntary conversion project
-        hint_html: <p>Enter the school and trust information.</p><p>This will create a conversion project for a school that has been issued a Directive academy order.</p>
+        hint_html: <p class="govuk-body">Enter the school and trust information.</p><p class="govuk-body">This will create a conversion project for a school that has been issued a Directive academy order.</p>
     voluntary:
       route: Voluntary
       new:
         title: Add a new voluntary conversion project
-        hint_html: <p>Enter the school and trust information.</p><p>This will create a conversion project for a school that has been granted an Academy order.</p>
-    summary:
-      route:
-        title: Route
+        hint_html: <p class="govuk-body">Enter the school and trust information.</p><p class="govuk-body">This will create a conversion project for a school that has been granted an Academy order.</p>
   helpers:
     label:
       conversion_project:

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -41,4 +41,4 @@ en:
         provisional_conversion_date: The provisional conversion date is always the first day of the month.
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
-        trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant documents.
+        trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -40,5 +40,5 @@ en:
         caseworker_id: The caseworker responsible for this project
         provisional_conversion_date: The provisional conversion date is always the first day of the month.
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
-        establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant documents.
+        establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant documents.

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -39,6 +39,6 @@ en:
           <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in a new tab)</a>.
         caseworker_id: The caseworker responsible for this project
         provisional_conversion_date: The provisional conversion date is always the 1st of the month.
-        advisory_board_conditions: If there are conditions to be met as a result of the advisory board.
+        advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant documents.
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant documents.

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -38,7 +38,7 @@ en:
           <br /><br />
           <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in a new tab)</a>.
         caseworker_id: The caseworker responsible for this project
-        provisional_conversion_date: The provisional conversion date is always the 1st of the month.
+        provisional_conversion_date: The provisional conversion date is always the first day of the month.
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant documents.
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant documents.

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -118,12 +118,12 @@ en:
     attributes:
       urn:
         blank: Enter a school URN
-        no_establishment_found: There’s no school with that URN. Check the number you entered is correct.
+        no_establishment_found: There's no school with that URN. Check the number you entered is correct.
         not_a_number: School URN can only contain numbers. No letters or special characters.
         wrong_length: URN must be 6 digits long. For example, 123456.
       incoming_trust_ukprn:
         blank: Enter a UKPRN
-        no_trust_found: There’s no trust with that UKPRN. Check the number you entered is correct.
+        no_trust_found: There's no trust with that UKPRN. Check the number you entered is correct.
         not_a_number: UKPRN can only contain numbers. No letters or special characters.
         must_be_correct_format: UKPRN must be 8 digits long and start with a 1. For example, 12345678.
       provisional_conversion_date:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -112,7 +112,7 @@ en:
         caseworker_id: The caseworker responsible for this project
         provisional_conversion_date: The provisional conversion date is always the first day of the month.
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
-        establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant documents.
+        establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant documents.
   errors:
     attributes:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -127,7 +127,7 @@ en:
         not_a_number: UKPRN can only contain numbers. No letters or special characters.
         must_be_correct_format: UKPRN must be 8 digits long and start with a 1. For example, 12345678.
       provisional_conversion_date:
-        blank: Enter a provisional conversion month and year
+        blank: Enter a month and year for the provisional conversion date, like 01 2023. If you do not know the provisional conversion date then enter a date that is at least six months after the advisory board.
         must_be_first_of_the_month: Provisional conversion date must be on the first day of the month
         must_be_in_the_future: Provisional conversion date must be in the future.
       regional_delivery_officer_id:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -101,10 +101,14 @@ en:
         advisory_board_date: Date of advisory board
     hint:
       project:
-        urn: <a href="https://www.get-information-schools.service.gov.uk/Search" class="govuk-link" rel="noreferrer noopener" target="_blank">Search Get Information About Schools (GIAS) to find the school's URN (opens in new tab)</a>.
+        urn: |
           This is the URN of the existing school which is converting to an academy. A URN is a 6-digit number.
-        incoming_trust_ukprn: <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in new tab)</a>.
+          <br /><br />
+          <a href="https://www.get-information-schools.service.gov.uk/Search" class="govuk-link" rel="noreferrer noopener" target="_blank">Search Get Information About Schools (GIAS) to find the school's URN (opens in new tab)</a>.
+        incoming_trust_ukprn: |
           A UKPRN is an 8-digit number that always starts with a 1.
+          <br/ ><br />
+          <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in new tab)</a>.
         caseworker_id: The caseworker responsible for this project
         provisional_conversion_date: The provisional conversion date is always the 1st of the month.
         advisory_board_conditions: If there are conditions to be met as a result of the advisory board.

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -110,7 +110,7 @@ en:
           <br/ ><br />
           <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in new tab)</a>.
         caseworker_id: The caseworker responsible for this project
-        provisional_conversion_date: The provisional conversion date is always the 1st of the month.
+        provisional_conversion_date: The provisional conversion date is always the first day of the month.
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant documents.
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant documents.

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -111,7 +111,7 @@ en:
           <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in new tab)</a>.
         caseworker_id: The caseworker responsible for this project
         provisional_conversion_date: The provisional conversion date is always the 1st of the month.
-        advisory_board_conditions: If there are conditions to be met as a result of the advisory board.
+        advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant documents.
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant documents.
   errors:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -113,7 +113,7 @@ en:
         provisional_conversion_date: The provisional conversion date is always the first day of the month.
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
-        trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant documents.
+        trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
   errors:
     attributes:
       urn:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -148,7 +148,7 @@ en:
       regional_delivery_officer_id:
         blank: Choose a regional delivery officer
       advisory_board_date:
-        blank: Enter a date of advisory board
+        blank: Enter a date for the advisory board, like 01 04 2023
         must_be_in_the_past: The advisory board date must be in the past
       establishment_sharepoint_link:
         blank: Enter a school SharePoint link

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -9,7 +9,22 @@ en:
         text: Edit
     new:
       handover_comments_label: Handover comments
-      handover_comments_hint: Please provide a brief overview of how the project has progressed so far, including any issues that have arisen or areas of concern.
+      handover_comments_hint:
+        <p class="govuk-body">Provide a brief overview of how the project has progressed so far, including any issues or concerns.</p>
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              What to make comments about
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <p class="govuk-body">Useful things to comment on include whether the:</p>
+              <ul class="govuk-list govuk-list--bullet">
+                <li>provisional conversion date has been agreed by the school, trust and local authority</li>
+                <li>local authority proforma has been received or requested</li>
+              </ul>
+          </div>
+        </details>
     create:
       success: Project has been created successfully
     edit:


### PR DESCRIPTION
## Changes

Content changes to new project screen including hints and errors.

- [x] Title change (for voluntary / in-voluntary projects) Done already
- [x] Involuntary academies description mentions Directive academy order Done already
- [x] Voluntary conversions mention Academy order Done already
- [x] School URN / Trust UKPRN hint text says what URN / UKPRN is then gives link on new line
- [x] Advisory board conditions hint is Enter details of conditions that must be met before the school can convert.
- [x] Advisory board notes and date goes above provisional conversion date
- [x] Provisional conversions date hint is The provisional conversion date is always the first day of the month.
- [x] Provisional conversion date no entry error is Enter a month and year for the provisional conversion date, like 01 2023. If you do not know the provisional conversion date then enter a date that is at least six months after the advisory board..
- [x] School Sharepoint hint text should be Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
- [x] Trust Sharepoint hint text should be Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
- [x] Handover comment hint is Provide a brief overview of how the project has progressed so far, including any issues or concerns.
- [x] Handover comment dropdown guidance is summary =What to make comments about content = Useful things to comment on include whether the:   - provisional conversion date has been agreed by the school, trust and local authority  - local authority proforma has been received or requested
- [x] Advisory date no entry error is Enter a date for the advisory board, like 01 04 2023
- [x] Add missing GDS tags to add project page




## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
