### PR TITLE
Use FormObject to create projects

### DIFF
--- a/app/controllers/conversion/involuntary/projects_controller.rb
+++ b/app/controllers/conversion/involuntary/projects_controller.rb
@@ -1,19 +1,12 @@
 class Conversion::Involuntary::ProjectsController < Conversion::ProjectsController
   def create
-    @note = Note.new(**note_params, user_id: user_id)
-    @project = Conversion::Project.new(**project_params, regional_delivery_officer_id: user_id, notes_attributes: [@note.attributes])
-
-    authorize @project
+    authorize Conversion::Project
+    @project = Conversion::Involuntary::CreateProjectForm.new(**project_params, user: current_user, note_body: note_params[:body])
 
     if @project.valid?
-      ActiveRecord::Base.transaction do
-        @project.save
-        Conversion::Involuntary::Details.create(project: @project)
-        TaskListCreator.new.call(@project, workflow_root: Conversion::Involuntary::Details::WORKFLOW_PATH)
-      end
+      @created_project = @project.save
 
-      redirect_to project_path(@project), notice: I18n.t("conversion_project.involuntary.create.success")
-
+      redirect_to project_path(@created_project), notice: I18n.t("conversion_project.involuntary.create.success")
     else
       render :new
     end

--- a/app/controllers/conversion/involuntary/projects_controller.rb
+++ b/app/controllers/conversion/involuntary/projects_controller.rb
@@ -1,7 +1,7 @@
 class Conversion::Involuntary::ProjectsController < Conversion::ProjectsController
   def create
     authorize Conversion::Project
-    @project = Conversion::Involuntary::CreateProjectForm.new(**project_params, user: current_user, note_body: note_params[:body])
+    @project = Conversion::Involuntary::CreateProjectForm.new(**project_params, user: current_user)
 
     if @project.valid?
       @created_project = @project.save

--- a/app/controllers/conversion/projects_controller.rb
+++ b/app/controllers/conversion/projects_controller.rb
@@ -12,11 +12,8 @@ class Conversion::ProjectsController < ProjectsController
       :advisory_board_date,
       :advisory_board_conditions,
       :establishment_sharepoint_link,
-      :trust_sharepoint_link
+      :trust_sharepoint_link,
+      :note_body
     )
-  end
-
-  private def note_params
-    params.require(:conversion_project).require(:note).permit(:body)
   end
 end

--- a/app/controllers/conversion/voluntary/projects_controller.rb
+++ b/app/controllers/conversion/voluntary/projects_controller.rb
@@ -1,7 +1,7 @@
 class Conversion::Voluntary::ProjectsController < Conversion::ProjectsController
   def create
     authorize Conversion::Project
-    @project = Conversion::Voluntary::CreateProjectForm.new(**project_params, user: current_user, note_body: note_params[:body])
+    @project = Conversion::Voluntary::CreateProjectForm.new(**project_params, user: current_user)
 
     if @project.valid?
       @created_project = @project.save

--- a/app/controllers/conversion/voluntary/projects_controller.rb
+++ b/app/controllers/conversion/voluntary/projects_controller.rb
@@ -1,20 +1,13 @@
 class Conversion::Voluntary::ProjectsController < Conversion::ProjectsController
   def create
-    @note = Note.new(**note_params, user_id: user_id)
-    @project = Conversion::Project.new(**project_params, regional_delivery_officer_id: user_id, notes_attributes: [@note.attributes])
-
-    authorize @project
+    authorize Conversion::Project
+    @project = Conversion::Voluntary::CreateProjectForm.new(**project_params, user: current_user, note_body: note_params[:body])
 
     if @project.valid?
-      ActiveRecord::Base.transaction do
-        @project.save
-        Conversion::Voluntary::Details.create(project: @project)
-        TaskListCreator.new.call(@project, workflow_root: Conversion::Voluntary::Details::WORKFLOW_PATH)
-      end
+      @created_project = @project.save
 
-      notify_team_leaders
-
-      redirect_to project_path(@project), notice: I18n.t("conversion_project.voluntary.create.success")
+      notify_team_leaders(@created_project)
+      redirect_to project_path(@created_project), notice: I18n.t("conversion_project.voluntary.create.success")
     else
       render :new
     end

--- a/app/controllers/conversion/voluntary/projects_controller.rb
+++ b/app/controllers/conversion/voluntary/projects_controller.rb
@@ -6,7 +6,6 @@ class Conversion::Voluntary::ProjectsController < Conversion::ProjectsController
     if @project.valid?
       @created_project = @project.save
 
