### PR TITLE
Add TaskList association to Project

### DIFF
--- a/app/forms/conversion/involuntary/create_project_form.rb
+++ b/app/forms/conversion/involuntary/create_project_form.rb
@@ -8,7 +8,8 @@ class Conversion::Involuntary::CreateProjectForm < Conversion::CreateProjectForm
       advisory_board_conditions: advisory_board_conditions,
       provisional_conversion_date: provisional_conversion_date,
       advisory_board_date: advisory_board_date,
-      regional_delivery_officer_id: user.id
+      regional_delivery_officer_id: user.id,
+      task_list: Conversion::Involuntary::TaskList.new
     )
 
     return nil unless valid?

--- a/app/forms/conversion/voluntary/create_project_form.rb
+++ b/app/forms/conversion/voluntary/create_project_form.rb
@@ -8,7 +8,8 @@ class Conversion::Voluntary::CreateProjectForm < Conversion::CreateProjectForm
       advisory_board_conditions: advisory_board_conditions,
       provisional_conversion_date: provisional_conversion_date,
       advisory_board_date: advisory_board_date,
-      regional_delivery_officer_id: user.id
+      regional_delivery_officer_id: user.id,
+      task_list: Conversion::Voluntary::TaskList.new
     )
 
     return nil unless valid?

--- a/app/models/concerns/task_list.rb
+++ b/app/models/concerns/task_list.rb
@@ -1,0 +1,7 @@
+module TaskList
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :project, as: :task_list, touch: true
+  end
+end

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -1,0 +1,16 @@
+class Conversion::Involuntary::TaskList < TaskList::Base
+  self.table_name = "conversion_involuntary_task_lists"
+
+  TASK_LIST_LAYOUT = [
+    {
+      identifier: :project_kick_off,
+      tasks: [
+        Conversion::Involuntary::Tasks::Handover
+      ]
+    }
+  ].freeze
+
+  def task_list_layout
+    TASK_LIST_LAYOUT
+  end
+end

--- a/app/models/conversion/involuntary/tasks/handover.rb
+++ b/app/models/conversion/involuntary/tasks/handover.rb
@@ -1,0 +1,3 @@
+class Conversion::Involuntary::Tasks::Handover < TaskList::Task
+  attribute :review
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,6 +3,8 @@ class Project < ApplicationRecord
 
   attr_writer :establishment, :incoming_trust
 
+  delegated_type :task_list, types: %w[ Conversion::Voluntary::TaskList ], dependent: :destroy
+
   has_many :sections, dependent: :destroy
   has_many :notes, dependent: :destroy
   has_many :contacts, dependent: :destroy

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,7 +3,7 @@ class Project < ApplicationRecord
 
   attr_writer :establishment, :incoming_trust
 
-  delegated_type :task_list, types: %w[ Conversion::Voluntary::TaskList ], dependent: :destroy
+  delegated_type :task_list, types: %w[Conversion::Voluntary::TaskList, Conversion::Involuntary::TaskList], dependent: :destroy
 
   has_many :sections, dependent: :destroy
   has_many :notes, dependent: :destroy

--- a/app/models/task_list/base.rb
+++ b/app/models/task_list/base.rb
@@ -1,4 +1,6 @@
 class TaskList::Base < ActiveRecord::Base
+  include TaskList
+
   self.abstract_class = true
 
   def sections

--- a/db/migrate/20221214132249_add_task_list_to_project.rb
+++ b/db/migrate/20221214132249_add_task_list_to_project.rb
@@ -1,0 +1,6 @@
+class AddTaskListToProject < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :task_list_id, :uuid
+    add_column :projects, :task_list_type, :string
+  end
+end

--- a/db/migrate/20221214134847_create_conversion_involuntary_task_list.rb
+++ b/db/migrate/20221214134847_create_conversion_involuntary_task_list.rb
@@ -1,0 +1,8 @@
+class CreateConversionInvoluntaryTaskList < ActiveRecord::Migration[7.0]
+  def change
+    create_table :conversion_involuntary_task_lists, id: :uuid do |t|
+      t.boolean :handover_review
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_14_132249) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_14_134847) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -42,6 +42,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_14_132249) do
   create_table "conversion_details", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "type"
     t.uuid "project_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "conversion_involuntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+    t.boolean "handover_review"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_12_121642) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_14_132249) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -82,6 +82,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_12_121642) do
     t.datetime "completed_at"
     t.text "trust_sharepoint_link"
     t.string "type"
