### PR TITLE
Test all locale strings exist for Conversions

### DIFF
--- a/app/views/conversions/involuntary/task_lists/tasks/church_supplemental_agreement.html.erb
+++ b/app/views/conversions/involuntary/task_lists/tasks/church_supplemental_agreement.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @task, url: conversion_involuntary_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+    <%= form_for @task, url: conversions_involuntary_project_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
       <%= form.govuk_error_summary %>
 
       <div class="govuk-form-group">

--- a/app/views/conversions/voluntary/task_lists/tasks/receive_grant_payment_certificate.html.erb
+++ b/app/views/conversions/voluntary/task_lists/tasks/receive_grant_payment_certificate.html.erb
@@ -20,6 +20,6 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
-    <%= render partial: "conversion/shared/task_notes" %>
+    <%= render partial: "conversions/shared/task_notes" %>
   </div>
 </div>

--- a/app/views/conversions/voluntary/task_lists/tasks/school_completed.html.erb
+++ b/app/views/conversions/voluntary/task_lists/tasks/school_completed.html.erb
@@ -1,7 +1,7 @@
 <%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
 
 <% content_for :pre_content_nav do %>
-  <% render partial: "shared/back_link", locals: {href: @project.task_list_path} %>
+  <% render partial: "shared/back_link", locals: {href: task_list_path(@project)} %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/config/locales/task_lists/conversion/involuntary/tenancy_at_will.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/tenancy_at_will.en.yml
@@ -18,9 +18,9 @@ en:
 
           email_signed:
             title: Email the trust to ask if all relevant parties have agreed and signed the Tenancy at will
-            receive_signed:
-              title: Receive email from the trust confirming all relevant parties have agreed and signed the Tenancy at will
-            save_signed:
-              title: Save a copy of the confirmation email in the school's SharePoint folder
+          receive_signed:
+            title: Receive email from the trust confirming all relevant parties have agreed and signed the Tenancy at will
+          save_signed:
+            title: Save a copy of the confirmation email in the school's SharePoint folder
           not_applicable:
             title: Not applicable

