### PR TITLE
Add involuntary task list content

### DIFF
--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -23,7 +23,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
         Conversion::Involuntary::Tasks::TrustModificationOrder,
         Conversion::Involuntary::Tasks::DirectionToTransfer,
         Conversion::Involuntary::Tasks::OneHundredAndTwentyFiveYearLease,
-        Conversion::Involuntary::Tasks::Subleases
+        Conversion::Involuntary::Tasks::Subleases,
+        Conversion::Involuntary::Tasks::TenancyAtWill
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -19,7 +19,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
         Conversion::Involuntary::Tasks::SupplementalFundingAgreement,
         Conversion::Involuntary::Tasks::ChurchSupplementalAgreement,
         Conversion::Involuntary::Tasks::MasterFundingAgreement,
-        Conversion::Involuntary::Tasks::ArticlesOfAssociation
+        Conversion::Involuntary::Tasks::ArticlesOfAssociation,
+        Conversion::Involuntary::Tasks::DeedOfVariation
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -34,14 +34,14 @@ class Conversion::Involuntary::TaskList < TaskList::Base
         Conversion::Involuntary::Tasks::CheckBaseline,
         Conversion::Involuntary::Tasks::SingleWorksheet,
         Conversion::Involuntary::Tasks::SchoolCompleted,
