### PR TITLE
Fix the CheckBoxActionComponent name creation

### DIFF
--- a/app/components/task_list/check_box_action_component.rb
+++ b/app/components/task_list/check_box_action_component.rb
@@ -8,7 +8,7 @@ class TaskList::CheckBoxActionComponent < ViewComponent::Base
     @hint = t("#{locales_path}.#{attribute}.hint.html", default: nil)
     @guidance_link = t("#{locales_path}.#{attribute}.guidance_link", default: nil)
     @guidance = t("#{locales_path}.#{attribute}.guidance.html", default: nil)
-    @action_id = "#{task.class.name.parameterize(separator: "_")}[#{attribute}]"
+    @action_id = "#{task.class.name.underscore.tr("/", "_")}[#{attribute}]"
   end
 
   def check_box_value

--- a/spec/components/task_list/check_box_action_component_spec.rb
+++ b/spec/components/task_list/check_box_action_component_spec.rb
@@ -39,12 +39,12 @@ RSpec.describe TaskList::CheckBoxActionComponent, type: :component do
     let(:attribute) { "notes" }
 
     before do
-      allow(task).to receive_message_chain("class.name").and_return("Conversion::Voluntary::Tasks::Handover")
+      allow(task).to receive_message_chain("class.name").and_return("Conversion::Voluntary::Tasks::HandoverTask")
       render_inline(TaskList::CheckBoxActionComponent.new(task: task, attribute: attribute))
     end
 
     it "renders the correct `name` for the form input" do
-      expect(page.find_field("conversion_voluntary_tasks_handover[notes]")).to be_present
+      expect(page.find_field("conversion_voluntary_tasks_handover_task[notes]")).to be_present
     end
   end
 end


### PR DESCRIPTION
## Changes

Previously we used `parameterize` which would concatonate a multi-word
class name like `StakeholderKickOff` to `stakeholderkickoff` which is
not what our naming conventions expect.

Switching to `underscore` and swapping the `/` for `_` solves this
issue, resulting in `stakeholder_kick_off`.

This issue hightlights:

- how important it is to get the naming right
- that we should use a custom form builder to make this less error prone