-      notify_team_leaders(@created_project)
       redirect_to project_path(@created_project), notice: I18n.t("conversion_project.voluntary.create.success")
     else
       render :new

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -20,9 +20,9 @@ class ProjectsController < ApplicationController
     authorize @project
   end
 
-  private def notify_team_leaders
+  private def notify_team_leaders(project)
     User.team_leaders.each do |team_leader|
-      TeamLeaderMailer.new_project_created(team_leader, @project).deliver_later
+      TeamLeaderMailer.new_project_created(team_leader, project).deliver_later
     end
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -19,10 +19,4 @@ class ProjectsController < ApplicationController
     @project = Project.includes(sections: [:tasks]).find(params[:id])
     authorize @project
   end
-
-  private def notify_team_leaders(project)
-    User.team_leaders.each do |team_leader|
-      TeamLeaderMailer.new_project_created(team_leader, project).deliver_later
-    end
-  end
 end

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -56,4 +56,10 @@ class Conversion::CreateProjectForm
   private def year_for(value)
     value[1]
   end
+
+  private def notify_team_leaders(project)
+    User.team_leaders.each do |team_leader|
+      TeamLeaderMailer.new_project_created(team_leader, project).deliver_later
+    end
+  end
 end

--- a/app/forms/conversion/voluntary/create_project_form.rb
+++ b/app/forms/conversion/voluntary/create_project_form.rb
@@ -18,6 +18,7 @@ class Conversion::Voluntary::CreateProjectForm < Conversion::CreateProjectForm
       @note = Note.create(body: note_body, project: @project, user: user) if note_body
       Conversion::Voluntary::Details.create(project: @project)
       TaskListCreator.new.call(@project, workflow_root: Conversion::Voluntary::Details::WORKFLOW_PATH)
+      notify_team_leaders(@project)
     end
 
     @project

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,8 +7,6 @@ class Project < ApplicationRecord
   has_many :notes, dependent: :destroy
   has_many :contacts, dependent: :destroy
 
-  accepts_nested_attributes_for :notes, reject_if: proc { |attributes| attributes[:body].blank? }
-
   validates :urn, presence: true
   validates :urn, urn: true
   validates :incoming_trust_ukprn, presence: true

--- a/app/views/conversion/involuntary/projects/new.html.erb
+++ b/app/views/conversion/involuntary/projects/new.html.erb
@@ -17,12 +17,9 @@
       <%= form.govuk_date_field :provisional_conversion_date, omit_day: true, form_group: {id: "provisional-conversion-date"} %>
       <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m"} %>
       <%= form.govuk_text_field :trust_sharepoint_link, label: {size: "m"} %>
-
-      <%= form.fields_for :note, @note do |note_form| %>
-        <%= note_form.govuk_text_area :body,
-              label: {text: t("project.new.handover_comments_label"), size: "m"},
-              hint: {text: t("project.new.handover_comments_hint").html_safe} %>
-      <% end %>
+      <%= form.govuk_text_area :note_body,
+            label: {text: t("project.new.handover_comments_label"), size: "m"},
+            hint: {text: t("project.new.handover_comments_hint").html_safe} %>
 
       <%= form.govuk_submit %>
     <% end %>

--- a/app/views/conversion/voluntary/projects/new.html.erb
+++ b/app/views/conversion/voluntary/projects/new.html.erb
@@ -17,12 +17,9 @@
       <%= form.govuk_date_field :provisional_conversion_date, omit_day: true, form_group: {id: "provisional-conversion-date"} %>
       <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m"} %>
       <%= form.govuk_text_field :trust_sharepoint_link, label: {size: "m"} %>
-
-      <%= form.fields_for :note, @note do |note_form| %>
-        <%= note_form.govuk_text_area :body,
-              label: {text: t("project.new.handover_comments_label"), size: "m"},
-              hint: {text: t("project.new.handover_comments_hint").html_safe} %>
-      <% end %>
+      <%= form.govuk_text_area :note_body,
+            label: {text: t("project.new.handover_comments_label"), size: "m"},
+            hint: {text: t("project.new.handover_comments_hint").html_safe} %>
 
       <%= form.govuk_submit %>
     <% end %>

--- a/spec/factories/conversion/create_project_form_factory.rb
+++ b/spec/factories/conversion/create_project_form_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/establishment-folder" }
     trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }
     user { association :user, :regional_delivery_officer }
+    note_body { "A note" }
   end
 
   factory :create_involuntary_project_form, parent: :create_project_form, class: "Conversion::Involuntary::CreateProjectForm" do

