### PR TITLE
Correctly validate incomplete, invalid or missing multipart dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   validation error.
 - When resubmitting a create project form which failed validation, the app would
   throw a 500 error.
+- When creating a new project, missing or invalid dates will render a validation
+  error on the UI with a helpful message to the user.
 
 #### Content
 

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -35,13 +35,13 @@ class Conversion::CreateProjectForm
 
   def provisional_conversion_date=(hash)
     @provisional_conversion_date = Date.new(year_for(hash), month_for(hash), day_for(hash))
-  rescue NoMethodError
+  rescue TypeError, NoMethodError
     nil
   end
 
   def advisory_board_date=(hash)
     @advisory_board_date = Date.new(year_for(hash), month_for(hash), day_for(hash))
-  rescue NoMethodError
+  rescue TypeError, NoMethodError
     nil
   end
 

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -4,6 +4,8 @@ class Conversion::CreateProjectForm
 
   SHAREPOINT_URLS = %w[educationgovuk-my.sharepoint.com educationgovuk.sharepoint.com].freeze
 
+  class NegativeValueError < StandardError; end
+
   attr_accessor :urn,
     :incoming_trust_ukprn,
     :establishment_sharepoint_link,
@@ -41,7 +43,7 @@ class Conversion::CreateProjectForm
   end
 
   def provisional_conversion_date=(hash)
-    @provisional_conversion_date = Date.new(year_for(hash), month_for(hash), day_for(hash))
+    @provisional_conversion_date = Date.new(value_at_position(hash, 1), value_at_position(hash, 2), value_at_position(hash, 3))
   rescue NoMethodError
     nil
   rescue TypeError, Date::Error
@@ -49,23 +51,17 @@ class Conversion::CreateProjectForm
   end
 
   def advisory_board_date=(hash)
-    @advisory_board_date = Date.new(year_for(hash), month_for(hash), day_for(hash))
+    @advisory_board_date = Date.new(value_at_position(hash, 1), value_at_position(hash, 2), value_at_position(hash, 3))
   rescue NoMethodError
     nil
-  rescue TypeError, Date::Error
+  rescue TypeError, Date::Error, NegativeValueError
     @attributes_with_invalid_values << :advisory_board_date
   end
 
-  private def day_for(value)
-    value[3]
-  end
-
-  private def month_for(value)
-    value[2]
-  end
-
-  private def year_for(value)
-    value[1]
+  private def value_at_position(hash, position)
+    value = hash[position]
+    return NegativeValueError if value.to_i < 0
+    value
   end
 
   private def multiparameter_date_attributes_values

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -33,16 +33,27 @@ class Conversion::CreateProjectForm
   validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
   validates :trust_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
 
+  validate :multiparameter_date_attributes_values
+
+  def initialize(params = {})
+    @attributes_with_invalid_values = []
+    super(params)
+  end
+
   def provisional_conversion_date=(hash)
     @provisional_conversion_date = Date.new(year_for(hash), month_for(hash), day_for(hash))
-  rescue TypeError, NoMethodError
+  rescue NoMethodError
     nil
+  rescue TypeError
+    @attributes_with_invalid_values << :provisional_conversion_date
   end
 
   def advisory_board_date=(hash)
     @advisory_board_date = Date.new(year_for(hash), month_for(hash), day_for(hash))
-  rescue TypeError, NoMethodError
+  rescue NoMethodError
     nil
+  rescue TypeError
+    @attributes_with_invalid_values << :advisory_board_date
   end
 
   private def day_for(value)
@@ -55,6 +66,11 @@ class Conversion::CreateProjectForm
 
   private def year_for(value)
     value[1]
+  end
+
+  private def multiparameter_date_attributes_values
+    return if @attributes_with_invalid_values.empty?
+    @attributes_with_invalid_values.each { |attribute| errors.add(attribute, :invalid) }
   end
 
   private def notify_team_leaders(project)

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -44,7 +44,7 @@ class Conversion::CreateProjectForm
     @provisional_conversion_date = Date.new(year_for(hash), month_for(hash), day_for(hash))
   rescue NoMethodError
     nil
-  rescue TypeError
+  rescue TypeError, Date::Error
     @attributes_with_invalid_values << :provisional_conversion_date
   end
 
