### PR TITLE
Update contacts based on user feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Solicitor has been added to the contact category options
 - Users cannot attempt to submit the 'choose category' option on a new contact
 - The order of contacts has been updated, it is now by category and name
+- Add 'Organisation' to contacts, users can store an organisation name here
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Users will use the new task list and task backend
+- Solicitor has been added to the contact category options
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Users will use the new task list and task backend
 - Solicitor has been added to the contact category options
 - Users cannot attempt to submit the 'choose category' option on a new contact
+- The order of contacts has been updated, it is now by category and name
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Users will use the new task list and task backend
 - Solicitor has been added to the contact category options
+- Users cannot attempt to submit the 'choose category' option on a new contact
 
 ### Fixed
 

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -56,7 +56,7 @@ class ContactsController < ApplicationController
   end
 
   private def find_grouped_contacts
-    @contacts = Contact.where(project: @project).group_by(&:category)
+    @contacts = @project.contacts.grouped_by_category
   end
 
   private def contact_params

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -15,7 +15,7 @@ class ContactsController < ApplicationController
     if @contact.valid?
       @contact.save
 
-      redirect_to project_contacts_path(@project), notice: I18n.t("contact.create.success")
+      redirect_to helpers.path_to_project_contacts(@project), notice: I18n.t("contact.create.success")
     else
       render :new
     end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -60,6 +60,6 @@ class ContactsController < ApplicationController
   end
 
   private def contact_params
-    params.require(:contact).permit(:name, :title, :category, :email, :phone)
+    params.require(:contact).permit(:name, :organisation_name, :title, :category, :email, :phone)
   end
 end

--- a/app/helpers/contacts_helper.rb
+++ b/app/helpers/contacts_helper.rb
@@ -2,8 +2,4 @@ module ContactsHelper
   def has_contacts?(contacts)
     contacts.present? && contacts.any?
   end
-
-  def format_category_name(category)
-    category.tr("_", " ").capitalize
-  end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,6 +1,7 @@
 class Contact < ApplicationRecord
   belongs_to :project
 
+  validates :category, presence: true, allow_blank: false
   validates :name, presence: true, allow_blank: false
   validates :title, presence: true, allow_blank: false
 

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -7,10 +7,11 @@ class Contact < ApplicationRecord
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}, allow_blank: true
 
   enum category: {
-    other: 0,
-    school: 1,
-    trust: 2,
+    diocese: 4,
     local_authority: 3,
-    diocese: 4
+    school: 1,
+    solicitor: 5,
+    trust: 2,
+    other: 0
   }
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -15,4 +15,6 @@ class Contact < ApplicationRecord
     trust: 2,
     other: 0
   }
+
+  scope :grouped_by_category, -> { order(:name, category: :desc).group_by(&:category) }
 end

--- a/app/views/contacts/_contacts.html.erb
+++ b/app/views/contacts/_contacts.html.erb
@@ -1,6 +1,6 @@
 <% @contacts.each do |category, contacts| %>
 
-  <h3 class="govuk-heading-m"><%= t("contact.index.category_heading", category_name: format_category_name(category)) %></h3>
+  <h3 class="govuk-heading-m"><%= t("contact.index.category_heading", category_name: category.humanize) %></h3>
 
   <% contacts.each_with_index do |contact, index| %>
 

--- a/app/views/contacts/_contacts.html.erb
+++ b/app/views/contacts/_contacts.html.erb
@@ -22,6 +22,10 @@
           row.key { t("contact.details.name") }
           row.value { contact.name }
         end
+        summary_list.row do |row|
+          row.key { t("contact.details.organisation_name") }
+          row.value { contact.organisation_name }
+        end
         if contact.email.present?
           summary_list.row do |row|
             row.key { t("contact.details.email") }

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -16,6 +16,7 @@
 
       <%= form.govuk_text_field :title, width: 20 %>
       <%= form.govuk_text_field :name %>
+      <%= form.govuk_text_field :organisation_name %>
       <%= form.govuk_email_field :email %>
       <%= form.govuk_phone_field :phone, width: 10 %>
 

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -12,7 +12,7 @@
       <%= form.govuk_collection_select :category,
             Contact.categories.keys,
             :to_s,
