### PR TITLE
Switch to new task list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added cookies page to describe how we use cookies
 - Send notification to caseworker when assigned to a project
 - Add a Content Security Policy
+- Completely new task list and task backend.
 
 #### Changed
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,14 +8,16 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
   rescue_from AcademiesApi::Client::Error, with: :client_error
 
-  private
-
-  def user_not_authorized
+  private def user_not_authorized
     flash[:alert] = I18n.t("unauthorised_action.message")
     redirect_back(fallback_location: root_path)
   end
 
-  def client_error
+  private def client_error
     render "pages/api_client_timeout", status: 500
+  end
+
+  private def not_found_error
+    render "pages/page_not_found", status: :not_found
   end
 end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -10,7 +10,7 @@ class AssignmentsController < ApplicationController
   def update_team_leader
     @project.update(team_leader_params)
 
-    redirect_to project_information_path(@project), notice: t("project.assign.team_leader.success")
+    redirect_to helpers.path_to_project_information(@project), notice: t("project.assign.team_leader.success")
   end
 
   def assign_regional_delivery_officer
@@ -20,7 +20,7 @@ class AssignmentsController < ApplicationController
   def update_regional_delivery_officer
     @project.update(regional_delivery_officer_params)
 
-    redirect_to project_information_path(@project), notice: t("project.assign.regional_delivery_officer.success")
+    redirect_to helpers.path_to_project_information(@project), notice: t("project.assign.regional_delivery_officer.success")
   end
 
   def assign_caseworker
@@ -33,7 +33,7 @@ class AssignmentsController < ApplicationController
 
     CaseworkerMailer.caseworker_assigned_notification(@project.caseworker, @project).deliver_later
 
-    redirect_to project_information_path(@project), notice: t("project.assign.caseworker.success")
+    redirect_to helpers.path_to_project_information(@project), notice: t("project.assign.caseworker.success")
   end
 
   private def authorize_user

--- a/app/controllers/conversions/involuntary/projects_controller.rb
+++ b/app/controllers/conversions/involuntary/projects_controller.rb
@@ -12,6 +12,7 @@ class Conversions::Involuntary::ProjectsController < Conversions::ProjectsContro
   def show
     @project = Project.conversions_involuntary.includes(sections: [:tasks]).find(params[:id])
     authorize @project
+    redirect_to conversions_involuntary_project_task_list_path(@project)
   end
 
   def new

--- a/app/controllers/conversions/involuntary/projects_controller.rb
+++ b/app/controllers/conversions/involuntary/projects_controller.rb
@@ -10,7 +10,7 @@ class Conversions::Involuntary::ProjectsController < Conversions::ProjectsContro
   end
 
   def show
-    @project = Project.conversions_involuntary.includes(sections: [:tasks]).find(params[:id])
+    @project = Project.conversions_involuntary.find(params[:id])
     authorize @project
     redirect_to conversions_involuntary_project_task_list_path(@project)
   end

--- a/app/controllers/conversions/involuntary/task_lists_controller.rb
+++ b/app/controllers/conversions/involuntary/task_lists_controller.rb
@@ -12,4 +12,8 @@ class Conversions::Involuntary::TaskListsController < TaskListsController
   def task_template_path(task_identifier)
     "conversions/involuntary/task_lists/tasks/#{task_identifier}"
   end
+
+  private def find_project
+    @project = Project.conversions_involuntary.find(params[:project_id])
+  end
 end

--- a/app/controllers/conversions/voluntary/projects_controller.rb
+++ b/app/controllers/conversions/voluntary/projects_controller.rb
@@ -12,6 +12,7 @@ class Conversions::Voluntary::ProjectsController < Conversions::ProjectsControll
   def show
     @project = Project.conversions_voluntary.includes(sections: [:tasks]).find(params[:id])
     authorize @project
+    redirect_to conversions_voluntary_project_task_list_path(@project)
   end
 
   def new