-        Conversion::Involuntary::Tasks::ConditionsMet,
-        Conversion::Involuntary::Tasks::ShareInformation
+        Conversion::Involuntary::Tasks::ConditionsMet
       ]
     },
     {
       identifier: :after_opening,
       tasks: [
-        Conversion::Involuntary::Tasks::TellRegionalDeliveryOfficer
+        Conversion::Involuntary::Tasks::TellRegionalDeliveryOfficer,
+        Conversion::Involuntary::Tasks::ShareInformation
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -31,7 +31,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
     {
       identifier: :get_ready_for_opening,
       tasks: [
-        Conversion::Involuntary::Tasks::CheckBaseline
+        Conversion::Involuntary::Tasks::CheckBaseline,
+        Conversion::Involuntary::Tasks::SingleWorksheet
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -5,7 +5,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
     {
       identifier: :project_kick_off,
       tasks: [
-        Conversion::Involuntary::Tasks::Handover
+        Conversion::Involuntary::Tasks::Handover,
+        Conversion::Involuntary::Tasks::StakeholderKickOff
       ]
     },
     {

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -21,7 +21,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
         Conversion::Involuntary::Tasks::MasterFundingAgreement,
         Conversion::Involuntary::Tasks::ArticlesOfAssociation,
         Conversion::Involuntary::Tasks::DeedOfVariation,
-        Conversion::Involuntary::Tasks::TrustModificationOrder
+        Conversion::Involuntary::Tasks::TrustModificationOrder,
+        Conversion::Involuntary::Tasks::DirectionToTransfer
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -27,6 +27,12 @@ class Conversion::Involuntary::TaskList < TaskList::Base
         Conversion::Involuntary::Tasks::TenancyAtWill,
         Conversion::Involuntary::Tasks::CommercialTransferAgreement
       ]
+    },
+    {
+      identifier: :get_ready_for_opening,
+      tasks: [
+        Conversion::Involuntary::Tasks::CheckBaseline
+      ]
     }
   ].freeze
 

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -33,7 +33,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
       tasks: [
         Conversion::Involuntary::Tasks::CheckBaseline,
         Conversion::Involuntary::Tasks::SingleWorksheet,
-        Conversion::Involuntary::Tasks::SchoolCompleted
+        Conversion::Involuntary::Tasks::SchoolCompleted,
+        Conversion::Involuntary::Tasks::ConditionsMet
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -22,7 +22,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
         Conversion::Involuntary::Tasks::ArticlesOfAssociation,
         Conversion::Involuntary::Tasks::DeedOfVariation,
         Conversion::Involuntary::Tasks::TrustModificationOrder,
-        Conversion::Involuntary::Tasks::DirectionToTransfer
+        Conversion::Involuntary::Tasks::DirectionToTransfer,
+        Conversion::Involuntary::Tasks::OneHundredAndTwentyFiveYearLease
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -43,7 +43,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
         Conversion::Involuntary::Tasks::TellRegionalDeliveryOfficer,
         Conversion::Involuntary::Tasks::ShareInformation,
         Conversion::Involuntary::Tasks::RedactAndSend,
-        Conversion::Involuntary::Tasks::UpdateEsfa
+        Conversion::Involuntary::Tasks::UpdateEsfa,
+        Conversion::Involuntary::Tasks::ReceiveGrantPaymentCertificate
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -14,7 +14,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
       identifier: :legal_documents,
       tasks: [
         Conversion::Involuntary::Tasks::Subleases,
-        Conversion::Involuntary::Tasks::LandQuestionnaire
+        Conversion::Involuntary::Tasks::LandQuestionnaire,
+        Conversion::Involuntary::Tasks::LandRegistry
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -34,7 +34,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
         Conversion::Involuntary::Tasks::CheckBaseline,
         Conversion::Involuntary::Tasks::SingleWorksheet,
         Conversion::Involuntary::Tasks::SchoolCompleted,
-        Conversion::Involuntary::Tasks::ConditionsMet
+        Conversion::Involuntary::Tasks::ConditionsMet,
+        Conversion::Involuntary::Tasks::ShareInformation
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -17,7 +17,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
         Conversion::Involuntary::Tasks::LandQuestionnaire,
         Conversion::Involuntary::Tasks::LandRegistry,
         Conversion::Involuntary::Tasks::SupplementalFundingAgreement,
-        Conversion::Involuntary::Tasks::ChurchSupplementalAgreement
+        Conversion::Involuntary::Tasks::ChurchSupplementalAgreement,
+        Conversion::Involuntary::Tasks::MasterFundingAgreement
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -32,7 +32,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
       identifier: :get_ready_for_opening,
       tasks: [
         Conversion::Involuntary::Tasks::CheckBaseline,
-        Conversion::Involuntary::Tasks::SingleWorksheet
+        Conversion::Involuntary::Tasks::SingleWorksheet,
+        Conversion::Involuntary::Tasks::SchoolCompleted
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -13,7 +13,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
     {
       identifier: :legal_documents,
       tasks: [
-        Conversion::Involuntary::Tasks::Subleases
+        Conversion::Involuntary::Tasks::Subleases,
+        Conversion::Involuntary::Tasks::LandQuestionnaire
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -24,7 +24,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
         Conversion::Involuntary::Tasks::DirectionToTransfer,
         Conversion::Involuntary::Tasks::OneHundredAndTwentyFiveYearLease,
         Conversion::Involuntary::Tasks::Subleases,
-        Conversion::Involuntary::Tasks::TenancyAtWill
+        Conversion::Involuntary::Tasks::TenancyAtWill,
+        Conversion::Involuntary::Tasks::CommercialTransferAgreement
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -37,6 +37,12 @@ class Conversion::Involuntary::TaskList < TaskList::Base
         Conversion::Involuntary::Tasks::ConditionsMet,
         Conversion::Involuntary::Tasks::ShareInformation
       ]
+    },
+    {
+      identifier: :after_opening,
+      tasks: [
+        Conversion::Involuntary::Tasks::TellRegionalDeliveryOfficer
+      ]
     }
   ].freeze
 

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -20,7 +20,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
         Conversion::Involuntary::Tasks::ChurchSupplementalAgreement,
         Conversion::Involuntary::Tasks::MasterFundingAgreement,
         Conversion::Involuntary::Tasks::ArticlesOfAssociation,
-        Conversion::Involuntary::Tasks::DeedOfVariation
+        Conversion::Involuntary::Tasks::DeedOfVariation,
+        Conversion::Involuntary::Tasks::TrustModificationOrder
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -18,7 +18,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
         Conversion::Involuntary::Tasks::LandRegistry,
         Conversion::Involuntary::Tasks::SupplementalFundingAgreement,
         Conversion::Involuntary::Tasks::ChurchSupplementalAgreement,
-        Conversion::Involuntary::Tasks::MasterFundingAgreement
+        Conversion::Involuntary::Tasks::MasterFundingAgreement,
+        Conversion::Involuntary::Tasks::ArticlesOfAssociation
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -16,7 +16,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
         Conversion::Involuntary::Tasks::Subleases,
         Conversion::Involuntary::Tasks::LandQuestionnaire,
         Conversion::Involuntary::Tasks::LandRegistry,
-        Conversion::Involuntary::Tasks::SupplementalFundingAgreement
+        Conversion::Involuntary::Tasks::SupplementalFundingAgreement,
+        Conversion::Involuntary::Tasks::ChurchSupplementalAgreement
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -6,7 +6,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
       identifier: :project_kick_off,
       tasks: [
         Conversion::Involuntary::Tasks::Handover,
-        Conversion::Involuntary::Tasks::StakeholderKickOff
+        Conversion::Involuntary::Tasks::StakeholderKickOff,
+        Conversion::Involuntary::Tasks::ConversionGrant
       ]
     },
     {

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -13,7 +13,6 @@ class Conversion::Involuntary::TaskList < TaskList::Base
     {
       identifier: :legal_documents,
       tasks: [
-        Conversion::Involuntary::Tasks::Subleases,
         Conversion::Involuntary::Tasks::LandQuestionnaire,
         Conversion::Involuntary::Tasks::LandRegistry,
         Conversion::Involuntary::Tasks::SupplementalFundingAgreement,
@@ -23,7 +22,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
         Conversion::Involuntary::Tasks::DeedOfVariation,
         Conversion::Involuntary::Tasks::TrustModificationOrder,
         Conversion::Involuntary::Tasks::DirectionToTransfer,
-        Conversion::Involuntary::Tasks::OneHundredAndTwentyFiveYearLease
+        Conversion::Involuntary::Tasks::OneHundredAndTwentyFiveYearLease,
+        Conversion::Involuntary::Tasks::Subleases
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -15,7 +15,8 @@ class Conversion::Involuntary::TaskList < TaskList::Base
       tasks: [
         Conversion::Involuntary::Tasks::Subleases,
         Conversion::Involuntary::Tasks::LandQuestionnaire,
-        Conversion::Involuntary::Tasks::LandRegistry
+        Conversion::Involuntary::Tasks::LandRegistry,
+        Conversion::Involuntary::Tasks::SupplementalFundingAgreement
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -41,7 +41,9 @@ class Conversion::Involuntary::TaskList < TaskList::Base
       identifier: :after_opening,
       tasks: [
         Conversion::Involuntary::Tasks::TellRegionalDeliveryOfficer,
-        Conversion::Involuntary::Tasks::ShareInformation
+        Conversion::Involuntary::Tasks::ShareInformation,
+        Conversion::Involuntary::Tasks::RedactAndSend,
+        Conversion::Involuntary::Tasks::UpdateEsfa
       ]
     }
   ].freeze

--- a/app/models/conversion/involuntary/tasks/articles_of_association.rb
+++ b/app/models/conversion/involuntary/tasks/articles_of_association.rb
@@ -1,4 +1,4 @@
-class Conversion::Involuntary::Tasks::ArticlesOfAssociation < TaskList::Task
+class Conversion::Involuntary::Tasks::ArticlesOfAssociation < TaskList::OptionalTask
   attribute :received
   attribute :cleared
   attribute :signed

--- a/app/models/conversion/involuntary/tasks/articles_of_association.rb
+++ b/app/models/conversion/involuntary/tasks/articles_of_association.rb
@@ -1,0 +1,6 @@
+class Conversion::Involuntary::Tasks::ArticlesOfAssociation < TaskList::Task
+  attribute :received
+  attribute :cleared
+  attribute :signed
+  attribute :saved
+end

--- a/app/models/conversion/involuntary/tasks/check_baseline.rb
+++ b/app/models/conversion/involuntary/tasks/check_baseline.rb
@@ -1,0 +1,3 @@
+class Conversion::Involuntary::Tasks::CheckBaseline < TaskList::Task
+  attribute :confirm
+end

--- a/app/models/conversion/involuntary/tasks/church_supplemental_agreement.rb
+++ b/app/models/conversion/involuntary/tasks/church_supplemental_agreement.rb
@@ -1,0 +1,10 @@
+class Conversion::Involuntary::Tasks::ChurchSupplementalAgreement < TaskList::Task
+  attribute :received
+  attribute :cleared
+  attribute :signed
+  attribute :signed_diocese
+  attribute :saved
+
+  attribute :sent
+  attribute :signed_secretary_state
+end

--- a/app/models/conversion/involuntary/tasks/church_supplemental_agreement.rb
+++ b/app/models/conversion/involuntary/tasks/church_supplemental_agreement.rb
@@ -1,4 +1,4 @@
-class Conversion::Involuntary::Tasks::ChurchSupplementalAgreement < TaskList::Task
+class Conversion::Involuntary::Tasks::ChurchSupplementalAgreement < TaskList::OptionalTask
   attribute :received
   attribute :cleared
   attribute :signed

--- a/app/models/conversion/involuntary/tasks/commercial_transfer_agreement.rb
+++ b/app/models/conversion/involuntary/tasks/commercial_transfer_agreement.rb
@@ -1,0 +1,5 @@
+class Conversion::Involuntary::Tasks::CommercialTransferAgreement < TaskList::Task
+  attribute :email_signed
+  attribute :receive_signed
+  attribute :save_signed
+end

--- a/app/models/conversion/involuntary/tasks/conditions_met.rb
+++ b/app/models/conversion/involuntary/tasks/conditions_met.rb
@@ -1,0 +1,3 @@
+class Conversion::Involuntary::Tasks::ConditionsMet < TaskList::Task
+  attribute :emailed
+end

--- a/app/models/conversion/involuntary/tasks/conversion_grant.rb
+++ b/app/models/conversion/involuntary/tasks/conversion_grant.rb
@@ -1,0 +1,7 @@
+class Conversion::Involuntary::Tasks::ConversionGrant < TaskList::Task
+  attribute :eligibility
+  attribute :payment_amount
+  attribute :payment_form
+  attribute :send_information
+  attribute :inform_trust
+end

--- a/app/models/conversion/involuntary/tasks/deed_of_variation.rb
+++ b/app/models/conversion/involuntary/tasks/deed_of_variation.rb
@@ -1,4 +1,4 @@
-class Conversion::Involuntary::Tasks::DeedOfVariation < TaskList::Task
+class Conversion::Involuntary::Tasks::DeedOfVariation < TaskList::OptionalTask
   attribute :received
   attribute :cleared
   attribute :signed

--- a/app/models/conversion/involuntary/tasks/deed_of_variation.rb
+++ b/app/models/conversion/involuntary/tasks/deed_of_variation.rb
@@ -1,0 +1,6 @@
+class Conversion::Involuntary::Tasks::DeedOfVariation < TaskList::Task
+  attribute :received
+  attribute :cleared
+  attribute :signed
+  attribute :saved
+end

--- a/app/models/conversion/involuntary/tasks/direction_to_transfer.rb
+++ b/app/models/conversion/involuntary/tasks/direction_to_transfer.rb
@@ -1,0 +1,6 @@
+class Conversion::Involuntary::Tasks::DirectionToTransfer < TaskList::Task
+  attribute :received
+  attribute :cleared
+  attribute :signed
+  attribute :saved
+end

--- a/app/models/conversion/involuntary/tasks/direction_to_transfer.rb
+++ b/app/models/conversion/involuntary/tasks/direction_to_transfer.rb
@@ -1,4 +1,4 @@
-class Conversion::Involuntary::Tasks::DirectionToTransfer < TaskList::Task
+class Conversion::Involuntary::Tasks::DirectionToTransfer < TaskList::OptionalTask
   attribute :received
   attribute :cleared
   attribute :signed

--- a/app/models/conversion/involuntary/tasks/handover.rb
+++ b/app/models/conversion/involuntary/tasks/handover.rb
@@ -1,3 +1,5 @@
 class Conversion::Involuntary::Tasks::Handover < TaskList::Task
   attribute :review
+  attribute :notes
+  attribute :meeting
 end

--- a/app/models/conversion/involuntary/tasks/handover.rb
+++ b/app/models/conversion/involuntary/tasks/handover.rb
@@ -1,4 +1,4 @@
-class Conversion::Involuntary::Tasks::Handover < TaskList::Task
+class Conversion::Involuntary::Tasks::Handover < TaskList::OptionalTask
   attribute :review
   attribute :notes
   attribute :meeting

--- a/app/models/conversion/involuntary/tasks/land_questionnaire.rb
+++ b/app/models/conversion/involuntary/tasks/land_questionnaire.rb
@@ -1,0 +1,6 @@
+class Conversion::Involuntary::Tasks::LandQuestionnaire < TaskList::Task
+  attribute :received
+  attribute :cleared
+  attribute :signed
+  attribute :saved
+end

--- a/app/models/conversion/involuntary/tasks/land_registry.rb
+++ b/app/models/conversion/involuntary/tasks/land_registry.rb
@@ -1,0 +1,5 @@
+class Conversion::Involuntary::Tasks::LandRegistry < TaskList::Task
+  attribute :received
+  attribute :cleared
+  attribute :saved
+end

--- a/app/models/conversion/involuntary/tasks/master_funding_agreement.rb
+++ b/app/models/conversion/involuntary/tasks/master_funding_agreement.rb
@@ -1,4 +1,4 @@
-class Conversion::Involuntary::Tasks::MasterFundingAgreement < TaskList::Task
+class Conversion::Involuntary::Tasks::MasterFundingAgreement < TaskList::OptionalTask
   attribute :received
   attribute :cleared
   attribute :signed

--- a/app/models/conversion/involuntary/tasks/master_funding_agreement.rb
+++ b/app/models/conversion/involuntary/tasks/master_funding_agreement.rb
@@ -1,0 +1,9 @@
+class Conversion::Involuntary::Tasks::MasterFundingAgreement < TaskList::Task
+  attribute :received
+  attribute :cleared
+  attribute :signed
+  attribute :saved
+
+  attribute :sent
+  attribute :signed_secretary_state
+end

--- a/app/models/conversion/involuntary/tasks/one_hundred_and_twenty_five_year_lease.rb
+++ b/app/models/conversion/involuntary/tasks/one_hundred_and_twenty_five_year_lease.rb
@@ -1,0 +1,5 @@
+class Conversion::Involuntary::Tasks::OneHundredAndTwentyFiveYearLease < TaskList::Task
+  attribute :email
+  attribute :receive
+  attribute :save
+end

--- a/app/models/conversion/involuntary/tasks/one_hundred_and_twenty_five_year_lease.rb
+++ b/app/models/conversion/involuntary/tasks/one_hundred_and_twenty_five_year_lease.rb
@@ -1,4 +1,4 @@
-class Conversion::Involuntary::Tasks::OneHundredAndTwentyFiveYearLease < TaskList::Task
+class Conversion::Involuntary::Tasks::OneHundredAndTwentyFiveYearLease < TaskList::OptionalTask
   attribute :email
   attribute :receive
   attribute :save

--- a/app/models/conversion/involuntary/tasks/receive_grant_payment_certificate.rb
+++ b/app/models/conversion/involuntary/tasks/receive_grant_payment_certificate.rb
@@ -1,0 +1,5 @@
+class Conversion::Involuntary::Tasks::ReceiveGrantPaymentCertificate < TaskList::Task
+  attribute :check_and_save
+  attribute :update_kim
+  attribute :update_sheet
+end

--- a/app/models/conversion/involuntary/tasks/redact_and_send.rb
+++ b/app/models/conversion/involuntary/tasks/redact_and_send.rb
@@ -1,0 +1,6 @@
+class Conversion::Involuntary::Tasks::RedactAndSend < TaskList::Task
+  attribute :redact
+  attribute :save
+  attribute :send
+  attribute :send_solicitors
+end

--- a/app/models/conversion/involuntary/tasks/school_completed.rb
+++ b/app/models/conversion/involuntary/tasks/school_completed.rb
@@ -1,0 +1,4 @@
+class Conversion::Involuntary::Tasks::SchoolCompleted < TaskList::Task
+  attribute :emailed
+  attribute :saved
+end

--- a/app/models/conversion/involuntary/tasks/share_information.rb
+++ b/app/models/conversion/involuntary/tasks/share_information.rb
@@ -1,0 +1,3 @@
+class Conversion::Involuntary::Tasks::ShareInformation < TaskList::Task
+  attribute :email
+end

--- a/app/models/conversion/involuntary/tasks/single_worksheet.rb
+++ b/app/models/conversion/involuntary/tasks/single_worksheet.rb
@@ -1,0 +1,5 @@
+class Conversion::Involuntary::Tasks::SingleWorksheet < TaskList::Task
+  attribute :complete
+  attribute :approve
+  attribute :send
+end

--- a/app/models/conversion/involuntary/tasks/stakeholder_kick_off.rb
+++ b/app/models/conversion/involuntary/tasks/stakeholder_kick_off.rb
@@ -1,0 +1,6 @@
+class Conversion::Involuntary::Tasks::StakeholderKickOff < TaskList::Task
+  attribute :introductory_emails
+  attribute :local_authority_proforma
+  attribute :confirm_target_conversion_date
+  attribute :setup_meeting
+end

--- a/app/models/conversion/involuntary/tasks/supplemental_funding_agreement.rb
+++ b/app/models/conversion/involuntary/tasks/supplemental_funding_agreement.rb
@@ -1,0 +1,9 @@
+class Conversion::Involuntary::Tasks::SupplementalFundingAgreement < TaskList::Task
+  attribute :received
+  attribute :cleared
+  attribute :signed
+  attribute :saved
+
+  attribute :sent
+  attribute :signed_secretary_state
+end

--- a/app/models/conversion/involuntary/tasks/tell_regional_delivery_officer.rb
+++ b/app/models/conversion/involuntary/tasks/tell_regional_delivery_officer.rb
@@ -1,0 +1,3 @@
+class Conversion::Involuntary::Tasks::TellRegionalDeliveryOfficer < TaskList::Task
+  attribute :email
+end

--- a/app/models/conversion/involuntary/tasks/tenancy_at_will.rb
+++ b/app/models/conversion/involuntary/tasks/tenancy_at_will.rb
@@ -1,0 +1,5 @@
+class Conversion::Involuntary::Tasks::TenancyAtWill < TaskList::Task
+  attribute :email_signed
+  attribute :receive_signed
+  attribute :save_signed
+end

--- a/app/models/conversion/involuntary/tasks/tenancy_at_will.rb
+++ b/app/models/conversion/involuntary/tasks/tenancy_at_will.rb
@@ -1,4 +1,4 @@
-class Conversion::Involuntary::Tasks::TenancyAtWill < TaskList::Task
+class Conversion::Involuntary::Tasks::TenancyAtWill < TaskList::OptionalTask
   attribute :email_signed
   attribute :receive_signed
   attribute :save_signed

--- a/app/models/conversion/involuntary/tasks/trust_modification_order.rb
+++ b/app/models/conversion/involuntary/tasks/trust_modification_order.rb
@@ -1,4 +1,4 @@
-class Conversion::Involuntary::Tasks::TrustModificationOrder < TaskList::Task
+class Conversion::Involuntary::Tasks::TrustModificationOrder < TaskList::OptionalTask
   attribute :received
   attribute :sent_legal
   attribute :cleared

--- a/app/models/conversion/involuntary/tasks/trust_modification_order.rb
+++ b/app/models/conversion/involuntary/tasks/trust_modification_order.rb
@@ -1,0 +1,6 @@
+class Conversion::Involuntary::Tasks::TrustModificationOrder < TaskList::Task
+  attribute :received
+  attribute :sent_legal
+  attribute :cleared
+  attribute :saved
+end

--- a/app/models/conversion/involuntary/tasks/update_esfa.rb
+++ b/app/models/conversion/involuntary/tasks/update_esfa.rb
@@ -1,0 +1,3 @@
+class Conversion::Involuntary::Tasks::UpdateEsfa < TaskList::Task
+  attribute :update
+end

--- a/app/views/conversion/involuntary/task_lists/tasks/articles_of_association.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/articles_of_association.html.erb
@@ -1,0 +1,32 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.articles_of_association.clear_section.title") %></h2>
+      <%= t("conversion.involuntary.tasks.articles_of_association.clear_section.hint.html") %>
+
+      <%= govuk_details(
+            summary_text: t("conversion.involuntary.tasks.articles_of_association.clear_section.guidance_link"),
+            text: t("conversion.involuntary.tasks.articles_of_association.clear_section.guidance.html")
+          ) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :received)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :cleared)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/articles_of_association.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/articles_of_association.html.erb
@@ -9,6 +9,10 @@
     <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
       <%= form.govuk_error_summary %>
 
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
       <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.articles_of_association.clear_section.title") %></h2>
       <%= t("conversion.involuntary.tasks.articles_of_association.clear_section.hint.html") %>
 

--- a/app/views/conversion/involuntary/task_lists/tasks/check_baseline.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/check_baseline.html.erb
@@ -1,0 +1,23 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-from-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :confirm)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/church_supplemental_agreement.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/church_supplemental_agreement.html.erb
@@ -9,6 +9,10 @@
     <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
       <%= form.govuk_error_summary %>
 
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
       <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.church_supplemental_agreement.clear_section.title") %></h2>
       <%= t("conversion.involuntary.tasks.church_supplemental_agreement.clear_section.hint.html") %>
 

--- a/app/views/conversion/involuntary/task_lists/tasks/church_supplemental_agreement.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/church_supplemental_agreement.html.erb
@@ -1,0 +1,39 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.church_supplemental_agreement.clear_section.title") %></h2>
+      <%= t("conversion.involuntary.tasks.church_supplemental_agreement.clear_section.hint.html") %>
+
+      <%= govuk_details(
+            summary_text: t("conversion.involuntary.tasks.church_supplemental_agreement.clear_section.guidance_link"),
+            text: t("conversion.involuntary.tasks.church_supplemental_agreement.clear_section.guidance.html")
+          ) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :received)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :cleared)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed_diocese)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
+
+      <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.church_supplemental_agreement.sign_section.title") %></h2>
+      <%= t("conversion.involuntary.tasks.church_supplemental_agreement.sign_section.hint.html") %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :sent)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed_secretary_state)) %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/commercial_transfer_agreement.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/commercial_transfer_agreement.html.erb
@@ -1,0 +1,25 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :email_signed)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :receive_signed)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :save_signed)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/conditions_met.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/conditions_met.html.erb
@@ -1,0 +1,23 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :emailed)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/conversion_grant.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/conversion_grant.html.erb
@@ -1,0 +1,29 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :eligibility)) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :payment_amount)) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :payment_form)) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :send_information)) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :inform_trust)) %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/deed_of_variation.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/deed_of_variation.html.erb
@@ -1,0 +1,32 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.deed_of_variation.clear_section.title") %></h2>
+      <%= t("conversion.involuntary.tasks.deed_of_variation.clear_section.hint.html") %>
+
+      <%= govuk_details(
+            summary_text: t("conversion.involuntary.tasks.deed_of_variation.clear_section.guidance_link"),
+            text: t("conversion.involuntary.tasks.deed_of_variation.clear_section.guidance.html")
+          ) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :received)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :cleared)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/deed_of_variation.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/deed_of_variation.html.erb
@@ -9,6 +9,10 @@
     <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
       <%= form.govuk_error_summary %>
 
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
       <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.deed_of_variation.clear_section.title") %></h2>
       <%= t("conversion.involuntary.tasks.deed_of_variation.clear_section.hint.html") %>
 