+    t.uuid "task_list_id"
+    t.string "task_list_type"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"
     t.index ["team_leader_id"], name: "index_projects_on_team_leader_id"

--- a/spec/factories/conversion/involuntary/project_factory.rb
+++ b/spec/factories/conversion/involuntary/project_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     advisory_board_date { (Date.today - 2.weeks) }
     establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/establishment-folder" }
     trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }
+    task_list { association :conversion_involuntary_task_list }
 
     after :create do |project|
       create :involuntary_conversion_project_details, project: project

--- a/spec/factories/conversion/involuntary/task_list_factory.rb
+++ b/spec/factories/conversion/involuntary/task_list_factory.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :conversion_involuntary_task_list, class: "Conversion::Involuntary::TaskList" do
+  end
+end

--- a/spec/factories/conversion/project_factory.rb
+++ b/spec/factories/conversion/project_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     advisory_board_date { (Date.today - 2.weeks) }
     establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/establishment-folder" }
     trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }
+    task_list { association :voluntary_conversion_task_list }
 
     after :create do |project|
       create :voluntary_conversion_project_details, project: project

--- a/spec/factories/conversion/task_list_factory.rb
+++ b/spec/factories/conversion/task_list_factory.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :voluntary_conversion_task_list, class: "Conversion::Voluntary::TaskList" do
+  end
+end

--- a/spec/forms/conversion/involuntary/create_project_form_spec.rb
+++ b/spec/forms/conversion/involuntary/create_project_form_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Conversion::Involuntary::CreateProjectForm, type: :model do
   let(:form_factory) { "create_involuntary_project_form" }
   let(:workflow_path) { Conversion::Involuntary::Details::WORKFLOW_PATH }
   let(:details_class) { "Conversion::Involuntary::Details" }
+  let(:task_list_class) { Conversion::Involuntary::TaskList }
 
   it_behaves_like "a conversion project FormObject"
 

--- a/spec/forms/conversion/voluntary/create_project_form_spec.rb
+++ b/spec/forms/conversion/voluntary/create_project_form_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Conversion::Voluntary::CreateProjectForm, type: :model do
   let(:form_factory) { "create_voluntary_project_form" }
   let(:workflow_path) { Conversion::Voluntary::Details::WORKFLOW_PATH }
   let(:details_class) { "Conversion::Voluntary::Details" }
+  let(:task_list_class) { Conversion::Voluntary::TaskList }
 
   it_behaves_like "a conversion project FormObject"
 

--- a/spec/models/conversion/involuntary/task_list_spec.rb
+++ b/spec/models/conversion/involuntary/task_list_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe Conversion::Involuntary::TaskList do
+  describe "#sections" do
+    it "returns all sections with tasks" do
+      task_list = Conversion::Involuntary::TaskList.create!
+
+      first_section = task_list.sections.first
+
+      expect(first_section).to be_an_instance_of(TaskList::Section)
+      expect(first_section.identifier).to be :project_kick_off
+      expect(first_section.tasks.first).to be_an_instance_of(Conversion::Voluntary::Tasks::Handover)
+    end
+  end
+
+  describe "#tasks" do
+    it "returns a flattened array of the tasks for all sections" do
+      task_list = Conversion::Involuntary::TaskList.create!
+
+      expect(task_list.tasks.first).to be_an_instance_of(Conversion::Involuntary::Tasks::Handover)
+    end
+  end
+
+  describe "#task" do
+    it "returns a single task by its identifier" do
+      task_list = Conversion::Involuntary::TaskList.create!
+      task_identifier = "handover"
+
+      task = task_list.task(task_identifier)
+
+      expect(task).to be_an_instance_of(Conversion::Involuntary::Tasks::Handover)
+    end
+  end
+
+  describe "#save_task" do
+    it "saves the attributes for the task" do
+      task_list = Conversion::Involuntary::TaskList.create!(
+        handover_review: true
+      )
+      task_identifier = "handover"
+
+      task = task_list.task(task_identifier)
+
+      task.assign_attributes(review: false)
+      task_list.save_task(task)
+
+      expect(task_list.reload.handover_review).to be false
+    end
+  end
+
+  describe "#task_list_layout" do
+    context "when undefined" do
+      let(:task_list_dup) { Conversion::Involuntary::TaskList.dup }
+      let(:error_message) { "Task lists must define a `#task_list_layout`." }
+
+      before { task_list_dup.remove_method(:task_list_layout) }
+
+      it "raises a #{NoMethodError}" do
+        expect { task_list_dup.new.task_list_layout }.to raise_error(NoMethodError, error_message)
+      end
+    end
+  end
+end