--- a/app/controllers/conversions/voluntary/projects_controller.rb
+++ b/app/controllers/conversions/voluntary/projects_controller.rb
@@ -10,7 +10,7 @@ class Conversions::Voluntary::ProjectsController < Conversions::ProjectsControll
   end
 
   def show
-    @project = Project.conversions_voluntary.includes(sections: [:tasks]).find(params[:id])
+    @project = Project.conversions_voluntary.find(params[:id])
     authorize @project
     redirect_to conversions_voluntary_project_task_list_path(@project)
   end

--- a/app/controllers/conversions/voluntary/task_lists_controller.rb
+++ b/app/controllers/conversions/voluntary/task_lists_controller.rb
@@ -12,4 +12,8 @@ class Conversions::Voluntary::TaskListsController < TaskListsController
   def task_template_path(task_identifier)
     "conversions/voluntary/task_lists/tasks/#{task_identifier}"
   end
+
+  private def find_project
+    @project = Project.conversions_voluntary.find(params[:project_id])
+  end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -20,8 +20,4 @@ class ProjectsController < ApplicationController
     @project = Project.includes(sections: [:tasks]).find(params[:id])
     authorize @project
   end
-
-  private def not_found_error
-    redirect_to "/404", status: :not_found
-  end
 end

--- a/app/controllers/task_lists_controller.rb
+++ b/app/controllers/task_lists_controller.rb
@@ -1,6 +1,7 @@
 class TaskListsController < ApplicationController
   before_action :find_project, :find_task_list
   before_action :find_task, :find_task_notes, only: %i[edit update]
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
 
   def index
   end
@@ -19,10 +20,6 @@ class TaskListsController < ApplicationController
     else
       render task_template_path(@task.class.identifier)
     end
-  end
-
-  private def find_project
-    @project = Project.find(params[:project_id])
   end
 
   private def find_task_list

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,4 +25,29 @@ module ApplicationHelper
       govuk_mail_to(Rails.application.config.support_email, name)
     end
   end
+
+  def path_to_project(project)
+    return conversions_voluntary_project_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
+  def path_to_project_task_list(project)
+    return conversions_voluntary_project_task_list_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_task_list_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
+  def path_to_project_notes(project)
+    return conversions_voluntary_project_notes_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_notes_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
+  def path_to_project_information(project)
+    return conversions_voluntary_project_information_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_information_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
+  def path_to_project_contacts(project)
+    return conversions_voluntary_project_contacts_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_contacts_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,4 +50,19 @@ module ApplicationHelper
     return conversions_voluntary_project_contacts_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
     return conversions_involuntary_project_contacts_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
   end
+
+  def path_to_team_lead_project_assignment(project)
+    return conversions_voluntary_project_assign_team_lead_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_assign_team_lead_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
+  def path_to_regional_delivery_officer_project_assignment(project)
+    return conversions_voluntary_project_assign_regional_delivery_officer_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_assign_regional_delivery_officer_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
+  def path_to_caseworker_project_assignment(project)
+    return conversions_voluntary_project_assign_caseworker_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_assign_caseworker_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
 end

--- a/app/views/assignments/assign_caseworker.html.erb
+++ b/app/views/assignments/assign_caseworker.html.erb
@@ -15,7 +15,7 @@
             options: {include_blank: true, selected: @project.caseworker&.id} %>
 
       <%= form.govuk_submit do %>
-        <%= govuk_link_to "Cancel", project_information_path(@project) %>
+        <%= govuk_link_to "Cancel", path_to_project_information(@project) %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/assignments/assign_regional_delivery_officer.html.erb
+++ b/app/views/assignments/assign_regional_delivery_officer.html.erb
@@ -15,7 +15,7 @@
             options: {include_blank: true, selected: @project.regional_delivery_officer&.id} %>
 
       <%= form.govuk_submit do %>
-        <%= govuk_link_to "Cancel", project_information_path(@project) %>
+        <%= govuk_link_to "Cancel", path_to_project_information(@project) %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/assignments/assign_team_leader.html.erb
+++ b/app/views/assignments/assign_team_leader.html.erb
@@ -15,7 +15,7 @@
             options: {include_blank: true, selected: @project.team_leader&.id} %>
 
       <%= form.govuk_submit do %>
