### PR TITLE
Fix bug where empty URNs and UKPRNs raise an API error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Features
 
-#### Addded
+#### Added
 
 #### Changed
 
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 #### Fixed
 
 - Format workflow yml files so that markdown renders correctly
+- When submitting the new project form, blank URNs and UKPRNs will show a
+  validation error.
 
 #### Content
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -21,7 +21,8 @@ class Project < ApplicationRecord
   validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}, on: :create
   validates :trust_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}, on: :create
 
-  validate :establishment_exists, :trust_exists, on: :create
+  validate :establishment_exists, on: :create, if: -> { urn.present? }
+  validate :trust_exists, on: :create, if: -> { incoming_trust_ukprn.present? }
 
   belongs_to :caseworker, class_name: "User", optional: true
   belongs_to :team_leader, class_name: "User", optional: true

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Project, type: :model do
       it { is_expected.to allow_value(123456).for(:urn) }
       it { is_expected.not_to allow_values(12345, 1234567).for(:urn) }
 
-      context "when no establishment with that URN exists in the API" do
+      context "when no establishment with that URN exists in the API and the URN is present" do
         let(:no_establishment_found_result) do
           AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError.new("Could not find establishment with URN: 12345"))
         end
@@ -92,6 +92,8 @@ RSpec.describe Project, type: :model do
         before do
           allow_any_instance_of(AcademiesApi::Client).to \
             receive(:get_establishment) { no_establishment_found_result }
+
+          subject.assign_attributes(urn: 123456)
         end
 
         it "is invalid" do
@@ -102,7 +104,7 @@ RSpec.describe Project, type: :model do
     end
 
     describe "#incoming_trust_ukprn" do
-      context "when no trust with that UKPRN exists in the API" do
+      context "when no trust with that UKPRN exists in the API and the UKPRN is present" do
         let(:no_trust_found_result) do
           AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError.new("No trust found with that UKPRN. Enter a valid UKPRN."))
         end
@@ -110,6 +112,8 @@ RSpec.describe Project, type: :model do
         before do
           allow_any_instance_of(AcademiesApi::Client).to \
             receive(:get_trust) { no_trust_found_result }
+
+          subject.assign_attributes(incoming_trust_ukprn: 12345678)
         end
 
         it "is invalid" do


### PR DESCRIPTION
## Changes
Currently, when creating a project with an empty URN or UKPRN, the project
model will try to validate these against the API. The API will throw a bad
request error, which is re-raised in the API client, and the user will see an
error page.

Instead, we can conditionally validate that the URN or UKPRN returns an
establishment or trust only if they are present. This ensures that a
blank URN or UKPRN will not call out to the API for validation, and will
instead show the error message associated with `presence: true`.


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