--- a/spec/models/conversion/involuntary/task_list_spec.rb
+++ b/spec/models/conversion/involuntary/task_list_spec.rb
@@ -1,63 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Conversion::Involuntary::TaskList do
-  describe "#sections" do
-    it "returns all sections with tasks" do
-      task_list = Conversion::Involuntary::TaskList.create!
+  let(:task_class) { Conversion::Involuntary::Tasks::Handover }
+  let(:task_list) {
+    Conversion::Involuntary::TaskList.create!(
+      handover_review: true
+    )
+  }
 
-      first_section = task_list.sections.first
-
-      expect(first_section).to be_an_instance_of(TaskList::Section)
-      expect(first_section.identifier).to be :project_kick_off
-      expect(first_section.tasks.first).to be_an_instance_of(Conversion::Voluntary::Tasks::Handover)
-    end
-  end
-
-  describe "#tasks" do
-    it "returns a flattened array of the tasks for all sections" do
-      task_list = Conversion::Involuntary::TaskList.create!
-
-      expect(task_list.tasks.first).to be_an_instance_of(Conversion::Involuntary::Tasks::Handover)
-    end
-  end
-
-  describe "#task" do
-    it "returns a single task by its identifier" do
-      task_list = Conversion::Involuntary::TaskList.create!
-      task_identifier = "handover"
-
-      task = task_list.task(task_identifier)
-
-      expect(task).to be_an_instance_of(Conversion::Involuntary::Tasks::Handover)
-    end
-  end
-
-  describe "#save_task" do
-    it "saves the attributes for the task" do
-      task_list = Conversion::Involuntary::TaskList.create!(
-        handover_review: true
-      )
-      task_identifier = "handover"
-
-      task = task_list.task(task_identifier)
-
-      task.assign_attributes(review: false)
-      task_list.save_task(task)
-
-      expect(task_list.reload.handover_review).to be false
-    end
-  end
-
-  describe "#task_list_layout" do
-    context "when undefined" do
-      let(:task_list_dup) { Conversion::Involuntary::TaskList.dup }
-      let(:error_message) { "Task lists must define a `#task_list_layout`." }
-
-      before { task_list_dup.remove_method(:task_list_layout) }
-
-      it "raises a #{NoMethodError}" do
-        expect { task_list_dup.new.task_list_layout }.to raise_error(NoMethodError, error_message)
-      end
-    end
-  end
+  it_behaves_like "a task list"
 end

--- a/spec/models/conversion/voluntary/task_list_spec.rb
+++ b/spec/models/conversion/voluntary/task_list_spec.rb
@@ -1,63 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Conversion::Voluntary::TaskList do
-  describe "#sections" do
-    it "returns all sections with tasks" do
-      task_list = Conversion::Voluntary::TaskList.create!
+  let(:task_class) { Conversion::Voluntary::Tasks::Handover }
+  let(:task_list) {
+    Conversion::Voluntary::TaskList.create!(
+      handover_review: true
+    )
+  }
 
-      first_section = task_list.sections.first
-
-      expect(first_section).to be_an_instance_of(TaskList::Section)
-      expect(first_section.identifier).to be :project_kick_off
-      expect(first_section.tasks.first).to be_an_instance_of(Conversion::Voluntary::Tasks::Handover)
-    end
-  end
-
-  describe "#tasks" do
-    it "returns a flattened array of the tasks for all sections" do
-      task_list = Conversion::Voluntary::TaskList.create!
-
-      expect(task_list.tasks.first).to be_an_instance_of(Conversion::Voluntary::Tasks::Handover)
-    end
-  end
-
-  describe "#task" do
-    it "returns a single task by its identifier" do
-      task_list = Conversion::Voluntary::TaskList.create!
-      task_identifier = "handover"
-
-      task = task_list.task(task_identifier)
-
-      expect(task).to be_an_instance_of(Conversion::Voluntary::Tasks::Handover)
-    end
-  end
-
-  describe "#save_task" do
-    it "saves the attributes for the task" do
-      task_list = Conversion::Voluntary::TaskList.create!(
-        handover_review: true
-      )
-      task_identifier = "handover"
-
-      task = task_list.task(task_identifier)
-
-      task.assign_attributes(review: false)
-      task_list.save_task(task)
-
-      expect(task_list.reload.handover_review).to be false
-    end
-  end
-
-  describe "#task_list_layout" do
-    context "when undefined" do
-      let(:task_list_dup) { Conversion::Voluntary::TaskList.dup }
-      let(:error_message) { "Task lists must define a `#task_list_layout`." }
-
-      before { task_list_dup.remove_method(:task_list_layout) }
-
-      it "raises a #{NoMethodError}" do
-        expect { task_list_dup.new.task_list_layout }.to raise_error(NoMethodError, error_message)
-      end
-    end
-  end
+  it_behaves_like "a task list"
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_many(:notes).dependent(:destroy) }
     it { is_expected.to belong_to(:caseworker).required(false) }
     it { is_expected.to belong_to(:team_leader).required(false) }