@@ -52,7 +52,7 @@ class Conversion::CreateProjectForm
     @advisory_board_date = Date.new(year_for(hash), month_for(hash), day_for(hash))
   rescue NoMethodError
     nil
-  rescue TypeError
+  rescue TypeError, Date::Error
     @attributes_with_invalid_values << :advisory_board_date
   end
 

--- a/spec/support/shared_examples/create_conversion_project_form.rb
+++ b/spec/support/shared_examples/create_conversion_project_form.rb
@@ -29,6 +29,34 @@ RSpec.shared_examples "a conversion project FormObject" do
         form.provisional_conversion_date = {3 => 1, 2 => 1, 1 => 2020}
         expect(form).to be_invalid
       end
+
+      context "when the date params are partially complete" do
+        it "treats the date as blank" do
+          form = build(form_factory.to_sym, provisional_conversion_date: {3 => 1, 2 => 10, 1 => nil})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:provisional_conversion_date, :blank)).to be true
+
+          form = build(form_factory.to_sym, provisional_conversion_date: {3 => 1, 2 => nil, 1 => 2022})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:provisional_conversion_date, :blank)).to be true
+        end
+      end
+
+      context "when the month and year are missing" do
+        it "treats the date as blank" do
+          form = build(form_factory.to_sym, provisional_conversion_date: {3 => 1, 2 => nil, 1 => nil})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:provisional_conversion_date, :blank)).to be true
+        end
+      end
+
+      context "when all the date parameters are missing" do
+        it "treats the date as blank" do
+          form = build(form_factory.to_sym, provisional_conversion_date: {3 => nil, 2 => nil, 1 => nil})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:provisional_conversion_date, :blank)).to be true
+        end
+      end
     end
 
     describe "advisory_board_date" do
@@ -54,6 +82,30 @@ RSpec.shared_examples "a conversion project FormObject" do
 
         form.advisory_board_date = {3 => 1, 2 => 1, 1 => 2030}
         expect(form).to be_invalid
+      end
+
+      context "when the date parameters are partially complete" do
+        it "treats the date as blank" do
+          form = build(form_factory.to_sym, advisory_board_date: {3 => nil, 2 => 10, 1 => 1})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :blank)).to be true
+
+          form = build(form_factory.to_sym, advisory_board_date: {3 => 2022, 2 => nil, 1 => 1})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :blank)).to be true
+
+          form = build(form_factory.to_sym, advisory_board_date: {3 => 2022, 2 => 10, 1 => nil})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :blank)).to be true
+        end
+      end
+
+      context "when all the date parameters are missing" do
+        it "treats the date as blank" do
+          form = build(form_factory.to_sym, advisory_board_date: {3 => nil, 2 => nil, 1 => nil})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :blank)).to be true
+        end
       end
 
       context "when no date value is set" do

--- a/spec/support/shared_examples/create_conversion_project_form.rb
+++ b/spec/support/shared_examples/create_conversion_project_form.rb
@@ -31,14 +31,14 @@ RSpec.shared_examples "a conversion project FormObject" do
       end
 
       context "when the date params are partially complete" do
-        it "treats the date as blank" do
+        it "treats the date as invalid" do
           form = build(form_factory.to_sym, provisional_conversion_date: {3 => 1, 2 => 10, 1 => nil})
           expect(form).to be_invalid
-          expect(form.errors.of_kind?(:provisional_conversion_date, :blank)).to be true
+          expect(form.errors.of_kind?(:provisional_conversion_date, :invalid)).to be true
 
           form = build(form_factory.to_sym, provisional_conversion_date: {3 => 1, 2 => nil, 1 => 2022})
           expect(form).to be_invalid
-          expect(form.errors.of_kind?(:provisional_conversion_date, :blank)).to be true
+          expect(form.errors.of_kind?(:provisional_conversion_date, :invalid)).to be true
         end
       end
 
@@ -85,18 +85,18 @@ RSpec.shared_examples "a conversion project FormObject" do
       end
 
       context "when the date parameters are partially complete" do
-        it "treats the date as blank" do
+        it "treats the date as invalid" do
           form = build(form_factory.to_sym, advisory_board_date: {3 => nil, 2 => 10, 1 => 1})
           expect(form).to be_invalid
