### PR TITLE
Use `write_attribute` in Note setter

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -12,7 +12,7 @@ class Note < ApplicationRecord
   # When no value is provided, Rails will store an empty string. Instead, we want to ensure
   # these are stored as NULL, so that we aren't mixing blanks and NULLs.
   def task_identifier=(value)
-    super(value) if value.present?
+    write_attribute(:task_identifier, value) if value.present?
   end
 
   # TODO: Remove this and the foreign key along with any references when removing the old (YAML) task list.


### PR DESCRIPTION
## Changes

In some instances `super` here will not be what you think it is - this
seems to always be true in production like environments.

Before this change, calling `super(value)` results in:

```
NoMethodError (super: no superclass method `task_identifier=' for #<Note>
```

Calling this in local development does work and we have not been able to
identify why.

The fix here is to use the `write_attribute` method to achieve the same
end result without using `super` i.e to set the attribute on the model.

We can only validate this fix will work in our development environment.

https://trello.com/c/FfXozFMT