--- a/app/views/conversion/involuntary/task_lists/tasks/direction_to_transfer.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/direction_to_transfer.html.erb
@@ -9,6 +9,10 @@
     <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
       <%= form.govuk_error_summary %>
 
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
       <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.direction_to_transfer.clear_section.title") %></h2>
       <%= t("conversion.involuntary.tasks.direction_to_transfer.clear_section.hint.html") %>
 

--- a/app/views/conversion/involuntary/task_lists/tasks/direction_to_transfer.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/direction_to_transfer.html.erb
@@ -1,0 +1,32 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.direction_to_transfer.clear_section.title") %></h2>
+      <%= t("conversion.involuntary.tasks.direction_to_transfer.clear_section.hint.html") %>
+
+      <%= govuk_details(
+            summary_text: t("conversion.involuntary.tasks.direction_to_transfer.clear_section.guidance_link"),
+            text: t("conversion.involuntary.tasks.direction_to_transfer.clear_section.guidance.html")
+          ) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :received)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :cleared)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/handover.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/handover.html.erb
@@ -9,11 +9,15 @@
     <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
       <%= form.govuk_error_summary %>
 
-      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :review)) %>
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
 
-      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :notes)) %>
-
-      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :meeting)) %>
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :review)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :notes)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :meeting)) %>
+      </div>
 
       <%= form.govuk_submit t("task_list.continue_button.text") %>
     <% end %>

--- a/app/views/conversion/involuntary/task_lists/tasks/handover.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/handover.html.erb
@@ -11,7 +11,11 @@
 
       <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :review)) %>
 
-      <%= form.govuk_submit %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :notes)) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :meeting)) %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
     <% end %>
   </div>
 

--- a/app/views/conversion/involuntary/task_lists/tasks/land_questionnaire.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/land_questionnaire.html.erb
@@ -1,0 +1,32 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.land_questionnaire.sub_section.title") %></h2>
+      <%= t("conversion.involuntary.tasks.land_questionnaire.sub_section.hint.html") %>
+
+      <%= govuk_details(
+            summary_text: t("conversion.involuntary.tasks.land_questionnaire.sub_section.guidance_link"),
+            text: t("conversion.involuntary.tasks.land_questionnaire.sub_section.guidance.html")
+          ) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :received)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :cleared)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/land_registry.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/land_registry.html.erb
@@ -1,0 +1,31 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.land_registry.sub_section.title") %></h2>
+      <%= t("conversion.involuntary.tasks.land_registry.sub_section.hint.html") %>
+
+      <%= govuk_details(
+            summary_text: t("conversion.involuntary.tasks.land_registry.sub_section.guidance_link"),
+            text: t("conversion.involuntary.tasks.land_registry.sub_section.guidance.html")
+          ) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :received)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :cleared)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/master_funding_agreement.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/master_funding_agreement.html.erb
@@ -9,6 +9,10 @@
     <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
       <%= form.govuk_error_summary %>
 
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
       <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.master_funding_agreement.clear_section.title") %></h2>
       <%= t("conversion.involuntary.tasks.master_funding_agreement.clear_section.hint.html") %>
 

--- a/app/views/conversion/involuntary/task_lists/tasks/master_funding_agreement.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/master_funding_agreement.html.erb
@@ -1,0 +1,41 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.master_funding_agreement.clear_section.title") %></h2>
+      <%= t("conversion.involuntary.tasks.master_funding_agreement.clear_section.hint.html") %>
+
+      <%= govuk_details(
+            summary_text: t("conversion.involuntary.tasks.master_funding_agreement.clear_section.guidance_link"),
+            text: t("conversion.involuntary.tasks.master_funding_agreement.clear_section.guidance.html")
+          ) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :received)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :cleared)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
+
+      <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.master_funding_agreement.sign_section.title") %></h2>
+      <%= govuk_details(
+            summary_text: t("conversion.involuntary.tasks.master_funding_agreement.sign_section.guidance_link"),
+            text: t("conversion.involuntary.tasks.master_funding_agreement.sign_section.guidance.html")
+          ) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :sent)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed_secretary_state)) %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/one_hundred_and_twenty_five_year_lease.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/one_hundred_and_twenty_five_year_lease.html.erb
@@ -1,0 +1,31 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
+      <div class="govuk-form-group">
+        <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.one_hundred_and_twenty_five_year_lease.confirm_section.title") %></h2>
+
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :email)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :receive)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :save)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/receive_grant_payment_certificate.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/receive_grant_payment_certificate.html.erb
@@ -1,0 +1,25 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_voluntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_voluntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :check_and_save)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :update_kim)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :update_sheet)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/redact_and_send.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/redact_and_send.html.erb
@@ -1,0 +1,26 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_voluntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_voluntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :redact)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :save)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :send)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :send_solicitors)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/school_completed.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/school_completed.html.erb
@@ -1,0 +1,24 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :emailed)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/share_information.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/share_information.html.erb
@@ -1,0 +1,23 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_voluntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_voluntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :email)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/single_worksheet.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/single_worksheet.html.erb
@@ -1,0 +1,25 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :complete)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :approve)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :send)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/stakeholder_kick_off.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/stakeholder_kick_off.html.erb
@@ -1,0 +1,27 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :introductory_emails)) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :local_authority_proforma)) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :confirm_target_conversion_date)) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :setup_meeting)) %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/supplemental_funding_agreement.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/supplemental_funding_agreement.html.erb
@@ -1,0 +1,38 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.supplemental_funding_agreement.clear_section.title") %></h2>
+      <%= t("conversion.involuntary.tasks.supplemental_funding_agreement.clear_section.hint.html") %>
+
+      <%= govuk_details(
+            summary_text: t("conversion.involuntary.tasks.supplemental_funding_agreement.clear_section.guidance_link"),
+            text: t("conversion.involuntary.tasks.supplemental_funding_agreement.clear_section.guidance.html")
+          ) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :received)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :cleared)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
+
+      <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.supplemental_funding_agreement.sign_section.title") %></h2>
+      <%= t("conversion.involuntary.tasks.supplemental_funding_agreement.sign_section.hint.html") %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :sent)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed_secretary_state)) %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/tell_regional_delivery_officer.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/tell_regional_delivery_officer.html.erb
@@ -1,0 +1,23 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :email)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/tenancy_at_will.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/tenancy_at_will.html.erb
@@ -1,0 +1,31 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
+      <div class="govuk-form-group">
+        <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.tenancy_at_will.confirm_section.title") %></h2>
+
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :email_signed)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :receive_signed)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :save_signed)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/trust_modification_order.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/trust_modification_order.html.erb
@@ -9,6 +9,10 @@
     <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
       <%= form.govuk_error_summary %>
 
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
       <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.trust_modification_order.clear_section.title") %></h2>
       <%= t("conversion.involuntary.tasks.trust_modification_order.clear_section.hint.html") %>
 

--- a/app/views/conversion/involuntary/task_lists/tasks/trust_modification_order.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/trust_modification_order.html.erb
@@ -1,0 +1,32 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <h2 class="govuk-heading-l"><%= t("conversion.involuntary.tasks.trust_modification_order.clear_section.title") %></h2>
+      <%= t("conversion.involuntary.tasks.trust_modification_order.clear_section.hint.html") %>
+
+      <%= govuk_details(
+            summary_text: t("conversion.involuntary.tasks.trust_modification_order.clear_section.guidance_link"),
+            text: t("conversion.involuntary.tasks.trust_modification_order.clear_section.guidance.html")
+          ) %>
+
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :received)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :sent_legal)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :cleared)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversion/involuntary/task_lists/tasks/update_esfa.html.erb
+++ b/app/views/conversion/involuntary/task_lists/tasks/update_esfa.html.erb
@@ -1,0 +1,23 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversion_involuntary_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :update)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversion/shared/task_notes" %>
+  </div>
+</div>

--- a/config/locales/task_lists/conversion/involuntary/articles_of_association.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/articles_of_association.en.yml
@@ -24,3 +24,5 @@ en:
             title: Signed by school or trust
           saved:
             title: Saved in the school's SharePoint folder
+          not_applicable:
+            title: Not applicable

--- a/config/locales/task_lists/conversion/involuntary/articles_of_association.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/articles_of_association.en.yml
@@ -1,0 +1,26 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        articles_of_association:
+          title: Articles of association
+          hint:
+            html: <p>The Articles of association must be updated if the trust currently uses a version from February 2016 or earlier.</p>
+          clear_section:
+            title: Check and clear the Articles of association
+            hint:
+              html: <p>You can use the <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Land-Transfer-and-shared-land-use.aspx" target="_blank">land transfer advice and guidance to check for common problems (opens in new tab)</a>.</p>
+            guidance_link: Help checking for changes
+            guidance:
+              html:
+                <p>Changes that personalise the model documents to a school or trust, and remove or add optional clauses, are expected. The wording of clauses should not change.</p>
+                <p>You'll need to <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Commissioning%20Form.aspx" target="_blank">contact the policy team (opens in new tab)</a> about changes to clause text.</p>
+
+          received:
+            title: Received
+          cleared:
+            title: Cleared
+          signed:
+            title: Signed by school or trust
+          saved:
+            title: Saved in the school's SharePoint folder

--- a/config/locales/task_lists/conversion/involuntary/check_baseline.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/check_baseline.en.yml
@@ -1,0 +1,28 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        check_baseline:
+          title: Check the Baseline
+          hint:
+            html: <p>You must confirm the conversion date within 3 working days of receiving the Baseline email. Indicate on the Baseline that the school is on track to open.</p>
+
+          confirm:
+            title: Confirm the school is on track to open on the provisional date
+            guidance_link: How to check the Baseline
+            guidance:
+              html:
+                <p>The Academies Operational Practice Unit will usually email the Baseline spreadsheet to you in the first week of each month.</p>
+                <p>Your projects should be on the Regional Casework Services Baseline spreadsheet. This contains a list of all the schools expected to open as academies the following month, across all regions.</p>
+                <p>Check the Regional Casework Services Baseline spreadsheet to confirm:</p>
+                <ul>
+                <li>your school is on it</li>
+                <li>the information about the school is correct</li>
+                </ul>
+                <p>Enter yes if the project is on track to convert, or no if it will not open on the target date.</p>
+                <p><strong>What to do if your school is not on the Baseline</strong></p>
+                <p>There is one Baseline spreadsheet for each region. These are only used by regional delivery officers.</p>
+                <p>Sometimes Regional Casework Services projects will show in the regional Baseline spreadsheets by accident.</p>
+                <p>If this happens, remove your school from the regional Baseline spreadsheet and add it to the Regional Casework Services Baseline spreadsheet.</p>
+                <p>If it doesn't appear at all, enter the school's information in the correct Baseline spreadsheet.</p>
+                <p>Email the Academy Operational Practice Unit at <a href="mailto:academiesdelivery.operations@education.gov.uk" class="govuk-link" target="_blank">academiesdelivery.operations@education.gov.uk</a> to tell them if you have had to move or add the school to the correct Baseline.</p>

