### PR TITLE
(965) `edit` and `update` for the new task list

### DIFF
--- a/app/controllers/conversion/involuntary/task_lists_controller.rb
+++ b/app/controllers/conversion/involuntary/task_lists_controller.rb
@@ -1,4 +1,4 @@
-class Conversion::Involuntary::TaskListsController < TaskListController
+class Conversion::Involuntary::TaskListsController < TaskListsController
   def task_edit_path(task)
     conversion_involuntary_task_path(@project.id, task.class.identifier)
   end

--- a/app/controllers/conversion/involuntary/task_lists_controller.rb
+++ b/app/controllers/conversion/involuntary/task_lists_controller.rb
@@ -1,2 +1,10 @@
 class Conversion::Involuntary::TaskListsController < TaskListController
+  def task_edit_path(task)
+    conversion_involuntary_task_path(@project.id, task.class.identifier)
+  end
+  helper_method :task_edit_path
+
+  def task_template_path(task_identifier)
+    "conversion/involuntary/task_lists/tasks/#{task_identifier}"
+  end
 end

--- a/app/controllers/conversion/voluntary/task_lists_controller.rb
+++ b/app/controllers/conversion/voluntary/task_lists_controller.rb
@@ -1,4 +1,4 @@
-class Conversion::Voluntary::TaskListsController < TaskListController
+class Conversion::Voluntary::TaskListsController < TaskListsController
   def task_edit_path(task)
     conversion_voluntary_task_path(@project.id, task.class.identifier)
   end

--- a/app/controllers/conversion/voluntary/task_lists_controller.rb
+++ b/app/controllers/conversion/voluntary/task_lists_controller.rb
@@ -1,2 +1,10 @@
 class Conversion::Voluntary::TaskListsController < TaskListController
+  def task_edit_path(task)
+    conversion_voluntary_task_path(@project.id, task.class.identifier)
+  end
+  helper_method :task_edit_path
+
+  def task_template_path(task_identifier)
+    "conversion/voluntary/task_lists/tasks/#{task_identifier}"
+  end
 end

--- a/app/controllers/task_list_controller.rb
+++ b/app/controllers/task_list_controller.rb
@@ -1,7 +1,24 @@
 class TaskListController < ApplicationController
   before_action :find_project, :find_task_list
+  before_action :find_task, only: %i[edit update]
 
   def index
+  end
+
+  def edit
+    render task_template_path(@task.class.identifier)
+  end
+
+  def update
+    @task.assign_attributes task_params
+
+    if @task.valid?
+      @task_list.save_task(@task)
+
+      redirect_to action: :index
+    else
+      render task_template_path(@task.class.identifier)
+    end
   end
 
   private def find_project
@@ -10,5 +27,17 @@ class TaskListController < ApplicationController
 
   private def find_task_list
     @task_list = @project.task_list
+  end
+
+  private def find_task
+    @task = @task_list.task(params[:task_id])
+  end
+
+  private def task_params
+    params.fetch(task_param_key, {}).permit @task.attributes.keys
+  end
+
+  def task_param_key
+    @task.class.model_name.param_key
   end
 end

--- a/app/controllers/task_lists_controller.rb
+++ b/app/controllers/task_lists_controller.rb
@@ -1,4 +1,4 @@
-class TaskListController < ApplicationController
+class TaskListsController < ApplicationController
   before_action :find_project, :find_task_list
   before_action :find_task, only: %i[edit update]
 

--- a/app/views/conversion/involuntary/task_lists/tasks/handover.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/handover.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_check_boxes_fieldset :progress, multiple: false, legend: nil do %>
+        <%= form.govuk_check_box :review, 1, 0, multiple: false, link_errors: true %>
+      <% end %>
+
+      <%= form.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/conversion/shared/_task_list.html.erb
+++ b/app/views/conversion/shared/_task_list.html.erb
@@ -10,6 +10,7 @@
               <span class="app-task-list__task-name">
                   <%= govuk_link_to(
                         task.title,
+                        task_edit_path(task),
                         aria: {describedby: task_status_id(task)}
                       ) %>
               </span>

--- a/app/views/conversion/voluntary/task_lists/tasks/handover.html.erb
+++ b/app/views/conversion/voluntary/task_lists/tasks/handover.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_voluntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_check_boxes_fieldset :progress, multiple: false, legend: nil do %>
+        <%= form.govuk_check_box :review, 1, 0, multiple: false, link_errors: true %>
+        <%= form.govuk_check_box :notes, 1, 0, multiple: false %>
+        <%= form.govuk_check_box :meeting, 1, 0, multiple: false %>
+      <% end %>
+
+      <%= form.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,52 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "02bae3df5dc344390e29342b85f949e8b77ea2e9d7a4a5e69823d7f8b9664a6c",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/controllers/task_lists_controller.rb",
+      "line": 9,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => task_template_path(Project.find(params[:project_id]).task_list.task(params[:task_id]).class.identifier), {})",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "TaskListsController",
+        "method": "edit"
+      },
+      "user_input": "params[:task_id]",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "4f12037a57acfa3b5eae5cc25928f12a5855e26274d9a337cbd90dc2eaffe246",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/controllers/task_lists_controller.rb",
+      "line": 20,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => task_template_path(Project.find(params[:project_id]).task_list.task(params[:task_id]).class.identifier), {})",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "TaskListsController",
+        "method": "update"
+      },
+      "user_input": "params[:task_id]",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ],
+      "note": ""
+    }
+  ],
+  "updated": "2022-12-19 14:08:48 +0000",
+  "brakeman_version": "5.3.1"
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,8 @@ Rails.application.routes.draw do
         get "new", to: "projects#new"
         post "new", to: "projects#create"
         get ":project_id/tasks", to: "task_lists#index", as: :tasks
