### PR TITLE
Use locales and ViewComponents to render parts of the TaskList

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@ $govuk-global-styles: true;
 @import "accessible-autocomplete/src/autocomplete";
 
 @import "components/task-list";
+@import "components/task_list/check-box-action-component";
 
 // The accessible autocomplete component does not use
 // GOV.UK fonts by default for suggestions.

--- a/app/assets/stylesheets/components/task_list/check-box-action-component.scss
+++ b/app/assets/stylesheets/components/task_list/check-box-action-component.scss
@@ -1,0 +1,21 @@
+.govuk-checkboxes__item {
+  label {
+    @extend .govuk-\!-font-weight-bold;
+  }
+
+  .hint {
+    display: block;
+    padding-right: govuk-spacing(3);
+    padding-left: govuk-spacing(3);
+
+    > p {
+      @extend .govuk-hint;
+    }
+  }
+
+  .guidance {
+    display: block;
+    padding-right: govuk-spacing(3);
+    padding-left: govuk-spacing(3);
+  }
+}

--- a/app/components/task_list/check_box_action_component.html.erb
+++ b/app/components/task_list/check_box_action_component.html.erb
@@ -1,0 +1,19 @@
+<div class="govuk-checkboxes__item">
+  <%= hidden_field_tag(@action_id, "0", {id: nil}) %>
+  <%= check_box_tag(@action_id, 1, check_box_value, {class: "govuk-checkboxes__input"}) %>
+  <%= label_tag(@action_id, @label, {class: "govuk-label govuk-checkboxes__label"}) %>
+
+  <% if @hint %>
+    <div class="hint">
+      <%= @hint %>
+    </div>
+  <% end %>
+
+  <% if @guidance %>
+    <div class="guidance">
+    <%= govuk_details(summary_text: @guidance_link) do %>
+      <%= @guidance %>
+    <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/components/task_list/check_box_action_component.rb
+++ b/app/components/task_list/check_box_action_component.rb
@@ -1,0 +1,17 @@
+class TaskList::CheckBoxActionComponent < ViewComponent::Base
+  def initialize(task:, attribute:)
+    locales_path = task.locales_path
+
+    @task = task
+    @attribute = attribute
+    @label = t("#{locales_path}.#{attribute}.title")
+    @hint = t("#{locales_path}.#{attribute}.hint.html", default: nil)
+    @guidance_link = t("#{locales_path}.#{attribute}.guidance_link", default: nil)
+    @guidance = t("#{locales_path}.#{attribute}.guidance.html", default: nil)
+    @action_id = "#{task.class.name.parameterize(separator: "_")}[#{attribute}]"
+  end
+
+  def check_box_value
+    @task.send(@attribute)
+  end
+end

--- a/app/components/task_list/task_header_component.html.erb
+++ b/app/components/task_list/task_header_component.html.erb
@@ -1,0 +1,18 @@
+<div class="govuk-grid-row govuk-!-margin-bottom-9">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @establishment_name %></span>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2"><%= @title %></h1>
+
+    <% if @hint %>
+      <div class="govuk-hint">
+        <%= @hint %>
+      </div>
+    <% end %>
+
+    <% if @guidance %>
+      <%= govuk_details(summary_text: @guidance_link) do %>
+        <%= @guidance %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/task_list/task_header_component.rb
+++ b/app/components/task_list/task_header_component.rb
@@ -1,0 +1,10 @@
+class TaskList::TaskHeaderComponent < ViewComponent::Base
+  def initialize(project:, task:)
+    locales_path = task.locales_path
+    @establishment_name = project.establishment.name
+    @title = t("#{locales_path}.title")
+    @hint = t("#{locales_path}.hint.html", default: nil)
+    @guidance_link = t("#{locales_path}.guidance_link", default: nil)
+    @guidance = t("#{locales_path}.guidance.html", default: nil)
+  end
+end

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -3,7 +3,12 @@ module TaskListHelper
     "#{task.title.parameterize}-status"
   end
 
