### PR TITLE
Make it explicit that the UserImporter will not create duplicate records

### DIFF
--- a/doc/user-accounts.md
+++ b/doc/user-accounts.md
@@ -119,3 +119,12 @@ provided to avoid not-null constraint errors. For example:
 | john.doe@education.gov.uk   | John       | Doe       | 1           | 0                         | 0          |
 | jane.doe@education.gov.uk   | Jane       | Doe       | 0           | 1                         | 0          |
 | joseph.doe@education.gov.uk | Joseph     | Doe       | 0           | 0                         | 1          |
+
+The User Importer will not create duplicates of existing user records (based on
+email). For example if `jane.doe@education.gov.uk` already exists in the
+database, another record for `jane.doe@education.gov.uk` will not be created if
+that email address is in the uploaded CSV.
+
+The User Importer can be used to update existing records, for example if
+`jane.doe@education.gov.uk` is promoted from a `team_leader` to
+`regional_delivery_officer`, the script can be used to update the user record.

--- a/spec/services/user_importer_spec.rb
+++ b/spec/services/user_importer_spec.rb
@@ -45,6 +45,23 @@ RSpec.describe UserImporter do
       ).to exist
     end
 
+    context "when an existing user has been updated" do
+      let(:users_csv) do
+        <<~CSV
+          email,first_name,last_name,team_leader,regional_delivery_officer
+          john.doe@education.gov.uk,John,Doe,1,0
+          jane.doe@education.gov.uk,Jane,Doe,1,0
+        CSV
+      end
+
+      it "updates the existing user in place" do
+        call_user_importer
+
+        expect(User.find_by(email: existing_user_email).regional_delivery_officer).to be false
+        expect(User.find_by(email: existing_user_email).team_leader).to be true
+      end
+    end
+
     context "when an error occurs" do
       let(:users_csv) do
         <<~CSV


### PR DESCRIPTION

## Changes

The UserImporter will not create duplicate records (based on email as the primary key). Make this explicit in the documentation, and add a test to show that User records can be updated in place with the UserImporter script.


## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
