### PR TITLE
Fix: Enable Google analytics helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -73,7 +73,7 @@ module ApplicationHelper
   def enable_google_tag_manager?
     return false unless ENV["SENTRY_ENV"] == "production"
     return false unless ENV["GOOGLE_TAG_MANAGER_ID"].present?
-    return false unless cookies[:ACCEPT_OPTIONAL_COOKIES] == true
+    return false unless cookies[:ACCEPT_OPTIONAL_COOKIES] == "true"
     true
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe ApplicationHelper, type: :helper do
           SENTRY_ENV: "production",
           GOOGLE_TAG_MANAGER_ID: "THISISANID"
         ) do
-          cookies[:ACCEPT_OPTIONAL_COOKIES] = true
+          cookies[:ACCEPT_OPTIONAL_COOKIES] = "true"
 
           expect(enable_google_tag_manager?).to eq(true)
         end


### PR DESCRIPTION
Previously the last check performed by the helper was to check the value
of the cookie, the check was for the true object, which a cookie will
not return as cookies store JSON and so must be parsed first.

As with the check for the SENTRY_ENV, we check for a string which fixes
the behavioiur.