--- a/config/locales/task_lists/conversion/involuntary/church_supplemental_agreement.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/church_supplemental_agreement.en.yml
@@ -1,0 +1,37 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        church_supplemental_agreement:
+          title: Church supplemental agreement
+          hint:
+            html: <p>This document is only required for Church of England and Catholic schools.</p>
+          clear_section:
+            title: Check and clear the Church supplemental agreement
+            hint:
+              html: <p>You can <a href="https://www.gov.uk/government/collections/convert-to-an-academy-documents-for-schools" class="govuk-link" target="_blank">view the model documents (opens in new tab)</a> to check for changes.</p>
+            guidance_link: Help checking the Church supplemental agreement
+            guidance:
+              html:
+                <p>Changes that personalise the model documents to a school or trust, and remove or add optional clauses, are expected. The wording of clauses should not change.</p>
+                <p>You'll need to <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Commissioning%20Form.aspx" class="govuk-link" target="_blank">contact the policy team (opens in new tab)</a> about changes to clause text.</p>
+          sign_section:
+            title: Signed by the Secretary of State
+            hint:
+              html: <p>The Secretary of State, or somebody with the authority to act on their behalf, must sign the Church supplemental agreement. Usually this is your team leader or the deputy director.</p>
+
+          received:
+            title: Received
+          cleared:
+            title: Cleared
+          signed:
+            title: Signed by school or trust
+          signed_diocese:
+            title: Signed by diocese
+          saved:
+            title: Saved in the school's SharePoint folder
+          sent:
+            title: Sent to team leader or deputy director
+          signed_secretary_state:
+            title: Document signed on behalf of the Secretary of State
+

--- a/config/locales/task_lists/conversion/involuntary/church_supplemental_agreement.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/church_supplemental_agreement.en.yml
@@ -34,4 +34,6 @@ en:
             title: Sent to team leader or deputy director
           signed_secretary_state:
             title: Document signed on behalf of the Secretary of State
+          not_applicable:
+            title: Not applicable
 

--- a/config/locales/task_lists/conversion/involuntary/commercial_transfer_agreement.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/commercial_transfer_agreement.en.yml
@@ -1,0 +1,16 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        commercial_transfer_agreement:
+          title: Commercial transfer agreement
+          hint:
+            html: <p>The Commercial transfer agreement is essential for all conversion projects.</p>
+
+          email_signed:
+            title: Email the school to ask if they have agreed and signed the Commercial transfer agreement
+          receive_signed:
+            title: Receive email from the school confirming the Commercial transfer agreement has relevant signatures
+          save_signed:
+            title: Save a copy of the confirmation email in school's SharePoint folder
+

--- a/config/locales/task_lists/conversion/involuntary/conditions_met.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/conditions_met.en.yml
@@ -1,0 +1,35 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        conditions_met:
+          title: Confirm all conditions have been met
+          hint:
+            html:
+              <p>The deadline to confirm all conditions have been met will be in the Baseline email you received. The school will not be able to open on the provisional conversion date unless all conditions have been met.</p>
+          guidance_link: What to do if conditions are not met
+          guidance:
+            html:
+              <p>All conditions must be met before a school can open as an academy.</p>
+              <p>If there are outstanding conditions, you must:</p>
+              <ol>
+              <li>inform the school of the outstanding tasks</li>
+              <li>agree a new target conversion date with all stakeholders</li>
+              <li>email the Academies Operational Practice Unit at <a href="mailto:academiesdelivery.operations@education.gov.uk" class="govuk-link" target="_blank">academiesdelivery.operations@education.gov.uk</a> with the new date</li>
+              <li>change the date in KIM</li>
+              <li>inform the regional delivery officer who started on this project</li>
+              </ol>
+
+          emailed:
+            title: Email Academies Operational Practice Unit to confirm all conditions have been met
+            guidance_link: How to confirm if conditions have been met
+            guidance:
+              html:
+                <p>You must email the Academies Operational Practice Unit at <a href="mailto:academiesdelivery.operations@education.gov.uk" target="_blank">academiesdelivery.operations@education.gov.uk</a> to confirm if all conditions are met for this school and it will open as an academy on the provisional conversion date. The email only needs to confirm if all conditions have been met, or not. You do not need to go into detail.</p>
+                <p>Things you'll need to check to confirm if all conditions have been met include:</p>
+                <ul>
+                <li>commercial transfer agreement signed</li>
+                <li>leases agreed and signed</li>
+                <li>risk protection arrangement in place and insurer confirmed</li>
+                <li>relevant documents signed</li>
+                </ul>

--- a/config/locales/task_lists/conversion/involuntary/conversion_grant.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/conversion_grant.en.yml
@@ -1,0 +1,104 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        conversion_grant:
+          title: Process the Sponsored support grant
+          hint:
+            html:
+              <p>Start this as soon as possible. Trusts can start getting charged by solicitors and the local authority early in the process.</p>
+
+          eligibility:
+            title: Check and confirm the school's grant eligibility
+            hint:
+              html:
+                <p>Confirm if the trust will receive the Fast track, Intermediate or Full sponsored grant.</p>
+            guidance_link: How to check grant eligibility
+            guidance:
+              html:
+                <p>All schools that are issued a Directive academy order are allocated
+                to an experienced trust. These trusts are also known as sponsors.</p>
+                <p>In most cases, the sponsor is entitled to the Fast track grant.</p>
+                <p>The sponsor will get:</p>
+                <ul>
+                <li>£70,000 for primary and special schools</li>
+                <li>£80,000 for secondary and all-through schools</li>
+                </ul>
+                <p>In some circumstances, the sponsor might be entitled to a larger
+                grant.</p>
+                <p>This would be the Intermediate grant, or the Full sponsored grant.</p>
+                <p>Intermediate grant amounts are:</p>
+                <ul>
+                <li>£90,000 for primary and special schools</li>
+                <li>£115,000 for secondary and all-through schools</li>
+                </ul>
+                <p>Full sponsored grant amounts are:</p>
+                <ul>
+                <li>£110,000 for primary and special schools</li>
+                <li>£150,000 secondary and all-through schools</li>
+                </ul>
+                <p>All grants include the £25,000 conversion grant. This is used to fund
+                conversion costs, such as legal expenses. Any amount left after
+                conversion costs have been paid for should be used for school
+                improvements.</p>
+                <p>A business case must be approved at advisory board, or by the regional
+                director, for a trust to get the Intermediate or Full sponsored grant.</p>
+                <p>There is more <a href="https://www.gov.uk/government/publications/sponsored-academies-funding-guidance-for-sponsors" class="govuk-link" target="_blank">guidance on grant eligibility and spending (opens in
+                new tab)</a> on GOV.UK.</p>
+
+          payment_amount:
+            title: Tell the trust how much they are entitled to and how to claim the grant
+            guidance_link: How to claim different grants
+            guidance:
+              html:
+                <p>The sponsor can claim for the Fast track grant first, then apply for
+                a top-up later through an Intermediate or Full sponsored grant.</p>
+                <p>The trust will need to complete and return the <a href="https://educationgovuk.sharepoint.com/:w:/r/sites/lvedfe00116/WorkplaceDocuments/ARDG%20Internal%20Guidance/Archive_April_2020/Pre-Opening_Funding_Grant_Letter_Claim_Form_Annex_1.docx?d=w6bce8b5b84d841dd977af39eb2191afd&amp;csf=1&amp;web=1&amp;e=h02JhV" class="govuk-link" target="_blank">grant claim form
+                (opens in new tab)</a> to claim the Fast track grant. Share the form with them.</p>
+                <p>There is <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Funding-and-Finance.aspx?xsdata=MDV8MDF8fGIzMTZmYzk3NGM2NjQ5OTg0NTNlMDhkYWQ4NTcyMjc2fGZhZDI3N2M5YzYwYTRkYTFiNWYzYjNiOGIzNGE4MmY5fDB8MHw2MzgwNjAxNjU5NzgyNzcxODJ8VW5rbm93bnxWR1ZoYlhOVFpXTjFjbWwwZVZObGNuWnBZMlY4ZXlKV0lqb2lNQzR3TGpBd01EQWlMQ0pRSWpvaVYybHVNeklpTENKQlRpSTZJazkwYUdWeUlpd2lWMVFpT2pFeGZRPT18MXxNVFkzTURReE9UYzVOamcwTnpzeE5qY3dOREU1TnprMk9EUTNPekU1T20xbFpYUnBibWRmVFhwck1GcHFhRzFPYWxWMFRYcHJNMWxUTURCTk1sSnBURmRGTWsxcVRYUmFSMVV6VGtSRmQxbDZSbTFaTWxFMFFIUm9jbVZoWkM1Mk1nPT18Y2I5OTQ1ODRkNzdiNDY3ODQ1M2UwOGRhZDg1NzIyNzZ8NDA4ZDc0YWZkZmYyNDY2MWIxNzU3OTYzNmQ0MGRkMmE%3D&amp;sdata=SFhTMGxCRWVUQkxvTHRTQmp0emVrUlNHREVQdTlEQjFCMlYzSEY3WlR4dz0%3D&amp;ovuser=fad277c9-c60a-4da1-b5f3-b3b8b34a82f9%2CJoanna.EVANS%40EDUCATION.GOV.UK&amp;OR=Teams-HL&amp;CT=1670513971254&amp;clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiIxNDE1LzIyMTEzMDA0MTAwIiwiSGFzRmVkZXJhdGVkVXNlciI6ZmFsc2V9" class="govuk-link" target="_blank">guidance about how to claim different grants (opens in new
+                tab)</a> in SharePoint that explains how a trust can claim the Intermediate and Full sponsored grants.</p>
+
+          payment_form:
+            title: Receive, check and save the converter support grant claim form in the school's SharePoint folder
+            hint:
+              html:
+                <p>Make sure no information is missing.</p>
+            guidance_link: How to check and save the form
+            guidance:
+              html:
+                <p>The trust must send you the grant claim form.</p>
+                <p>Check it's complete and save it in the school's SharePoint folder.</p>
+
+          send_information:
+            title: Send the grant information to the payments team
+            hint:
+              html:
+                <p>Send them the Academy order and Grant claim form.</p>
+            guidance_link: Guidance on what information to send
+            guidance:
+              html:
+                <p>You'll find the Direct academy order and Grant claim form in the
+                school's SharePoint folder.</p>
+                <p>You should send the documents to the Grant payments team by email at
+                <a href="mailto:cfugrantpayments.regionsgroup@education.gov.uk" class="govuk-link" target="_blank">cfugrantpayments.regionsgroup@education.gov.uk</a>.</p>
+                <p>The subject line of the email must include the:</p>
+                <ul class="govuk-list govuk-list--bullet">
+                <li>region the school is in</li>
+                <li>converter grant type</li>
+                <li>support grant type</li>
+                <li>school's name</li>
+                </ul>
+                <p>The content of the email must include the:</p>
+                <ul class="govuk-list govuk-list--bullet">
+                <li>type of grant, or grants, needed</li>
+                <li>amount of money the school is eligible for</li>
+                <li>school's name</li>
+                <li>trust it's joining</li>
+                <li>provisional conversion date</li>
+                </ul>
+                <p>It's helpful to include the school or trust's vendor account number
+                too. The Grant payments team will need this to be able to send the
+                money to whoever will receive it.</p>
+
+          inform_trust:
+            title: Tell the trust the grant information as been sent

--- a/config/locales/task_lists/conversion/involuntary/deed_of_variation.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/deed_of_variation.en.yml
@@ -1,0 +1,27 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        deed_of_variation:
+          title: Deed of variation
+          hint:
+            html: <p>You'll only need to complete and clear a Deed of variation if there are changes to the funding agreements.</p>
+
+          clear_section:
+            title: Check and clear the Deed of variation
+            hint:
+              html: <p>You can <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Academy-Funding-Agreement-Guidance.aspx" target="_blank">find the right Deed of variation to use (opens in new tab)</a> on SharePoint.</p>
+            guidance_link: Help checking for changes
+            guidance:
+              html:
+                <p>Changes that personalise the model documents to a school or trust, and remove or add optional clauses, are expected. The wording of clauses should not change.</p>
+                <p>You'll need to <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Commissioning%20Form.aspx" class="govuk-link" target="_blank">contact the policy team (opens in new tab)</a> about changes to clause text.</p>
+
+          received:
+            title: Received
+          cleared:
+            title: Cleared
+          signed:
+            title: Signed by school or trust
+          saved:
+            title: Saved in the school's SharePoint folder

--- a/config/locales/task_lists/conversion/involuntary/deed_of_variation.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/deed_of_variation.en.yml
@@ -25,3 +25,5 @@ en:
             title: Signed by school or trust
           saved:
             title: Saved in the school's SharePoint folder
+          not_applicable:
+            title: Not applicable

--- a/config/locales/task_lists/conversion/involuntary/direction_to_transfer.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/direction_to_transfer.en.yml
@@ -1,0 +1,32 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        direction_to_transfer:
+          title: Direction to transfer
+          hint:
+            html:
+              <p>A Direction to transfer is only needed when freehold land is owned by a foundation school, governing body or trustees and that land needs to be transferred to the trust or diocese.</p>
+              <p>You can <a href="https://www.get-information-schools.service.gov.uk/Search" target="_blank">search Get Information About Schools (opens in new tab)</a> to check if it's needed for this school.</p>
+
+          clear_section:
+            title: Check and clear the Direction to transfer
+            hint:
+              html: <p>Make sure information in the Direction to transfer is correct and compare it against the model document.</p>
+            guidance_link: Help checking for changes
+            guidance:
+              html:
+                <p>You should check that information in the Direction to transfer is correct.</p>
+                <p>You'll also need to <a href="https://www.gov.uk/government/publications/academy-land-transfers-model-directions" class="govuk-link" target="_blank">compare the Direction to transfer against the model documents (opens in a new tab)</a> to check for any changes.</p>
+                <p>Send the Direction to transfer to the Operations team for signing and clearing.</p>
+                <p>You can <a href="mailto:academiesdelivery.operations@education.gov.uk" class="govuk-link" target="_blank">email the Operations team at academiesdelivery.operations@education.gov.uk</a>.</p>
+                <p>It can take several weeks to hear back from the Operations team.</p>
+
+          received:
+            title: Received
+          cleared:
+            title: Cleared
+          signed:
+            title: Signed by caseworker
+          saved:
+            title: Saved in the school's SharePoint folder

