### PR TITLE
Refactor GitHub workflow outputs

### DIFF
--- a/.github/workflows/build-and-push-image-development.yml
+++ b/.github/workflows/build-and-push-image-development.yml
@@ -29,8 +29,8 @@ jobs:
             VERSION=sha-${GITHUB_SHA}
             TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
           fi
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=deploy-version::${VERSION}
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "deploy-version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Push image
         uses: docker/build-push-action@v3

--- a/.github/workflows/build-and-push-image-production.yml
+++ b/.github/workflows/build-and-push-image-production.yml
@@ -13,7 +13,7 @@ jobs:
       version: ${{steps.release-version.outputs.version}}
     steps:
       - id: release-version
-        run: echo "::set-output name=version::release-9"
+        run: echo "version=release-9" >> $GITHUB_OUTPUT
 
   build-and-push-image-production:
     name: Build and push image production
@@ -44,8 +44,8 @@ jobs:
             VERSION=sha-${GITHUB_SHA}
             TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${{needs.set-test-release-version.outputs.version}}"
           fi
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=deploy-version::${VERSION}
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "deploy-version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Push image
         uses: docker/build-push-action@v3

--- a/.github/workflows/build-and-push-image-test.yml
+++ b/.github/workflows/build-and-push-image-test.yml
@@ -13,7 +13,7 @@ jobs:
       version: ${{steps.release-version.outputs.version}}
     steps:
       - id: release-version
-        run: echo "::set-output name=version::release-9"
+        run: echo "version=release-9" >> $GITHUB_OUTPUT
 
   build-and-push-image-test:
     name: Build and push image test
@@ -44,8 +44,8 @@ jobs:
             VERSION=sha-${GITHUB_SHA}
             TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${{needs.set-test-release-version.outputs.version}}"
           fi
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=deploy-version::${VERSION}
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "deploy-version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Push image
         uses: docker/build-push-action@v3


### PR DESCRIPTION
* The `set-output` command is depreciated. This refactors the workflows to output them into the `GITHUB_OUTPUT` environment variable instead.
* ```Warning: The \`set-output\` command is deprecated and will be disabled soon.```