-        <%= govuk_link_to "Cancel", project_information_path(@project) %>
+        <%= govuk_link_to "Cancel", path_to_project_information(@project) %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/conversions/involuntary/task_lists/index.html.erb
+++ b/app/views/conversions/involuntary/task_lists/index.html.erb
@@ -3,6 +3,7 @@
 <% end %>
 
 <%= render partial: "shared/project_summary" %>
+<%= render partial: "shared/project_sub_navigation" %>
 
 <h2 class="govuk-heading-l"><%= t("project.show.title") %></h2>
 

--- a/app/views/conversions/voluntary/task_lists/index.html.erb
+++ b/app/views/conversions/voluntary/task_lists/index.html.erb
@@ -2,6 +2,9 @@
   <% render partial: "shared/back_link", locals: {href: root_path} %>
 <% end %>
 
+<%= render partial: "shared/project_summary" %>
+<%= render partial: "shared/project_sub_navigation" %>
+
 <h2 class="govuk-heading-l"><%= t("project.show.title") %></h2>
 
 <%= render "conversions/shared/task_list" %>

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -8,7 +8,7 @@
         row.action(text: "Email", href: mail_to_path(@project.caseworker.email), visually_hidden_text: "caseworker")
       end
       if policy(:assignment).assign_caseworker?
-        row.action(href: project_assign_caseworker_path(@project), visually_hidden_text: "caseworker")
+        row.action(href: path_to_caseworker_project_assignment(@project), visually_hidden_text: "caseworker")
       end
     end
     summary_list.row do |row|
@@ -18,7 +18,7 @@
         row.action(text: "Email", href: mail_to_path(@project.team_leader.email), visually_hidden_text: "team leader")
       end
       if policy(:assignment).assign_team_leader?
-        row.action(href: project_assign_team_lead_path(@project), visually_hidden_text: "team leader")
+        row.action(href: path_to_team_lead_project_assignment(@project), visually_hidden_text: "team leader")
       end
     end
     summary_list.row do |row|
@@ -28,7 +28,7 @@
         row.action(text: "Email", href: mail_to_path(@project.regional_delivery_officer.email), visually_hidden_text: "regional delivery officer")
       end
       if policy(:assignment).assign_regional_delivery_officer?
-        row.action(href: project_assign_regional_delivery_officer_path(@project), visually_hidden_text: "regional delivery officer")
+        row.action(href: path_to_regional_delivery_officer_project_assignment(@project), visually_hidden_text: "regional delivery officer")
       end
     end
     summary_list.row do |row|

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -6,7 +6,7 @@
 
 <%= render partial: "shared/project_sub_navigation" %>
 
-<h2 class="govuk-heading-l"><%= t("project.show.title") %></h2>
+<h2 class="govuk-heading-l">Old task list (do not use!)</h2>
 <%= render "projects/show/task_list" %>
 
 <%= render "projects/show/complete" unless @project.completed? %>

--- a/app/views/shared/_project_sub_navigation.html.erb
+++ b/app/views/shared/_project_sub_navigation.html.erb
@@ -1,13 +1,13 @@
 <nav class="moj-sub-navigation" aria-label="Project sub-navigation">
   <ul class="moj-sub-navigation__list">
 
-    <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.project_task_list"), path: project_path(@project)} %>
+    <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.project_task_list"), path: path_to_project_task_list(@project)} %>
 
-    <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.project_information"), path: project_information_path(@project)} %>
+    <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.project_information"), path: path_to_project_information(@project)} %>
 
-    <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.notes"), path: project_notes_path(@project)} %>
+    <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.notes"), path: path_to_project_notes(@project)} %>
 
-    <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.contacts"), path: project_contacts_path(@project)} %>
+    <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.contacts"), path: path_to_project_contacts(@project)} %>
 
   </ul>
 </nav>

--- a/app/views/shared/projects/_list.html.erb
+++ b/app/views/shared/projects/_list.html.erb
@@ -6,7 +6,7 @@
       <li>
         <span class="govuk-caption-m">URN <%= project.urn %></span>
         <h2 class="govuk-heading-m govuk-heading-m--school-name">