--- a/config/locales/task_lists/conversion/involuntary/direction_to_transfer.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/direction_to_transfer.en.yml
@@ -30,3 +30,5 @@ en:
             title: Signed by caseworker
           saved:
             title: Saved in the school's SharePoint folder
+          not_applicable:
+            title: Not applicable

--- a/config/locales/task_lists/conversion/involuntary/handover.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/handover.en.yml
@@ -41,3 +41,4 @@ en:
                 <p>Discuss any questions you have about the project in the meeting.</p>
           not_applicable:
             title: Not applicable
+

--- a/config/locales/task_lists/conversion/involuntary/handover.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/handover.en.yml
@@ -1,0 +1,43 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        handover:
+          title: Handover with regional delivery officer
+          review:
+            title: Review the project information, check the documents and carry out research
+            hint:
+              html:
+                <p>Check that no information is missing from the existing project documents and there are no errors.</p>
+            guidance_link: What to check for
+            guidance:
+              html:
+                <p>You should check existing project documents, including:</p>
+                <ul>
+                <li>Academy order</li>
+                <li>Application to convert</li>
+                </ul>
+                <p>Check that no information is missing and there are no errors.</p>
+                <p>You should also research the background of the project before you meet with the regional delivery officer.</p>
+
+                <p>Things to check during your background research include:</p>
+                <ul>
+                <li>Project information, such as advisory board conditions</li>
+                <li>School or trust website for more information about the school</li>
+                <li>Google maps for potential land issues</li>
+                </ul>
+          notes:
+            title: Make notes and write questions to as the regional delivery officer
+            guidance_link: What to make notes about
+            guidance:
+              html:
+                <p>Note down things you want to ask and talk about with the regional delivery officer at the handover meeting.</p>
+
+                <p>This is an opportunity to clarify anything that you're unsure about after reviewing the project and doing your background research.</p>
+          meeting:
+            title: Attend handover meeting with regional delivery officer
+            hint:
+              html:
+                <p>Discuss any questions you have about the project in the meeting.</p>
+          not_applicable:
+            title: Not applicable

--- a/config/locales/task_lists/conversion/involuntary/land_questionnaire.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/land_questionnaire.en.yml
@@ -1,0 +1,29 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        land_questionnaire:
+          title: Land questionnaire
+          hint:
+            html: <p>Make sure that any proposals for the land meet legal requirements and Ministerial preferences.</p>
+          sub_section:
+            title: Check and clear the Land questionnaire
+            hint:
+              html:
+                <p>You can <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Land-Transfer-and-shared-land-use.aspx" class="govuk-link" target="_blank">use the land transfer advice and guidance to check for common problems (opens in new tab)</a>.</p>
+            guidance_link: How to clear a Land questionnaire
+            guidance:
+              html:
+                <p>You must <a href="https://www.gov.uk/government/publications/academy-land-questionnaires" class="govuk-link" target="_blank">check the school is using the right Land questionnaire (opens in a new tab)</a>. There are four different types.</p>
+                <p>You need to clear the land questionnaire before the Master funding agreement and the Supplemental funding agreement.</p>
+                <p>The Land questionnaire is critical. It is the basis for all land decisions.</p>
+                <p>The answers given inform how the land will be treated. It decides which leases, directions and other land agreements are needed.</p>
+
+          received:
+            title: Received
+          cleared:
+            title: Cleared
+          signed:
+            title: Signed by school or trust
+          saved:
+            title: Saved in the school's SharePoint folder

--- a/config/locales/task_lists/conversion/involuntary/land_registry.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/land_registry.en.yml
@@ -1,0 +1,26 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        land_registry:
+          title: Land registry title plans
+          hint:
+            html: The Land registry title plans are an essential document in all conversions.
+          sub_section:
+            title: Help checking the Land registry title plans
+            hint:
+              html: <p>Check an official copy of the title plans for boundary issues and buildings that have not been excluded.</p>
+            guidance_link: Help checking the Land registry title plans
+            guidance:
+              html:
+                <p>Check you have an official copy of the title plans. An official copy will state that it's from the Land Registry, include a title plan and title number.</p>
+                <p>It's a good idea to look at the site on Google maps and compare that to the title plan. This can help you find out if there's anything to question on the title plan.</p>
+                <p>The boundary should include all school or trust buildings. If the land has become unregistered you should check the title plan.</p>
+                <p>Talk to your line manager or the relevant solicitor if you have questions about anything on the title plan.</p>
+
+          received:
+            title: Received
+          cleared:
+            title: Cleared
+          saved:
+            title: Saved in the school's SharePoint folder

--- a/config/locales/task_lists/conversion/involuntary/master_funding_agreement.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/master_funding_agreement.en.yml
@@ -1,0 +1,46 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        master_funding_agreement:
+          title: Master funding agreement
+          hint:
+            html: <p>Master funding agreements from before 2018 should be updated to the newer versions.</p>
+
+          clear_section:
+            title: Check and clear the Master funding agreement
+            hint:
+              html: <p>You can <a href="https://www.gov.uk/government/publications/academy-and-free-school-funding-agreements" target="_blank">view the model documents (opens in new tab)</a> to check for changes.</p>
+            guidance_link: Help checking and updating the Master funding agreement
+            guidance:
+              html:
+                <p>Changes that personalise the model documents to a school or trust, and remove or add optional clauses, are expected. The wording of clauses should not change.</p>
+                <p>You'll need to <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Commissioning%20Form.aspx" class="govuk-link" target="_blank">contact the policy team (opens in new tab)</a> about changes to clause text.</p>
+                <p>If the trust uses a pre-2018 Master funding agreement, they have two options.</p>
+                <p>They can update to a 2020 version of the Master funding agreement and update any pre-2018 Supplemental funding agreements in the trust too.</p>
+                <p>Alternatively, they can adopt an additional 2020 Master funding agreement which the new academy's Supplemental funding agreement will sit under. This will allow the rest of the academies in the trust to stay under the pre-2018 Master funding agreement.</p>
+                <p>You will need to clear any new and updated documents. These may need a Deed of variation.</p>
+          sign_section:
+            title: Signed by the Secretary of State
+            guidance_link: How to sign the Master funding agreement
+            guidance:
+              html:
+                <p>Changes that personalise the model documents to a school or trust, and remove or add optional clauses, are expected. The wording of clauses should not change.</p>
+                <p>You'll need to <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Commissioning%20Form.aspx" class="govuk-link" target="_blank">contact the policy team (opens in new tab)</a> about changes to clause text.</p>
+                <p>If the trust uses a pre-2018 Master funding agreement, they have two options.</p>
+                <p>They can update to a 2020 version of the Master funding agreement and update any pre-2018 Supplemental funding agreements in the trust too.</p>
+                <p>Alternatively, they can adopt an additional 2020 Master funding agreement which the new academy's Supplemental funding agreement will sit under. This will allow the rest of the academies in the trust to stay under the pre-2018 Master funding agreement.</p>
+                <p>You will need to clear any new and updated documents. These may need a Deed of variation.</p>
+
+          received:
+            title: Received
+          cleared:
+            title: Cleared
+          signed:
+            title: Signed by school or trust
+          saved:
+            title: Saved in the school's SharePoint folder
+          sent:
+            title: Sent to team leader or deputy director
+          signed_secretary_state:
+            title: Document signed on behalf of the Secretary of State

--- a/config/locales/task_lists/conversion/involuntary/master_funding_agreement.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/master_funding_agreement.en.yml
@@ -44,3 +44,5 @@ en:
             title: Sent to team leader or deputy director
           signed_secretary_state:
             title: Document signed on behalf of the Secretary of State
+          not_applicable:
+            title: Not applicable

--- a/config/locales/task_lists/conversion/involuntary/one_hundred_and_twenty_five_year_lease.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/one_hundred_and_twenty_five_year_lease.en.yml
@@ -1,0 +1,20 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        one_hundred_and_twenty_five_year_lease:
+          title: 125 year lease
+          hint:
+            html: <p>The 125 year lease is the most common way for land to be transferred between the local authority and the trust.</p>
+
+          confirm_section:
+            title: Confirm the 125 year lease has been signed
+
+          email:
+            title: Email the school to check all relevant parties have signed the 125 year lease
+          receive:
+            title: Receive email from the school confirming the 125 year lease is agreed and signed
+          save:
+            title: Save a copy of the confirmation email in school's SharePoint folder
+          not_applicable:
+            title: Not applicable

--- a/config/locales/task_lists/conversion/involuntary/receive_grant_payment_certificate.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/receive_grant_payment_certificate.en.yml
@@ -1,0 +1,27 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        receive_grant_payment_certificate:
+          title: Receive grant payment certificate
+          hint:
+            html: <p>You should already have sent a copy of the <a href="https://www.gov.uk/government/publications/academy-support-grant" target="_blank">Grant payment certificate (opens in new tab)</a> when confirming the school's opening date.</p>
+
+          check_and_save:
+            title: Check and save the Grant payment certificate in the school's SharePoint folder
+            hint:
+              html: <p>Make sure the right template has been used and there is no missing information.</p>
+            guidance_link: What to do if you have not received the Grant payment certificate
+            guidance:
+              html:
+                <p>You should ask the school to send the certificate. You must record the date each time you contact them in <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&amp;file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&amp;action=default&amp;mobileredirect=true" target="_blank">the Support grant assurance report (opens in new tab)</a></p>
+
+          update_kim:
+            title: Update KIM with date certificate is received
+            hint:
+              html: <p>Find this information in the ESFA handover section in KIM.</p>
+
+          update_sheet:
+            title: Update the Support grant assurance report spreadsheet
+            hint:
+              html: <p>You can <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&amp;file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&amp;action=default&amp;mobileredirect=true" target="_blank">open the Support grant assurance report (opens in new tab)</a> to update it.</p>

--- a/config/locales/task_lists/conversion/involuntary/redact_and_send.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/redact_and_send.en.yml
@@ -1,0 +1,44 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        redact_and_send:
+          title: Redact and send documents
+          hint:
+            html:
+              <p>All relevant documents will be added to GOV.UK and the school or trust websites. These documents must be redacted to remove sensitive information.</p>
+
+          redact:
+            title: Redact all relevant documents
+            guidance_link: Help redacting the documents
+            guidance:
+              html:
+                <p>You need to create a redacted version of each applicable document after they've been signed by the Secretary of State:</p>
+                <ul>
+                <li>Supplemental Funding Agreement</li>
+                <li>Master Funding Agreement (if applicable)</li>
+                <li>Church Supplemental Agreement (if applicable)</li>
+                <li>Deed of Variation (if applicable)</li>
+                </ul>
+                <p>You must remove or hide:</p>
+                <ul>
+                <li>names</li>
+                <li>signatures</li>
+                <li>home addresses</li>
+                <li>any other personal information</li>
+                </ul>
+
+          save:
+            title: Save relevant documents in the school's SharePoint folder
+
+          send:
+            title: Send the redacted documents to the funding team to be published on GOV.UK
+            guidance_link: Help sending documents
+            guidance:
+              html:
+                <p>Send the redacted funding agreement documents to the funding team at <a href="mailto:FundingAgreements.CONVERTERS@education.gov.uk" class="govuk-link" target="_blank">FundingAgreements.CONVERTERS@education.gov.uk</a>.</p>
+
+          send_solicitors:
+            title: Send the redacted and unredacted versions of documents to the solicitors
+            hint:
+              html: <p>You can copy the school and trust into this email too. They will publish relevant documents on their websites.</p>

--- a/config/locales/task_lists/conversion/involuntary/school_completed.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/school_completed.en.yml
@@ -1,0 +1,31 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        school_completed:
+          title: Confirm the school has completed all actions
+          hint:
+            html: <p>Check the school have completed all their tasks and save their responses in the school's SharePoint folder.</p>
+
+          emailed:
+            title: Email the main contact for the conversion
+            guidance_link: How to structure your email
+            guidance:
+              html:
+                <p>You should ask them to check and confirm they've completed all tasks.</p>
+                <p>You can <a href="https://educationgovuk.sharepoint.com/:w:/r/sites/lvedfe00116/_layouts/15/Doc.aspx?sourcedoc=%7BA4E75C24-7E01-4732-9065-EEC840AFE132%7D&amp;file=RSCApprovaltoAcademyOpeningDeskInstructions20200922.docx&amp;action=default&amp;mobileredirect=true" target="_blank">use the email template (opens in a new tab)</a> on pages 19 and 20 in your desk instructions to help structure your email.</p>
+
+          saved:
+            title: Save the responses to the checklist in the school's SharePoint folder
+            guidance_link: What to do if the school has not completed the tasks
+            guidance:
+              html:
+                <p>Depending on the scale of the outstanding tasks, you may need to move the target conversion date to the next month, or later.</p>
+                <p>If the conversion date needs to be moved, you must:</p>
+                <ol>
+                <li>inform the school of the outstanding tasks</li>
+                <li>agree a new target conversion date with all stakeholders</li>
+                <li>email the Academies Operational Practice Unit at <a href="mailto:academiesdelivery.operations@education.gov.uk" class="govuk-link" target="_blank">academiesdelivery.operations@education.gov.uk</a> with the new date</li>
+                <li>change the date in KIM</li>
+                <li>inform the regional delivery officer who started on this project</li>
+                </ol>