--- a/spec/features/all_conversion_project_tasks_have_locales_spec.rb
+++ b/spec/features/all_conversion_project_tasks_have_locales_spec.rb
@@ -1,0 +1,288 @@
+require "rails_helper"
+
+RSpec.feature "All task lists have a locale file & all keys are present" do
+  let(:user) { create(:user, :regional_delivery_officer) }
+  let(:involuntary_project) { create(:involuntary_conversion_project) }
+  let(:voluntary_project) { create(:voluntary_conversion_project) }
+
+  before do
+    mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    sign_in_with_user(user)
+  end
+
+  context "involuntary project" do
+    describe "has locales for all tasks" do
+      before do
+        visit conversions_involuntary_project_task_list_path(involuntary_project.id)
+      end
+
+      it "has all the links for the involuntary tasks" do
+        expect(page.find_all("ol.app-task-list ul li a").count).to eq 25
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.handover.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.handover.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.stakeholder_kick_off.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.stakeholder_kick_off.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.conversion_grant.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.conversion_grant.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.land_questionnaire.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.land_questionnaire.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.land_registry.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.land_registry.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.supplemental_funding_agreement.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.supplemental_funding_agreement.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.church_supplemental_agreement.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.church_supplemental_agreement.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.master_funding_agreement.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.master_funding_agreement.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.articles_of_association.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.articles_of_association.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.deed_of_variation.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.deed_of_variation.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.trust_modification_order.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.trust_modification_order.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.direction_to_transfer.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.direction_to_transfer.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.one_hundred_and_twenty_five_year_lease.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.one_hundred_and_twenty_five_year_lease.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.subleases.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.subleases.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.tenancy_at_will.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.tenancy_at_will.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.commercial_transfer_agreement.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.commercial_transfer_agreement.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.check_baseline.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.check_baseline.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.single_worksheet.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.single_worksheet.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.school_completed.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.school_completed.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.conditions_met.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.conditions_met.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.share_information.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.share_information.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.tell_regional_delivery_officer.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.tell_regional_delivery_officer.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.redact_and_send.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.redact_and_send.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.update_esfa.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.update_esfa.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.involuntary.tasks.receive_grant_payment_certificate.title")}" do
+        click_on I18n.t("conversion.involuntary.tasks.receive_grant_payment_certificate.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+    end
+  end
+
+  context "voluntary project" do
+    describe "has locales for all tasks" do
+      before do
+        visit conversions_voluntary_project_task_list_path(voluntary_project.id)
+      end
+
+      it "has all the links for the voluntary tasks" do
+        expect(page.find_all("ol.app-task-list ul li a").count).to eq 25
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.handover.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.handover.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.stakeholder_kick_off.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.stakeholder_kick_off.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.conversion_grant.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.conversion_grant.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.land_questionnaire.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.land_questionnaire.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.land_registry.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.land_registry.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.supplemental_funding_agreement.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.supplemental_funding_agreement.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.church_supplemental_agreement.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.church_supplemental_agreement.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.master_funding_agreement.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.master_funding_agreement.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.articles_of_association.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.articles_of_association.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.deed_of_variation.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.deed_of_variation.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.trust_modification_order.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.trust_modification_order.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.direction_to_transfer.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.direction_to_transfer.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.one_hundred_and_twenty_five_year_lease.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.one_hundred_and_twenty_five_year_lease.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.subleases.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.subleases.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.tenancy_at_will.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.tenancy_at_will.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.commercial_transfer_agreement.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.commercial_transfer_agreement.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.check_baseline.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.check_baseline.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.single_worksheet.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.single_worksheet.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.school_completed.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.school_completed.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.conditions_met.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.conditions_met.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.share_information.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.share_information.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.tell_regional_delivery_officer.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.tell_regional_delivery_officer.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.redact_and_send.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.redact_and_send.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.update_esfa.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.update_esfa.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+
+      it "has locales for #{I18n.t("conversion.voluntary.tasks.receive_grant_payment_certificate.title")}" do
+        click_on I18n.t("conversion.voluntary.tasks.receive_grant_payment_certificate.title")
+        expect(page).to_not have_css(".translation_missing")
+      end
+    end
+  end
+end

--- a/spec/features/all_conversion_project_tasks_have_locales_spec.rb
+++ b/spec/features/all_conversion_project_tasks_have_locales_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "All task lists have a locale file & all keys are present" do
       end
 
       it "has all the links for the involuntary tasks" do
-        expect(page.find_all("ol.app-task-list ul li a").count).to eq 25
+        expect(page.find_all("ol.app-task-list ul li a").count).to eq tasks.count
         expect(page).to_not have_css(".translation_missing")
       end
 
@@ -43,7 +43,7 @@ RSpec.feature "All task lists have a locale file & all keys are present" do
       end
 
       it "has all the links for the voluntary tasks" do
-        expect(page.find_all("ol.app-task-list ul li a").count).to eq 25
+        expect(page.find_all("ol.app-task-list ul li a").count).to eq tasks.count
         expect(page).to_not have_css(".translation_missing")
       end
 

--- a/spec/features/all_conversion_project_tasks_have_locales_spec.rb
+++ b/spec/features/all_conversion_project_tasks_have_locales_spec.rb
@@ -10,6 +10,12 @@ RSpec.feature "All task lists have a locale file & all keys are present" do
     sign_in_with_user(user)
   end
 
+  tasks = %w[articles_of_association check_baseline church_supplemental_agreement commercial_transfer_agreement
+    conditions_met conversion_grant deed_of_variation direction_to_transfer handover land_questionnaire land_registry
+    master_funding_agreement one_hundred_and_twenty_five_year_lease receive_grant_payment_certificate redact_and_send
+    school_completed share_information single_worksheet stakeholder_kick_off subleases supplemental_funding_agreement
+    tell_regional_delivery_officer tenancy_at_will trust_modification_order update_esfa]
+
   context "involuntary project" do
     describe "has locales for all tasks" do
       before do
@@ -21,129 +27,11 @@ RSpec.feature "All task lists have a locale file & all keys are present" do
         expect(page).to_not have_css(".translation_missing")
       end
 
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.handover.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.handover.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.stakeholder_kick_off.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.stakeholder_kick_off.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.conversion_grant.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.conversion_grant.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.land_questionnaire.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.land_questionnaire.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.land_registry.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.land_registry.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.supplemental_funding_agreement.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.supplemental_funding_agreement.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.church_supplemental_agreement.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.church_supplemental_agreement.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.master_funding_agreement.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.master_funding_agreement.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.articles_of_association.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.articles_of_association.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.deed_of_variation.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.deed_of_variation.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.trust_modification_order.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.trust_modification_order.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.direction_to_transfer.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.direction_to_transfer.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.one_hundred_and_twenty_five_year_lease.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.one_hundred_and_twenty_five_year_lease.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.subleases.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.subleases.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.tenancy_at_will.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.tenancy_at_will.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.commercial_transfer_agreement.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.commercial_transfer_agreement.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.check_baseline.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.check_baseline.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.single_worksheet.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.single_worksheet.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.school_completed.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.school_completed.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.conditions_met.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.conditions_met.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.share_information.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.share_information.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.tell_regional_delivery_officer.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.tell_regional_delivery_officer.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.redact_and_send.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.redact_and_send.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.update_esfa.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.update_esfa.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.involuntary.tasks.receive_grant_payment_certificate.title")}" do
-        click_on I18n.t("conversion.involuntary.tasks.receive_grant_payment_certificate.title")
-        expect(page).to_not have_css(".translation_missing")
+      tasks.each do |task|
+        it "has locales for #{I18n.t("conversion.involuntary.tasks.#{task}.title")}" do
+          click_on I18n.t("conversion.involuntary.tasks.#{task}.title")
+          expect(page).to_not have_css(".translation_missing")
+        end
       end
     end
   end
@@ -159,129 +47,11 @@ RSpec.feature "All task lists have a locale file & all keys are present" do
         expect(page).to_not have_css(".translation_missing")
       end
 
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.handover.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.handover.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.stakeholder_kick_off.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.stakeholder_kick_off.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.conversion_grant.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.conversion_grant.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.land_questionnaire.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.land_questionnaire.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.land_registry.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.land_registry.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.supplemental_funding_agreement.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.supplemental_funding_agreement.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.church_supplemental_agreement.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.church_supplemental_agreement.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.master_funding_agreement.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.master_funding_agreement.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.articles_of_association.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.articles_of_association.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.deed_of_variation.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.deed_of_variation.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.trust_modification_order.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.trust_modification_order.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.direction_to_transfer.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.direction_to_transfer.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.one_hundred_and_twenty_five_year_lease.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.one_hundred_and_twenty_five_year_lease.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.subleases.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.subleases.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.tenancy_at_will.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.tenancy_at_will.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.commercial_transfer_agreement.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.commercial_transfer_agreement.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.check_baseline.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.check_baseline.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.single_worksheet.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.single_worksheet.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.school_completed.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.school_completed.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.conditions_met.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.conditions_met.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.share_information.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.share_information.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.tell_regional_delivery_officer.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.tell_regional_delivery_officer.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.redact_and_send.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.redact_and_send.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.update_esfa.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.update_esfa.title")
-        expect(page).to_not have_css(".translation_missing")
-      end
-
-      it "has locales for #{I18n.t("conversion.voluntary.tasks.receive_grant_payment_certificate.title")}" do
-        click_on I18n.t("conversion.voluntary.tasks.receive_grant_payment_certificate.title")
-        expect(page).to_not have_css(".translation_missing")
+      tasks.each do |task|
+        it "has locales for #{I18n.t("conversion.voluntary.tasks.#{task}.title")}" do
+          click_on I18n.t("conversion.voluntary.tasks.#{task}.title")
+          expect(page).to_not have_css(".translation_missing")
+        end
       end
     end
   end


### PR DESCRIPTION
## Changes

Add a feature test to check all locale strings are present for tasks.

This is more long-winded than I intended. I had hoped to do this more automatically - to visit the task list pages, iterate over any link on the page, check the content and then go back to the task list page. E.g. 

```
page.find_all("ol.app-task-list ul li a").each do |link|
  click_link link.text
  expect(page).to_not have_css(".translation_missing")
  click_link "Back"
end
```

But for some reason Rspec doesn't like this, it only goes into the first link and exits.

I also looked into using shared examples but I think these make it harder to debug and pinpoint where the missing strings are. 

In this implementation, every time a new task is added to a task list, it will have to be added to the list of tasks, plus the overall number of tasks will need to be amended. 

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