-          <%= link_to project.establishment.name, project_path(project) %>
+          <%= link_to project.establishment.name, path_to_project(project) %>
         </h2>
 
         <%= render partial: "projects/index/project_summary", locals: {project: project} %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "02bae3df5dc344390e29342b85f949e8b77ea2e9d7a4a5e69823d7f8b9664a6c",
+      "fingerprint": "8ad9a557b5cb233983e1d9eced500829f233497749e8795f65a6f960912e1606",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/controllers/task_lists_controller.rb",
-      "line": 9,
+      "line": 10,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => task_template_path(Project.find(params[:project_id]).task_list.task(params[:task_id]).class.identifier), {})",
+      "code": "render(action => task_template_path(Project.conversions_involuntary.find(params[:project_id]).task_list.task(params[:task_id]).class.identifier), {})",
       "render_path": null,
       "location": {
         "type": "method",
@@ -26,13 +26,13 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "4f12037a57acfa3b5eae5cc25928f12a5855e26274d9a337cbd90dc2eaffe246",
+      "fingerprint": "e784caf6337e321fcd095fe7f7257bf30d79c72e87876cc59b8a3785fd7db819",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/controllers/task_lists_controller.rb",
-      "line": 20,
+      "line": 21,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => task_template_path(Project.find(params[:project_id]).task_list.task(params[:task_id]).class.identifier), {})",
+      "code": "render(action => task_template_path(Project.conversions_involuntary.find(params[:project_id]).task_list.task(params[:task_id]).class.identifier), {})",
       "render_path": null,
       "location": {
         "type": "method",
@@ -47,6 +47,6 @@
       "note": ""
     }
   ],
-  "updated": "2022-12-19 14:08:48 +0000",
+  "updated": "2023-01-12 10:14:27 +0000",
   "brakeman_version": "5.3.1"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,19 +36,30 @@ Rails.application.routes.draw do
     resources :notes, except: %i[show], concerns: :has_destroy_confirmation, controller: "/notes"
   end
 
+  concern :assignable do
+    namespace :assign, controller: "/assignments" do
+      get "team-lead", action: :assign_team_leader
+      post "team-lead", action: :update_team_leader
+      get "regional-delivery-officer", action: :assign_regional_delivery_officer
+      post "regional-delivery-officer", action: :update_regional_delivery_officer
+      get "caseworker", action: :assign_caseworker
+      post "caseworker", action: :update_caseworker
+    end
+  end
+
   namespace :conversions do
     get "/", to: "/conversions/projects#index"
     namespace :voluntary do
       get "/", to: "/conversions/voluntary/projects#index"
       resources :projects,
         only: %i[show new create],
-        concerns: %i[task_listable contactable notable]
+        concerns: %i[task_listable contactable notable assignable]
     end
     namespace :involuntary do
       get "/", to: "/conversions/involuntary/projects#index"
       resources :projects,
         only: %i[show new create],
-        concerns: %i[task_listable contactable notable]
+        concerns: %i[task_listable contactable notable assignable]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,19 +32,23 @@ Rails.application.routes.draw do
     resources :contacts, except: %i[show], concerns: :has_destroy_confirmation, controller: "/contacts"
   end
 
+  concern :notable do
+    resources :notes, except: %i[show], concerns: :has_destroy_confirmation, controller: "/notes"
+  end
+
   namespace :conversions do
     get "/", to: "/conversions/projects#index"
     namespace :voluntary do
       get "/", to: "/conversions/voluntary/projects#index"
       resources :projects,
         only: %i[show new create],
-        concerns: %i[task_listable contactable]
+        concerns: %i[task_listable contactable notable]
     end
     namespace :involuntary do
       get "/", to: "/conversions/involuntary/projects#index"
       resources :projects,
         only: %i[show new create],
-        concerns: %i[task_listable contactable]
+        concerns: %i[task_listable contactable notable]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,19 +47,23 @@ Rails.application.routes.draw do
     end
   end
 
