### PR TITLE
(934) Send notification to caseworker when assigned to a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 #### Added
 
+- Send notification to caseworker when assigned to a project
+
 #### Changed
 
 - Church supplemental guidance link now points to specific guidance rather than

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -31,6 +31,8 @@ class AssignmentsController < ApplicationController
     @project.update(caseworker_assigned_at: DateTime.now) if @project.caseworker_assigned_at.nil?
     @project.update(caseworker_params)
 
+    CaseworkerMailer.caseworker_assigned_notification(@project.caseworker, @project).deliver_later
+
     redirect_to project_information_path(@project), notice: t("project.assign.caseworker.success")
   end
 

--- a/app/mailers/caseworker_mailer.rb
+++ b/app/mailers/caseworker_mailer.rb
@@ -1,0 +1,12 @@
+class CaseworkerMailer < ApplicationMailer
+  def caseworker_assigned_notification(caseworker, project)
+    template_mail(
+      "ec6823ec-0aae-439b-b2f9-c626809b7c61",
+      to: caseworker.email,
+      personalisation: {
+        first_name: caseworker.first_name,
+        project_url: project_information_url(project.id)
+      }
+    )
+  end
+end

--- a/spec/mailers/caseworker_mailer_spec.rb
+++ b/spec/mailers/caseworker_mailer_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe CaseworkerMailer do
+  describe "#caseworker_assigned_notification" do
+    let(:caseworker) { create(:user, :caseworker) }
+    let(:project) { create(:conversion_project) }
+    let(:template_id) { "ec6823ec-0aae-439b-b2f9-c626809b7c61" }
+    let(:expected_personalisation) { {first_name: caseworker.first_name, project_url: project_information_url(project.id)} }
+
+    subject(:send_mail) { described_class.caseworker_assigned_notification(caseworker, project).deliver_now }
+
+    before { mock_successful_api_responses(urn: 123456, ukprn: 10061021) }
+
+    it "sends an email with the correct personalisation" do
+      expect_any_instance_of(Mail::Notify::Mailer)
+        .to receive(:template_mail)
+        .with(template_id, {to: caseworker.email, personalisation: expected_personalisation})
+
+      send_mail
+    end
+  end
+end

--- a/spec/requests/assignments_controller_spec.rb
+++ b/spec/requests/assignments_controller_spec.rb
@@ -145,5 +145,13 @@ RSpec.describe AssignmentsController, type: :request do
       expect(project.reload.caseworker).to eq caseworker
       expect(project.reload.caseworker_assigned_at).to eq DateTime.now
     end
+
+    it "sends a notification to the caseworker" do
+      perform_request
+
+      expect(ActionMailer::MailDeliveryJob)
+        .to(have_been_enqueued.on_queue("default")
+        .with("CaseworkerMailer", "caseworker_assigned_notification", "deliver_now", args: [caseworker, Project.last]))
+    end
   end
 end


### PR DESCRIPTION
## Changes

When a caseworker is assigned to a project, they will receive an email notification informing them of the assignment along with a link to the project.
The email template has been set up in `Notify`

Currently an email is sent when a reassignment is made, even if it that reassignment is to the same caseworker that is already the current caseworker. I don't necessarily think this is a problem, but it's worth noting. 

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