+        get ":project_id/tasks/:task_id", to: "task_lists#edit", as: :task
+        put ":project_id/tasks/:task_id", to: "task_lists#update", as: :update_task
       end
 
       namespace :voluntary do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
         get "new", to: "projects#new"
         post "new", to: "projects#create"
         get ":project_id/tasks", to: "task_lists#index", as: :tasks
+        get ":project_id/tasks/:task_id", to: "task_lists#edit", as: :task
+        put ":project_id/tasks/:task_id", to: "task_lists#update", as: :update_task
       end
     end
   end

--- a/spec/factories/conversion/involuntary/task_factory.rb
+++ b/spec/factories/conversion/involuntary/task_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :involuntary_conversion_task_handover, class: "Conversion::Involuntary::Tasks::Handover" do
+    review { false }
+  end
+end

--- a/spec/factories/conversion/task_factory.rb
+++ b/spec/factories/conversion/task_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :voluntary_conversion_task_handover, class: "Conversion::Voluntary::Tasks::Handover" do
+    review { false }
+    notes { false }
+    meeting { false }
+  end
+end

--- a/spec/requests/conversion/involuntary/task_lists_controller_spec.rb
+++ b/spec/requests/conversion/involuntary/task_lists_controller_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe Conversion::Involuntary::TaskListsController do
   let(:project) { create(:involuntary_conversion_project) }
   let(:project_id) { project.id }
   let(:index_path) { conversion_involuntary_tasks_path(project_id) }
+  let(:task) { build(:involuntary_conversion_task_handover) }
+  let(:edit_path) { conversion_involuntary_task_path(project_id, task_identifier) }
+  let(:edit_template_path) { "conversion/involuntary/task_lists/tasks/handover" }
+  let(:update_path) { conversion_involuntary_task_path(project_id, task_identifier) }
+  let(:update_params) { {conversion_involuntary_tasks_handover: {review: 1}} }
+  let(:expected_update_attributes) { {handover_review: true} }
 
   it_behaves_like "a task lists controller"
 end

--- a/spec/requests/conversion/voluntary/task_lists_controller_spec.rb
+++ b/spec/requests/conversion/voluntary/task_lists_controller_spec.rb
@@ -6,4 +6,59 @@ RSpec.describe Conversion::Voluntary::TaskListsController do
   let(:index_path) { conversion_voluntary_tasks_path(project_id) }
 
   it_behaves_like "a task lists controller"
+
+  describe "#edit" do
+    let(:user) { create(:user, :caseworker) }
+    let(:task) { build(:voluntary_conversion_task_handover) }
+    let(:task_identifier) { task.class.identifier }
+
+    before do
+      sign_in_with(user)
+      mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    end
+
+    subject(:perform_request) do
+      get conversion_voluntary_task_path(project_id, task_identifier)
+      response
+    end
+
+    it "renders a task from the task template path" do
+      expect(perform_request).to have_http_status :success
+      expect(response).to render_template "conversion/voluntary/task_lists/tasks/handover"
+    end
+  end
+
+  describe "#update" do
+    let(:user) { create(:user, :caseworker) }
+    let(:task) { build(:voluntary_conversion_task_handover) }
+    let(:task_identifier) { task.class.identifier }
+    let(:params) { {conversion_voluntary_tasks_handover: {review: 1, notes: 1, meeting: 0}} }
+
+    subject(:perform_request) do
+      put conversion_voluntary_task_path(project_id, task_identifier), params: params
+      response
+    end
+
+    before do
+      sign_in_with(user)
+      mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    end
+
+    it "saves the task against the task list and redirects to the task list index page" do
+      perform_request
+
+      expect(project.reload.task_list).to have_attributes(handover_review: true, handover_notes: true, handover_meeting: false)
+      expect(response).to redirect_to(conversion_voluntary_tasks_path(project_id))
+    end
+
+    context "when the task is invalid" do
+      before { allow_any_instance_of(Conversion::Voluntary::Tasks::Handover).to receive(:valid?).and_return(false) }
+
+      it "renders the task template path" do
+        perform_request
+
+        expect(response).to render_template "conversion/voluntary/task_lists/tasks/handover"
+      end
+    end
+  end
 end

--- a/spec/requests/conversion/voluntary/task_lists_controller_spec.rb
+++ b/spec/requests/conversion/voluntary/task_lists_controller_spec.rb
@@ -4,61 +4,12 @@ RSpec.describe Conversion::Voluntary::TaskListsController do
   let(:project) { create(:conversion_project) }
   let(:project_id) { project.id }
   let(:index_path) { conversion_voluntary_tasks_path(project_id) }
