### PR TITLE
Content maintenance following link audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   should contact policy team for advice if one is needed. Voluntary &
   involuntary
 - Fix broken link to email templates in external stakeholder kick-off task
+- Make guidance link content more descriptive of destination in Articles of
+  association
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix broken link to email templates in external stakeholder kick-off task
 - Make guidance link content more descriptive of destination in Articles of
   association
+- Remove 'with the trust' from Share the grant certificate and information about
+  opening task in the voluntary task list as school and trust should be made
+  aware here
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Tenancy at will guidance now explains how rarely it is used and that users
   should contact policy team for advice if one is needed. Voluntary &
   involuntary
+- Fix broken link to email templates in external stakeholder kick-off task
 
 #### Fixed
 

--- a/app/workflows/lists/conversion/involuntary/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/involuntary/sections/clear-legal-docs.yml
@@ -216,9 +216,9 @@ tasks:
       - type: subheading
         title: Check and clear the Articles of association
         hint:
-          You can use the [land transfer advice and guidance to check for common
-          problems (opens in new
-          tab)](https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Academy-Governance-(includes-clearing-Articles-of-Association).aspx).
+          You can use the [academy governance guidance (opens in new
+          tab)](https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Academy-Governance-(includes-clearing-Articles-of-Association).aspx)
+          to help you check and clear the Articles of association.
         guidance_summary: Help checking for changes
         guidance_text: |
           Changes that personalise the model documents to a school or trust, and remove or add optional clauses, are expected. The wording of clauses should not change.

--- a/app/workflows/lists/conversion/involuntary/sections/kickoff.yml
+++ b/app/workflows/lists/conversion/involuntary/sections/kickoff.yml
@@ -48,7 +48,7 @@ tasks:
           You should also contact the local authority, but do this separately.
         guidance_summary: What to include in introductory emails
         guidance_text: |
-          You can [choose an email template (opens in new tab)](https://educationgovuk.sharepoint.com/:f:/r/sites/ServiceDeliveryDirectorate/Shared%20Documents/Operational%20Delivery/Training%20and%20Resources/Resources/Project%20templates?csf=1&web=1&e=Hf4exC) to help you write your introductory emails. There are templates for the school or trust, their solicitors and the local authority.
+          You can [choose an email template (opens in new tab)](https://educationgovuk.sharepoint.com/sites/ServiceDeliveryDirectorate/Shared%20Documents/Forms/AllItems.aspx?FolderCTID=0x012000265B42F1C27524438F6B1CC14FCF9E05&id=%2Fsites%2FServiceDeliveryDirectorate%2FShared%20Documents%2FOperational%20Delivery%2FGuidance%2C%20Training%20and%20Resources%2F%281%29%20CONVERSIONS%20%2D%20Guidance%20and%20Templates%2FCONVERSIONS%20%2D%20Template%20Emails%20%26%20Documents&viewid=84d1a8e7%2D052b%2D4a94%2D8d1b%2D850c4e6f284f) to help you write your introductory emails. There are templates for the school or trust, their solicitors and the local authority.
           This will help you to:
 
           * organise kick-off meetings

--- a/app/workflows/lists/conversion/voluntary/sections/clear-legal-docs.yml
+++ b/app/workflows/lists/conversion/voluntary/sections/clear-legal-docs.yml
@@ -216,9 +216,9 @@ tasks:
       - type: subheading
         title: Check and clear the Articles of association
         hint:
-          You can use the [land transfer advice and guidance to check for common
-          problems (opens in new
-          tab)](https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Academy-Governance-(includes-clearing-Articles-of-Association).aspx).
+          You can use the [academy governance guidance (opens in new
+          tab)](https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Academy-Governance-(includes-clearing-Articles-of-Association).aspx)
+          to help you check and clear the Articles of association.
         guidance_summary: Help checking for changes
         guidance_text: |
           Changes that personalise the model documents to a school or trust, and remove or add optional clauses, are expected. The wording of clauses should not change.

--- a/app/workflows/lists/conversion/voluntary/sections/kickoff.yml
+++ b/app/workflows/lists/conversion/voluntary/sections/kickoff.yml
@@ -46,7 +46,7 @@ tasks:
           You should also contact the local authority, but do this separately.
         guidance_summary: What to include in introductory emails
         guidance_text: |
-          You can [choose an email template (opens in new tab)](https://educationgovuk.sharepoint.com/:f:/r/sites/ServiceDeliveryDirectorate/Shared%20Documents/Operational%20Delivery/Training%20and%20Resources/Resources/Project%20templates?csf=1&web=1&e=Hf4exC) to help you write your introductory emails. There are templates for the school or trust, their solicitors and the local authority.
+          You can [choose an email template (opens in new tab)](https://educationgovuk.sharepoint.com/sites/ServiceDeliveryDirectorate/Shared%20Documents/Forms/AllItems.aspx?FolderCTID=0x012000265B42F1C27524438F6B1CC14FCF9E05&id=%2Fsites%2FServiceDeliveryDirectorate%2FShared%20Documents%2FOperational%20Delivery%2FGuidance%2C%20Training%20and%20Resources%2F%281%29%20CONVERSIONS%20%2D%20Guidance%20and%20Templates%2FCONVERSIONS%20%2D%20Template%20Emails%20%26%20Documents&viewid=84d1a8e7%2D052b%2D4a94%2D8d1b%2D850c4e6f284f) to help you write your introductory emails. There are templates for the school or trust, their solicitors and the local authority.
 
           This will help you to:
 

--- a/app/workflows/lists/conversion/voluntary/sections/ready-for-opening.yml
+++ b/app/workflows/lists/conversion/voluntary/sections/ready-for-opening.yml
@@ -126,8 +126,7 @@ tasks:
           * risk protection arrangement in place and insurer confirmed
           * relevant documents signed
   - slug: share-the-grant-certificate-and-information-about-opening-with-the-trust
-    title:
-      Share the grant certificate and information about opening with the trust
+    title: Share the grant certificate and information about opening
     hint: |
       Once you have confirmed that all conditions have been met, contact the
       school and trust to tell them they can convert on the provisional conversion


### PR DESCRIPTION
## Changes

Morrighan and Steve reviewed and listed all the things the Dev environment build links out to. This includes:

- Documents on SharePoint
- Guidance on the DfE Intranet
- Model documents on GOV.UK
- Email addresses for teams

During that, we spotted 3 things to resolve:

- a [broken link in the External stakeholder kick-off](https://trello.com/c/kvEhmmtl/982-fix-broken-link-in-external-stakeholder-kick-off-task) task
- inaccurate [language in a link to guidance in Articles of association](https://trello.com/c/NzfVzQhU/983-review-and-update-language-used-in-link-to-articles-of-association-guidance-to-check-its-relevant) task
- inaccurate [language in title of Share the grant certificate and information about opening with the trust task](https://trello.com/c/1IVWQMKf/984-check-language-in-share-the-grant-certificate-and-information-about-opening-with-the-trust-task-is-right-in-the-voluntary-task-l) for voluntary task list

This PR fixes those things.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
