### PR TITLE
Fix workflow docker tag shas

### DIFF
--- a/.github/workflows/build-and-push-image-development.yml
+++ b/.github/workflows/build-and-push-image-development.yml
@@ -26,7 +26,8 @@ jobs:
           VERSION=latest
           TAGS="${DOCKER_IMAGE}:${VERSION}"
           if [ "${{ github.event_name }}" = "push" ]; then
-            VERSION=sha-${GITHUB_SHA}
+            CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
+            VERSION=sha-${CHECKED_OUT_SHA}
             TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
           fi
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-and-push-image-production.yml
+++ b/.github/workflows/build-and-push-image-production.yml
@@ -41,7 +41,8 @@ jobs:
           VERSION=latest
           TAGS="${DOCKER_IMAGE}:${VERSION}"
           if [ "${{ github.event_name }}" = "push" ]; then
-            VERSION=sha-${GITHUB_SHA}
+            CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
+            VERSION=sha-${CHECKED_OUT_SHA}
             TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${{needs.set-test-release-version.outputs.version}}"
           fi
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-and-push-image-test.yml
+++ b/.github/workflows/build-and-push-image-test.yml
@@ -41,7 +41,8 @@ jobs:
           VERSION=latest
           TAGS="${DOCKER_IMAGE}:${VERSION}"
           if [ "${{ github.event_name }}" = "push" ]; then
-            VERSION=sha-${GITHUB_SHA}
+            CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
+            VERSION=sha-${CHECKED_OUT_SHA}
             TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${{needs.set-test-release-version.outputs.version}}"
           fi
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
* The `GITHUB_SHA` is the sha of the commit that triggered the workflow, not the sha of the commit that is checked out by the checkout action
* This ensures that the correct sha is used to tag the image before it is pushed