### PR TITLE
Update support email address & add subject line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add actions to the Process the Sponsored support grant task telling user to
   check and confirm the trust's grant eligibility and tell the trust the amount
   they're able to claim
+- Support email address changed to regionalservices.rg@education.gov.uk and an
+  optional subject line added to the email helper
 
 #### Fixed
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,8 +16,13 @@ module ApplicationHelper
     sanitize(link, attributes: allowed_attributes)
   end
 
-  def support_email(name = nil)
+  def support_email(name = nil, with_custom_subject = true)
     name = Rails.application.config.support_email if name.nil?
-    govuk_mail_to(Rails.application.config.support_email, name)
+    if with_custom_subject
+      subject = I18n.t("support_email_subject")
+      govuk_mail_to(Rails.application.config.support_email, name, subject: subject)
+    else
+      govuk_mail_to(Rails.application.config.support_email, name)
+    end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,7 +49,7 @@
       </main>
     </div>
 
-    <%= govuk_footer(meta_items_title: "Helpful links", meta_items: {"Privacy notice" => page_path(id: "privacy"), "Accessibility Statement" => page_path(id: "accessibility"), "Cookies" => page_path(id: "cookies")}) %>
+    <%= govuk_footer(meta_items_title: "Helpful links", meta_items: {"Privacy notice" => page_path(id: "privacy"), "Accessibility Statement" => page_path(id: "accessibility"), "Cookies" => page_path(id: "cookies"), "Email support" => "mailto:#{Rails.application.config.support_email}?subject=#{I18n.t("support_email_subject")}"}) %>
 
   </body>
   <%= javascript_include_tag "application" %>

--- a/app/views/pages/api_client_timeout.html.erb
+++ b/app/views/pages/api_client_timeout.html.erb
@@ -7,7 +7,6 @@
 
     <p class="govuk-body">
       <%= t("pages.api_client_timeout.email_help",
-            team_name: t("service_name"),
             email: support_email).html_safe %>
     </p>
   </div>

--- a/app/views/pages/internal_server_error.html.erb
+++ b/app/views/pages/internal_server_error.html.erb
@@ -1,10 +1,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
-    <p class="govuk-body">Try again later.</p>
+    <h1 class="govuk-heading-l"><%= t("pages.internal_server_error.title") %></h1>
+    <p class="govuk-body"><%= t("pages.internal_server_error.body_text") %></p>
 
     <p class="govuk-body">
-      <%= support_email("Contact the #{t("service_name")} team") %> if you have any questions.
+      <%= t("pages.internal_server_error.email_help", email: support_email).html_safe %>
     </p>
   </div>
 </div>

--- a/app/views/pages/page_not_found.html.erb
+++ b/app/views/pages/page_not_found.html.erb
@@ -1,15 +1,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Page not found</h1>
+    <h1 class="govuk-heading-l"><%= t("pages.page_not_found.title") %></h1>
     <p class="govuk-body">
-      If you typed the web address, check it is correct.
+      <%= t("pages.page_not_found.body_text_1") %>
     </p>
     <p class="govuk-body">
-      If you pasted the web address, check you copied the entire address.
+      <%= t("pages.page_not_found.body_text_2") %>
     </p>
     <p class="govuk-body">
-      If the web address is correct or you selected a link or button, email the
-      <%= t("service_name") %> team at <%= support_email %>.
+      <%= t("pages.page_not_found.email_help", email: support_email).html_safe %>
     </p>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,6 @@ module DfeCompleteConversionsTransfersAndChanges
 
     config.exceptions_app = routes
 
-    config.support_email = "complete.rsd@education.gov.uk"
+    config.support_email = "regionalservices.rg@education.gov.uk"
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,5 +77,14 @@ en:
   pages:
     api_client_timeout:
       title: Sorry, there was a problem
-      body_text: There was an error getting the details for the school or trust. Refresh the page to try again.
-      email_help: Email the %{team_name} team at %{email} if this error continues.
+      body_text: The service timed out when getting the details of the school or trust. Refresh trhe page to try again.
+      email_help: Email the support team at %{email} if this error continues.
+    page_not_found:
+      title: Page not found
+      body_text_1: If you typed the web address, check it is correct.
+      body_text_2: If you pasted the web address, check you copied the entire address.
+      email_help: Email the support team at %{email} if the web address is correct or you clicked a link or button.
+    internal_server_error:
+      title: Sorry, there is a problem with the service
+      body_text: The service has an internal server error. Refresh the page and if the problem continues, try again later.
+      email_help: Email the support team at %{email} if the problem still occurrs.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,7 +77,7 @@ en:
   pages:
     api_client_timeout:
       title: Sorry, there was a problem
