### PR TITLE
896 project created confirmation tells users what to do next

### DIFF
--- a/app/controllers/conversion/involuntary/projects_controller.rb
+++ b/app/controllers/conversion/involuntary/projects_controller.rb
@@ -12,7 +12,8 @@ class Conversion::Involuntary::ProjectsController < Conversion::ProjectsControll
         TaskListCreator.new.call(@project, workflow_root: Conversion::Involuntary::Details::WORKFLOW_PATH)
       end
 
-      redirect_to project_path(@project), notice: I18n.t("project.create.success")
+      redirect_to project_path(@project), notice: I18n.t("conversion_project.involuntary.create.success")
+
     else
       render :new
     end

--- a/app/controllers/conversion/voluntary/projects_controller.rb
+++ b/app/controllers/conversion/voluntary/projects_controller.rb
@@ -14,7 +14,7 @@ class Conversion::Voluntary::ProjectsController < Conversion::ProjectsController
 
       notify_team_leaders
 
-      redirect_to project_path(@project), notice: I18n.t("project.create.success")
+      redirect_to project_path(@project), notice: I18n.t("conversion_project.voluntary.create.success")
     else
       render :new
     end

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-notification-banner__content">
     <% flash.each do |type, msg| %>
       <div class="flash <%= type %>">
-        <p><%= msg %></p>
+        <p class="govuk-notification-banner__heading"><%= msg.html_safe %></p>
       </div>
     <% end %>
   </div>

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -5,14 +5,22 @@ en:
       new:
         title: Add a new involuntary conversion project
         hint_html: <p class="govuk-body">Enter the school and trust information.</p><p class="govuk-body">This will create a conversion project for a school that has been issued a Directive academy order.</p>
+      create:
+        success:
+          Involuntary project successfully created
+          <p class="govuk-body">Add details of any contacts you have for the school, trust, local authority and solicitors.</p>
+          <p class="govuk-body">Use the task list to manage the project.</p>
     voluntary:
       route: Voluntary
       new:
         title: Add a new voluntary conversion project
         hint_html: <p class="govuk-body">Enter the school and trust information.</p><p class="govuk-body">This will create a conversion project for a school that has been granted an Academy order.</p>
-    summary:
-      route:
-        title: Route
+      create:
+        success:
+          Voluntary project successfully created
+          <p class="govuk-body">Add details of any contacts you have for the school, trust, local authority and solicitors.</p>
+          <p class="govuk-body">A caseworker will be assigned this project.</p>
+          <p class="govuk-body">There is nothing more for you to do.</p>
   helpers:
     label:
       conversion_project:
@@ -42,3 +50,4 @@ en:
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
+

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -25,8 +25,6 @@ en:
               </ul>
           </div>
         </details>
-    create:
-      success: Project has been created successfully
     edit:
       title: Edit a project
     update:


### PR DESCRIPTION
## Changes

Now supports bespoke project creation banner for voluntary and involuntary routes. 

This also renders the flash message as `html_safe` so that message formatting can be defined in the translations file


![image](https://user-images.githubusercontent.com/13239597/206733917-3046cc68-e95b-4921-8605-9c4ccce3e6c7.png)
![image](https://user-images.githubusercontent.com/13239597/206734067-523ef6a0-5640-474b-b980-33d11ebabb14.png)


## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
