### PR TITLE
Redirect to correct path after create project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased][unreleased]
+
+### Fixed
+
+- after creating a new project, users are redirected to the correct project page
+
 ## [Release 10][release-10]
 
 ### Features

--- a/app/controllers/conversions/involuntary/projects_controller.rb
+++ b/app/controllers/conversions/involuntary/projects_controller.rb
@@ -27,7 +27,7 @@ class Conversions::Involuntary::ProjectsController < Conversions::ProjectsContro
     if @project.valid?
       @created_project = @project.save
 
-      redirect_to project_path(@created_project), notice: I18n.t("conversion_project.involuntary.create.success")
+      redirect_to conversions_involuntary_project_path(@created_project), notice: I18n.t("conversion_project.involuntary.create.success")
     else
       render :new
     end

--- a/app/controllers/conversions/voluntary/projects_controller.rb
+++ b/app/controllers/conversions/voluntary/projects_controller.rb
@@ -27,7 +27,7 @@ class Conversions::Voluntary::ProjectsController < Conversions::ProjectsControll
     if @project.valid?
       @created_project = @project.save
 
-      redirect_to project_path(@created_project), notice: I18n.t("conversion_project.voluntary.create.success")
+      redirect_to conversions_voluntary_project_path(@created_project), notice: I18n.t("conversion_project.voluntary.create.success")
     else
       render :new
     end

--- a/spec/requests/conversions/involuntary/projects_contoller_spec.rb
+++ b/spec/requests/conversions/involuntary/projects_contoller_spec.rb
@@ -58,4 +58,12 @@ RSpec.describe Conversions::Involuntary::ProjectsController do
       expect(response).to have_http_status(:not_found)
     end
   end
+
+  describe "after creating a new project" do
+    it "redirects to the project page" do
+      post conversions_involuntary_projects_path, params: {"#{project_form_params_key}": {**project_form_params}}
+
+      expect(response).to redirect_to conversions_involuntary_project_path(Project.last)
+    end
+  end
 end

--- a/spec/requests/conversions/voluntary/projects_contoller_spec.rb
+++ b/spec/requests/conversions/voluntary/projects_contoller_spec.rb
@@ -58,4 +58,12 @@ RSpec.describe Conversions::Voluntary::ProjectsController do
       expect(response).to have_http_status(:not_found)
     end
   end
+
+  describe "after creating a new project" do
+    it "redirects to the project page" do
+      post conversions_voluntary_projects_path, params: {"#{project_form_params_key}": {**project_form_params}}
+
+      expect(response).to redirect_to conversions_voluntary_project_path(Project.last)
+    end
+  end
 end

--- a/spec/support/shared_examples/conversion_project.rb
+++ b/spec/support/shared_examples/conversion_project.rb
@@ -38,8 +38,7 @@ RSpec.shared_examples "a conversion project" do
         perform_request
       end
 
-      it "assigns the regional delivery officer, calls the TaskListCreator, and redirects to the project path" do
-        expect(response).to redirect_to(project_path(new_project_record.id))
+      it "assigns the regional delivery officer, calls the TaskListCreator" do
         expect(task_list_creator).to have_received(:call).with(new_project_record, workflow_root: workflow_root)
         expect(new_project_record.regional_delivery_officer).to eq regional_delivery_officer
       end


### PR DESCRIPTION
## Changes

When a new project is created we want to take the user to that project
on the correct path, whilst the generic projects paths can handle this
right now, this may not always be the case.

I couldn't find a good way to test this with the shared example so I
settled on this approach - I am not loving it, but I think it will have
to do given time constriants right now.

https://trello.com/c/KUzM7u6w

