### PR TITLE
New Involuntary conversions notificaitons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Content iterations to the add project pages including, copy, hints and errors
 - Page load speed has been improved on pages that fetch project data from the
   API. The project index page fetches establishments and trusts in bulk.
+- Regional team leads are no longer notified upon the creation of an involuntary
+  converison project.
 
 #### Fixed
 

--- a/app/controllers/conversion/involuntary/projects_controller.rb
+++ b/app/controllers/conversion/involuntary/projects_controller.rb
@@ -12,8 +12,6 @@ class Conversion::Involuntary::ProjectsController < Conversion::ProjectsControll
         TaskListCreator.new.call(@project, workflow_root: Conversion::Involuntary::Details::WORKFLOW_PATH)
       end
 
-      notify_team_leaders
-
       redirect_to project_path(@project), notice: I18n.t("project.create.success")
     else
       render :new

--- a/spec/requests/conversion/involuntary/projects_controller_spec.rb
+++ b/spec/requests/conversion/involuntary/projects_controller_spec.rb
@@ -11,4 +11,19 @@ RSpec.describe Conversion::Involuntary::ProjectsController, type: :request do
   end
 
   it_behaves_like "a conversion project"
+
+  describe "notifications" do
+    context "when a new involuntary conversion project is created" do
+      it "does not send a notification to team leaders" do
+        mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+        project_params = attributes_for(:conversion_project)
+        _team_leader = create(:user, :team_leader)
+        _another_team_leader = create(:user, :team_leader)
+
+        post create_path, params: {conversion_project: {**project_params, note: {body: ""}}}
+
+        expect(ActionMailer::MailDeliveryJob).not_to(have_been_enqueued.on_queue("default"))
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples/conversion_project.rb
+++ b/spec/support/shared_examples/conversion_project.rb
@@ -48,12 +48,6 @@ RSpec.shared_examples "a conversion project" do
         expect(Note.last.user).to eq regional_delivery_officer
       end
 
-      it "sends a new project created email to team leaders" do
-        expect(ActionMailer::MailDeliveryJob)
-          .to(have_been_enqueued.on_queue("default")
-                                .with("TeamLeaderMailer", "new_project_created", "deliver_now", args: [team_leader, new_project_record]))
-      end
-
       context "when the note body is empty" do
         let(:note_params) { {body: ""} }
 


### PR DESCRIPTION
## Changes

Right now, when a new involuntary conversion project is created, there
is no value in notifying a Regional caseworker team lead as they play
no role in the projects life.

Here we remove the notification for involuntary conversions and move the
coverage from the shared example and into specific specs.

https://trello.com/c/2bLWZ5Ig