--- a/spec/forms/conversion/involuntary/create_project_form_spec.rb
+++ b/spec/forms/conversion/involuntary/create_project_form_spec.rb
@@ -6,4 +6,24 @@ RSpec.describe Conversion::Involuntary::CreateProjectForm, type: :model do
   let(:details_class) { "Conversion::Involuntary::Details" }
 
   it_behaves_like "a conversion project FormObject"
+
+  context "when the project is successfully created" do
+    let(:establishment) { build(:academies_api_establishment) }
+    before do
+      mock_successful_api_establishment_response(urn: 123456, establishment:)
+      mock_successful_api_trust_response(ukprn: 10061021)
+
+      ActiveJob::Base.queue_adapter = :test
+      ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    end
+
+    it "does not send a notification to team leaders" do
+      _team_leader = create(:user, :team_leader)
+      _another_team_leader = create(:user, :team_leader)
+
+      _project = build(:create_involuntary_project_form).save
+
+      expect(ActionMailer::MailDeliveryJob).to_not(have_been_enqueued)
+    end
+  end
 end

--- a/spec/forms/conversion/voluntary/create_project_form_spec.rb
+++ b/spec/forms/conversion/voluntary/create_project_form_spec.rb
@@ -6,4 +6,29 @@ RSpec.describe Conversion::Voluntary::CreateProjectForm, type: :model do
   let(:details_class) { "Conversion::Voluntary::Details" }
 
   it_behaves_like "a conversion project FormObject"
+
+  context "when the project is successfully created" do
+    let(:establishment) { build(:academies_api_establishment) }
+    before do
+      mock_successful_api_establishment_response(urn: 123456, establishment:)
+      mock_successful_api_trust_response(ukprn: 10061021)
+
+      ActiveJob::Base.queue_adapter = :test
+      ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    end
+
+    it "sends a notification to team leaders" do
+      team_leader = create(:user, :team_leader)
+      another_team_leader = create(:user, :team_leader)
+
+      project = build(:create_voluntary_project_form).save
+
+      expect(ActionMailer::MailDeliveryJob)
+        .to(have_been_enqueued.on_queue("default")
+        .with("TeamLeaderMailer", "new_project_created", "deliver_now", args: [team_leader, project]))
+      expect(ActionMailer::MailDeliveryJob)
+        .to(have_been_enqueued.on_queue("default")
+        .with("TeamLeaderMailer", "new_project_created", "deliver_now", args: [another_team_leader, project]))
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -24,31 +24,6 @@ RSpec.describe Project, type: :model do
     it { is_expected.to belong_to(:caseworker).required(false) }
     it { is_expected.to belong_to(:team_leader).required(false) }
 
-    describe "accept nested attributes for note" do
-      let(:user) { create(:user) }
-      let(:note_attributes) { attributes_for(:note, body: note_body, project: nil, user: user) }
-      let(:project_attributes) { attributes_for(:conversion_project) }
-
-      before { Project.create!(**project_attributes, notes_attributes: [note_attributes]) }
-
-      context "when the note body is blank" do
-        let(:note_body) { nil }
-
-        it "does not save the note" do
-          expect(Note.count).to be 0
-        end
-      end
-
-      context "when the note body is not blank" do
-        let(:note_body) { "A new note" }
-
-        it "saves the note" do
-          expect(Note.count).to be 1
-          expect(Note.last.body).to eq note_body
-        end
-      end
-    end
-
     describe "delete related entities" do
       context "when the project is deleted" do
         it "destroys all the related notes, contacts, sections leaving nothing orphaned" do

--- a/spec/requests/conversion/involuntary/projects_controller_spec.rb
+++ b/spec/requests/conversion/involuntary/projects_controller_spec.rb
@@ -4,7 +4,18 @@ RSpec.describe Conversion::Involuntary::ProjectsController, type: :request do
   let(:regional_delivery_officer) { create(:user, :regional_delivery_officer) }
   let(:create_path) { conversion_involuntary_new_path }
   let(:workflow_root) { Conversion::Involuntary::Details::WORKFLOW_PATH }
-  let(:this_controller) { Conversion::Involuntary::ProjectsController }
+  let(:form_class) { Conversion::Involuntary::CreateProjectForm }
+  let(:project_form) { build(:create_involuntary_project_form) }
+  let(:project_form_params) {
+    attributes_for(:create_involuntary_project_form,
+      "provisional_conversion_date(3i)": "1",
+      "provisional_conversion_date(2i)": "1",
+      "provisional_conversion_date(1i)": "2030",
+      "advisory_board_date(3i)": "1",
+      "advisory_board_date(2i)": "1",
+      "advisory_board_date(1i)": "2022",
+      regional_delivery_officer: nil)
+  }
 
   before do
     sign_in_with(regional_delivery_officer)