-            ->(category_name) { format_category_name(category_name) } %>
+            ->(category_name) { category_name.humanize } %>
 
       <%= form.govuk_text_field :title, width: 20 %>
       <%= form.govuk_text_field :name %>

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :pre_content_nav do %>
-  <% render partial: "shared/back_link", locals: {href: project_contacts_path(@project)} %>
+  <% render partial: "shared/back_link", locals: {href: path_to_project_contacts(@project)} %>
 <% end %>
 
 <h1 class="govuk-heading-l"><%= t("contact.edit.title") %></h1>

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -9,10 +9,12 @@
     <%= form_for [@project, @contact], url: project_contacts_path(@project) do |form| %>
       <%= form.govuk_error_summary %>
 
-      <%= form.govuk_collection_select :category,
-            Contact.categories.keys,
-            :to_s,
-            ->(category_name) { format_category_name(category_name) } %>
+      <%= form.govuk_select(:category) do %>
+        <option selected="selected" value=""><%= t("contact.categories.choose") %></option>
+        <% Contact.categories.each do |name, category| %>
+          <option value="<%= name %>"><%= name.humanize %></option>
+        <% end %>
+      <% end %>
 
       <%= form.govuk_text_field :title, width: 20 %>
       <%= form.govuk_text_field :name %>

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -18,6 +18,7 @@
 
       <%= form.govuk_text_field :title, width: 20 %>
       <%= form.govuk_text_field :name %>
+      <%= form.govuk_text_field :organisation_name %>
       <%= form.govuk_email_field :email %>
       <%= form.govuk_phone_field :phone, width: 10 %>
 

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :pre_content_nav do %>
-  <% render partial: "shared/back_link", locals: {href: project_contacts_path(@project)} %>
+  <% render partial: "shared/back_link", locals: {href: path_to_project_contacts(@project)} %>
 <% end %>
 
 <h1 class="govuk-heading-l"><%= t("contact.new.title") %></h1>

--- a/app/views/cookies/shared/_cookie_banner.html.erb
+++ b/app/views/cookies/shared/_cookie_banner.html.erb
@@ -1,0 +1,45 @@
+<% unless accept_optional_cookies? %>
+<div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on [name of service]">
+  <div class="govuk-cookie-banner__message govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on [name of service]</h2>
+        <div class="govuk-cookie-banner__content">
+          <p class="govuk-body">We use some essential cookies to make this service work.</p>
+          <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+        </div>
+      </div>
+    </div>
+    <div class="govuk-button-group">
+      <button value="accept" type="button" name="cookies" class="govuk-button" data-module="govuk-button">
+        Accept analytics cookies
+      </button>
+      <button value="reject" type="button" name="cookies" class="govuk-button" data-module="govuk-button">
+        Reject analytics cookies
+      </button>
+      <a class="govuk-link" href="/cookies">View cookies</a>
+    </div>
+  </div>
+</div>
+<% end %>
+
+<% if hide_cookie_banner? %>
+<form method="POST">
+  <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on [name of service]">
+    <div class="govuk-cookie-banner__message govuk-width-container">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <div class="govuk-cookie-banner__content">
+            <p class="govuk-body">You’ve accepted additional cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        <a href="#" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+          Hide cookie message
+        </a>
+      </div>
+    </div>
+  </div>
+</form>
+<% end %>

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -37,3 +37,7 @@ en:
         name: Name
         email: Email
         phone: Phone
+  errors:
+    attributes:
+      category:
+        blank: Choose a category

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -27,6 +27,8 @@ en:
       title:
         Are you sure you want to delete %{contact_name}?
       guidance: This will remove the contact for %{contact_title} called %{contact_name} from the contacts list.
+    categories:
+      choose: Choose category
   helpers:
     label:
       contact:

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -7,6 +7,7 @@ en:
       no_contacts_yet: There are not any contacts for this project yet.
     details:
       name: Name
+      organisation_name: Organisation
       title: Role
       email: Email
       phone: Phone
@@ -35,6 +36,7 @@ en:
         category: Contact for
         title: Role
         name: Name
+        organisation_name: Organisation
         email: Email
         phone: Phone
   errors:

--- a/db/migrate/20230113150412_add_organisation_to_contact.rb
+++ b/db/migrate/20230113150412_add_organisation_to_contact.rb
@@ -1,0 +1,5 @@
+class AddOrganisationToContact < ActiveRecord::Migration[7.0]
+  def change
+    add_column :contacts, :organisation_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_09_144257) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_13_150412) do
   create_table "actions", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "title", null: false
     t.integer "order", null: false
