### PR TITLE
Project complete view links to survey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Completed projec page includes a link to the feedback survey
+
 ## [Release 11][release-11]
 
 ### Added

--- a/app/views/projects_complete/completed.html.erb
+++ b/app/views/projects_complete/completed.html.erb
@@ -2,6 +2,9 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_panel(title_text: "Project completed") %>
 
+    <h2 class="govuk-heading-m">Help us make improvements to the service</h2>
+    <p class="govuk-body">Please fill in this <a href="https://forms.office.com/e/xf0k4LcWVN" class="govuk-link" target="_blank">short survey (opens in a new tab)</a>.</p>
+
     <h2 class="govuk-heading-m">What to do next</h2>
     <p class="govuk-body">Go back to your project list and choose another project to work on.</p>
 

--- a/spec/features/users_can_complete_a_project_spec.rb
+++ b/spec/features/users_can_complete_a_project_spec.rb
@@ -17,6 +17,8 @@ RSpec.feature "Users can complete a project" do
     expect(page).to have_content("Project completed")
     expect(project.reload.completed_at).not_to be_nil
 
+    expect(page).to have_link "short survey", href: "https://forms.office.com/e/xf0k4LcWVN"
+
     click_on I18n.t("project.complete.back_link")
     # The project listing is no longer on the index page (open projects only)
     expect(page).to_not have_content(project.establishment.name)


### PR DESCRIPTION
## Changes

To help us collect feedback from users are key points on the journey,
here we add a feedback link to the view seen when a project is
completed.

![Screenshot 2023-01-13 at 12-10-39 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/212318462-54b1750d-8905-41c9-8316-7f6e8302ab62.png)