--- a/config/locales/task_lists/conversion/involuntary/share_information.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/share_information.en.yml
@@ -1,0 +1,24 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        share_information:
+          title: Share the grant certificate and information about opening
+          hint:
+            html:
+              <p>Once you have confirmed that all conditions have been met, contact the school and trust to tell them they can convert on the provisional conversion date.</p>
+
+          email:
+            title: Email relevant information to your main contact
+            guidance_link: What to tell the school
+            guidance:
+              html:
+                <p>Email your main contact at the school or trust.</p>
+                <p>Your email should include:</p>
+                <ul>
+                <li>confirmation the school will convert on the provisional date</li>
+                <li>the school's new URN</li>
+                <li>the <a href="https://www.gov.uk/government/publications/academy-support-grant" class="govuk-link" target="_blank">Grant expenditure certificate (opens in new tab)</a> that they need to complete and return</li>
+                <li>the feedback form (if applicable)</li>
+                </ul>
+                <p>You can split this information over more than one email if you do not immediately have everything you need.</p>

--- a/config/locales/task_lists/conversion/involuntary/single_worksheet.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/single_worksheet.en.yml
@@ -1,0 +1,26 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        single_worksheet:
+          title: Complete and send Single worksheet
+          hint:
+            html:
+              <p>You need to <a href="https://educationgovuk.sharepoint.com/:w:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7B16F44F65-3D80-457D-9FB4-D22574FBE8EB%7D&amp;file=Updated_Single_Worksheet.docx" target="_blank">download a single worksheet template (opens in new tab)</a> and save it in the school's SharePoint folder.</p>
+
+          complete:
+            title: Complete the Single worksheet
+            hint:
+              html: <p>Fill out the Single worksheet and confirm the information in it is correct.</p>
+          approve:
+            title: Email the Single worksheet to your line manager for approval
+            hint:
+              html: <p>Your line manager will reply by email to tell you if they've approved the worksheet.</p>
+          send:
+            title: Send the approved Single worksheet to Academies Operational Practice Unit
+            hint:
+              html: <p>Send the Single worksheet and, if needed, the Direction to transfer and Trust modification order to <a href="mailto:academiesdelivery.operations@education.gov.uk" target="_blank">academiesdelivery.operations@education.gov.uk.</a></p>
+            guidance_link: When you must complete this
+            guidance:
+              html:
+                <p>The deadline for this work is normally 5 working days after the Baseline is confirmed. The exact deadline will be in the baseline email sent by The Academies Operational Practice Unit.</p>

--- a/config/locales/task_lists/conversion/involuntary/stakeholder_kick_off.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/stakeholder_kick_off.en.yml
@@ -1,0 +1,60 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        stakeholder_kick_off:
+          title: External stakeholder kick-off
+          hint:
+            html:
+              <p>You should start this work after you've had the handover with the regional delivery officer. This is a good opportunity for you to talk about common problems and how to avoid them.</p>
+          introductory_emails:
+            title: Send introductory emails to the trust and solicitors
+            hint:
+              html:
+                <p>You should also contact the local authority, but do this separately.</p>
+            guidance_link: What to include in introductory emails
+            guidance:
+              html:
+                <p>You can <a href="https://educationgovuk.sharepoint.com/:f:/r/sites/ServiceDeliveryDirectorate/Shared%20Documents/Operational%20Delivery/Training%20and%20Resources/Resources/Project%20templates?csf=1&web=1&e=Hf4exC" target="blank">choose an email template (opens in new tab)</a> to help you write your introductory emails. There are templates for the school or trust, their solicitors and the local authority.</p>
+
+                <p>This will help you to:</p>
+
+                <ul>
+                <li>organise kick-off meetings</li>
+                <li>clarify roles and expectations</li>
+                <li>establish dates and deadlines</li>
+                <li>provide links to documents that need to be completed</li>
+                <li>agree ways of working</li>
+                </ul>
+
+                <p>You should aim to do this in the first week of picking up the project.</p>
+                <p>Ideally the kick-off meeting should take place within the first couple of weeks.</p>
+          local_authority_proforma:
+            title: Check that the local authority proforma is saved in the school's SharePoint folder
+            guidance_link: What to do if you don't have the local authority proforma
+            guidance:
+              html:
+                <p>The regional delivery officer should have sent the Local authority proforma to the local authority to complete.</p>
+                <p>If you haven't received it yet, check that the regional delivery officer sent it and then ask the local authority if they have completed and shared it.</p>
+
+          confirm_target_conversion_date:
+            title: Confirm the provisional conversion date with the local authority
+            hint:
+              html: <p>Check that the local authority has capacity to convert the school by the provisional date</p>
+            guidance_link: What to do if the local authority does not have capacity
+            guidance:
+              html:
+                <p>The school and trust will have given a provisional date they want to convert on.</p>
+                <p>Tell them if the local authority cannot complete the conversion by the provisional date.</p>
+                <p>If the local authority cannot complete the conversion by the provisional date, you'll need to work with the trust and local authority to agree a new date.</p>
+
+          setup_meeting:
+            title: Send invites to the kick-off meeting or call
+            hint:
+              html: <p>Check who the trust would like to attend the kick-off meeting.</p>
+            guidance_link: How to arrange the kick-off meeting
+            guidance:
+              html:
+                <p>Your introductory email should have included some possible dates for a kick-off meeting.</p>
+                <p>Once the school have got back to you with a suitable date and list of attendees, send out invites to arrange the time, date and location of the meeting. It’s likely to be a video call over Microsoft Teams.</p>
+                <p>Some schools and trusts may prefer to have a 1-to-1 call with you, rather than a meeting involving all stakeholders.</p>

--- a/config/locales/task_lists/conversion/involuntary/supplemental_funding_agreement.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/supplemental_funding_agreement.en.yml
@@ -1,0 +1,40 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        supplemental_funding_agreement:
+          title: Supplemental funding agreement
+          hint:
+            html: <p>Check the Supplemental funding agreement for changes from the model documents.</p>
+          clear_section:
+            title: Check and clear the Supplemental funding agreement
+            hint:
+              html:
+                <p>You can <a href="https://www.gov.uk/government/publications/academy-and-free-school-funding-agreements" class="govuk-link" target="_blank">view the model documents (opens in new tab)</a> to check for changes.</p>
+            guidance_link: Help checking the Supplemental funding agreement
+            guidance:
+              html:
+                <p>Changes that personalise the model documents to a school or trust, and remove or add optional clauses, are expected. The wording of clauses should not change.</p>
+                <p>You'll need to <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Commissioning%20Form.aspx" class="govuk-link" target="_blank">contact the policy team (opens in new tab)</a> about changes to clause text.</p>
+                <p>We only accept new Supplemental funding agreements that use the 2020 edition of the model documents.</p>
+                <p>Supplemental funding agreements from 2020 onwards and Master funding agreements from 2018 onwards are compatible.</p>
+
+          sign_section:
+            title: Signed by the Secretary of State
+            hint:
+              html:
+                <p>The Secretary of State, or somebody with the authority to act on their behalf, must sign the Supplemental funding agreement. Usually this is your team leader or the deputy director.</p>
+
+          received:
+            title: Received
+          cleared:
+            title: Cleared
+          signed:
+            title: Signed by school or trust
+          saved:
+            title: Saved in the school's SharePoint folder
+          sent:
+            title: Sent to team leader or deputy director
+          signed_secretary_state:
+            title: Document signed on behalf of the Secretary of State
+

--- a/config/locales/task_lists/conversion/involuntary/tell_regional_delivery_officer.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/tell_regional_delivery_officer.en.yml
@@ -1,0 +1,11 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        tell_regional_delivery_officer:
+          title: Tell the regional delivery officer that the academy has opened
+          hint:
+            html: <p>You should email the regional delivery officer. Send the school's name, date it opened as an academy and link to the project.</p>
+
+          email:
+            title: Email the regional delivery officer

--- a/config/locales/task_lists/conversion/involuntary/tenancy_at_will.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/tenancy_at_will.en.yml
@@ -1,0 +1,20 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        tenancy_at_will:
+          title: Tenancy at will
+          hint:
+            html: <p>A Tenancy at will allows a tenant and landlord to agree that the tenant can use the land owned by the landlord indefinitely.</p>
+
+          confirm_section:
+            title: Confirm the Tenancy at will has been signed
+
+          email_signed:
+            title: Email the school to ask if they have agreed and signed the Tenancy at will
+          receive_signed:
+            title: Receive email from the school confirming the Tenancy at will has all relevant signatures
+          save_signed:
+            title: Save a copy of the confirmation email in school's SharePoint folder
+          not_applicable:
+            title: Not applicable

--- a/config/locales/task_lists/conversion/involuntary/trust_modification_order.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/trust_modification_order.en.yml
@@ -34,3 +34,5 @@ en:
             title: Cleared by Legal advisers office
           saved:
             title: Saved in the school's SharePoint folder
+          not_applicable:
+            title: Not applicable

--- a/config/locales/task_lists/conversion/involuntary/trust_modification_order.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/trust_modification_order.en.yml
@@ -1,0 +1,36 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        trust_modification_order:
+          title: Trust modification order
+          hint:
+            html:
+              <p>The Trust modification order is only needed if there are restrictions on the land titles that need resolving.</p>
+              <p>The Land questionnaire will show if one is needed for this project. You can also check with the solicitors dealing with land issues.</p>
+
+          clear_section:
+            title: Clear and sign the Trust modification order
+            hint:
+              html:
+                <p>If one is needed, send the Trust modification order and a copy of the original deed to the Operations team at <a href="mailto:academiesdelivery.operations@education.gov.uk" class="govuk-link" target="_blank">academiesdelivery.operations@education.gov.uk</a>. They will organise how it's signed and cleared.</p>
+                <p>It can take several weeks to hear back from the Operations team.</p>
+            guidance_link: When to use a Trust modification order
+            guidance:
+              html:
+                <p>A Trust modification order is used when a voluntary or foundation school's land is held by a trust or foundation that is not a diocese.</p>
+                <p>A Trust modification order is likely to be needed if the school is a:</p>
+                <ul>
+                <li>voluntary-controlled school</li>
+                <li>voluntary-aided school</li>
+                <li>foundation school</li>
+                </ul>
+
+          received:
+            title: Received
+          sent_legal:
+            title: Sent to Legal advisers office
+          cleared:
+            title: Cleared by Legal advisers office
+          saved:
+            title: Saved in the school's SharePoint folder

--- a/config/locales/task_lists/conversion/involuntary/update_esfa.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/update_esfa.en.yml
@@ -1,0 +1,27 @@
+en:
+  conversion:
+    involuntary:
+      tasks:
+        update_esfa:
+          title: Update ESFA data in KIM
+          hint:
+            html: <p>Carry out final checks and update project information if necessary so the ESFA (Education and Skills Funding Agency) can issue the funding when the project is handed over.</p>
+
+          update:
+            title: Update any ESFA fields in KIM and add notes if necessary
+            guidance_link: Things you may want to write notes about
+            guidance:
+              html:
+                <p>It can be helpful to include notes about:</p>
+                <ul>
+                <li>funding or financial issues</li>
+                <li>significant changes to the model funding</li>
+                <li>agreements and articles</li>
+                <li>issues relating to governance</li>
+                <li>land issues including tenancies at will, condition of buildings, carve out of children's centre, access disputes and sub-leases</li>
+                <li>falling rolls</li>
+                <li>fluctuation in Key Stage 2 or 4 performance</li>
+                <li>enquires about expanding the age range or any other <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Significant-Change.aspx?OR=Teams-HL&amp;CT=1663336368280&amp;clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiIyNy8yMjA3MzEwMTAwNSIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3d%3d" target="_blank">significant changes (opens in new tab)</a></li>
+                <li>audit trail for resolved disputes with the local authority or complex</li>
+                <li>schools joining a single academy trust to enable it to become a multi-academy trust</li>
+                </ul>

--- a/config/locales/task_lists/conversion_involuntary.en.yml
+++ b/config/locales/task_lists/conversion_involuntary.en.yml
@@ -4,29 +4,5 @@ en:
       task_list:
         project_kick_off:
           title: Project kick-off
