### PR TITLE
Add `TaskList::Base` class and basic `Conversion::Voluntary::TaskList`

### DIFF
--- a/app/models/conversion/voluntary/task_list.rb
+++ b/app/models/conversion/voluntary/task_list.rb
@@ -1,0 +1,16 @@
+class Conversion::Voluntary::TaskList < TaskList::Base
+  self.table_name = "conversion_voluntary_task_lists"
+
+  TASK_LIST_LAYOUT = [
+    {
+      identifier: :project_kick_off,
+      tasks: [
+        Conversion::Voluntary::Tasks::Handover
+      ]
+    }
+  ].freeze
+
+  def task_list_layout
+    TASK_LIST_LAYOUT
+  end
+end

--- a/app/models/conversion/voluntary/tasks/handover.rb
+++ b/app/models/conversion/voluntary/tasks/handover.rb
@@ -1,0 +1,5 @@
+class Conversion::Voluntary::Tasks::Handover < TaskList::Task
+  attribute :review
+  attribute :notes
+  attribute :meeting
+end

--- a/app/models/task_list/base.rb
+++ b/app/models/task_list/base.rb
@@ -13,8 +13,8 @@ class TaskList::Base < ActiveRecord::Base
     sections.map(&:tasks).flatten
   end
 
-  def task(key)
-    tasks.find { |task| task.class.key == key }
+  def task(identifier)
+    tasks.find { |task| task.class.identifier == identifier }
   end
 
   def save_task(task)
@@ -28,11 +28,11 @@ class TaskList::Base < ActiveRecord::Base
 
   private def attributes_for_task(task)
     attributes
-      .select { |key| key.start_with?(task.key) }
-      .transform_keys { |key| key.sub("#{task.key}_", "") }
+      .select { |key| key.start_with?(task.identifier) }
+      .transform_keys { |key| key.sub("#{task.identifier}_", "") }
   end
 
   private def attributes_for_task_list(task)
-    task.attributes.transform_keys { |key| "#{task.class.key}_#{key}" }
+    task.attributes.transform_keys { |key| "#{task.class.identifier}_#{key}" }
   end
 end

--- a/app/models/task_list/base.rb
+++ b/app/models/task_list/base.rb
@@ -1,0 +1,38 @@
+class TaskList::Base < ActiveRecord::Base
+  self.abstract_class = true
+
+  def sections
+    task_list_layout.map do |section|
+      tasks = section[:tasks].map { |task| task.new(attributes_for_task(task)) }
+
+      TaskList::Section.new(identifier: section[:identifier], tasks: tasks)
+    end
+  end
+
+  def tasks
+    sections.map(&:tasks).flatten
+  end
+
+  def task(key)
+    tasks.find { |task| task.class.key == key }
+  end
+
+  def save_task(task)
+    assign_attributes(attributes_for_task_list(task))
+    save!
+  end
+
+  def task_list_layout
+    raise NoMethodError, "Task lists must define a `#task_list_layout`."
+  end
+
+  private def attributes_for_task(task)
+    attributes
+      .select { |key| key.start_with?(task.key) }
+      .transform_keys { |key| key.sub("#{task.key}_", "") }
+  end
+
+  private def attributes_for_task_list(task)
+    task.attributes.transform_keys { |key| "#{task.class.key}_#{key}" }
+  end
+end

--- a/app/models/task_list/section.rb
+++ b/app/models/task_list/section.rb
@@ -1,0 +1,8 @@
+class TaskList::Section
+  attr_accessor :identifier, :tasks
+
+  def initialize(identifier:, tasks:)
+    @identifier = identifier
+    @tasks = tasks
+  end
+end

--- a/app/models/task_list/task.rb
+++ b/app/models/task_list/task.rb
@@ -6,10 +6,6 @@ class TaskList::Task
     def identifier
       name.split("::").last.underscore
     end
-
-    def humanized_name
-      identifier.humanize
-    end
   end
 
   def status

--- a/app/models/task_list/task.rb
+++ b/app/models/task_list/task.rb
@@ -3,12 +3,12 @@ class TaskList::Task
   include ActiveModel::Attributes
 
   class << self
-    def key
+    def identifier
       name.split("::").last.underscore
     end
 
     def humanized_name
-      key.humanize
+      identifier.humanize
     end
   end
 

--- a/db/migrate/20221212121642_add_conversion_voluntary_task_lists.rb
+++ b/db/migrate/20221212121642_add_conversion_voluntary_task_lists.rb
@@ -1,0 +1,11 @@
+class AddConversionVoluntaryTaskLists < ActiveRecord::Migration[7.0]
+  def change
+    create_table :conversion_voluntary_task_lists, id: :uuid do |t|
+      t.boolean :handover_review
+      t.boolean :handover_notes
+      t.boolean :handover_meeting
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_24_153430) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_12_121642) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -42,6 +42,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_24_153430) do
   create_table "conversion_details", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "type"
     t.uuid "project_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+    t.boolean "handover_review"
+    t.boolean "handover_notes"
+    t.boolean "handover_meeting"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/models/conversion/voluntary/task_list_spec.rb
+++ b/spec/models/conversion/voluntary/task_list_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe Conversion::Voluntary::TaskList do
   end
 
   describe "#task" do