-  def task_status_tag(task)
+  def task_id(task)
+    task_title = t("#{task.locales_path}.title").parameterize
+    "#{task_title}-status"
+  end
+
+  def task_status_tag(task, task_status_id)
     # Colours as per https://govuk-components.netlify.app/components/tag/
     tags_for_states = {
       not_started: {
@@ -34,7 +39,7 @@ module TaskListHelper
       text: task_state[:text],
       colour: task_state[:colour],
       classes: "app-task-list__tag",
-      html_attributes: {id: task_status_id(task)}
+      html_attributes: {id: task_status_id}
     )
   end
 end

--- a/app/models/task_list/base.rb
+++ b/app/models/task_list/base.rb
@@ -7,7 +7,7 @@ class TaskList::Base < ActiveRecord::Base
     task_list_layout.map do |section|
       tasks = section[:tasks].map { |task| task.new(attributes_for_task(task)) }
 
-      TaskList::Section.new(identifier: section[:identifier], tasks: tasks)
+      TaskList::Section.new(identifier: section[:identifier], tasks: tasks, locales_path: locales_path)
     end
   end
 

--- a/app/models/task_list/base.rb
+++ b/app/models/task_list/base.rb
@@ -11,6 +11,10 @@ class TaskList::Base < ActiveRecord::Base
     end
   end
 
+  def locales_path
+    self.class.name.underscore.tr("/", ".")
+  end
+
   def tasks
     sections.map(&:tasks).flatten
   end

--- a/app/models/task_list/section.rb
+++ b/app/models/task_list/section.rb
@@ -7,10 +7,6 @@ class TaskList::Section
     @tasks = tasks
   end
 
-  def title
-    I18n.t("task_list.sections.#{identifier}.title")
-  end
-
   def locales_path
     "#{@locales_path}.#{identifier}"
   end

--- a/app/models/task_list/section.rb
+++ b/app/models/task_list/section.rb
@@ -1,12 +1,17 @@
 class TaskList::Section
   attr_accessor :identifier, :tasks
 
-  def initialize(identifier:, tasks:)
+  def initialize(identifier:, tasks:, locales_path:)
+    @locales_path = locales_path
     @identifier = identifier
     @tasks = tasks
   end
 
   def title
     I18n.t("task_list.sections.#{identifier}.title")
+  end
+
+  def locales_path
+    "#{@locales_path}.#{identifier}"
   end
 end

--- a/app/models/task_list/task.rb
+++ b/app/models/task_list/task.rb
@@ -16,10 +16,6 @@ class TaskList::Task
     :not_started
   end
 
-  def title
-    I18n.t("task_list.tasks.#{self.class.identifier}.title")
-  end
-
   def locales_path
     self.class.name.underscore.tr("/", ".")
   end

--- a/app/models/task_list/task.rb
+++ b/app/models/task_list/task.rb
@@ -20,6 +20,10 @@ class TaskList::Task
     I18n.t("task_list.tasks.#{self.class.identifier}.title")
   end
 
+  def locales_path
+    self.class.name.underscore.tr("/", ".")
+  end
+
   private def in_progress?
     attributes.values.any?(&:present?)
   end

--- a/app/views/conversion/involuntary/task_lists/index.html.erb
+++ b/app/views/conversion/involuntary/task_lists/index.html.erb
@@ -2,6 +2,8 @@
   <% render partial: "shared/back_link", locals: {href: root_path} %>
 <% end %>
 
+<%= render partial: "shared/project_summary" %>
+
 <h2 class="govuk-heading-l"><%= t("project.show.title") %></h2>
 
 <%= render "conversion/shared/task_list" %>

--- a/app/views/conversion/involuntary/task_lists/tasks/handover.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/handover.html.erb
@@ -1,5 +1,9 @@
 <%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
 
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversion/involuntary/task_lists/tasks/handover.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/handover.html.erb
@@ -1,11 +1,11 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
       <%= form.govuk_error_summary %>
 
-      <%= form.govuk_check_boxes_fieldset :progress, multiple: false, legend: nil do %>
-        <%= form.govuk_check_box :review, 1, 0, multiple: false, link_errors: true %>
-      <% end %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :review)) %>
 
       <%= form.govuk_submit %>
     <% end %>