-      tasks:
-        handover:
-          title: Handover with regional delivery officer
-          hint:
-            html: <p class="govuk-hint">How to make sure the handover with the regional delivery officer is completed, and you can begin work on the project.</p>
-          guidance_link: Additional guidance
-          guidance:
-            html: This is the addtional guidance
-          review:
-            title: Review the project information, check the documents and carry out research
-            hint:
-              html: <p>Check that no information is missing from the existing project documents and there are no errors.</p>
-            guidance_link: What to check for
-            guidance:
-              html:
-                <p>You should check existing project documents, including:</p>
-                <ul>
-                <li>Academy order</li>
-                <li>Application to convert</li>
-                </ul>
-                <p>Check that no information is missing and there are no errors. You should also research the background of the project before you meet with the regional delivery officer. Things to check during your background research include:</p>
-                  <ul>
-                  <li>Project information, such as advisory board conditions</li>
-                  <li>School or trust website for more information about the school</li>
-                  <li>Google maps for potential land issues</li>
-                  </ul>
+        legal_documents:
+          title: Clear and sign legal documents

--- a/config/locales/task_lists/conversion_involuntary.en.yml
+++ b/config/locales/task_lists/conversion_involuntary.en.yml
@@ -8,3 +8,5 @@ en:
           title: Clear and sign legal documents
         get_ready_for_opening:
           title: Get ready for opening
+        after_opening:
+          title: After opening

--- a/config/locales/task_lists/conversion_involuntary.en.yml
+++ b/config/locales/task_lists/conversion_involuntary.en.yml
@@ -6,3 +6,5 @@ en:
           title: Project kick-off
         legal_documents:
           title: Clear and sign legal documents
+        get_ready_for_opening:
+          title: Get ready for opening

--- a/db/migrate/20230104152636_add_handover_task.rb
+++ b/db/migrate/20230104152636_add_handover_task.rb
@@ -1,0 +1,6 @@
+class AddHandoverTask < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :handover_notes, :boolean
+    add_column :conversion_involuntary_task_lists, :handover_meeting, :boolean
+  end
+end

--- a/db/migrate/20230104154152_add_stakeholder_kick_off_task.rb
+++ b/db/migrate/20230104154152_add_stakeholder_kick_off_task.rb
@@ -1,0 +1,8 @@
+class AddStakeholderKickOffTask < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :stakeholder_kick_off_introductory_emails, :boolean
+    add_column :conversion_involuntary_task_lists, :stakeholder_kick_off_local_authority_proforma, :boolean
+    add_column :conversion_involuntary_task_lists, :stakeholder_kick_off_confirm_target_conversion_date, :boolean
+    add_column :conversion_involuntary_task_lists, :stakeholder_kick_off_setup_meeting, :boolean
+  end
+end

--- a/db/migrate/20230105103520_add_conversion_grant_task.rb
+++ b/db/migrate/20230105103520_add_conversion_grant_task.rb
@@ -1,0 +1,9 @@
+class AddConversionGrantTask < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :conversion_grant_eligibility, :boolean
+    add_column :conversion_involuntary_task_lists, :conversion_grant_payment_amount, :boolean
+    add_column :conversion_involuntary_task_lists, :conversion_grant_payment_form, :boolean
+    add_column :conversion_involuntary_task_lists, :conversion_grant_send_information, :boolean
+    add_column :conversion_involuntary_task_lists, :conversion_grant_inform_trust, :boolean
+  end
+end

--- a/db/migrate/20230105111357_add_involuntary_land_questionnaire_task.rb
+++ b/db/migrate/20230105111357_add_involuntary_land_questionnaire_task.rb
@@ -1,0 +1,8 @@
+class AddInvoluntaryLandQuestionnaireTask < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :land_questionnaire_received, :boolean
+    add_column :conversion_involuntary_task_lists, :land_questionnaire_cleared, :boolean
+    add_column :conversion_involuntary_task_lists, :land_questionnaire_signed, :boolean
+    add_column :conversion_involuntary_task_lists, :land_questionnaire_saved, :boolean
+  end
+end

--- a/db/migrate/20230105114246_add_involuntary_land_registry_task.rb
+++ b/db/migrate/20230105114246_add_involuntary_land_registry_task.rb
@@ -1,0 +1,7 @@
+class AddInvoluntaryLandRegistryTask < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :land_registry_received, :boolean
+    add_column :conversion_involuntary_task_lists, :land_registry_cleared, :boolean
+    add_column :conversion_involuntary_task_lists, :land_registry_saved, :boolean
+  end
+end

--- a/db/migrate/20230105115735_add_involuntary_supplemental_funding_agreement.rb
+++ b/db/migrate/20230105115735_add_involuntary_supplemental_funding_agreement.rb
@@ -1,0 +1,10 @@
+class AddInvoluntarySupplementalFundingAgreement < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :supplemental_funding_agreeement_received, :boolean
+    add_column :conversion_involuntary_task_lists, :supplemental_funding_agreeement_cleared, :boolean
+    add_column :conversion_involuntary_task_lists, :supplemental_funding_agreeement_signed, :boolean
+    add_column :conversion_involuntary_task_lists, :supplemental_funding_agreeement_saved, :boolean
+    add_column :conversion_involuntary_task_lists, :supplemental_funding_agreeement_sent, :boolean
+    add_column :conversion_involuntary_task_lists, :supplemental_funding_agreeement_signed_secretary_state, :boolean
+  end
+end

--- a/db/migrate/20230105122150_add_involuntary_church_supplemental_agreement.rb
+++ b/db/migrate/20230105122150_add_involuntary_church_supplemental_agreement.rb
@@ -1,0 +1,11 @@
+class AddInvoluntaryChurchSupplementalAgreement < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :church_supplemental_agreement_received, :boolean
+    add_column :conversion_involuntary_task_lists, :church_supplemental_agreement_cleared, :boolean
+    add_column :conversion_involuntary_task_lists, :church_supplemental_agreement_signed, :boolean
+    add_column :conversion_involuntary_task_lists, :church_supplemental_agreement_signed_diocese, :boolean
+    add_column :conversion_involuntary_task_lists, :church_supplemental_agreement_saved, :boolean
+    add_column :conversion_involuntary_task_lists, :church_supplemental_agreement_sent, :boolean
+    add_column :conversion_involuntary_task_lists, :church_supplemental_agreement_signed_secretary_state, :boolean
+  end
+end

--- a/db/migrate/20230105142906_add_involuntary_master_funding_agreement.rb
+++ b/db/migrate/20230105142906_add_involuntary_master_funding_agreement.rb
@@ -1,0 +1,11 @@
+class AddInvoluntaryMasterFundingAgreement < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :master_funding_agreement_received, :boolean
+    add_column :conversion_involuntary_task_lists, :master_funding_agreement_cleared, :boolean
+    add_column :conversion_involuntary_task_lists, :master_funding_agreement_signed, :boolean
+    add_column :conversion_involuntary_task_lists, :master_funding_agreement_saved, :boolean
+
+    add_column :conversion_involuntary_task_lists, :master_funding_agreement_sent, :boolean
+    add_column :conversion_involuntary_task_lists, :master_funding_agreement_signed_secretary_state, :boolean
+  end
+end

--- a/db/migrate/20230105144125_add_involuntary_articles_of_association.rb
+++ b/db/migrate/20230105144125_add_involuntary_articles_of_association.rb
@@ -1,0 +1,8 @@
+class AddInvoluntaryArticlesOfAssociation < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :articles_of_association_received, :boolean
+    add_column :conversion_involuntary_task_lists, :articles_of_association_cleared, :boolean
+    add_column :conversion_involuntary_task_lists, :articles_of_association_signed, :boolean
+    add_column :conversion_involuntary_task_lists, :articles_of_association_saved, :boolean
+  end
+end

--- a/db/migrate/20230105144822_add_involuntary_deed_of_variation.rb
+++ b/db/migrate/20230105144822_add_involuntary_deed_of_variation.rb
@@ -1,0 +1,8 @@
+class AddInvoluntaryDeedOfVariation < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :deed_of_variation_received, :boolean
+    add_column :conversion_involuntary_task_lists, :deed_of_variation_cleared, :boolean
+    add_column :conversion_involuntary_task_lists, :deed_of_variation_signed, :boolean
+    add_column :conversion_involuntary_task_lists, :deed_of_variation_saved, :boolean
+  end
+end

--- a/db/migrate/20230105145521_add_involuntary_trust_modification_order.rb
+++ b/db/migrate/20230105145521_add_involuntary_trust_modification_order.rb
@@ -1,0 +1,8 @@
+class AddInvoluntaryTrustModificationOrder < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :trust_modification_order_received, :boolean
+    add_column :conversion_involuntary_task_lists, :trust_modification_order_sent_legal, :boolean
+    add_column :conversion_involuntary_task_lists, :trust_modification_order_cleared, :boolean
+    add_column :conversion_involuntary_task_lists, :trust_modification_order_saved, :boolean
+  end
+end

--- a/db/migrate/20230105150503_add_involuntary_direction_to_transfer.rb
+++ b/db/migrate/20230105150503_add_involuntary_direction_to_transfer.rb
@@ -1,0 +1,8 @@
+class AddInvoluntaryDirectionToTransfer < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :direction_to_transfer_received, :boolean
+    add_column :conversion_involuntary_task_lists, :direction_to_transfer_cleared, :boolean
+    add_column :conversion_involuntary_task_lists, :direction_to_transfer_signed, :boolean
+    add_column :conversion_involuntary_task_lists, :direction_to_transfer_saved, :boolean
+  end
+end

--- a/db/migrate/20230105151645_add_involuntary125_year_lease.rb
+++ b/db/migrate/20230105151645_add_involuntary125_year_lease.rb
@@ -1,0 +1,8 @@
+class AddInvoluntary125YearLease < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :one_hundred_and_twenty_five_year_lease_not_applicable, :boolean
+    add_column :conversion_involuntary_task_lists, :one_hundred_and_twenty_five_year_lease_email, :boolean
+    add_column :conversion_involuntary_task_lists, :one_hundred_and_twenty_five_year_lease_receive, :boolean
+    add_column :conversion_involuntary_task_lists, :one_hundred_and_twenty_five_year_lease_save, :boolean
+  end
+end

--- a/db/migrate/20230105152348_add_involuntary_tenancy_at_will.rb
+++ b/db/migrate/20230105152348_add_involuntary_tenancy_at_will.rb
@@ -1,0 +1,8 @@
+class AddInvoluntaryTenancyAtWill < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :tenancy_at_will_email_signed, :boolean
+    add_column :conversion_involuntary_task_lists, :tenancy_at_will_receive_signed, :boolean
+    add_column :conversion_involuntary_task_lists, :tenancy_at_will_save_signed, :boolean
+    add_column :conversion_involuntary_task_lists, :tenancy_at_will_not_applicable, :boolean
+  end
+end

--- a/db/migrate/20230105153216_add_involuntary_commercial_transfer_agreement.rb
+++ b/db/migrate/20230105153216_add_involuntary_commercial_transfer_agreement.rb
@@ -1,0 +1,7 @@
+class AddInvoluntaryCommercialTransferAgreement < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :commercial_transfer_agreement_email_signed, :boolean
+    add_column :conversion_involuntary_task_lists, :commercial_transfer_agreement_receive_signed, :boolean
+    add_column :conversion_involuntary_task_lists, :commercial_transfer_agreement_save_signed, :boolean
+  end
+end

--- a/db/migrate/20230105154428_add_involuntary_missing_not_applicable_boxes.rb
+++ b/db/migrate/20230105154428_add_involuntary_missing_not_applicable_boxes.rb
@@ -1,0 +1,11 @@
+class AddInvoluntaryMissingNotApplicableBoxes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :handover_not_applicable, :boolean
+    add_column :conversion_involuntary_task_lists, :church_supplemental_agreement_not_applicable, :boolean
+    add_column :conversion_involuntary_task_lists, :master_funding_agreement_not_applicable, :boolean
+    add_column :conversion_involuntary_task_lists, :articles_of_association_not_applicable, :boolean
+    add_column :conversion_involuntary_task_lists, :deed_of_variation_not_applicable, :boolean
+    add_column :conversion_involuntary_task_lists, :trust_modification_order_not_applicable, :boolean
+    add_column :conversion_involuntary_task_lists, :direction_to_tansfer_not_applicable, :boolean
+  end
+end

--- a/db/migrate/20230105160230_add_involuntary_check_baseline_task.rb
+++ b/db/migrate/20230105160230_add_involuntary_check_baseline_task.rb
@@ -1,0 +1,5 @@
+class AddInvoluntaryCheckBaselineTask < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :check_baseline_confirm, :boolean
+  end
+end

--- a/db/migrate/20230105161218_add_involuntary_single_worksheet.rb
+++ b/db/migrate/20230105161218_add_involuntary_single_worksheet.rb
@@ -1,0 +1,7 @@
+class AddInvoluntarySingleWorksheet < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :single_worksheet_complete, :boolean
+    add_column :conversion_involuntary_task_lists, :single_worksheet_approve, :boolean
+    add_column :conversion_involuntary_task_lists, :single_worksheet_send, :boolean
+  end
+end

