### PR TITLE
(1002) Not applicable task

### DIFF
--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -7,6 +7,12 @@ class Conversion::Involuntary::TaskList < TaskList::Base
       tasks: [
         Conversion::Involuntary::Tasks::Handover
       ]
+    },
+    {
+      identifier: :legal_documents,
+      tasks: [
+        Conversion::Involuntary::Tasks::Subleases
+      ]
     }
   ].freeze
 

--- a/app/models/conversion/involuntary/tasks/subleases.rb
+++ b/app/models/conversion/involuntary/tasks/subleases.rb
@@ -1,0 +1,10 @@
+class Conversion::Involuntary::Tasks::Subleases < TaskList::OptionalTask
+  attribute :received, :boolean
+  attribute :cleared, :boolean
+  attribute :signed, :boolean
+  attribute :saved, :boolean
+
+  attribute :email_signed, :boolean
+  attribute :receive_signed, :boolean
+  attribute :save_signed, :boolean
+end

--- a/app/models/conversion/involuntary/tasks/subleases.rb
+++ b/app/models/conversion/involuntary/tasks/subleases.rb
@@ -7,4 +7,12 @@ class Conversion::Involuntary::Tasks::Subleases < TaskList::OptionalTask
   attribute :email_signed, :boolean
   attribute :receive_signed, :boolean
   attribute :save_signed, :boolean
+
+  private def not_applicable_only_key
+    :actions
+  end
+
+  private def not_applicable_only_message
+    I18n.t("errors.conversion_involuntary_tasks_subleases.actions.invalid")
+  end
 end

--- a/app/models/task_list/optional_task.rb
+++ b/app/models/task_list/optional_task.rb
@@ -1,6 +1,8 @@
 class TaskList::OptionalTask < TaskList::Task
   attribute :not_applicable, :boolean
 
+  validate :not_applicable_only
+
   private def not_applicable?
     not_applicable
   end
@@ -11,5 +13,11 @@ class TaskList::OptionalTask < TaskList::Task
 
   private def actions_when_applicable
     attributes.except("not_applicable")
+  end
+
+  private def not_applicable_only
+    if actions_when_applicable.values.any?(&:present?) && not_applicable
+      errors.add(not_applicable_only_key, not_applicable_only_message)
+    end
   end
 end

--- a/app/models/task_list/optional_task.rb
+++ b/app/models/task_list/optional_task.rb
@@ -1,0 +1,15 @@
+class TaskList::OptionalTask < TaskList::Task
+  attribute :not_applicable, :boolean
+
+  private def not_applicable?
+    not_applicable
+  end
+
+  private def completed?
+    actions_when_applicable.values.all?(&:present?)
+  end
+
+  private def actions_when_applicable
+    attributes.except("not_applicable")
+  end
+end

--- a/app/views/conversion/involuntary/task_lists/tasks/subleases.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/subleases.html.erb
@@ -1,0 +1,37 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_check_boxes_fieldset :actions, legend: {hidden: true} do %>
+
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+
+        <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.subleases.clear_section.title") %></h2>
+
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :received)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :cleared)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
+
+        <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.subleases.confirm_section.title") %></h2>
+
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :email_signed)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :receive_signed)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :save_signed)) %>
+      <% end %>
+
+      <%= form.govuk_submit %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/config/locales/task_lists/conversion/involuntary/subleases.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/subleases.en.yml
@@ -1,0 +1,31 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        subleases:
+          title: Subleases
+          hint:
+            html: <p>When schools convert, sometimes there are existing land arrangements that are covered by subleases. You will need to clear any subleases that have changed.</p>
+
+          clear_section:
+            title: Clear any changed subleases
+
+          confirm_section:
+            title: Confirm any subleases have been signed
+
+          not_applicable:
+            title: Not applicable
+          received:
+            title: Received
+          cleared:
+            title: Cleared
+          signed:
+            title: Signed for school or trust
+          saved:
+            title: Saved in school's Sharepoint folder
+          email_signed:
+            title: Email the trust to ask if all relevant parties have agreed and signed any subleases
+          receive_signed:
+            title: Receive email from the trust confirming all relevant parties have agreed and signed any subleases
+          save_signed:
+            title: Save a copy of the confirmation email in the school's SharePoint folder

--- a/config/locales/task_lists/conversion/involuntary/subleases.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/subleases.en.yml
@@ -29,3 +29,8 @@ en:
             title: Receive email from the trust confirming all relevant parties have agreed and signed any subleases
           save_signed:
             title: Save a copy of the confirmation email in the school's SharePoint folder
+
+  errors:
+    conversion_involuntary_tasks_subleases:
+      actions:
+        invalid: "Select completed actions, or select ‘Not applicable’"