--- a/app/views/conversion/shared/_task_list.html.erb
+++ b/app/views/conversion/shared/_task_list.html.erb
@@ -2,19 +2,19 @@
   <% @project.task_list.sections.each do |section| %>
     <li>
       <h3 class="app-task-list__section">
-        <%= section.title %>
+        <%= t("#{section.locales_path}.title") %>
       </h3>
       <ul class="app-task-list__items">
         <% section.tasks.each do |task| %>
           <li class="app-task-list__item">
               <span class="app-task-list__task-name">
                   <%= govuk_link_to(
-                        task.title,
+                        t("#{task.locales_path}.title"),
                         task_edit_path(task),
-                        aria: {describedby: task_status_id(task)}
+                        aria: {describedby: task_id(task)}
                       ) %>
               </span>
-            <%= task_status_tag(task) %>
+            <%= task_status_tag(task, task_id(task)) %>
           </li>
         <% end %>
       </ul>

--- a/app/views/conversion/voluntary/task_lists/tasks/handover.html.erb
+++ b/app/views/conversion/voluntary/task_lists/tasks/handover.html.erb
@@ -1,15 +1,17 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: conversion_voluntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
       <%= form.govuk_error_summary %>
 
-      <%= form.govuk_check_boxes_fieldset :progress, multiple: false, legend: nil do %>
-        <%= form.govuk_check_box :review, 1, 0, multiple: false, link_errors: true %>
-        <%= form.govuk_check_box :notes, 1, 0, multiple: false %>
-        <%= form.govuk_check_box :meeting, 1, 0, multiple: false %>
-      <% end %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :review)) %>
 
-      <%= form.govuk_submit %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :notes)) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :meeting)) %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
     <% end %>
   </div>
 

--- a/app/views/conversion/voluntary/task_lists/tasks/handover.html.erb
+++ b/app/views/conversion/voluntary/task_lists/tasks/handover.html.erb
@@ -1,5 +1,9 @@
 <%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
 
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_voluntary_tasks_path(@project)} %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: conversion_voluntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/projects/show/_task_list.html.erb
+++ b/app/views/projects/show/_task_list.html.erb
@@ -14,7 +14,7 @@
                         aria: {describedby: task_status_id(task)}
                       ) %>
               </span>
-            <%= task_status_tag(task) %>
+            <%= task_status_tag(task, task_status_id(task)) %>
           </li>
         <% end %>
       </ul>

--- a/config/locales/task_list.en.yml
+++ b/config/locales/task_list.en.yml
@@ -1,14 +1,4 @@
 en:
   task_list:
-    sections:
-      project_kick_off:
-        title:
-          Project kick-off
-
-    tasks:
-      handover:
-        title:
-          Handover with regional delivery officer
-
     continue_button:
       text: Save and return

--- a/config/locales/task_lists/conversion_involuntary.en.yml
+++ b/config/locales/task_lists/conversion_involuntary.en.yml
@@ -7,3 +7,26 @@ en:
       tasks:
         handover:
           title: Handover with regional delivery officer
+          hint:
+            html: <p class="govuk-hint">How to make sure the handover with the regional delivery officer is completed, and you can begin work on the project.</p>
+          guidance_link: Additional guidance
+          guidance:
+            html: This is the addtional guidance
+          review:
+            title: Review the project information, check the documents and carry out research
+            hint:
+              html: <p>Check that no information is missing from the existing project documents and there are no errors.</p>
+            guidance_link: What to check for
+            guidance:
+              html:
+                <p>You should check existing project documents, including:</p>
+                <ul>
+                <li>Academy order</li>
+                <li>Application to convert</li>
+                </ul>
+                <p>Check that no information is missing and there are no errors. You should also research the background of the project before you meet with the regional delivery officer. Things to check during your background research include:</p>
+                  <ul>
+                  <li>Project information, such as advisory board conditions</li>
+                  <li>School or trust website for more information about the school</li>
+                  <li>Google maps for potential land issues</li>
+                  </ul>

