### PR TITLE
Add a link to the school's page in GIAS on project information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add task generators
+- Added a link to the school's information in GIAS on the project information
+  page.
 
 ## [Release 12][release-12]
 

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -55,7 +55,7 @@
   <%= govuk_summary_list(actions: false) do |summary_list|
     summary_list.row do |row|
       row.key { t('project_information.show.school_details.rows.original_school_name') }
-      row.value { @project.establishment.name }
+      row.value { t("project_information.show.school_details.rows.school_name_link_to_gias.html", school_name: @project.establishment.name, link_to_gias: safe_link_to(t('project_information.show.school_details.rows.view_in_gias'), "https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/#{@project.urn}")) }
     end
     summary_list.row do |row|
       row.key { t('project_information.show.school_details.rows.old_urn') }

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -88,6 +88,11 @@ en:
         title: School details
         rows:
           original_school_name: Original school name
+          school_name_link_to_gias:
+            html: |
+              %{school_name}<br/>
+              %{link_to_gias}
+          view_in_gias: View the school's information in GIAS (opens in new tab)
           old_urn: Old Unique Reference Number
           school_type: School type
           age_range: Age range


### PR DESCRIPTION


## Changes

In the Project Information tab, add a link to the school's page on GIAS.

Wasn't sure of the layout for this so I've done: 

<img width="883" alt="Screenshot 2023-01-25 at 12 26 04" src="https://user-images.githubusercontent.com/1089521/214566979-e755d3ab-5861-4c8b-b443-83be0c1c956c.png">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
