### PR TITLE
Change validations on `Project` and `CreateProjectForm`

### DIFF
--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -1,41 +1,41 @@
 class Conversion::CreateProjectForm
   include ActiveModel::Model
+  include ActiveModel::Attributes
   include ActiveRecord::AttributeAssignment
 
   SHAREPOINT_URLS = %w[educationgovuk-my.sharepoint.com educationgovuk.sharepoint.com].freeze
 
   class NegativeValueError < StandardError; end
 
-  attr_accessor :urn,
-    :incoming_trust_ukprn,
-    :establishment_sharepoint_link,
-    :trust_sharepoint_link,
-    :advisory_board_conditions,
-    :note_body,
-    :user
+  attribute :urn, :integer
+  attribute :incoming_trust_ukprn, :integer
+
+  attr_accessor :establishment_sharepoint_link,
+  :trust_sharepoint_link,
+  :advisory_board_conditions,
+  :note_body,
+  :user
 
   attr_reader :provisional_conversion_date,
     :advisory_board_date
 
-  validates :urn,
-    :incoming_trust_ukprn,
-    :establishment_sharepoint_link,
-    :trust_sharepoint_link,
-    :provisional_conversion_date,
+  validates :provisional_conversion_date,
     :advisory_board_date,
     presence: true
 
-  validates :urn, urn: true
-  validates :incoming_trust_ukprn, ukprn: true
-
-  validates :provisional_conversion_date, date_in_the_future: true
-  validates :provisional_conversion_date, first_day_of_month: true
+  validates :provisional_conversion_date, date_in_the_future: true, first_day_of_month: true
   validates :advisory_board_date, date_in_the_past: true
 
   validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
   validates :trust_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
 
+  validates :urn, presence: true, urn: true
+  validates :incoming_trust_ukprn, presence: true, ukprn: true
+
   validate :multiparameter_date_attributes_values
+
+  validate :establishment_exists, if: -> { urn.present? }
+  validate :trust_exists, if: -> { incoming_trust_ukprn.present? }
 
   def initialize(params = {})
     @attributes_with_invalid_values = []
@@ -73,5 +73,19 @@ class Conversion::CreateProjectForm
     User.team_leaders.each do |team_leader|
       TeamLeaderMailer.new_project_created(team_leader, project).deliver_later
     end
+  end
+
+  private def establishment_exists
+    result = AcademiesApi::Client.new.get_establishment(urn)
+    raise result.error if result.error.present?
+  rescue AcademiesApi::Client::NotFoundError
+    errors.add(:urn, :no_establishment_found)
+  end
+
+  private def trust_exists
+    result = AcademiesApi::Client.new.get_trust(incoming_trust_ukprn)
+    raise result.error if result.error.present?
+  rescue AcademiesApi::Client::NotFoundError
+    errors.add(:incoming_trust_ukprn, :no_trust_found)
   end
 end

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -9,12 +9,11 @@ class Conversion::CreateProjectForm
 
   attribute :urn, :integer
   attribute :incoming_trust_ukprn, :integer
-
-  attr_accessor :establishment_sharepoint_link,
-  :trust_sharepoint_link,
-  :advisory_board_conditions,
-  :note_body,
-  :user
+  attribute :establishment_sharepoint_link
+  attribute :trust_sharepoint_link
+  attribute :advisory_board_conditions
+  attribute :note_body
+  attribute :user
 
   attr_reader :provisional_conversion_date,
     :advisory_board_date

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -17,8 +17,8 @@ class Project < ApplicationRecord
   validates :provisional_conversion_date, first_day_of_month: true
   validates :advisory_board_date, presence: true
   validates :advisory_board_date, date_in_the_past: true
-  validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}, on: :create
-  validates :trust_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}, on: :create
+  validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
+  validates :trust_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
 
   validate :establishment_exists, on: :create, if: -> { urn.present? }
   validate :trust_exists, on: :create, if: -> { incoming_trust_ukprn.present? }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -20,8 +20,8 @@ class Project < ApplicationRecord
   validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
   validates :trust_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
 
-  validate :establishment_exists, on: :create, if: -> { urn.present? }
-  validate :trust_exists, on: :create, if: -> { incoming_trust_ukprn.present? }
+  validate :establishment_exists, if: -> { urn.present? }
+  validate :trust_exists, if: -> { incoming_trust_ukprn.present? }
 
   belongs_to :caseworker, class_name: "User", optional: true
   belongs_to :team_leader, class_name: "User", optional: true

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,7 +15,7 @@ class Project < ApplicationRecord
   validates :incoming_trust_ukprn, ukprn: true
   validates :provisional_conversion_date, presence: true
   validates :provisional_conversion_date, first_day_of_month: true