--- a/config/locales/task_lists/conversion_involuntary.en.yml
+++ b/config/locales/task_lists/conversion_involuntary.en.yml
@@ -1,0 +1,9 @@
+en:
+  conversion:
+    involuntary:
+      task_list:
+        project_kick_off:
+          title: Project kick-off
+      tasks:
+        handover:
+          title: Handover with regional delivery officer

--- a/config/locales/task_lists/conversion_voluntary.en.yml
+++ b/config/locales/task_lists/conversion_voluntary.en.yml
@@ -7,3 +7,35 @@ en:
       tasks:
         handover:
           title: Handover with regional delivery officer
+
+          review:
+            title: Review the project information, check the documents and carry out research
+            hint:
+              html:
+                <p>Check that no information is missing from the existing project documents and there are no errors.</p>
+                <p>You should also research the background of the project before you meet with the regional delivery officer.</p>
+            guidance_link: What to check for
+            guidance:
+              html:
+                <p>Things to check during your background research include:</p>
+
+                <ul>
+                  <li>Project information, such as advisory board conditions</li>
+                  <li>School or trust website for more information about the school</li>
+                  <li>Google maps for potential land issues</li>
+                </ul>
+
+                <p>You should also check existing project documents, including:</p>
+
+                <ul>
+                  <li>Academy order</li>
+                  <li>Application to convert</li>
+                </ul>
+          notes:
+            title: Make notes and write questions to as the regional delivery officer
+
+          meeting:
+            title: Attend handover meeting with regional delivery officer
+            hint:
+              html:
+                <p>Discuss any questions you have about the project in the meeting.</p>

--- a/config/locales/task_lists/conversion_voluntary.en.yml
+++ b/config/locales/task_lists/conversion_voluntary.en.yml
@@ -1,0 +1,9 @@
+en:
+  conversion:
+    voluntary:
+      task_list:
+        project_kick_off:
+          title: Project kick-off
+      tasks:
+        handover:
+          title: Handover with regional delivery officer

--- a/spec/components/task_list/check_box_action_component_spec.rb
+++ b/spec/components/task_list/check_box_action_component_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe TaskList::CheckBoxActionComponent, type: :component do
+  let(:task) { double(status: :not_started, locales_path: "conversion.voluntary.tasks.handover") }
+
+  before do
+    allow(task).to receive(attribute.to_sym).and_return(true)
+    render_inline(TaskList::CheckBoxActionComponent.new(task: task, attribute: attribute))
+  end
+
+  context "when the checkbox only has a title" do
+    let(:attribute) { "notes" }
+
+    it "renders the title" do
+      expect(page).to have_text("Make notes and write questions to as the regional delivery officer")
+    end
+  end
+
+  context "when the checkbox has a title and hint" do
+    let(:attribute) { "meeting" }
+
+    it "renders the title and hint" do
+      expect(page).to have_text("Attend handover meeting with regional delivery officer")
+      expect(page).to have_text("Discuss any questions you have about the project in the meeting.")
+    end
+  end
+
+  context "when the checkbox has a title, hint and guidance" do
+    let(:attribute) { "review" }
+
+    it "renders the title, hint and guidance" do
+      expect(page).to have_text("Review the project information, check the documents and carry out research")
+      expect(page).to have_text("Check that no information is missing from the existing project documents and there are no errors.")
+      expect(page).to have_text("Things to check during your background research include:")
+    end
+  end
+
+  context "when the checkbox task is a 'Conversion::Voluntary' task" do
+    let(:attribute) { "notes" }
+
+    before do
+      allow(task).to receive_message_chain("class.name").and_return("Conversion::Voluntary::Tasks::Handover")
+      render_inline(TaskList::CheckBoxActionComponent.new(task: task, attribute: attribute))
+    end
+
+    it "renders the correct `name` for the form input" do
+      expect(page.find_field("conversion_voluntary_tasks_handover[notes]")).to be_present
+    end
+  end
+end