--- a/db/migrate/20230105162231_add_involuntary_school_completed.rb
+++ b/db/migrate/20230105162231_add_involuntary_school_completed.rb
@@ -1,0 +1,6 @@
+class AddInvoluntarySchoolCompleted < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :school_completed_emailed, :boolean
+    add_column :conversion_involuntary_task_lists, :school_completed_saved, :boolean
+  end
+end

--- a/db/migrate/20230105163204_add_involuntary_conditions_met.rb
+++ b/db/migrate/20230105163204_add_involuntary_conditions_met.rb
@@ -1,0 +1,5 @@
+class AddInvoluntaryConditionsMet < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :conditions_met_emailed, :boolean
+  end
+end

--- a/db/migrate/20230105163830_add_involuntary_share_information.rb
+++ b/db/migrate/20230105163830_add_involuntary_share_information.rb
@@ -1,0 +1,5 @@
+class AddInvoluntaryShareInformation < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :share_information_email, :boolean
+  end
+end

--- a/db/migrate/20230105164339_add_involuntary_tell_regional_delivery_officer.rb
+++ b/db/migrate/20230105164339_add_involuntary_tell_regional_delivery_officer.rb
@@ -1,0 +1,5 @@
+class AddInvoluntaryTellRegionalDeliveryOfficer < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :tell_regional_delivery_officer_email, :boolean
+  end
+end

--- a/db/migrate/20230105164913_add_involuntary_redact_and_send.rb
+++ b/db/migrate/20230105164913_add_involuntary_redact_and_send.rb
@@ -1,0 +1,8 @@
+class AddInvoluntaryRedactAndSend < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :redact_and_send_redact, :boolean
+    add_column :conversion_involuntary_task_lists, :redact_and_send_save, :boolean
+    add_column :conversion_involuntary_task_lists, :redact_and_send_send, :boolean
+    add_column :conversion_involuntary_task_lists, :redact_and_send_send_solicitors, :boolean
+  end
+end

--- a/db/migrate/20230105165414_add_involuntary_update_esfa.rb
+++ b/db/migrate/20230105165414_add_involuntary_update_esfa.rb
@@ -1,0 +1,5 @@
+class AddInvoluntaryUpdateEsfa < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :update_esfa_update, :boolean
+  end
+end

--- a/db/migrate/20230105170219_add_involuntary_receive_grant_payment_certificate.rb
+++ b/db/migrate/20230105170219_add_involuntary_receive_grant_payment_certificate.rb
@@ -1,0 +1,7 @@
+class AddInvoluntaryReceiveGrantPaymentCertificate < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :receive_grant_payment_certificate_check_and_save, :boolean
+    add_column :conversion_involuntary_task_lists, :receive_grant_payment_certificate_update_kim, :boolean
+    add_column :conversion_involuntary_task_lists, :receive_grant_payment_certificate_update_sheet, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_154428) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_160230) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -129,6 +129,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_154428) do
     t.boolean "trust_modification_order_not_applicable"
     t.boolean "direction_to_tansfer_not_applicable"
     t.boolean "handover_not_applicable"
+    t.boolean "check_baseline_confirm"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_162231) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_163204) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -135,6 +135,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_162231) do
     t.boolean "single_worksheet_send"
     t.boolean "school_completed_emailed"
     t.boolean "school_completed_saved"
+    t.boolean "conditions_met_emailed"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_150503) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_151645) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -111,6 +111,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_150503) do
     t.boolean "direction_to_transfer_cleared"
     t.boolean "direction_to_transfer_signed"
     t.boolean "direction_to_transfer_saved"
+    t.boolean "one_hundred_and_twenty_five_year_lease_not_applicable"
+    t.boolean "one_hundred_and_twenty_five_year_lease_email"
+    t.boolean "one_hundred_and_twenty_five_year_lease_receive"
+    t.boolean "one_hundred_and_twenty_five_year_lease_save"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_135830) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_04_152636) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -58,6 +58,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_135830) do
     t.boolean "subleases_email_signed"
     t.boolean "subleases_receive_signed"
     t.boolean "subleases_save_signed"
+    t.boolean "handover_notes"
+    t.boolean "handover_meeting"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_163204) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_163830) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -136,6 +136,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_163204) do
     t.boolean "school_completed_emailed"
     t.boolean "school_completed_saved"
     t.boolean "conditions_met_emailed"
+    t.boolean "share_information_email"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_144822) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_145521) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -103,6 +103,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_144822) do
     t.boolean "deed_of_variation_cleared"
     t.boolean "deed_of_variation_signed"
     t.boolean "deed_of_variation_saved"
+    t.boolean "trust_modification_order_received"
+    t.boolean "trust_modification_order_sent_legal"
+    t.boolean "trust_modification_order_cleared"
+    t.boolean "trust_modification_order_saved"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_163830) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_164339) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -137,6 +137,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_163830) do
     t.boolean "school_completed_saved"
     t.boolean "conditions_met_emailed"
     t.boolean "share_information_email"
+    t.boolean "tell_regional_delivery_officer_email"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_145521) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_150503) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -107,6 +107,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_145521) do
     t.boolean "trust_modification_order_sent_legal"
     t.boolean "trust_modification_order_cleared"
     t.boolean "trust_modification_order_saved"
+    t.boolean "direction_to_transfer_received"
+    t.boolean "direction_to_transfer_cleared"
+    t.boolean "direction_to_transfer_signed"
+    t.boolean "direction_to_transfer_saved"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_04_152636) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_04_154152) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -60,6 +60,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_04_152636) do
     t.boolean "subleases_save_signed"
     t.boolean "handover_notes"
     t.boolean "handover_meeting"
+    t.boolean "stakeholder_kick_off_introductory_emails"
+    t.boolean "stakeholder_kick_off_local_authority_proforma"
+    t.boolean "stakeholder_kick_off_confirm_target_conversion_date"
+    t.boolean "stakeholder_kick_off_setup_meeting"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_153216) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_154428) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -122,6 +122,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_153216) do
     t.boolean "commercial_transfer_agreement_email_signed"
     t.boolean "commercial_transfer_agreement_receive_signed"
     t.boolean "commercial_transfer_agreement_save_signed"
+    t.boolean "church_supplemental_agreement_not_applicable"
+    t.boolean "master_funding_agreement_not_applicable"
+    t.boolean "articles_of_association_not_applicable"
+    t.boolean "deed_of_variation_not_applicable"
+    t.boolean "trust_modification_order_not_applicable"
+    t.boolean "direction_to_tansfer_not_applicable"
+    t.boolean "handover_not_applicable"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_144125) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_144822) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -99,6 +99,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_144125) do
     t.boolean "articles_of_association_cleared"
     t.boolean "articles_of_association_signed"
     t.boolean "articles_of_association_saved"
+    t.boolean "deed_of_variation_received"
+    t.boolean "deed_of_variation_cleared"
+    t.boolean "deed_of_variation_signed"
+    t.boolean "deed_of_variation_saved"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_04_154152) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_103520) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -64,6 +64,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_04_154152) do
     t.boolean "stakeholder_kick_off_local_authority_proforma"
     t.boolean "stakeholder_kick_off_confirm_target_conversion_date"
     t.boolean "stakeholder_kick_off_setup_meeting"
+    t.boolean "conversion_grant_eligibility"
+    t.boolean "conversion_grant_payment_amount"
+    t.boolean "conversion_grant_payment_form"
+    t.boolean "conversion_grant_send_information"
+    t.boolean "conversion_grant_inform_trust"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_161218) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_162231) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -133,6 +133,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_161218) do
     t.boolean "single_worksheet_complete"
     t.boolean "single_worksheet_approve"
     t.boolean "single_worksheet_send"
+    t.boolean "school_completed_emailed"
+    t.boolean "school_completed_saved"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_142906) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_144125) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -95,6 +95,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_142906) do
     t.boolean "master_funding_agreement_saved"
     t.boolean "master_funding_agreement_sent"
     t.boolean "master_funding_agreement_signed_secretary_state"
+    t.boolean "articles_of_association_received"
+    t.boolean "articles_of_association_cleared"
+    t.boolean "articles_of_association_signed"
+    t.boolean "articles_of_association_saved"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_115735) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_122150) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -82,6 +82,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_115735) do
     t.boolean "supplemental_funding_agreeement_saved"
     t.boolean "supplemental_funding_agreeement_sent"
     t.boolean "supplemental_funding_agreeement_signed_secretary_state"
+    t.boolean "church_supplemental_agreement_received"
+    t.boolean "church_supplemental_agreement_cleared"
+    t.boolean "church_supplemental_agreement_signed"
+    t.boolean "church_supplemental_agreement_signed_diocese"
+    t.boolean "church_supplemental_agreement_saved"
+    t.boolean "church_supplemental_agreement_sent"
+    t.boolean "church_supplemental_agreement_signed_secretary_state"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_114246) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_115735) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -76,6 +76,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_114246) do
     t.boolean "land_registry_received"
     t.boolean "land_registry_cleared"
     t.boolean "land_registry_saved"
+    t.boolean "supplemental_funding_agreeement_received"
+    t.boolean "supplemental_funding_agreeement_cleared"
+    t.boolean "supplemental_funding_agreeement_signed"
+    t.boolean "supplemental_funding_agreeement_saved"
+    t.boolean "supplemental_funding_agreeement_sent"
+    t.boolean "supplemental_funding_agreeement_signed_secretary_state"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_165414) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_170219) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -143,6 +143,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_165414) do
     t.boolean "redact_and_send_send"
     t.boolean "redact_and_send_send_solicitors"
     t.boolean "update_esfa_update"
+    t.boolean "receive_grant_payment_certificate_check_and_save"
+    t.boolean "receive_grant_payment_certificate_update_kim"
+    t.boolean "receive_grant_payment_certificate_update_sheet"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_164339) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_164913) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -138,6 +138,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_164339) do
     t.boolean "conditions_met_emailed"
     t.boolean "share_information_email"
     t.boolean "tell_regional_delivery_officer_email"
+    t.boolean "redact_and_send_redact"
+    t.boolean "redact_and_send_save"
+    t.boolean "redact_and_send_send"
+    t.boolean "redact_and_send_send_solicitors"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_152348) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_153216) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -119,6 +119,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_152348) do
     t.boolean "tenancy_at_will_receive_signed"
     t.boolean "tenancy_at_will_save_signed"
     t.boolean "tenancy_at_will_not_applicable"
+    t.boolean "commercial_transfer_agreement_email_signed"
+    t.boolean "commercial_transfer_agreement_receive_signed"
+    t.boolean "commercial_transfer_agreement_save_signed"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_122150) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_142906) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -89,6 +89,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_122150) do
     t.boolean "church_supplemental_agreement_saved"
     t.boolean "church_supplemental_agreement_sent"
     t.boolean "church_supplemental_agreement_signed_secretary_state"
+    t.boolean "master_funding_agreement_received"
+    t.boolean "master_funding_agreement_cleared"
+    t.boolean "master_funding_agreement_signed"
+    t.boolean "master_funding_agreement_saved"
+    t.boolean "master_funding_agreement_sent"
+    t.boolean "master_funding_agreement_signed_secretary_state"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_103520) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_111357) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -69,6 +69,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_103520) do
     t.boolean "conversion_grant_payment_form"
     t.boolean "conversion_grant_send_information"
     t.boolean "conversion_grant_inform_trust"
+    t.boolean "land_questionnaire_received"
+    t.boolean "land_questionnaire_cleared"
+    t.boolean "land_questionnaire_signed"
+    t.boolean "land_questionnaire_saved"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_151645) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_152348) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -115,6 +115,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_151645) do
     t.boolean "one_hundred_and_twenty_five_year_lease_email"
     t.boolean "one_hundred_and_twenty_five_year_lease_receive"
     t.boolean "one_hundred_and_twenty_five_year_lease_save"
+    t.boolean "tenancy_at_will_email_signed"
+    t.boolean "tenancy_at_will_receive_signed"
+    t.boolean "tenancy_at_will_save_signed"
+    t.boolean "tenancy_at_will_not_applicable"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_160230) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_161218) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -130,6 +130,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_160230) do
     t.boolean "direction_to_tansfer_not_applicable"
     t.boolean "handover_not_applicable"
     t.boolean "check_baseline_confirm"
+    t.boolean "single_worksheet_complete"
+    t.boolean "single_worksheet_approve"
+    t.boolean "single_worksheet_send"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_111357) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_114246) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -73,6 +73,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_111357) do
     t.boolean "land_questionnaire_cleared"
     t.boolean "land_questionnaire_signed"
     t.boolean "land_questionnaire_saved"
+    t.boolean "land_registry_received"
+    t.boolean "land_registry_cleared"
+    t.boolean "land_registry_saved"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_164913) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_165414) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -142,6 +142,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_164913) do
     t.boolean "redact_and_send_save"
     t.boolean "redact_and_send_send"
     t.boolean "redact_and_send_send_solicitors"
+    t.boolean "update_esfa_update"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Changes

Much like https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/430 add the task list models, database columns and content for the involuntary task list. 

The content will need to be proof-read after merge. 

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
