### PR TITLE
View component uses `public_send`

### DIFF
--- a/app/components/task_list/check_box_action_component.rb
+++ b/app/components/task_list/check_box_action_component.rb
@@ -12,6 +12,6 @@ class TaskList::CheckBoxActionComponent < ViewComponent::Base
   end
 
   def check_box_value
-    @task.send(@attribute)
+    @task.public_send(@attribute)
   end
 end


### PR DESCRIPTION
## Changes
Our view component dynaically calls a model attribute, we have seen instances of this failing, most likely due to encapsulation issues, where a private method exists with the same name as the attribute.

We switch to `public_send` here to avoid these issues, see:

https://ruby-doc.org/3.2.0/Object.html#method-i-public_send