--- a/spec/components/task_list/task_header_component_spec.rb
+++ b/spec/components/task_list/task_header_component_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe TaskList::TaskHeaderComponent, type: :component do
+  let(:project) { create(:conversion_project) }
+  let(:task) { double(status: :not_started, locales_path: "conversion.voluntary.tasks.handover") }
+
+  before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+  it "renders the title component" do
+    render_inline(TaskList::TaskHeaderComponent.new(project: project, task: task))
+
+    expect(page).to have_text(project.establishment.name)
+    expect(page).to have_text("Handover with regional delivery officer")
+  end
+end

--- a/spec/helpers/task_list_helper_spec.rb
+++ b/spec/helpers/task_list_helper_spec.rb
@@ -1,25 +1,31 @@
 require "rails_helper"
 
 RSpec.describe TaskListHelper, type: :helper do
-  describe "#task_status_id" do
-    let(:task) { Task.new(title: "Clear land questionnaire") }
+  let(:task) { Task.new(title: "Clear land questionnaire") }
+  let(:id_for_task) { "clear-land-questionnaire-status" }
 
+  describe "#task_status_id" do
     it "returns the task title as kebab case with '-status' appended" do
       expect(helper.task_status_id(task)).to eq "clear-land-questionnaire-status"
     end
   end
 
-  describe "#task_status_tag" do
-    let(:task) { Task.new(title: "Clear land questionnaire") }
+  describe "#task_id" do
+    it "returns the task title from the locales in kebab case with '-status' appended" do
+      task = Conversion::Voluntary::Tasks::Handover.new
+      expect(helper.task_id(task)).to eq "handover-with-regional-delivery-officer-status"
+    end
+  end
 
+  describe "#task_status_tag" do
     it "returns a tag representing the task status when the status is known" do
       allow(task).to receive(:status).and_return(:completed)
-      expect(helper.task_status_tag(task)).to eq '<strong class="govuk-tag govuk-tag--turquoise app-task-list__tag" id="clear-land-questionnaire-status">Completed</strong>'
+      expect(helper.task_status_tag(task, id_for_task)).to eq '<strong class="govuk-tag govuk-tag--turquoise app-task-list__tag" id="clear-land-questionnaire-status">Completed</strong>'
     end
 
     it "returns a tag representing an unknown status where the status is not known" do
       allow(task).to receive(:status).and_return(:unexpected)
-      expect(helper.task_status_tag(task)).to eq '<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="clear-land-questionnaire-status">Unknown</strong>'
+      expect(helper.task_status_tag(task, id_for_task)).to eq '<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="clear-land-questionnaire-status">Unknown</strong>'
     end
   end
 end

--- a/spec/models/conversion/involuntary/task_list_spec.rb
+++ b/spec/models/conversion/involuntary/task_list_spec.rb
@@ -9,4 +9,10 @@ RSpec.describe Conversion::Involuntary::TaskList do
   }
 
   it_behaves_like "a task list"
+
+  describe "#locales_path" do
+    it "returns the appropriate locales path based on the class path" do
+      expect(task_list.locales_path).to eq "conversion.involuntary.task_list"
+    end
+  end
 end

--- a/spec/models/conversion/voluntary/task_list_spec.rb
+++ b/spec/models/conversion/voluntary/task_list_spec.rb
@@ -9,4 +9,10 @@ RSpec.describe Conversion::Voluntary::TaskList do
   }
 
   it_behaves_like "a task list"
+
+  describe "#locales_path" do
+    it "returns the appropriate locales path based on the class path" do
+      expect(task_list.locales_path).to eq "conversion.voluntary.task_list"
+    end
+  end
 end

