### PR TITLE
Force GOVUK styles in hints and guidance

### DIFF
--- a/app/assets/stylesheets/components/task_list/check-box-action-component.scss
+++ b/app/assets/stylesheets/components/task_list/check-box-action-component.scss
@@ -8,8 +8,12 @@
     padding-right: govuk-spacing(3);
     padding-left: govuk-spacing(3);
 
-    > p {
+    p {
       @extend .govuk-hint;
+
+      a {
+        @extend .govuk-link;
+      }
     }
   }
 
@@ -17,5 +21,23 @@
     display: block;
     padding-right: govuk-spacing(3);
     padding-left: govuk-spacing(3);
+
+    p {
+      @extend .govuk-body;
+
+      a {
+        @extend .govuk-link;
+      }
+    }
+
+    ul {
+      @extend .govuk-list;
+      @extend .govuk-list--bullet;
+    }
+
+    ol {
+      @extend .govuk-list;
+      @extend .govuk-list--number;
+    }
   }
 }


### PR DESCRIPTION
## Changes
Content for hints and guidance is in the locales files and we want to
minimise the markup developers have to remember to add there.

We can force any content to have GOVUK styles by targeting elements,
this means no styles are required in the locales.