-  validates :advisory_board_date, presence: true, on: :create
+  validates :advisory_board_date, presence: true
   validates :advisory_board_date, date_in_the_past: true
   validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}, on: :create
   validates :trust_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}, on: :create

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -14,7 +14,6 @@ class Project < ApplicationRecord
   validates :incoming_trust_ukprn, presence: true
   validates :incoming_trust_ukprn, ukprn: true
   validates :provisional_conversion_date, presence: true
-  validates :provisional_conversion_date, date_in_the_future: true
   validates :provisional_conversion_date, first_day_of_month: true
   validates :advisory_board_date, presence: true, on: :create
   validates :advisory_board_date, date_in_the_past: true

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -111,24 +111,6 @@ RSpec.describe Project, type: :model do
           expect(subject.errors[:provisional_conversion_date]).to include(I18n.t("errors.attributes.provisional_conversion_date.must_be_first_of_the_month"))
         end
       end
-
-      context "when date is today" do
-        subject { build(:conversion_project, provisional_conversion_date: Date.today) }
-
-        it "is invalid" do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:provisional_conversion_date]).to include(I18n.t("errors.attributes.provisional_conversion_date.must_be_in_the_future"))
-        end
-      end
-
-      context "when date is in the past" do
-        subject { build(:conversion_project, provisional_conversion_date: Date.yesterday) }
-
-        it "is invalid" do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:provisional_conversion_date]).to include(I18n.t("errors.attributes.provisional_conversion_date.must_be_in_the_future"))
-        end
-      end
     end
 
     describe "#establishment_sharepoint_link" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Project, type: :model do
   describe "Validations" do
     before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 
-    it { is_expected.to validate_presence_of(:advisory_board_date).on(:create) }
+    it { is_expected.to validate_presence_of(:advisory_board_date) }
 
     describe "#urn" do
       it { is_expected.to validate_presence_of(:urn) }

--- a/spec/support/shared_examples/create_conversion_project_form.rb
+++ b/spec/support/shared_examples/create_conversion_project_form.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.shared_examples "a conversion project FormObject" do
   describe "validations" do
+    before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
     it { is_expected.to validate_presence_of(:establishment_sharepoint_link) }
     it { is_expected.to validate_presence_of(:trust_sharepoint_link) }
 
@@ -159,6 +161,8 @@ RSpec.shared_examples "a conversion project FormObject" do
   end
 
   describe "urn" do
+    before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
     it { is_expected.to validate_presence_of(:urn) }
     it { is_expected.to allow_value(123456).for(:urn) }
     it { is_expected.not_to allow_values(12345, 1234567).for(:urn) }
@@ -174,12 +178,17 @@ RSpec.shared_examples "a conversion project FormObject" do
       end
 
       it "is invalid" do
-        expect(subject).to_not be_valid
+        form = build(form_factory.to_sym)
+        expect(form).to be_invalid
       end
     end
   end
 
   describe "incoming_trust_ukprn" do
+    before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+    it { is_expected.to validate_presence_of(:incoming_trust_ukprn) }
+
     context "when no trust with that UKPRN exists in the API" do
       let(:no_trust_found_result) do
         AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError.new("No trust found with that UKPRN. Enter a valid UKPRN."))
@@ -191,7 +200,8 @@ RSpec.shared_examples "a conversion project FormObject" do
       end
 
       it "is invalid" do
-        expect(subject).to_not be_valid
+        form = build(form_factory.to_sym)
+        expect(form).to be_invalid
       end
     end
   end


### PR DESCRIPTION
## Changes

Now that we have a FormObject (CreateProjectForm) for creating projects, we no longer create them with the Project model directly. This means we can change some of the validations. We have:

- Loosened the `provisional_conversion_date` validation. It now only checks the date is in the future on creation (via the form). In the project model, the date only needs to exist, as the project should still be valid even if the conversion date has passed.
- Changed the validation of `advisory_board_date` - it should always be in the past, even if the project is being edited, so we should not check it only on create.
- The sharepoint links should always be validated, not just on create.
- Added the `trust_exists` and `establishment_exists` validations to the FormObject, as these need to be checked on project creation via the form.

TODO: Do we need to remove `trust_exists` and `establishment_exists` validations from the Project model? Are these attributes ever likely to be edited?

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