--- a/spec/models/task_list/section_spec.rb
+++ b/spec/models/task_list/section_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe TaskList::Section do
   describe "#title" do
-    let(:section) { described_class.new(identifier:, tasks: []) }
+    let(:section) { described_class.new(identifier:, tasks: [], locales_path: "path.to.locales") }
     let(:identifier) { :project_kick_off }
     let(:title) { "Project kick-off" }
 
@@ -12,6 +12,16 @@ RSpec.describe TaskList::Section do
 
     it "returns the section title from the translation file" do
       expect(subject).to eq title
+    end
+  end
+
+  describe "#locales_path" do
+    it "returns the locales path based on the task list class path" do
+      task_list = Conversion::Voluntary::TaskList.new
+      section = described_class
+        .new(identifier: :identifier, tasks: [], locales_path: task_list.locales_path)
+
+      expect(section.locales_path).to eq "conversion.voluntary.task_list.identifier"
     end
   end
 end

--- a/spec/models/task_list/section_spec.rb
+++ b/spec/models/task_list/section_spec.rb
@@ -1,20 +1,6 @@
 require "rails_helper"
 
 RSpec.describe TaskList::Section do
-  describe "#title" do
-    let(:section) { described_class.new(identifier:, tasks: [], locales_path: "path.to.locales") }
-    let(:identifier) { :project_kick_off }
-    let(:title) { "Project kick-off" }
-
-    before { allow(I18n).to receive(:t).with("task_list.sections.#{identifier}.title").and_return(title) }
-
-    subject { section.title }
-
-    it "returns the section title from the translation file" do
-      expect(subject).to eq title
-    end
-  end
-
   describe "#locales_path" do
     it "returns the locales path based on the task list class path" do
       task_list = Conversion::Voluntary::TaskList.new

--- a/spec/models/task_list/task_spec.rb
+++ b/spec/models/task_list/task_spec.rb
@@ -12,18 +12,6 @@ RSpec.describe TaskList::Task, type: :model do
     end
   end
 
-  describe "#title" do
-    let(:title) { "Test title" }
-
-    before { allow(I18n).to receive(:t).with("task_list.tasks.#{testing_model.identifier}.title").and_return(title) }
-
-    subject { testing_model_instance.title }
-
-    it "returns the task title from the translation file" do
-      expect(subject).to eq title
-    end
-  end
-
   describe "#locales_path" do
     it "returns the correct locale path based on the class path" do
       expect(testing_model_instance.locales_path).to eq "conversion.voluntary.testing_class"

--- a/spec/models/task_list/task_spec.rb
+++ b/spec/models/task_list/task_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe TaskList::Task, type: :model do
     end
   end
 
+  describe "#locales_path" do
+    it "returns the correct locale path based on the class path" do
+      expect(testing_model_instance.locales_path).to eq "conversion.voluntary.testing_class"
+    end
+  end
+
   describe "#status" do
     subject { testing_model_instance.status }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,8 @@ require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 require "support/factory_bot"
+require "view_component/test_helpers"
+require "capybara/rspec"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -77,6 +79,9 @@ RSpec.configure do |config|
   config.include AcademiesApiHelpers
   config.include FeatureHelpers, type: :feature
   config.include ProjectHelpers
+
+  config.include ViewComponent::TestHelpers, type: :component
+  config.include Capybara::RSpecMatchers, type: :component
 
   # cleanup Omniauth after each example
   config.after(:each) do |example|


### PR DESCRIPTION
## Changes

This PR has two main parts:

1. Use locales to render the text for tasks, instead of the workflow YAML files.
2. Use ViewComponents to render the TaskLists, instead of partials.

Using ViewComponents should hopefully result in a less complex way of building the new TaskLists, instead of nested partials which can get very complicated quickly. 

In order to use ViewComponents, we needed the Tasks to be aware of their locales, and therefore tie a task to a particular locale file for its content. We can then use the locale files to output the required text for the Task.

This PR also adds templates for the ViewComponents, and relevant styling; as well as unit tests for the ViewComponents.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
