### PR TITLE
Correct CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Completed projec page includes a link to the feedback survey
+- Completed project page includes a link to the feedback survey
+- Solicitor has been added to the contact category options
+- Users cannot attempt to submit the 'choose category' option on a new contact
+- The order of contacts has been updated, it is now by category and name
+- Add 'Organisation' to contacts, users can store an organisation name here
 
 ### Changed
 
 - Removed the old tasks & task lists. The editable tasklist YAML files in
+  `workflows` are no longer used
 
 ## [Release 11][release-11]
 
 ### Added
 
 - Users will use the new task list and task backend
-- Solicitor has been added to the contact category options
-- Users cannot attempt to submit the 'choose category' option on a new contact
-- The order of contacts has been updated, it is now by category and name
-- Add 'Organisation' to contacts, users can store an organisation name here
 
 ### Fixed
 


### PR DESCRIPTION


## Changes

The CHANGELOG got corrupted, probably by a bad merge. We had lost a sentence from one of the unreleased changes, and the changes related to project contacts had been merged into Release 11, not the Unreleased section where they belong.

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