--- a/db/migrate/20230105102319_add_subleases_to_involuntary_conversion_task_list.rb
+++ b/db/migrate/20230105102319_add_subleases_to_involuntary_conversion_task_list.rb
@@ -1,0 +1,12 @@
+class AddSubleasesToInvoluntaryConversionTaskList < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :subleases_not_applicable, :boolean
+    add_column :conversion_involuntary_task_lists, :subleases_received, :boolean
+    add_column :conversion_involuntary_task_lists, :subleases_cleared, :boolean
+    add_column :conversion_involuntary_task_lists, :subleases_signed, :boolean
+    add_column :conversion_involuntary_task_lists, :subleases_saved, :boolean
+    add_column :conversion_involuntary_task_lists, :subleases_email_signed, :boolean
+    add_column :conversion_involuntary_task_lists, :subleases_receive_signed, :boolean
+    add_column :conversion_involuntary_task_lists, :subleases_save_signed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_04_155248) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_102319) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -50,6 +50,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_04_155248) do
     t.boolean "handover_review"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "subleases_not_applicable"
+    t.boolean "subleases_received"
+    t.boolean "subleases_cleared"
+    t.boolean "subleases_signed"
+    t.boolean "subleases_saved"
+    t.boolean "subleases_email_signed"
+    t.boolean "subleases_receive_signed"
+    t.boolean "subleases_save_signed"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/models/conversion/involuntary/tasks/subleases_spec.rb
+++ b/spec/models/conversion/involuntary/tasks/subleases_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Conversion::Involuntary::Tasks::Subleases, type: :model do
+  describe "Validations" do
+    subject { described_class.new }
+
+    before { subject.assign_attributes(not_applicable:, received:, cleared:) }
+
+    describe "not_applicable_only" do
+      context "when `not_applicable` and any other actions are selected" do
+        let(:not_applicable) { true }
+        let(:received) { true }
+        let(:cleared) { false }
+
+        it "adds an error to the actions key" do
+          expect(subject.valid?).to be false
+          expect(subject.errors[:actions]).to include(I18n.t("errors.conversion_involuntary_tasks_subleases.actions.invalid"))
+        end
+      end
+    end
+  end
+end

--- a/spec/models/task_list/optional_task_spec.rb
+++ b/spec/models/task_list/optional_task_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe TaskList::OptionalTask, type: :model do
+  let(:testing_model) { Conversion::Voluntary::OptionalTestingClass }
+  let(:testing_model_instance) { testing_model.new }
+
+  describe "#status" do
+    subject { testing_model_instance.status }
+
+    before { testing_model_instance.assign_attributes(not_applicable:, received:, cleared:) }
+
+    context "when not applicable" do
+      let(:not_applicable) { true }
+      let(:received) { true }
+      let(:cleared) { true }
+
+      it { expect(subject).to be :not_applicable }
+    end
+
+    context "when all values except `not_applicable` are present" do
+      let(:not_applicable) { false }
+      let(:received) { true }
+      let(:cleared) { true }
+
+      it { expect(subject).to be :completed }
+    end
+
+    context "when some values are present" do
+      let(:not_applicable) { false }
+      let(:received) { true }
+      let(:cleared) { false }
+
+      it { expect(subject).to be :in_progress }
+    end
+
+    context "when no values are present" do
+      let(:not_applicable) { false }
+      let(:received) { false }
+      let(:cleared) { false }
+
+      it { expect(subject).to be :not_started }
+    end
+  end
+end
+
+class Conversion::Voluntary::OptionalTestingClass < TaskList::OptionalTask
+  attribute :received, :boolean
+  attribute :cleared, :boolean
+end


### PR DESCRIPTION
## Changes
### Add an optional task model
We have a bunch of tasks which can be optional/not applicable.

Add a derived class of TaskList::Task which computes the status of a optional
task.

### Add subleases task to involuntary task list
This adds an "optional" Sublease task for the involuntary conversion task
list.

The checkboxes are wrapped in a `govuk_check_boxes_fieldset` from the form
builder so that we can display errors correctly.

### Add validation when both `not_applicable` and other actions are selected
Users should not be able to select both "not applicable" and any other
actions.

Add validation to the optional task model, derived models must define an error
key and message.

It's important to note that the attributes of an optional task must be cast
(via the attribute method on the task model) for the validation and subsequent
re-rendering of the page, else they get assigned as "0" and "1" (which are both
true), and we have to handle the cast manually.

## Screenshots
![image](https://user-images.githubusercontent.com/47089130/210761829-b6260b00-b4ff-47be-acf8-1b9a70579104.png)

NOTE: Error message should sit above main heading

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