-      body_text: The service timed out when getting the details of the school or trust. Refresh trhe page to try again.
+      body_text: The service timed out when getting the details of the school or trust. Refresh the page to try again.
       email_help: Email the support team at %{email} if this error continues.
     page_not_found:
       title: Page not found
@@ -87,4 +87,4 @@ en:
     internal_server_error:
       title: Sorry, there is a problem with the service
       body_text: The service has an internal server error. Refresh the page and if the problem continues, try again later.
-      email_help: Email the support team at %{email} if the problem still occurrs.
+      email_help: Email the support team at %{email} if the problem still occurs.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,7 @@
 
 en:
   service_name: Complete conversions, transfers and changes
+  support_email_subject: "Complete conversions, transfers and changes: support query"
   phase_banner:
     phase: Beta
     phase_notice:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -51,21 +51,43 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#support_email" do
-    context "when the display name is nil" do
-      subject { helper.support_email }
+    context "when the custom email subject is required (default)" do
+      context "when the display name is nil" do
+        subject { helper.support_email }
 
-      it "returns a mailto link to the support email with the email as the display name" do
-        expect(subject).to eq "<a class=\"govuk-link\" href=\"mailto:regionalservices.rg@education.gov.uk\">regionalservices.rg@education.gov.uk</a>"
+        it "returns a mailto link to the support email, with a custom subject and the email as the display name" do
+          expect(subject).to eq "<a class=\"govuk-link\" href=\"mailto:regionalservices.rg@education.gov.uk?subject=Complete%20conversions%2C%20transfers%20and%20changes%3A%20support%20query\">regionalservices.rg@education.gov.uk</a>"
+        end
+      end
+
+      context "when the display name is not nil" do
+        let(:name) { "contact the complete conversions, transfers and changes team" }
+
+        subject { helper.support_email(name) }
+
+        it "returns a mailto link to the support email, with a custom subject and the supplied name" do
+          expect(subject).to eq "<a class=\"govuk-link\" href=\"mailto:regionalservices.rg@education.gov.uk?subject=Complete%20conversions%2C%20transfers%20and%20changes%3A%20support%20query\">#{name}</a>"
+        end
       end
     end
 
-    context "when the display name is not nil" do
-      let(:name) { "contact the complete conversions, transfers and changes team" }
+    context "when the custom email subject is not required" do
+      context "when the display name is nil" do
+        subject { helper.support_email(nil, false) }
 
-      subject { helper.support_email(name) }
+        it "returns a mailto link to the support email with the email as the display name" do
+          expect(subject).to eq "<a class=\"govuk-link\" href=\"mailto:regionalservices.rg@education.gov.uk\">regionalservices.rg@education.gov.uk</a>"
+        end
+      end
 
-      it "returns a mailto link to the support email with the supplied name" do
-        expect(subject).to eq "<a class=\"govuk-link\" href=\"mailto:regionalservices.rg@education.gov.uk\">#{name}</a>"
+      context "when the display name is not nil" do
+        let(:name) { "contact the complete conversions, transfers and changes team" }
+
+        subject { helper.support_email(name, false) }
+
+        it "returns a mailto link to the support email with the supplied name" do
+          expect(subject).to eq "<a class=\"govuk-link\" href=\"mailto:regionalservices.rg@education.gov.uk\">#{name}</a>"
+        end
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       subject { helper.support_email }
 
       it "returns a mailto link to the support email with the email as the display name" do
-        expect(subject).to eq "<a class=\"govuk-link\" href=\"mailto:complete.rsd@education.gov.uk\">complete.rsd@education.gov.uk</a>"
+        expect(subject).to eq "<a class=\"govuk-link\" href=\"mailto:regionalservices.rg@education.gov.uk\">regionalservices.rg@education.gov.uk</a>"
       end
     end
 
@@ -65,7 +65,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       subject { helper.support_email(name) }
 
       it "returns a mailto link to the support email with the supplied name" do
-        expect(subject).to eq "<a class=\"govuk-link\" href=\"mailto:complete.rsd@education.gov.uk\">#{name}</a>"
+        expect(subject).to eq "<a class=\"govuk-link\" href=\"mailto:regionalservices.rg@education.gov.uk\">#{name}</a>"
       end
     end
   end


### PR DESCRIPTION
## Changes

https://trello.com/c/plnRSrK7

Update the support email address to regionalservices.rg@education.gov.uk
Change the support email helper to output an optional subject line, to help email filtering in the support inbox. This subject is on by default, as so far the acceptance criteria expect it to always be there.
Add a new support email link to the footer.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