@@ -35,6 +35,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_09_144257) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "category", default: 0, null: false
+    t.string "organisation_name"
     t.index ["category"], name: "index_contacts_on_category"
     t.index ["project_id"], name: "index_contacts_on_project_id"
   end

--- a/spec/factories/contact_factory.rb
+++ b/spec/factories/contact_factory.rb
@@ -3,6 +3,8 @@ FactoryBot.define do
     name { "Jo Example" }
     title { "CEO of Learning" }
 
+    organisation_name { "Some Organisation" }
+
     email { "jo@example.com" }
     phone { "01632 960123" }
 

--- a/spec/features/users_can_create_and_view_and_delete_contacts_spec.rb
+++ b/spec/features/users_can_create_and_view_and_delete_contacts_spec.rb
@@ -27,6 +27,8 @@ RSpec.feature "Users can create and view and delete contacts" do
 
     expect(page).to have_current_path(new_project_contact_path(project))
 
+    expect(page).to have_select("Contact for", selected: "Choose category")
+
     select "Trust", from: "Contact for"
     fill_in "Name", with: "Some One"
     fill_in "Role", with: "Chief of Knowledge"

--- a/spec/features/users_can_manage_contacts_spec.rb
+++ b/spec/features/users_can_manage_contacts_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Users can create and view and delete contacts" do
+RSpec.feature "Users can manage contacts" do
   before do
     mock_successful_api_responses(urn: 123456, ukprn: 10061021)
     sign_in_with_user(user)
@@ -8,49 +8,51 @@ RSpec.feature "Users can create and view and delete contacts" do
 
   let!(:contact) { create(:contact, project: project) }
   let(:user) { create(:user) }
-  let(:project) { create(:conversion_project) }
-  let(:project_id) { project.id }
+  let(:project) { create(:voluntary_conversion_project) }
 
-  scenario "User views contacts" do
-    visit project_contacts_path(project_id)
+  scenario "they can view a projects contacts" do
+    visit conversions_voluntary_project_contacts_path(project)
 
     expect(page).to have_content("Other contacts")
 
     expect_page_to_have_contact(
       name: "Jo Example",
+      organisation_name: "Some Organisation",
       title: "CEO of Learning",
       email: "jo@example.com",
       phone: "01632 960123"
     )
+  end
+
+  scenario "they can add a new contact" do
+    visit conversions_voluntary_project_contacts_path(project)
 
     click_link "Add contact"
-
-    expect(page).to have_current_path(new_project_contact_path(project))
 
     expect(page).to have_select("Contact for", selected: "Choose category")
 
     select "Trust", from: "Contact for"
     fill_in "Name", with: "Some One"
+    fill_in "Organisation", with: "Trust Name"
     fill_in "Role", with: "Chief of Knowledge"
     fill_in "Email", with: "some@example.com"
     fill_in "Phone", with: "01632 960456"
 
     click_button("Add contact")
 
-    expect(page).to have_current_path(project_contacts_path(project_id))
-
     expect(page).to have_content("Trust contacts")
 
     expect_page_to_have_contact(
       name: "Some One",
       title: "Chief of Knowledge",
+      organisation_name: "Trust Name",
       email: "some@example.com",
       phone: "01632 960456"
     )
   end
 
