### PR TITLE
(985) Content Security Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 #### Added
 
 - Send notification to caseworker when assigned to a project
+- Add a Content Security Policy
 
 #### Changed
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
   </head>
 
   <body class="govuk-template__body ">
-    <script>
+    <script nonce="<%= content_security_policy_nonce %>">
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 

--- a/app/views/shared/_autocomplete.html.erb
+++ b/app/views/shared/_autocomplete.html.erb
@@ -1,6 +1,6 @@
 <% content_for :footer_post_js do %>
   <%= javascript_include_tag "accessible-autocomplete/dist/accessible-autocomplete.min" %>
-  <script>
+  <script nonce="<%= content_security_policy_nonce %>">
       accessibleAutocomplete.enhanceSelectElement({
           selectElement: document.querySelector("<%= selector %>")
       })

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,22 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap and inline scripts
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.font_src :self
+    policy.img_src :self
+    policy.object_src :none
+    policy.script_src :self
+    policy.style_src :self
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+
+  # Generate session nonces for permitted importmap and inline scripts
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w[script-src]
+
+  #   # Report violations without enforcing the policy.
+  #   # config.content_security_policy_report_only = true
+end


### PR DESCRIPTION
> I've had a good browse around. Everything seems to work as expected, and I don't see any violations.

## Changes
### Enable Content Security Policy
Our recent IT Health Check raised the lack of a CSP as a medium warning for the
application.

This enables the Rails CSP with minimal rules.

For now, we won't report any CSP violations via the `report-uri`, however, this
may be revisited later.

### Add nonce to inline scripts so that are not blocked by the CSP
We have added a CSP to the application. 

This is blocking our inline scripts for:
- Enabling the GOV.UK JavaScript
- Enabling the Accessible Autocomplete component.

This adds nonces to the inline scripts. Because a nonce generator is configured
in `content_security_policy.rb`, we can simply call
`content_security_policy_nonce`.

Note: It's nicer to add nonces to a `javascript_tag` (for example `<%=
javascript_tag nonce: true do %>`). However, the ERB linter suggests avoiding
`javascript_tag` altogether.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
