### PR TITLE
Make it explicit where the console & log sections are

### DIFF
--- a/doc/console-and-logs.md
+++ b/doc/console-and-logs.md
@@ -8,7 +8,8 @@ All developers on the team have access to the resources in Azure.
 
 ### Development
 
-Console and log access is available with no further actions
+[Console](#console-access) and [log](#log-access) access is available with no
+further actions.
 
 ### Test and Production
 
@@ -29,7 +30,8 @@ Steps to open a PIM:
   privileges
 - Another member of the team can approve the PIM, you'll receive an email upon
   approval (you can all view your pending request in PIM module)
-- Once approved your account will have access to the console and logs
+- Once approved your account will have access to the [Console](#console-access)
+  and [logs](#log-access)
 
 ## Console access
 


### PR DESCRIPTION

## Changes

When trying to log into the Development site for the first time, it wasn't obvious at first that the Console & Log access sections were below the PIM section. It's easy to miss them if you're trying to access Development and don't need a PIM.

Add a couple of links to the "Development" paragraph to show where the console and log access sections are.

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