-    it "returns a single task by its key" do
+    it "returns a single task by its identifier" do
       task_list = Conversion::Voluntary::TaskList.create!
-      task_key = "handover"
+      task_identifier = "handover"
 
-      task = task_list.task(task_key)
+      task = task_list.task(task_identifier)
 
       expect(task).to be_an_instance_of(Conversion::Voluntary::Tasks::Handover)
     end
@@ -37,9 +37,9 @@ RSpec.describe Conversion::Voluntary::TaskList do
       task_list = Conversion::Voluntary::TaskList.create!(
         handover_review: true
       )
-      task_key = "handover"
+      task_identifier = "handover"
 
-      task = task_list.task(task_key)
+      task = task_list.task(task_identifier)
 
       task.assign_attributes(review: false)
       task_list.save_task(task)

--- a/spec/models/conversion/voluntary/task_list_spec.rb
+++ b/spec/models/conversion/voluntary/task_list_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe Conversion::Voluntary::TaskList do
+  describe "#sections" do
+    it "returns all sections with tasks" do
+      task_list = Conversion::Voluntary::TaskList.create!
+
+      first_section = task_list.sections.first
+
+      expect(first_section).to be_an_instance_of(TaskList::Section)
+      expect(first_section.identifier).to be :project_kick_off
+      expect(first_section.tasks.first).to be_an_instance_of(Conversion::Voluntary::Tasks::Handover)
+    end
+  end
+
+  describe "#tasks" do
+    it "returns a flattened array of the tasks for all sections" do
+      task_list = Conversion::Voluntary::TaskList.create!
+
+      expect(task_list.tasks.first).to be_an_instance_of(Conversion::Voluntary::Tasks::Handover)
+    end
+  end
+
+  describe "#task" do
+    it "returns a single task by its key" do
+      task_list = Conversion::Voluntary::TaskList.create!
+      task_key = "handover"
+
+      task = task_list.task(task_key)
+
+      expect(task).to be_an_instance_of(Conversion::Voluntary::Tasks::Handover)
+    end
+  end
+
+  describe "#save_task" do
+    it "saves the attributes for the task" do
+      task_list = Conversion::Voluntary::TaskList.create!(
+        handover_review: true
+      )
+      task_key = "handover"
+
+      task = task_list.task(task_key)
+
+      task.assign_attributes(review: false)
+      task_list.save_task(task)
+
+      expect(task_list.reload.handover_review).to be false
+    end
+  end
+
+  describe "#task_list_layout" do
+    context "when undefined" do
+      let(:task_list_dup) { Conversion::Voluntary::TaskList.dup }
+      let(:error_message) { "Task lists must define a `#task_list_layout`." }
+
+      before { task_list_dup.remove_method(:task_list_layout) }
+
+      it "raises a #{NoMethodError}" do
+        expect { task_list_dup.new.task_list_layout }.to raise_error(NoMethodError, error_message)
+      end
+    end
+  end
+end

--- a/spec/models/task_list/task_spec.rb
+++ b/spec/models/task_list/task_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe TaskList::Task, type: :model do
   let(:testing_model) { Conversion::Voluntary::TestingClass }
   let(:testing_model_instance) { testing_model.new }
 
-  describe ".key" do
-    subject { testing_model.key }
+  describe ".identifier" do
+    subject { testing_model.identifier }
 
-    it "returns a snake_case key based on the class name" do
+    it "returns a snake_case identifier based on the class name" do
       expect(subject).to eq("testing_class")
     end
   end

--- a/spec/models/task_list/task_spec.rb
+++ b/spec/models/task_list/task_spec.rb
@@ -12,14 +12,6 @@ RSpec.describe TaskList::Task, type: :model do
     end
   end
 
-  describe ".humanized_name" do
-    subject { testing_model.humanized_name }
-
-    it "returns a humanized name based on the class name" do
-      expect(subject).to eq("Testing class")
-    end
-  end
-
   describe "#status" do
     subject { testing_model_instance.status }
 


### PR DESCRIPTION
## Changes
### Add `TaskList::Base` class and basic `Conversion::Voluntary::TaskList`
We want an easy way to create different types of task list by defining a
task list layout composed of `TaskList::Task` objects.

The `TaskList::Base` class handles the mapping of the `TaskList::Task` objects
to the task list database table. This uses the `TaskList::Task` key/identifier,
which must be named consistently with the database columns. For example, a task
list containing a `TaskList::Task` named
`Conversion::Voluntary::Tasks::Handover` which has a `review` attribute, must
have a column named `handover_review`.

For now, the base class is tested through an instance of a
`Conversion::Voluntary::TaskList`. As we introduce more task list types, this
will likely be moved into a shared spec.

### Rename `TaskList::Task.key` to `identifier`
Rename the `key` method of the `Task` class so that:
- It's more consistent with the `Section` model.
- It's not confused with a key for a Ruby Hash.

### Remove `TaskList::Task.humanized_name`
We plan to use locales to store the task name instead.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