+    it { is_expected.to belong_to(:task_list).required(true) }
 
     describe "delete related entities" do
       context "when the project is deleted" do
@@ -39,11 +40,12 @@ RSpec.describe Project, type: :model do
 
           project.destroy
 
-          expect(Note.count).to eql 0
-          expect(Contact.count).to eql 0
-          expect(Section.count).to eql 0
-          expect(Task.count).to eql 0
-          expect(Action.count).to eql 0
+          expect(Note.count).to be_zero
+          expect(Contact.count).to be_zero
+          expect(Section.count).to be_zero
+          expect(Task.count).to be_zero
+          expect(Action.count).to be_zero
+          expect(Conversion::Voluntary::TaskList.count).to be_zero
         end
       end
     end

--- a/spec/support/shared_examples/create_conversion_project_form.rb
+++ b/spec/support/shared_examples/create_conversion_project_form.rb
@@ -118,6 +118,11 @@ RSpec.shared_examples "a conversion project FormObject" do
         expect(project.class.name).to eq("Conversion::Project")
       end
 
+      it "also creates a task list" do
+        project = build(form_factory.to_sym).save
+        expect(project.task_list).to be_a(task_list_class)
+      end
+
       it "creates a note if the note_body is not empty" do
         form = build(
           form_factory.to_sym,

--- a/spec/support/shared_examples/task_list.rb
+++ b/spec/support/shared_examples/task_list.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.shared_examples "a task list" do
+  describe "#sections" do
+    it "returns all sections with tasks" do
+      first_section = task_list.sections.first
+
+      expect(first_section).to be_an_instance_of(TaskList::Section)
+      expect(first_section.identifier).to be :project_kick_off
+      expect(first_section.tasks.first).to be_an_instance_of(task_class)
+    end
+  end
+
+  describe "#tasks" do
+    it "returns a flattened array of the tasks for all sections" do
+      expect(task_list.tasks.first).to be_an_instance_of(task_class)
+    end
+  end
+
+  describe "#task" do
+    it "returns a single task by its identifier" do
+      task_identifier = "handover"
+
+      task = task_list.task(task_identifier)
+
+      expect(task).to be_an_instance_of(task_class)
+    end
+  end
+
+  describe "#save_task" do
+    it "saves the attributes for the task" do
+      task_identifier = "handover"
+
+      task = task_list.task(task_identifier)
+
+      task.assign_attributes(review: false)
+      task_list.save_task(task)
+
+      expect(task_list.reload.handover_review).to be false
+    end
+  end
+
+  describe "#task_list_layout" do
+    context "when undefined" do
+      let(:task_list_dup) { task_list.class.dup }
+      let(:error_message) { "Task lists must define a `#task_list_layout`." }
+
+      before { task_list_dup.remove_method(:task_list_layout) }
+
+      it "raises a #{NoMethodError}" do
+        expect { task_list_dup.new.task_list_layout }.to raise_error(NoMethodError, error_message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are doing a bunch of work to bring the concept of the 'task list' into Ruby and allow it to be constructed of more data type than a simple checkbox value.

The model of `TaskList` has already been introduced, with a base that allows us the have different task lists backed by database tables. Here we joing our two main concepts up with a `Project` having a `TaskList` and so access to all of the attributes it stores.

We've chosen delegated types to achieve this 'reverse polymorphic' associtation, which is a relatively new feature of Rails that seems to fit our use case:

https://edgeapi.rubyonrails.org/classes/ActiveRecord/DelegatedType.html

In order to exercise this fully, we've added a really basic involuntary conversion task list with a single task and attribute, this is purely to give us confidence that eveything is working as anticipated and the task list will be fleshed out in comign work.

https://trello.com/c/PDB1zZpl