@@ -14,13 +25,19 @@ RSpec.describe Conversion::Involuntary::ProjectsController, type: :request do
 
   describe "notifications" do
     context "when a new involuntary conversion project is created" do
-      it "does not send a notification to team leaders" do
+      before do
         mock_successful_api_responses(urn: 123456, ukprn: 10061021)
-        project_params = attributes_for(:conversion_project)
+        project = create(:involuntary_conversion_project)
+        create_project_form = build(:create_involuntary_project_form)
+        allow(Conversion::Involuntary::CreateProjectForm).to receive(:new).and_return(create_project_form)
+        allow(create_project_form).to receive(:save).and_return(project)
+      end
+
+      it "does not send a notification to team leaders" do
         _team_leader = create(:user, :team_leader)
         _another_team_leader = create(:user, :team_leader)
 
-        post create_path, params: {conversion_project: {**project_params, note: {body: ""}}}
+        post create_path, params: {conversion_project: {**project_form_params, note: {body: ""}}}
 
         expect(ActionMailer::MailDeliveryJob).not_to(have_been_enqueued.on_queue("default"))
       end

--- a/spec/requests/conversion/involuntary/projects_controller_spec.rb
+++ b/spec/requests/conversion/involuntary/projects_controller_spec.rb
@@ -22,25 +22,4 @@ RSpec.describe Conversion::Involuntary::ProjectsController, type: :request do
   end
 
   it_behaves_like "a conversion project"
-
-  describe "notifications" do
-    context "when a new involuntary conversion project is created" do
-      before do
-        mock_successful_api_responses(urn: 123456, ukprn: 10061021)
-        project = create(:involuntary_conversion_project)
-        create_project_form = build(:create_involuntary_project_form)
-        allow(Conversion::Involuntary::CreateProjectForm).to receive(:new).and_return(create_project_form)
-        allow(create_project_form).to receive(:save).and_return(project)
-      end
-
-      it "does not send a notification to team leaders" do
-        _team_leader = create(:user, :team_leader)
-        _another_team_leader = create(:user, :team_leader)
-
-        post create_path, params: {conversion_project: {**project_form_params, note: {body: ""}}}
-
-        expect(ActionMailer::MailDeliveryJob).not_to(have_been_enqueued.on_queue("default"))
-      end
-    end
-  end
 end

--- a/spec/requests/conversion/voluntary/projects_controller_spec.rb
+++ b/spec/requests/conversion/voluntary/projects_controller_spec.rb
@@ -22,31 +22,4 @@ RSpec.describe Conversion::Voluntary::ProjectsController, type: :request do
   end
 
   it_behaves_like "a conversion project"
-
-  describe "notifications" do
-    context "when a new voluntary conversion project is created" do
-      before do
-        mock_successful_api_responses(urn: 123456, ukprn: 10061021)
-        project = create(:voluntary_conversion_project)
-        create_project_form = build(:create_voluntary_project_form)
-        allow(Conversion::Voluntary::CreateProjectForm).to receive(:new).and_return(create_project_form)
-        allow(create_project_form).to receive(:save).and_return(project)
-      end
-
-      it "sends a notification to team leaders" do
-        team_leader = create(:user, :team_leader)
-        another_team_leader = create(:user, :team_leader)
-        project_form_params = attributes_for(:create_voluntary_project_form, user: regional_delivery_officer)
-
-        post create_path, params: {conversion_project: {**project_form_params, note: {body: ""}}}
-
-        expect(ActionMailer::MailDeliveryJob)
-          .to(have_been_enqueued.on_queue("default")
-          .with("TeamLeaderMailer", "new_project_created", "deliver_now", args: [team_leader, Project.last]))
-        expect(ActionMailer::MailDeliveryJob)
-          .to(have_been_enqueued.on_queue("default")
-          .with("TeamLeaderMailer", "new_project_created", "deliver_now", args: [another_team_leader, Project.last]))
-      end
-    end
-  end
 end

--- a/spec/requests/conversion/voluntary/projects_controller_spec.rb
+++ b/spec/requests/conversion/voluntary/projects_controller_spec.rb
@@ -4,7 +4,18 @@ RSpec.describe Conversion::Voluntary::ProjectsController, type: :request do
   let(:regional_delivery_officer) { create(:user, :regional_delivery_officer) }
   let(:create_path) { conversion_voluntary_new_path }
   let(:workflow_root) { Conversion::Voluntary::Details::WORKFLOW_PATH }