+  let(:task) { build(:voluntary_conversion_task_handover) }
+  let(:edit_path) { conversion_voluntary_task_path(project_id, task_identifier) }
+  let(:edit_template_path) { "conversion/voluntary/task_lists/tasks/handover" }
+  let(:update_path) { conversion_voluntary_task_path(project_id, task_identifier) }
+  let(:update_params) { {conversion_voluntary_tasks_handover: {review: 1, notes: 1, meeting: 0}} }
+  let(:expected_update_attributes) { {handover_review: true, handover_notes: true, handover_meeting: false} }
 
   it_behaves_like "a task lists controller"
-
-  describe "#edit" do
-    let(:user) { create(:user, :caseworker) }
-    let(:task) { build(:voluntary_conversion_task_handover) }
-    let(:task_identifier) { task.class.identifier }
-
-    before do
-      sign_in_with(user)
-      mock_successful_api_responses(urn: 123456, ukprn: 10061021)
-    end
-
-    subject(:perform_request) do
-      get conversion_voluntary_task_path(project_id, task_identifier)
-      response
-    end
-
-    it "renders a task from the task template path" do
-      expect(perform_request).to have_http_status :success
-      expect(response).to render_template "conversion/voluntary/task_lists/tasks/handover"
-    end
-  end
-
-  describe "#update" do
-    let(:user) { create(:user, :caseworker) }
-    let(:task) { build(:voluntary_conversion_task_handover) }
-    let(:task_identifier) { task.class.identifier }
-    let(:params) { {conversion_voluntary_tasks_handover: {review: 1, notes: 1, meeting: 0}} }
-
-    subject(:perform_request) do
-      put conversion_voluntary_task_path(project_id, task_identifier), params: params
-      response
-    end
-
-    before do
-      sign_in_with(user)
-      mock_successful_api_responses(urn: 123456, ukprn: 10061021)
-    end
-
-    it "saves the task against the task list and redirects to the task list index page" do
-      perform_request
-
-      expect(project.reload.task_list).to have_attributes(handover_review: true, handover_notes: true, handover_meeting: false)
-      expect(response).to redirect_to(conversion_voluntary_tasks_path(project_id))
-    end
-
-    context "when the task is invalid" do
-      before { allow_any_instance_of(Conversion::Voluntary::Tasks::Handover).to receive(:valid?).and_return(false) }
-
-      it "renders the task template path" do
-        perform_request
-
-        expect(response).to render_template "conversion/voluntary/task_lists/tasks/handover"
-      end
-    end
-  end
 end

--- a/spec/support/shared_examples/task_lists_controller.rb
+++ b/spec/support/shared_examples/task_lists_controller.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples "a task lists controller" do
 
   describe "#index" do
     subject(:perform_request) do
-      get conversion_voluntary_tasks_path(project_id)
+      get index_path
       response
     end
 
@@ -18,6 +18,46 @@ RSpec.shared_examples "a task lists controller" do
       expect(subject).to have_http_status :success
 
       expect(response.body).to include "Task list"
+    end
+  end
+
+  describe "#edit" do
+    let(:task_identifier) { task.class.identifier }
+
+    subject(:perform_request) do
+      get edit_path
+      response
+    end
+
+    it "renders a task from the task template path" do
+      expect(perform_request).to have_http_status :success
+      expect(response).to render_template edit_template_path
+    end
+  end
+
+  describe "#update" do
+    let(:task_identifier) { task.class.identifier }
+
+    subject(:perform_request) do
+      put update_path, params: update_params
+      response
+    end
+
+    it "saves the task against the task list and redirects to the task list index page" do
+      perform_request
+
+      expect(project.reload.task_list).to have_attributes(expected_update_attributes)
+      expect(response).to redirect_to(index_path)
+    end
+
+    context "when the task is invalid" do
+      before { allow_any_instance_of(task.class).to receive(:valid?).and_return(false) }
+
+      it "renders the task template path" do
+        perform_request
+
+        expect(response).to render_template edit_template_path
+      end
     end
   end
 end


### PR DESCRIPTION
## Changes
### Add `update` and `edit` actions for the voluntary task list
Add `update` and `edit` functionality for the voluntary task list. This:

- Adds generic `update` and `edit` actions to the base `TaskListController`
  from which the various types of task list controller will derive from.
- Adds `task_edit_path` and `task_template_path` methods to the voluntary
  conversion controller. These must be configured in the derived controllers. 
- Adds routes for the voluntary task list edit and update actions.

### Add `edit` and `update` actions for the involuntary task list
This adds `update` and `edit` functionality for the involuntary task list. This
follows a commit which adds generic actions to the base `TaskListController`.

Request specs are moved into a shared example.

### Ignore Brakeman `Dynamic Render Path` warnings
We generate our task path by matching the  `:task_id` param at the end of the
path to a task, then using the `identifier` of the task to find the relevant view.

This is desired behaviour, users won't be able to use this to perform any
malicious behaviour.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
