### PR TITLE
Rollback Sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem "faraday"
 gem "sentry-ruby"
 gem "sentry-rails"
 
-gem "sidekiq"
+gem "sidekiq", "< 7.0"
 
 gem "pagy"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,8 +286,7 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     redcarpet (3.5.1)
-    redis-client (0.11.1)
-      connection_pool
+    redis (4.8.0)
     regexp_parser (2.6.0)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -349,11 +348,10 @@ GEM
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (5.2.0)
       activesupport (>= 5.2.0)
-    sidekiq (7.0.1)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.9.0)
+    sidekiq (6.5.7)
+      connection_pool (>= 2.2.5)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -449,7 +447,7 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   shoulda-matchers (~> 5.1)
-  sidekiq
+  sidekiq (< 7.0)
   simplecov (~> 0.21.2)
   sprockets-rails
   standard


### PR DESCRIPTION
## Changes
We discovered that the version of Redis running in Azure is not yet
compatible with Sidekiq 7.

As we don't use any Sidekiq 7 features and there is a block on upgrading
Redis in Azure for at least 10 days [1], we think it best to rollback
and lock sidekiq to the 6.x branch for the moment.

[1] https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-how-to-upgrade#upgrade-using-the-azure-portal

https://trello.com/c/D83bHMfs
