### PR TITLE
Add notification banner component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - renamed the "Contacts" tab to "External contacts"
 - moved the Caseworker, Team Leader and Regional Delivery Officer details to a
   new "Internal contacts" tab.
+- The notification banner shown to users after a successful operation has a new
+  visual style.
 
 ## [Release 14][release-14]
 
 ### Changed
 
 - Update hint text and error message for provisional conversion date entry
+- the notification banner now has a unique style for when it informs users of a
+  successful action.
 
 ## [Release 13][release-13]
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,7 @@ $govuk-global-styles: true;
 @import "components/task-list";
 @import "components/task_list/check-box-action-component";
 @import "components/task_list/task-header-component";
+@import "components/notification-banner";
 
 // The accessible autocomplete component does not use
 // GOV.UK fonts by default for suggestions.

--- a/app/assets/stylesheets/components/notification-banner.scss
+++ b/app/assets/stylesheets/components/notification-banner.scss
@@ -1,0 +1,14 @@
+.govuk-notification-banner {
+  .govuk-notification-banner__content > div {
+    @extend .govuk-body;
+    h3 {
+      @extend .govuk-notification-banner__heading;
+    }
+    p {
+      @extend .govuk-body;
+    }
+    a {
+      @extend .govuk-notification-banner__link;
+    }
+  }
+}

--- a/app/components/notification_banner.html.erb
+++ b/app/components/notification_banner.html.erb
@@ -1,0 +1,25 @@
+<% if @flashes.present? %>
+  <% @flashes.each do |type, msg| %>
+    <% if type == "notice" %>
+    <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+      <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+          Success
+        </h2>
+      </div>
+    <% else %>
+    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+      <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+          Important
+        </h2>
+      </div>
+    <% end %>
+      <div class="govuk-notification-banner__content">
+        <div class="flash <%= type %>">
+          <%= msg.html_safe %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/notification_banner.rb
+++ b/app/components/notification_banner.rb
@@ -1,0 +1,5 @@
+class NotificationBanner < ViewComponent::Base
+  def initialize(flashes:)
+    @flashes = flashes
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,7 +47,7 @@
     <div class="govuk-width-container ">
       <%= yield :pre_content_nav %>
       <main class="govuk-main-wrapper " id="main-content" role="main">
-        <%= render partial: "shared/flash" %>
+        <%= render(NotificationBanner.new(flashes: flash)) %>
 
         <%= yield %>
       </main>

--- a/spec/components/notification_banner_component_spec.rb
+++ b/spec/components/notification_banner_component_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe NotificationBanner, type: :component do
+  context "when there is a notice flash" do
+    it "displays the correct notification banner" do
+      flash = ActionDispatch::Flash::FlashHash.new
+      flash.notice = "This is a notice"
+
+      render_inline(described_class.new(flashes: flash))
+
+      expect(page).to have_selector(".govuk-notification-banner--success")
+      expect(page).to have_text("Success")
+    end
+  end
+
+  context "when there is an alert flash" do
+    it "displays the correct notification banner" do
+      flash = ActionDispatch::Flash::FlashHash.new
+      flash.alert = "This is an alert"
+
+      render_inline(described_class.new(flashes: flash))
+
+      expect(page).not_to have_selector(".govuk-notification-banner--success")
+      expect(page).to have_text("Important")
+    end
+  end
+
+  context "when there is no flash" do
+    it "does nothing" do
+      render_inline(described_class.new(flashes: nil))
+
+      expect(page).not_to have_selector(".govuk-notification-banner")
+    end
+  end
+end


### PR DESCRIPTION
We make use of the Rails flashes. Our general approach is to show one
after a successful operation such as:

- user adds a note
- user adds a contact
- user adds a project
- user signed out

We chose to use the Notfication banner component for this [1], did not
use the explicit 'success' version. This version is designed
specifically for

> Reacting to something the user has done

which is a much better fit for our use case.

We do have a couple of instances where the flash is used for
unsuccessful events, such as:

- user is not registered
- user could not be signed in
- user is not authorised

Here we introduce a view component to handle both cases, using a view
component helps us encapsulate all the behaviour and make it easy to
test.

The component takes the two standard Rails flash types notice and alert
and renders the appropriate design.

We also add styles to control the content of the flashes so that
developers do not have to.

[1] https://design-system.service.gov.uk/components/notification-banner/

![Screenshot 2023-02-06 at 12-12-24 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/216968483-bc4113f9-d91e-4411-a81d-f06216bda21a.png)
