### PR TITLE
Contacts are ordered as a user might expect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- the order of the contact groups is now as users might expect.
+
 ## [Release 12][release-12]
 
 ### Added

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,8 +1,8 @@
 class ContactsController < ApplicationController
   before_action :find_project
-  before_action :find_grouped_contacts, only: :index
 
   def index
+    @grouped_contacts = @project.contacts.by_name.group_by(&:category).with_indifferent_access
   end
 
   def new
@@ -53,10 +53,6 @@ class ContactsController < ApplicationController
 
   private def find_project
     @project = Project.find(params[:project_id])
-  end
-
-  private def find_grouped_contacts
-    @contacts = @project.contacts.grouped_by_category
   end
 
   private def contact_params

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -8,13 +8,13 @@ class Contact < ApplicationRecord
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}, allow_blank: true
 
   enum category: {
-    diocese: 4,
-    local_authority: 3,
     school: 1,
-    solicitor: 5,
     trust: 2,
+    local_authority: 3,
+    solicitor: 5,
+    diocese: 4,
     other: 0
   }
 
-  scope :grouped_by_category, -> { order(:name, category: :desc).group_by(&:category) }
+  scope :by_name, -> { order(:name) }
 end

--- a/app/views/contacts/_contact_group.html.erb
+++ b/app/views/contacts/_contact_group.html.erb
@@ -1,12 +1,6 @@
-<% @contacts.each do |category, contacts| %>
-
   <h3 class="govuk-heading-m"><%= t("contact.index.category_heading", category_name: category.humanize) %></h3>
 
-  <% contacts.each_with_index do |contact, index| %>
-
-  <% unless index == 0 %>
-    <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-  <% end %>
+  <% contacts.each do |contact| %>
 
   <%= govuk_summary_list do |summary_list|
         summary_list.row do |row|
@@ -41,4 +35,3 @@
       end %>
 
   <% end %>
-<% end %>

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -10,7 +10,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l"><%= t("contact.index.contacts") %></h2>
 
-    <% unless has_contacts?(@contacts) %>
+    <% if @grouped_contacts.empty? %>
       <%= govuk_inset_text(text: t("contact.index.no_contacts_yet")) %>
     <% end %>
 
@@ -18,8 +18,11 @@
       <%= govuk_button_link_to t("contact.index.add_contact_button"), new_project_contact_path(@project) %>
     </div>
 
-    <% if has_contacts?(@contacts) %>
-      <%= render "contacts/contacts" %>
+    <% Contact.categories.keys.each do |category| %>
+      <% if @grouped_contacts[category].present? %>
+        <%= render partial: "contact_group", locals: {category: category, contacts: @grouped_contacts[category]} %>
+      <% end %>
     <% end %>
+
   </div>
 </div>

--- a/spec/features/users_can_manage_contacts_spec.rb
+++ b/spec/features/users_can_manage_contacts_spec.rb
@@ -24,6 +24,31 @@ RSpec.feature "Users can manage contacts" do
     )
   end
 
+  scenario "the contact groups are in the order users might expect to use them" do
+    create(:contact, category: :other, project: project)
+    create(:contact, category: :school, project: project)
+    create(:contact, category: :trust, project: project)
+    create(:contact, category: :solicitor, project: project)
+    create(:contact, category: :diocese, project: project)
+    create(:contact, category: :local_authority, project: project)
+
+    visit conversions_voluntary_project_contacts_path(project)
+
+    order_categories = page.find_all("h3.govuk-heading-m")
+
+    %i[
+      school
+      trust
+      local_authority
+      solicitor
+      diocese
+      other
+    ].each_with_index do |category, index|
+      expect(order_categories[index].text)
+        .to eql I18n.t("contact.index.category_heading", category_name: category.to_s.humanize)
+    end
+  end
+
   scenario "they can add a new contact" do
     visit conversions_voluntary_project_contacts_path(project)
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -25,23 +25,17 @@ RSpec.describe Contact, type: :model do
   end
 
   describe "scopes" do
-    describe "grouped_by_category" do
-      it "groups and orders by category" do
+    describe "by_name" do
+      it "orders by name" do
         mock_successful_api_responses(urn: any_args, ukprn: any_args)
         project = create(:voluntary_conversion_project)
         first_solicitor_contact = create(:contact, category: :solicitor, name: "B solicitor", project: project)
         second_solicitor_contact = create(:contact, category: :solicitor, name: "A solicitor", project: project)
-        _other_contact = create(:contact, category: :other, project: project)
 
-        contacts = project.contacts.grouped_by_category
-        groups = contacts.keys
-        solicitor_group = contacts["solicitor"]
+        ordered_contacts = project.contacts.by_name
 
-        expect(groups.first).to eql "solicitor"
-        expect(groups.last).to eql "other"
-
-        expect(solicitor_group.first).to eq second_solicitor_contact
-        expect(solicitor_group.last).to eq first_solicitor_contact
+        expect(ordered_contacts.first).to eq second_solicitor_contact
+        expect(ordered_contacts.last).to eq first_solicitor_contact
       end
     end
   end


### PR DESCRIPTION
## Changes

During a recent product review it was noted that the contact groups were
ordered in an unexpected way. We talked about this and decided that the
order users expect would likely be by the likelyhood of using the
contacts, so pretty arbitary.

Previously, we used `group_by`, an enumerable [1] method, not active
record in a scope. Revisiting this, it felt wrong for a scope to return a
hash, so we have changed the approach here. We also noted that group_by
does not honour sorting - which was resulting in a seemingly random
order of the contact groups noted.

Honestly, this felt far more difficult that it should be! We have relied
on the category order on the Contact model to define the expected order.
Some acceptably small logic in the view pulls out contacts from the
groups in the order defined in the class.

[1] https://ruby-doc.org/3.1.2/Enumerable.html#method-i-group_by

