### PR TITLE
906 update link in csa page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Features
+
+#### Addded
+
+#### Changed
+
+- Church supplemental guidance link now points to specific guidance rather than
+  general model documents page
+
+#### Fixed
+
+#### Content
+
 ## [Release 9][release-9]
 
 ### Features

--- a/app/workflows/lists/conversion/involuntary/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/involuntary/sections/clear-legal-docs.yml
@@ -107,7 +107,7 @@ tasks:
         title: Check and clear the Church supplemental agreement
         hint:
           You can [view the model documents (opens in new
-          tab)](https://www.gov.uk/government/collections/convert-to-an-academy-documents-for-schools)
+          tab)](https://www.gov.uk/government/publications/church-academies-model-documents)
           to check for changes.
         guidance_summary: Help checking for changes
         guidance_text: |

--- a/app/workflows/lists/conversion/voluntary/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/voluntary/sections/clear-legal-docs.yml
@@ -116,7 +116,7 @@ tasks:
         title: Check and clear the Church supplemental agreement
         hint:
           You can [view the model documents (opens in new
-          tab)](https://www.gov.uk/government/collections/convert-to-an-academy-documents-for-schools)
+          tab)](https://www.gov.uk/government/publications/church-academies-model-documents)
           to check for changes.
         guidance_summary: Help checking for changes
         guidance_text: |


### PR DESCRIPTION
## Changes

Tiny PR to change the link URL for the Church supplemental agreement so that it now points to specific guidance rather than a general model docs page.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
