### PR TITLE
932 rarely used legal docs have consistent confirm and signed actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 #### Content
 
 - Fix typo on phase banner feeback becomes feedback
+- 125 year lease, subleases, tenancy at will and commercial transfer agreement
+  have standardised actions that use the same language
 
 ## [Release 9][release-9]
 

--- a/app/workflows/lists/conversion/involuntary/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/involuntary/sections/clear-legal-docs.yml
@@ -411,15 +411,16 @@ tasks:
         title: Confirm the Tenancy at will has been signed
       - type: single-checkbox
         title:
-          Email the trust to ask if they have agreed and signed the Tenancy at
-          will
+          Email the trust to ask if all relevant parties have agreed and signed
+          the Tenancy at will
       - type: single-checkbox
         title:
-          Receive email from the trust confirming the Tenancy at will has all
-          relevant signatures
+          Receive email from the trust confirming all relevant parties have
+          agreed and signed the Tenancy at will
       - type: single-checkbox
         title:
-          Save a copy of the confirmation email in school's SharePoint folder
+          Save a copy of the confirmation email in the school's SharePoint
+          folder
 
   - slug: commercial-transfer-agreement
     title: Commercial transfer agreement

--- a/app/workflows/lists/conversion/involuntary/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/involuntary/sections/clear-legal-docs.yml
@@ -389,15 +389,16 @@ tasks:
         title: Confirm any subleases have been signed
       - type: single-checkbox
         title:
-          Email the trust to check all relevant parties have signed any
-          subleases
+          Email the trust to ask if all relevant parties have agreed and signed
+          any subleases
       - type: single-checkbox
         title:
-          Receive email from the trust confirming any subleases are agreed and
-          signed
+          Receive email from the trust confirming all relevant parties have
+          agreed and signed any subleases
       - type: single-checkbox
         title:
-          Save a copy of the confirmation email in school's SharePoint folder
+          Save a copy of the confirmation email in the school's SharePoint
+          folder
 
   - slug: tenancy-at-will
     title: Tenancy at will

--- a/app/workflows/lists/conversion/involuntary/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/involuntary/sections/clear-legal-docs.yml
@@ -429,10 +429,11 @@ tasks:
       projects.
     actions:
       - title:
-          Email the trust to ask if they have agreed and signed the Commercial
-          transfer agreement
+          Email the trust to ask if all relevant parties have agreed and signed
+          the Commercial transfer agreement
       - title:
-          Receive email from the trust confirming the Commercial transfer
-          agreement has relevant signatures
+          Receive email from the trust confirming all relevant parties have
+          agreed and signed the Commercial transfer agreement
       - title:
-          Save a copy of the confirmation email in school's SharePoint folder
+          Save a copy of the confirmation email in the school's SharePoint
+          folder

--- a/app/workflows/lists/conversion/involuntary/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/involuntary/sections/clear-legal-docs.yml
@@ -356,14 +356,15 @@ tasks:
         title: Confirm the 125 year lease has been signed
       - type: single-checkbox
         title:
-          Email the trust to check all relevant parties have signed the 125 year
-          lease
+          Email the trust to ask if all relevant parties have agreed and signed
+          the 125 year lease
       - title:
-          Receive email from the trust confirming the 125 year lease is agreed
-          and signed
+          Receive email from the trust confirming all relevant parties have
+          agreed and signed the 125 year lease
       - type: single-checkbox
         title:
-          Save a copy of the confirmation email in school's SharePoint folder
+          Save a copy of the confirmation email in the school's SharePoint
+          folder
 
   - slug: subleases
     title: Subleases

--- a/app/workflows/lists/conversion/voluntary/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/voluntary/sections/clear-legal-docs.yml
@@ -429,10 +429,11 @@ tasks:
       projects.
     actions:
       - title:
-          Email the school to ask if they have agreed and signed the Commercial
-          transfer agreement
+          Email the school to ask if all relevant parties have agreed and signed
+          the Commercial transfer agreement
       - title:
-          Receive email from the school confirming the Commercial transfer
-          agreement has relevant signatures
+          Receive email from the school confirming all relevant parties have
+          agreed and signed the Commercial transfer agreement
       - title:
-          Save a copy of the confirmation email in school's SharePoint folder
+          Save a copy of the confirmation email in the school's SharePoint
+          folder

--- a/app/workflows/lists/conversion/voluntary/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/voluntary/sections/clear-legal-docs.yml
@@ -389,15 +389,16 @@ tasks:
         title: Confirm any subleases have been signed
       - type: single-checkbox
         title:
-          Email the school to check all relevant parties have signed any
-          subleases
+          Email the school to ask if all relevant parties have agreed and signed
+          any subleases
       - type: single-checkbox
         title:
-          Receive email from the school confirming any subleases are agreed and
-          signed
+          Receive email from the school confirming all relevant parties have
+          agreed and signed any subleases
       - type: single-checkbox
         title:
-          Save a copy of the confirmation email in school's SharePoint folder
+          Save a copy of the confirmation email in the school's SharePoint
+          folder
 
   - slug: tenancy-at-will
     title: Tenancy at will

--- a/app/workflows/lists/conversion/voluntary/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/voluntary/sections/clear-legal-docs.yml
@@ -411,15 +411,16 @@ tasks:
         title: Confirm the Tenancy at will has been signed
       - type: single-checkbox
         title:
-          Email the school to ask if they have agreed and signed the Tenancy at
-          will
+          Email the school to ask if all relevant parties have agreed and signed
+          the Tenancy at will
       - type: single-checkbox
         title:
-          Receive email from the school confirming the Tenancy at will has all
-          relevant signatures
+          Receive email from the school confirming all relevant parties have
+          agreed and signed the Tenancy at will
       - type: single-checkbox
         title:
-          Save a copy of the confirmation email in school's SharePoint folder
+          Save a copy of the confirmation email in the school's SharePoint
+          folder
 
   - slug: commercial-transfer-agreement
     title: Commercial transfer agreement

--- a/app/workflows/lists/conversion/voluntary/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/voluntary/sections/clear-legal-docs.yml
@@ -356,14 +356,15 @@ tasks:
         title: Confirm the 125 year lease has been signed
       - type: single-checkbox
         title:
-          Email the school to check all relevant parties have signed the 125
-          year lease
+          Email the school to ask if all relevant parties have agreed and signed
+          the 125 year lease
       - title:
-          Receive email from the school confirming the 125 year lease is agreed
-          and signed
+          Receive email from the school confirming all relevant parties have
+          agreed and signed the 125 year lease
       - type: single-checkbox
         title:
-          Save a copy of the confirmation email in school's SharePoint folder
+          Save a copy of the confirmation email in the school's SharePoint
+          folder
 
   - slug: subleases
     title: Subleases


### PR DESCRIPTION
## Changes

125 year lease, subleases, commercial transfer agreement and tenancy at will actions follow the following format:

- Email the school to ask if all relevant parties have agreed and signed DOCUMENT
- Receive email from the school confirming all relevant parties have agreed and signed DOCUMENT
- Save a copy of the confirmation email in the school's SharePoint folder

This applies for both voluntary and involuntary routes.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