-  let(:this_controller) { Conversion::Voluntary::ProjectsController }
+  let(:form_class) { Conversion::Voluntary::CreateProjectForm }
+  let(:project_form) { build(:create_voluntary_project_form) }
+  let(:project_form_params) {
+    attributes_for(:create_voluntary_project_form,
+      "provisional_conversion_date(3i)": "1",
+      "provisional_conversion_date(2i)": "1",
+      "provisional_conversion_date(1i)": "2030",
+      "advisory_board_date(3i)": "1",
+      "advisory_board_date(2i)": "1",
+      "advisory_board_date(1i)": "2022",
+      regional_delivery_officer: nil)
+  }
 
   before do
     sign_in_with(regional_delivery_officer)
@@ -13,14 +24,21 @@ RSpec.describe Conversion::Voluntary::ProjectsController, type: :request do
   it_behaves_like "a conversion project"
 
   describe "notifications" do
-    context "when a new involuntary conversion project is created" do
-      it "sends a notification to team leaders" do
+    context "when a new voluntary conversion project is created" do
+      before do
         mock_successful_api_responses(urn: 123456, ukprn: 10061021)
-        project_params = attributes_for(:conversion_project)
+        project = create(:voluntary_conversion_project)
+        create_project_form = build(:create_voluntary_project_form)
+        allow(Conversion::Voluntary::CreateProjectForm).to receive(:new).and_return(create_project_form)
+        allow(create_project_form).to receive(:save).and_return(project)
+      end
+
+      it "sends a notification to team leaders" do
         team_leader = create(:user, :team_leader)
         another_team_leader = create(:user, :team_leader)
+        project_form_params = attributes_for(:create_voluntary_project_form, user: regional_delivery_officer)
 
-        post create_path, params: {conversion_project: {**project_params, note: {body: ""}}}
+        post create_path, params: {conversion_project: {**project_form_params, note: {body: ""}}}
 
         expect(ActionMailer::MailDeliveryJob)
           .to(have_been_enqueued.on_queue("default")

--- a/spec/support/shared_examples/conversion_project.rb
+++ b/spec/support/shared_examples/conversion_project.rb
@@ -3,19 +3,22 @@ require "rails_helper"
 RSpec.shared_examples "a conversion project" do
   describe "#create" do
     let(:project) { build(:conversion_project) }
-    let(:project_params) { attributes_for(:conversion_project, regional_delivery_officer: nil) }
     let(:note_params) { {body: "new note"} }
     let!(:team_leader) { create(:user, :team_leader) }
 
     subject(:perform_request) do
-      post create_path, params: {conversion_project: {**project_params, note: note_params}}
+      post create_path, params: {conversion_project: {**project_form_params, note: note_params}}
       response
+    end
+
+    before do
+      mock_successful_api_responses(urn: any_args, ukprn: any_args)
     end
 
     context "when the project is not valid" do
       before do
-        allow(Project).to receive(:new).and_return(project)
-        allow(project).to receive(:valid?).and_return false
+        allow(form_class).to receive(:new).and_return(project_form)
+        allow(project_form).to receive(:valid?).and_return false
       end
 
       it "re-renders the new template" do

--- a/spec/support/shared_examples/conversion_project.rb
+++ b/spec/support/shared_examples/conversion_project.rb
@@ -3,11 +3,10 @@ require "rails_helper"
 RSpec.shared_examples "a conversion project" do
   describe "#create" do
     let(:project) { build(:conversion_project) }
-    let(:note_params) { {body: "new note"} }
     let!(:team_leader) { create(:user, :team_leader) }
 
     subject(:perform_request) do
-      post create_path, params: {conversion_project: {**project_form_params, note: note_params}}
+      post create_path, params: {conversion_project: {**project_form_params}}
       response
     end
 
@@ -52,7 +51,10 @@ RSpec.shared_examples "a conversion project" do
       end
 
       context "when the note body is empty" do
-        let(:note_params) { {body: ""} }
+        subject(:perform_request) do
+          post create_path, params: {conversion_project: {**project_form_params, note_body: ""}}
+          response
+        end
 
         it "does not create a new note" do
           expect(Note.count).to be 0


### PR DESCRIPTION
## Changes

Now that we have a FormObject pattern to create Involuntary & Voluntary conversion projects, change the form in the UI to submit the Project Create form to the FormObject. This will then handle creating the project, creating a note if one is required, and assigning the correct Tasklist to the project. 

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
