### PR TITLE
Add simple helper for project urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - after creating a new project, users are redirected to the correct project page
+- links in email notifcations use the correct urls
 
 ## [Release 10][release-10]
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,2 +1,6 @@
 class ApplicationMailer < Mail::Notify::Mailer
+  def url_to_project(project)
+    return conversions_involuntary_project_url(project) if project.task_list.is_a?(Conversion::Involuntary::TaskList)
+    return conversions_voluntary_project_url(project) if project.task_list.is_a?(Conversion::Voluntary::TaskList)
+  end
 end

--- a/app/mailers/caseworker_mailer.rb
+++ b/app/mailers/caseworker_mailer.rb
@@ -5,7 +5,7 @@ class CaseworkerMailer < ApplicationMailer
       to: caseworker.email,
       personalisation: {
         first_name: caseworker.first_name,
-        project_url: project_information_url(project.id)
+        project_url: url_to_project(project)
       }
     )
   end

--- a/app/mailers/team_leader_mailer.rb
+++ b/app/mailers/team_leader_mailer.rb
@@ -5,7 +5,7 @@ class TeamLeaderMailer < ApplicationMailer
       to: team_leader.email,
       personalisation: {
         first_name: team_leader.first_name,
-        project_url: project_information_url(project.id)
+        project_url: url_to_project(project)
       }
     )
   end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe ApplicationMailer do
+  before { mock_successful_api_responses(urn: 123456, ukprn: 10061021) }
+
+  describe "#url_to_project" do
+    context "when the conversion is involuntary" do
+      it "returns the correct url" do
+        project = create(:involuntary_conversion_project)
+        mailer = ApplicationMailer.new
+
+        expect(mailer.url_to_project(project)).to eq conversions_involuntary_project_url(project)
+      end
+    end
+
+    context "when the conversion is voluntary" do
+      it "returns the correct url" do
+        project = create(:voluntary_conversion_project)
+        mailer = ApplicationMailer.new
+
+        expect(mailer.url_to_project(project)).to eql conversions_voluntary_project_url(project)
+      end
+    end
+  end
+end

--- a/spec/mailers/caseworker_mailer_spec.rb
+++ b/spec/mailers/caseworker_mailer_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe CaseworkerMailer do
   describe "#caseworker_assigned_notification" do
     let(:caseworker) { create(:user, :caseworker) }
-    let(:project) { create(:conversion_project) }
+    let(:project) { create(:voluntary_conversion_project) }
     let(:template_id) { "ec6823ec-0aae-439b-b2f9-c626809b7c61" }
-    let(:expected_personalisation) { {first_name: caseworker.first_name, project_url: project_information_url(project.id)} }
+    let(:expected_personalisation) { {first_name: caseworker.first_name, project_url: conversions_voluntary_project_url(project.id)} }
 
     subject(:send_mail) { described_class.caseworker_assigned_notification(caseworker, project).deliver_now }
 

--- a/spec/mailers/team_leader_mailer_spec.rb
+++ b/spec/mailers/team_leader_mailer_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe TeamLeaderMailer do
   describe "#new_project_created" do
     let(:team_leader) { create(:user, :team_leader) }
-    let(:project) { create(:conversion_project) }
+    let(:project) { create(:voluntary_conversion_project) }
     let(:template_id) { "ea4f72e4-f5bb-4b1a-b5f9-a94cc1840353" }
-    let(:expected_personalisation) { {first_name: team_leader.first_name, project_url: project_information_url(project.id)} }
+    let(:expected_personalisation) { {first_name: team_leader.first_name, project_url: conversions_voluntary_project_url(project.id)} }
 
     subject(:send_mail) { described_class.new_project_created(team_leader, project).deliver_now }
 


### PR DESCRIPTION
## Changes

When we send a user an email with a link to a project the link should be
to the appropriate path.

Here we add a helper in the application mailer so it can be reused by
any mailer and then update our current mailers to use it.

https://trello.com/c/KUzM7u6w