+  concern :informationable do
+    get "information", to: "/project_information#show"
+  end
+
   namespace :conversions do
     get "/", to: "/conversions/projects#index"
     namespace :voluntary do
       get "/", to: "/conversions/voluntary/projects#index"
       resources :projects,
         only: %i[show new create],
-        concerns: %i[task_listable contactable notable assignable]
+        concerns: %i[task_listable contactable notable assignable informationable]
     end
     namespace :involuntary do
       get "/", to: "/conversions/involuntary/projects#index"
       resources :projects,
         only: %i[show new create],
-        concerns: %i[task_listable contactable notable assignable]
+        concerns: %i[task_listable contactable notable assignable informationable]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,19 +51,23 @@ Rails.application.routes.draw do
     get "information", to: "/project_information#show"
   end
 
+  concern :completable do
+    put "complete", to: "/projects_complete#complete"
+  end
+
   namespace :conversions do
     get "/", to: "/conversions/projects#index"
     namespace :voluntary do
       get "/", to: "/conversions/voluntary/projects#index"
       resources :projects,
         only: %i[show new create],
-        concerns: %i[task_listable contactable notable assignable informationable]
+        concerns: %i[task_listable contactable notable assignable informationable completable]
     end
     namespace :involuntary do
       get "/", to: "/conversions/involuntary/projects#index"
       resources :projects,
         only: %i[show new create],
-        concerns: %i[task_listable contactable notable assignable informationable]
+        concerns: %i[task_listable contactable notable assignable informationable completable]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,15 +28,23 @@ Rails.application.routes.draw do
     put "task-list/:task_id", to: "task_lists#update", as: :update_task
   end
 
+  concern :contactable do
+    resources :contacts, except: %i[show], concerns: :has_destroy_confirmation, controller: "/contacts"
+  end
+
   namespace :conversions do
     get "/", to: "/conversions/projects#index"
     namespace :voluntary do
       get "/", to: "/conversions/voluntary/projects#index"
-      resources :projects, only: %i[show new create], concerns: %i[task_listable]
+      resources :projects,
+        only: %i[show new create],
+        concerns: %i[task_listable contactable]
     end
     namespace :involuntary do
       get "/", to: "/conversions/involuntary/projects#index"
-      resources :projects, only: %i[show new create], concerns: %i[task_listable]
+      resources :projects,
+        only: %i[show new create],
+        concerns: %i[task_listable contactable]
     end
   end
 

--- a/spec/features/team_leaders_can_assign_users_to_project_roles_spec.rb
+++ b/spec/features/team_leaders_can_assign_users_to_project_roles_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Team leaders can assign users to project roles" do
       click_on "Change"
     end
 
-    expect(page).to have_current_path(project_assign_team_lead_path(project))
+    expect(page).to have_current_path(conversions_voluntary_project_assign_team_lead_path(project))
 
     select team_leader.full_name, from: I18n.t("assignment.assign_team_leader.title", school_name: project.establishment.name)
 
@@ -46,7 +46,7 @@ RSpec.feature "Team leaders can assign users to project roles" do
       click_on "Change"
     end
 
-    expect(page).to have_current_path(project_assign_regional_delivery_officer_path(project))
+    expect(page).to have_current_path(conversions_voluntary_project_assign_regional_delivery_officer_path(project))
 
     select regional_delivery_officer.full_name, from: I18n.t("assignment.assign_regional_delivery_officer.title", school_name: project.establishment.name)
 
@@ -68,7 +68,7 @@ RSpec.feature "Team leaders can assign users to project roles" do
       click_on "Change"
     end
 
-    expect(page).to have_current_path(project_assign_caseworker_path(project))
+    expect(page).to have_current_path(conversions_voluntary_project_assign_caseworker_path(project))
 
     select caseworker.full_name, from: I18n.t("assignment.assign_caseworker.title", school_name: project.establishment.name)
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -104,6 +104,10 @@ RSpec.describe ApplicationHelper, type: :helper do
         expect(helper.path_to_project_information(project)).to eq conversions_voluntary_project_information_path(project)
         expect(helper.path_to_project_notes(project)).to eq conversions_voluntary_project_notes_path(project)
         expect(helper.path_to_project_contacts(project)).to eq conversions_voluntary_project_contacts_path(project)
