### PR TITLE
Refactor readme and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ As a digital service being developed in DfE we aim to follow the
 Console and logs can be accessed on all three environments, details are in
 [accessing console and logs](/doc/console-and-logs.md)
 
+## Errors and monitoring
+
+We use
+[sentry.io](https://sentry.io/organizations/sdd-n7/projects/complete-conversions-transfers-and-changes/?project=6684508)
+to monitor errors and the performance of the application.
+
+## Architecture decision records
+
+You can find the ADRs for this project in [doc/decisions](/doc/decisions).
+
 ## Shared components and patterns
 
 - [DfE GOV.UK Components](https://govuk-components.netlify.app/)
@@ -28,79 +38,13 @@ Console and logs can be accessed on all three environments, details are in
 If this is your first time running the application, see the
 [`getting started documentation`](/doc/getting-started.md) for instructions.
 
-## Additional documentation
+## In-depth documentation
 
 - [The workflow files](/doc/workflow-files.md)
 - [User accounts](/doc/user-accounts.md)
 - [Microsoft SQL Server](/doc/microsoft-sql-server.md)
-
-## Running a server
-
-To start a local server, run `script/server`. Once started the application is
-available at [`http://localhost:3000/`](http://localhost:3000/).
-
-## Testing
-
-To run the test suite, run `script/test`.
-
-### Reducing test scope
-
-You can optionally use `ONLY_LINTING` and `ONLY_APP_TESTS` environment variables
-to selectively run either linting/formatting/schema tests or application tests
-respectively, for example
-
-```bash
-ONLY_LINTING=1 script/test
-```
-
-### Fixing formatting
-
-By default, linters will cause a test failure if there are formatting problems.
-However, you can automatically fix formatting in many cases by using the
-`AUTO_FIX_FORMATTING` environment variable:
-
-```bash
-AUTO_FIX_FORMATTING=1 script/test
-```
-
-This can also be combined with the reduced scopes for fast formatting fixes, for
-example:
-
-```bash
-AUTO_FIX_FORMATTING=1 ONLY_LINTING=1 script/test
-```
-
-### Running accessibility tests
-
-To run accessibility tests locally, see the
-[accessibility tests documenation](/doc/accessibility-tests.md) for details.
-
-## Environment variables
-
-See [.env.example](./.env.example)
-
-For production environments,
-[additional variables are required](./doc/environment-variables.md)
-
-## Releases and deployments
-
-See [releases and deployments](./doc/releases-and-deploys.md)
-
-## ADRs
-
-You can find the [ADRs](https://adr.github.io/) for this project in the
-[`doc/decisions`](/doc/decisions) folder.
-
-## Errors and monitoring
-
-We use
-[sentry.io](https://sentry.io/organizations/sdd-n7/projects/complete-conversions-transfers-and-changes/?project=6684508)
-to monitor errors and the performance of the application.
-
-## Infrastructure
-
-We use infrastructure as code ([Terraform](https://www.terraform.io/)) to deploy
-and manage resources hosting the app. This is stored in the `terraform`
-directory.
-
-Documentation: [terraform/README.md](/terraform/README.md)
+- [Automated accessibility checks](/doc/accessibility-tests.md)
+- [Console and logs in live environments](/doc/console-and-logs.md)
+- [Releases and deployments](/doc/releases-and-deploys.md)
+- [Environment variables](/doc/environment-variables.md)
+- [Infrastructure and Terraform](/doc/infrastructure-and-terraform.md)

--- a/doc/environment-variables.md
+++ b/doc/environment-variables.md
@@ -1,7 +1,9 @@
 # Environment variables
 
-We have three production environments i.e. where Rails is running in
-'production' with RAILS_ENV="production":
+See [.env.example](./.env.example) for local environment variables.
+
+We have three live environments i.e. where Rails is running in 'production' with
+RAILS_ENV="production":
 
 - development
 - test

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -54,3 +54,44 @@ tasks.
 ## Add yourself as a user
 
 [See 'Creating a new user'](/doc/users-accounts.md#creating-a-new-user)
+
+## Running a server
+
+To start a local server, run `script/server`. Once started the application is
+available at [`http://localhost:3000/`](http://localhost:3000/).
+
+## Testing
+
+To run the test suite, run `script/test`.
+
+### Reducing test scope
+
+You can optionally use `ONLY_LINTING` and `ONLY_APP_TESTS` environment variables
+to selectively run either linting/formatting/schema tests or application tests
+respectively, for example
+
+```bash
+ONLY_LINTING=1 script/test
+```
+
+### Fixing formatting
+
+By default, linters will cause a test failure if there are formatting problems.
+However, you can automatically fix formatting in many cases by using the
+`AUTO_FIX_FORMATTING` environment variable:
+
+```bash
+AUTO_FIX_FORMATTING=1 script/test
+```
+
+This can also be combined with the reduced scopes for fast formatting fixes, for
+example:
+
+```bash
+AUTO_FIX_FORMATTING=1 ONLY_LINTING=1 script/test
+```
+
+### Running accessibility tests
+
+To run accessibility tests locally, see the
+[accessibility tests documenation](/doc/accessibility-tests.md) for details.

--- a/doc/infrastructure-and-terraform.md
+++ b/doc/infrastructure-and-terraform.md
@@ -1,0 +1,7 @@
+## Infrastructure and Terraform
+
+We use infrastructure as code ([Terraform](https://www.terraform.io/)) to deploy
+and manage resources hosting the app. This is stored in the `terraform`
+directory.
+
+In-depth Documentation: [terraform/README.md](/terraform/README.md)


### PR DESCRIPTION
As we move into running a live service and because healthy documentation
is a good thing, we want to keep our readme focused.

Here we create more in-depth documentaiton and link from the readme, the
intention is to help layer the documentation from light in the top level
readme to very in-depth, for example in the Terrafrom specific readme.