-  scenario "User deletes a contact" do
-    visit project_contacts_path(project_id)
+  scenario "they can delete a contact" do
+    visit conversions_voluntary_project_contacts_path(project)
     expect(page).to have_content("Other contacts")
 
     expect_page_to_have_contact(
@@ -62,22 +64,19 @@ RSpec.feature "Users can create and view and delete contacts" do
 
     click_link "Change"
 
-    expect(page).to have_current_path(edit_project_contact_path(project, contact))
+    click_link("Delete")
 
-    click_link("Delete") # Link styled as button
-
-    expect(page).to have_current_path(project_contact_delete_path(project, contact))
     expect(page).to have_content("Are you sure you want to delete Jo Example?")
     expect(page).to have_content("This will remove the contact for CEO of Learning called Jo Example from the contacts list.")
 
     click_button("Delete")
 
-    expect(page).to have_current_path(project_contacts_path(project_id))
     expect(page).to have_content("There are not any contacts for this project yet.")
   end
 
-  private def expect_page_to_have_contact(name:, title:, email: nil, phone: nil)
+  private def expect_page_to_have_contact(name:, title:, organisation_name: nil, email: nil, phone: nil)
     expect(page).to have_content(name)
+    expect(page).to have_content(organisation_name)
     expect(page).to have_content(title)
     expect(page).to have_content(email) if email
     expect(page).to have_content(phone) if phone

--- a/spec/helpers/contacts_helper_spec.rb
+++ b/spec/helpers/contacts_helper_spec.rb
@@ -26,14 +26,4 @@ RSpec.describe ContactsHelper, type: :helper do
       end
     end
   end
-
-  describe "#format_category_name" do
-    context "given a category name" do
-      let(:category_name) { "test_category_with_spaces" }
-
-      it "formats the category name as expected" do
-        expect(helper.format_category_name(category_name)).to eq "Test category with spaces"
-      end
-    end
-  end
 end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Contact, type: :model do
     it { is_expected.to have_db_column(:title).of_type :string }
     it { is_expected.to have_db_column(:email).of_type :string }
     it { is_expected.to have_db_column(:phone).of_type :string }
+    it { is_expected.to have_db_column(:organisation_name).of_type :string }
   end
 
   describe "Relationships" do

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -13,15 +13,9 @@ RSpec.describe Contact, type: :model do
   end
 
   describe "Validations" do
-    describe "#name" do
-      it { is_expected.to validate_presence_of(:name) }
-      it { is_expected.to_not allow_values("", nil).for(:name) }
-    end
-
-    describe "#title" do
-      it { is_expected.to validate_presence_of(:title) }
-      it { is_expected.to_not allow_values("", nil).for(:title) }
-    end
+    it { should validate_presence_of(:category) }
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:title) }
 
     describe "#email" do
       it { is_expected.to allow_value("test@example.com").for(:email) }

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -22,4 +22,26 @@ RSpec.describe Contact, type: :model do
       it { is_expected.to_not allow_value("notavalidemail").for(:email) }
     end
   end
+
+  describe "scopes" do
+    describe "grouped_by_category" do
+      it "groups and orders by category" do
+        mock_successful_api_responses(urn: any_args, ukprn: any_args)
+        project = create(:voluntary_conversion_project)
+        first_solicitor_contact = create(:contact, category: :solicitor, name: "B solicitor", project: project)
+        second_solicitor_contact = create(:contact, category: :solicitor, name: "A solicitor", project: project)
+        _other_contact = create(:contact, category: :other, project: project)
+
+        contacts = project.contacts.grouped_by_category
+        groups = contacts.keys
+        solicitor_group = contacts["solicitor"]
+
+        expect(groups.first).to eql "solicitor"
+        expect(groups.last).to eql "other"
+
+        expect(solicitor_group.first).to eq second_solicitor_contact
+        expect(solicitor_group.last).to eq first_solicitor_contact
+      end
+    end
+  end
 end

--- a/spec/requests/contacts_controller_spec.rb
+++ b/spec/requests/contacts_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ContactsController, type: :request do
   end
 
   describe "#create" do
-    let(:project) { create(:conversion_project) }
+    let(:project) { create(:voluntary_conversion_project) }
     let(:project_id) { project.id }
     let(:mock_contact) { build(:contact) }
     let(:new_contact_name) { "Josephine Bloggs" }
@@ -79,7 +79,7 @@ RSpec.describe ContactsController, type: :request do
 
     context "when the contact is valid" do
       it "saves the contact and redirects to the index view with a success message" do
-        expect(subject).to redirect_to(project_contacts_path(project.id))
+        expect(subject).to redirect_to(conversions_voluntary_project_contacts_path(project))
         expect(request.flash[:notice]).to eq(I18n.t("contact.create.success"))
 
         expect(Contact.count).to be 1


### PR DESCRIPTION
## Changes

Users told us that the order and presentation of the contact category options could be improved. They felt having 'other' first and the default felt unhelpful.

They also felt a way to store 'the name of an organistation the contact represents' would be helpful.

We also missed adding a category for 'solicitor'

This PR updates the Contact model to meet these needs.

We re-ordered the contact category select box and added a 'choose category' option as the default that cannot be submitted.

We decieded not to use the 'choose category' option on the edit view as the category will have a value at this point.

We add a scope to order the contacts and groups on the index view and added test coverage for that.

The `organisation_name` attribute  gets added to Contact.

And fianlly we take the opportunity to switch to more specific back and redirect paths based on the project type and route.

https://trello.com/c/qhaJaaAh

![image](https://user-images.githubusercontent.com/480578/212360404-f8b3f6c4-bd73-41bc-aae3-c56ab69464bb.png)