+
+        expect(helper.path_to_team_lead_project_assignment(project)).to eq conversions_voluntary_project_assign_team_lead_path(project)
+        expect(helper.path_to_regional_delivery_officer_project_assignment(project)).to eq conversions_voluntary_project_assign_regional_delivery_officer_path(project)
+        expect(helper.path_to_caseworker_project_assignment(project)).to eq conversions_voluntary_project_assign_caseworker_path(project)
       end
     end
 
@@ -116,6 +120,10 @@ RSpec.describe ApplicationHelper, type: :helper do
         expect(helper.path_to_project_information(project)).to eq conversions_involuntary_project_information_path(project)
         expect(helper.path_to_project_notes(project)).to eq conversions_involuntary_project_notes_path(project)
         expect(helper.path_to_project_contacts(project)).to eq conversions_involuntary_project_contacts_path(project)
+
+        expect(helper.path_to_team_lead_project_assignment(project)).to eq conversions_involuntary_project_assign_team_lead_path(project)
+        expect(helper.path_to_regional_delivery_officer_project_assignment(project)).to eq conversions_involuntary_project_assign_regional_delivery_officer_path(project)
+        expect(helper.path_to_caseworker_project_assignment(project)).to eq conversions_involuntary_project_assign_caseworker_path(project)
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -91,4 +91,32 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "project paths" do
+    before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+    context "when the project is a voluntary conversion" do
+      it "returns the correct paths" do
+        project = create(:voluntary_conversion_project)
+
+        expect(helper.path_to_project(project)).to eq conversions_voluntary_project_path(project)
+        expect(helper.path_to_project_task_list(project)).to eq conversions_voluntary_project_task_list_path(project)
+        expect(helper.path_to_project_information(project)).to eq conversions_voluntary_project_information_path(project)
+        expect(helper.path_to_project_notes(project)).to eq conversions_voluntary_project_notes_path(project)
+        expect(helper.path_to_project_contacts(project)).to eq conversions_voluntary_project_contacts_path(project)
+      end
+    end
+
+    context "when the project is a involuntary conversion" do
+      it "returns the correct path" do
+        project = create(:involuntary_conversion_project)
+
+        expect(helper.path_to_project(project)).to eq conversions_involuntary_project_path(project)
+        expect(helper.path_to_project_task_list(project)).to eq conversions_involuntary_project_task_list_path(project)
+        expect(helper.path_to_project_information(project)).to eq conversions_involuntary_project_information_path(project)
+        expect(helper.path_to_project_notes(project)).to eq conversions_involuntary_project_notes_path(project)
+        expect(helper.path_to_project_contacts(project)).to eq conversions_involuntary_project_contacts_path(project)
+      end
+    end
+  end
 end

--- a/spec/requests/assignments_controller_spec.rb
+++ b/spec/requests/assignments_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe AssignmentsController, type: :request do
   describe "#assign_team_leader" do
     it_behaves_like "an action which redirects unauthorized users"
 
-    let(:project) { create(:conversion_project) }
+    let(:project) { create(:voluntary_conversion_project) }
     let(:project_id) { project.id }
 
     subject(:perform_request) do
@@ -48,7 +48,7 @@ RSpec.describe AssignmentsController, type: :request do
     end
 
     it "assigns the project team lead and redirefcts with a message" do
-      expect(perform_request).to redirect_to(project_information_path(project))
+      expect(perform_request).to redirect_to(conversions_voluntary_project_information_path(project))
       expect(request.flash[:notice]).to eq(I18n.t("project.assign.team_leader.success"))
 
       expect(project.reload.team_leader).to eq team_leader
@@ -84,7 +84,7 @@ RSpec.describe AssignmentsController, type: :request do
     end
 
     it "assigns the project regional delivery officer and redirefcts with a message" do
