### PR TITLE
Suppress `nil` warning when running test

### DIFF
--- a/spec/features/users_can_manage_contacts_spec.rb
+++ b/spec/features/users_can_manage_contacts_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature "Users can manage contacts" do
 
   private def expect_page_to_have_contact(name:, title:, organisation_name: nil, email: nil, phone: nil)
     expect(page).to have_content(name)
-    expect(page).to have_content(organisation_name)
+    expect(page).to have_content(organisation_name) if organisation_name
     expect(page).to have_content(title)
     expect(page).to have_content(email) if email
     expect(page).to have_content(phone) if phone


### PR DESCRIPTION
## Changes

Running the test at `/spec/features/users_can_manage_contacts_spec.rb:79` was raising this warning:
```
Checking for expected text of nil is confusing and/or pointless since it will
always match. Please specify a string or regexp instead.
/spec/features/users_can_manage_contacts_spec.rb:79
```

Amend the test to only check for the `organisation_name` if it is not `nil`