-          expect(form.errors.of_kind?(:advisory_board_date, :blank)).to be true
+          expect(form.errors.of_kind?(:advisory_board_date, :invalid)).to be true
 
           form = build(form_factory.to_sym, advisory_board_date: {3 => 2022, 2 => nil, 1 => 1})
           expect(form).to be_invalid
-          expect(form.errors.of_kind?(:advisory_board_date, :blank)).to be true
+          expect(form.errors.of_kind?(:advisory_board_date, :invalid)).to be true
 
           form = build(form_factory.to_sym, advisory_board_date: {3 => 2022, 2 => 10, 1 => nil})
           expect(form).to be_invalid
-          expect(form.errors.of_kind?(:advisory_board_date, :blank)).to be true
+          expect(form.errors.of_kind?(:advisory_board_date, :invalid)).to be true
         end
       end
 

--- a/spec/support/shared_examples/create_conversion_project_form.rb
+++ b/spec/support/shared_examples/create_conversion_project_form.rb
@@ -68,6 +68,10 @@ RSpec.shared_examples "a conversion project FormObject" do
 
       context "when the isn't a date" do
         it "treats the date as invalid" do
+          form = build(form_factory.to_sym, provisional_conversion_date: {3 => -1, 2 => -1, 1 => 0})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:provisional_conversion_date, :invalid)).to be true
+
           form = build(form_factory.to_sym, provisional_conversion_date: {3 => "not", 2 => "a", 1 => "date"})
           expect(form).to be_invalid
           expect(form.errors.of_kind?(:provisional_conversion_date, :invalid)).to be true
@@ -142,6 +146,10 @@ RSpec.shared_examples "a conversion project FormObject" do
 
       context "when the isn't a date" do
         it "treats the date as invalid" do
+          form = build(form_factory.to_sym, advisory_board_date: {3 => -1, 2 => -1, 1 => 0})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :invalid)).to be true
+
           form = build(form_factory.to_sym, advisory_board_date: {3 => "not", 2 => "a", 1 => "date"})
           expect(form).to be_invalid
           expect(form.errors.of_kind?(:advisory_board_date, :invalid)).to be true

--- a/spec/support/shared_examples/create_conversion_project_form.rb
+++ b/spec/support/shared_examples/create_conversion_project_form.rb
@@ -57,6 +57,22 @@ RSpec.shared_examples "a conversion project FormObject" do
           expect(form.errors.of_kind?(:provisional_conversion_date, :blank)).to be true
         end
       end
+
+      context "when the date doesn't exist" do
+        it "treats the date as invalid" do
+          form = build(form_factory.to_sym, provisional_conversion_date: {3 => 31, 2 => 2, 1 => 2030})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:provisional_conversion_date, :invalid)).to be true
+        end
+      end
+
+      context "when the isn't a date" do
+        it "treats the date as invalid" do
+          form = build(form_factory.to_sym, provisional_conversion_date: {3 => "not", 2 => "a", 1 => "date"})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:provisional_conversion_date, :invalid)).to be true
+        end
+      end
     end
 
     describe "advisory_board_date" do
@@ -113,6 +129,22 @@ RSpec.shared_examples "a conversion project FormObject" do
           form = build(form_factory.to_sym, advisory_board_date: nil)
           expect(form).to be_invalid
           expect(form.errors.of_kind?(:advisory_board_date, :blank)).to be true
+        end
+      end
+
+      context "when the date doesn't exist" do
+        it "treats the date as invalid" do
+          form = build(form_factory.to_sym, advisory_board_date: {3 => 31, 2 => 2, 1 => 2030})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :invalid)).to be true
+        end
+      end
+
+      context "when the isn't a date" do
+        it "treats the date as invalid" do
+          form = build(form_factory.to_sym, advisory_board_date: {3 => "not", 2 => "a", 1 => "date"})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :invalid)).to be true
         end
       end
     end


### PR DESCRIPTION
## Changes

When entering dates in the create project form, we want to be able to validate them in a meaningful way. Previously missing or incomplete dates were throwing MultipartAssignment errors on the front end (translating to a 500 error and a bad experience for the user).

This PR checks for:
- Blank dates
- Partially complete dates (e.g. missing a month or year)
- Invalid dates (like 31st February)
- "Dates" made up of strings of letters

All but the first of these result in the user being told the date entered is invalid. The first renders an error which tells the user the date is blank.  

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