-      expect(perform_request).to redirect_to(project_information_path(project))
+      expect(perform_request).to redirect_to(conversions_voluntary_project_information_path(project))
       expect(request.flash[:notice]).to eq(I18n.t("project.assign.regional_delivery_officer.success"))
 
       expect(project.reload.regional_delivery_officer).to eq regional_delivery_officer
@@ -139,7 +139,7 @@ RSpec.describe AssignmentsController, type: :request do
     end
 
     it "assigns the project caseworker and redirefcts with a message" do
-      expect(perform_request).to redirect_to(project_information_path(project))
+      expect(perform_request).to redirect_to(conversions_voluntary_project_information_path(project))
       expect(request.flash[:notice]).to eq(I18n.t("project.assign.caseworker.success"))
 
       expect(project.reload.caseworker).to eq caseworker

--- a/spec/requests/conversions/involuntary/projects_contoller_spec.rb
+++ b/spec/requests/conversions/involuntary/projects_contoller_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Conversions::Involuntary::ProjectsController do
       involuntary_conversion_project = create(:involuntary_conversion_project, urn: 123456, regional_delivery_officer: regional_delivery_officer)
 
       get conversions_involuntary_project_path(involuntary_conversion_project)
+      follow_redirect!
 
       expect(response.body).to include(involuntary_conversion_project.urn.to_s)
     end

--- a/spec/requests/conversions/involuntary/task_lists_controller_spec.rb
+++ b/spec/requests/conversions/involuntary/task_lists_controller_spec.rb
@@ -12,4 +12,16 @@ RSpec.describe Conversions::Involuntary::TaskListsController do
   let(:expected_update_attributes) { {handover_review: true} }
 
   it_behaves_like "a task lists controller"
+
+  describe "wrong project type" do
+    it "renders an error when the project is the wrong type and so cannot be found" do
+      sign_in_with(create(:user, :caseworker))
+      mock_successful_api_responses(urn: any_args, ukprn: any_args)
+      voluntary_conversion_project = create(:voluntary_conversion_project)
+
+      get conversions_involuntary_project_task_list_path(voluntary_conversion_project)
+
+      expect(response).to have_http_status :not_found
+    end
+  end
 end

--- a/spec/requests/conversions/voluntary/projects_contoller_spec.rb
+++ b/spec/requests/conversions/voluntary/projects_contoller_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Conversions::Voluntary::ProjectsController do
       voluntary_conversion_project = create(:conversion_project, urn: 123456, regional_delivery_officer: regional_delivery_officer)
 
       get conversions_voluntary_project_path(voluntary_conversion_project)
+      follow_redirect!
 
       expect(response.body).to include(voluntary_conversion_project.urn.to_s)
     end

--- a/spec/requests/conversions/voluntary/task_lists_controller_spec.rb
+++ b/spec/requests/conversions/voluntary/task_lists_controller_spec.rb
@@ -12,4 +12,16 @@ RSpec.describe Conversions::Voluntary::TaskListsController do
   let(:expected_update_attributes) { {handover_review: true, handover_notes: true, handover_meeting: false} }
 
   it_behaves_like "a task lists controller"
+
+  describe "wrong project type" do
+    it "renders an error when the project is the wrong type and so cannot be found" do
+      sign_in_with(create(:user, :caseworker))
+      mock_successful_api_responses(urn: any_args, ukprn: any_args)
+      involuntary_conversion_project = create(:involuntary_conversion_project)
+
+      get conversions_voluntary_project_task_list_path(involuntary_conversion_project)
+
+      expect(response).to have_http_status :not_found
+    end
+  end
 end


### PR DESCRIPTION
## Changes

This is the one! 🎉 This PR updates a bunch of things to make the application use the 'new task list'.

It's mostly about routes and path helpers as the new task list is already running.

Nothing here removes any of the old task list, we'll do that seperately.

I am not 100% about the 'path helpers' heing helpers as it makes using them in controllers ugly with the `helpers` prefix - but I think it is good enough for right now.

