### PR TITLE
Create internal and external contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   This has now been corrected. Users may want to verify they have completed the
   action in the task.
 - renamed the "Contacts" tab to "External contacts"
+- moved the Caseworker, Team Leader and Regional Delivery Officer details to a
+  new "Internal contacts" tab.
 
 ## [Release 14][release-14]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - the voluntary conversion, stakeholder kick off task had a duplicated action.
   This has now been corrected. Users may want to verify they have completed the
   action in the task.
+- renamed the "Contacts" tab to "External contacts"
 
 ## [Release 14][release-14]
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -10,7 +10,7 @@ class AssignmentsController < ApplicationController
   def update_team_leader
     @project.update(team_leader_params)
 
-    redirect_to project_internal_contacts_path(@project), notice: t("project.assign.team_leader.success")
+    redirect_to helpers.path_to_project_internal_contacts(@project), notice: t("project.assign.team_leader.success")
   end
 
   def assign_regional_delivery_officer
@@ -20,7 +20,7 @@ class AssignmentsController < ApplicationController
   def update_regional_delivery_officer
     @project.update(regional_delivery_officer_params)
 
-    redirect_to project_internal_contacts_path(@project), notice: t("project.assign.regional_delivery_officer.success")
+    redirect_to helpers.path_to_project_internal_contacts(@project), notice: t("project.assign.regional_delivery_officer.success")
   end
 
   def assign_caseworker
@@ -33,7 +33,7 @@ class AssignmentsController < ApplicationController
 
     CaseworkerMailer.caseworker_assigned_notification(@project.caseworker, @project).deliver_later
 
-    redirect_to project_internal_contacts_path(@project), notice: t("project.assign.caseworker.success")
+    redirect_to helpers.path_to_project_internal_contacts(@project), notice: t("project.assign.caseworker.success")
   end
 
   private def authorize_user

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -10,7 +10,7 @@ class AssignmentsController < ApplicationController
   def update_team_leader
     @project.update(team_leader_params)
 
-    redirect_to helpers.path_to_project_information(@project), notice: t("project.assign.team_leader.success")
+    redirect_to project_internal_contacts_path(@project), notice: t("project.assign.team_leader.success")
   end
 
   def assign_regional_delivery_officer
@@ -20,7 +20,7 @@ class AssignmentsController < ApplicationController
   def update_regional_delivery_officer
     @project.update(regional_delivery_officer_params)
 
-    redirect_to helpers.path_to_project_information(@project), notice: t("project.assign.regional_delivery_officer.success")
+    redirect_to project_internal_contacts_path(@project), notice: t("project.assign.regional_delivery_officer.success")
   end
 
   def assign_caseworker
@@ -33,7 +33,7 @@ class AssignmentsController < ApplicationController
 
     CaseworkerMailer.caseworker_assigned_notification(@project.caseworker, @project).deliver_later
 
-    redirect_to helpers.path_to_project_information(@project), notice: t("project.assign.caseworker.success")
+    redirect_to project_internal_contacts_path(@project), notice: t("project.assign.caseworker.success")
   end
 
   private def authorize_user

--- a/app/controllers/internal_contacts_controller.rb
+++ b/app/controllers/internal_contacts_controller.rb
@@ -1,0 +1,10 @@
+class InternalContactsController < ApplicationController
+  before_action :find_project
+
+  def show
+  end
+
+  private def find_project
+    @project = Project.find(params[:project_id])
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,6 +51,11 @@ module ApplicationHelper
     return conversions_involuntary_project_contacts_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
   end
 
+  def path_to_project_internal_contacts(project)
+    return conversions_voluntary_project_internal_contacts_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_internal_contacts_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
   def path_to_team_lead_project_assignment(project)
     return conversions_voluntary_project_assign_team_lead_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
     return conversions_involuntary_project_assign_team_lead_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l"><%= t("contact.index.contacts") %></h2>
+    <h2 class="govuk-heading-l"><%= t("contact.index.external_contacts") %></h2>
 
     <% if @grouped_contacts.empty? %>
       <%= govuk_inset_text(text: t("contact.index.no_contacts_yet")) %>

--- a/app/views/internal_contacts/show.html.erb
+++ b/app/views/internal_contacts/show.html.erb
@@ -1,0 +1,43 @@
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: root_path} %>
+<% end %>
+
+<%= render partial: "projects/shared/project_summary" %>
+
+<%= render partial: "projects/shared/project_sub_navigation" %>
+
+<div id="projectInternalContacts">
+  <h2 class="govuk-heading-l"><%= t("contact.index.internal_contacts") %></h2>
+  <%= govuk_summary_list do |summary_list|
+        summary_list.row do |row|
+          row.key { t("project_information.show.project_details.rows.caseworker") }
+          row.value { display_name(@project.caseworker) }
+          if @project.caseworker.present?
+            row.action(text: "Email", href: mail_to_path(@project.caseworker.email), visually_hidden_text: "caseworker")
+          end
+          if policy(:assignment).assign_caseworker?
+            row.action(href: path_to_caseworker_project_assignment(@project), visually_hidden_text: "caseworker")
+          end
+        end
+        summary_list.row do |row|
+          row.key { t("project_information.show.project_details.rows.team_lead") }
+          row.value { display_name(@project.team_leader) }
+          if @project.team_leader.present?
+            row.action(text: "Email", href: mail_to_path(@project.team_leader.email), visually_hidden_text: "team leader")
+          end
+          if policy(:assignment).assign_team_leader?
+            row.action(href: path_to_team_lead_project_assignment(@project), visually_hidden_text: "team leader")
+          end
+        end
+        summary_list.row do |row|
+          row.key { t("project_information.show.project_details.rows.regional_delivery_officer") }
+          row.value { display_name(@project.regional_delivery_officer) }
+          if @project.regional_delivery_officer.present?
+            row.action(text: "Email", href: mail_to_path(@project.regional_delivery_officer.email), visually_hidden_text: "regional delivery officer")
+          end
+          if policy(:assignment).assign_regional_delivery_officer?
+            row.action(href: path_to_regional_delivery_officer_project_assignment(@project), visually_hidden_text: "regional delivery officer")
+          end
+        end
+      end %>
+</div>

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -2,36 +2,6 @@
   <h2 class="govuk-heading-l"><%= t('project_information.show.project_details.title') %></h2>
   <%= govuk_summary_list do |summary_list|
     summary_list.row do |row|
-      row.key { t('project_information.show.project_details.rows.caseworker') }
-      row.value { display_name(@project.caseworker) }
-      if @project.caseworker.present?
-        row.action(text: "Email", href: mail_to_path(@project.caseworker.email), visually_hidden_text: "caseworker")
-      end
-      if policy(:assignment).assign_caseworker?
-        row.action(href: path_to_caseworker_project_assignment(@project), visually_hidden_text: "caseworker")
-      end
-    end
-    summary_list.row do |row|
-      row.key { t('project_information.show.project_details.rows.team_lead') }
-      row.value { display_name(@project.team_leader) }
-      if @project.team_leader.present?
-        row.action(text: "Email", href: mail_to_path(@project.team_leader.email), visually_hidden_text: "team leader")
-      end
-      if policy(:assignment).assign_team_leader?
-        row.action(href: path_to_team_lead_project_assignment(@project), visually_hidden_text: "team leader")
-      end
-    end
-    summary_list.row do |row|
-      row.key { t('project_information.show.project_details.rows.regional_delivery_officer') }
-      row.value { display_name(@project.regional_delivery_officer) }
-      if @project.regional_delivery_officer.present?
-        row.action(text: "Email", href: mail_to_path(@project.regional_delivery_officer.email), visually_hidden_text: "regional delivery officer")
-      end
-      if policy(:assignment).assign_regional_delivery_officer?
-        row.action(href: path_to_regional_delivery_officer_project_assignment(@project), visually_hidden_text: "regional delivery officer")
-      end
-    end
-    summary_list.row do |row|
       row.key { t('project_information.show.project_details.rows.advisory_board_date') }
       row.value { @project.advisory_board_date.to_date.to_formatted_s(:govuk) }
     end

--- a/app/views/projects/shared/_project_sub_navigation.html.erb
+++ b/app/views/projects/shared/_project_sub_navigation.html.erb
@@ -7,7 +7,7 @@
 
     <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.notes"), path: path_to_project_notes(@project)} %>
 
-    <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.contacts"), path: path_to_project_contacts(@project)} %>
+    <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.external_contacts"), path: path_to_project_contacts(@project)} %>
 
   </ul>
 </nav>

--- a/app/views/projects/shared/_project_sub_navigation.html.erb
+++ b/app/views/projects/shared/_project_sub_navigation.html.erb
@@ -9,7 +9,7 @@
 
     <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.external_contacts"), path: path_to_project_contacts(@project)} %>
 
-    <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.internal_contacts"), path: project_internal_contacts_path(@project)} %>
+    <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.internal_contacts"), path: path_to_project_internal_contacts(@project)} %>
 
   </ul>
 </nav>

--- a/app/views/projects/shared/_project_sub_navigation.html.erb
+++ b/app/views/projects/shared/_project_sub_navigation.html.erb
@@ -9,5 +9,7 @@
 
     <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.external_contacts"), path: path_to_project_contacts(@project)} %>
 
+    <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.internal_contacts"), path: project_internal_contacts_path(@project)} %>
+
   </ul>
 </nav>

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -2,6 +2,7 @@ en:
   contact:
     index:
       external_contacts: External contacts
+      internal_contacts: Internal contacts
       category_heading: "%{category_name} contacts"
       add_contact_button: Add contact
       no_contacts_yet: There are not any contacts for this project yet.

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -1,7 +1,7 @@
 en:
   contact:
     index:
-      contacts: Contacts
+      external_contacts: External contacts
       category_heading: "%{category_name} contacts"
       add_contact_button: Add contact
       no_contacts_yet: There are not any contacts for this project yet.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,7 @@ en:
     in_progress_projects: In progress
     notes: Notes
     external_contacts: External contacts
+    internal_contacts: Internal contacts
   pages:
     api_client_timeout:
       title: Sorry, there was a problem

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,7 +75,7 @@ en:
     completed_projects: Completed
     in_progress_projects: In progress
     notes: Notes
-    contacts: Contacts
+    external_contacts: External contacts
   pages:
     api_client_timeout:
       title: Sorry, there was a problem

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,8 @@ Rails.application.routes.draw do
 
     put "complete", to: "projects_complete#complete"
 
+    get "internal_contacts", to: "internal_contacts#show"
+
     resources :notes, except: %i[show], concerns: :has_destroy_confirmation
     resources :contacts, path: :external_contacts, except: %i[show], concerns: :has_destroy_confirmation
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
   end
 
   concern :contactable do
-    resources :contacts, except: %i[show], concerns: :has_destroy_confirmation, controller: "/contacts"
+    resources :contacts, path: :external_contacts, except: %i[show], concerns: :has_destroy_confirmation, controller: "/contacts"
   end
 
   concern :notable do
@@ -80,7 +80,7 @@ Rails.application.routes.draw do
     put "complete", to: "projects_complete#complete"
 
     resources :notes, except: %i[show], concerns: :has_destroy_confirmation
-    resources :contacts, except: %i[show], concerns: :has_destroy_confirmation
+    resources :contacts, path: :external_contacts, except: %i[show], concerns: :has_destroy_confirmation
 
     namespace :assign, controller: "/assignments" do
       get "team-lead", action: :assign_team_leader

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,19 +55,23 @@ Rails.application.routes.draw do
     put "complete", to: "/projects_complete#complete"
   end
 
+  concern :internal_contactable do
+    get "internal_contacts", to: "/internal_contacts#show"
+  end
+
   namespace :conversions do
     get "/", to: "/conversions/projects#index"
     namespace :voluntary do
       get "/", to: "/conversions/voluntary/projects#index"
       resources :projects,
         only: %i[show new create],
-        concerns: %i[task_listable contactable notable assignable informationable completable]
+        concerns: %i[task_listable contactable notable assignable informationable completable internal_contactable]
     end
     namespace :involuntary do
       get "/", to: "/conversions/involuntary/projects#index"
       resources :projects,
         only: %i[show new create],
-        concerns: %i[task_listable contactable notable assignable informationable completable]
+        concerns: %i[task_listable contactable notable assignable informationable completable internal_contactable]
     end
   end
 
@@ -78,8 +82,6 @@ Rails.application.routes.draw do
     get "information", to: "project_information#show"
 
     put "complete", to: "projects_complete#complete"
-
-    get "internal_contacts", to: "internal_contacts#show"
 
     resources :notes, except: %i[show], concerns: :has_destroy_confirmation
     resources :contacts, path: :external_contacts, except: %i[show], concerns: :has_destroy_confirmation

--- a/spec/features/team_leaders_can_assign_users_to_project_roles_spec.rb
+++ b/spec/features/team_leaders_can_assign_users_to_project_roles_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Team leaders can assign users to project roles" do
   end
 
   scenario "Team leader assigns a user to the team leader role" do
-    visit project_internal_contacts_path(project_id)
+    visit conversions_voluntary_project_internal_contacts_path(project_id)
 
     team_leader_summary_list_row = -> { page.find("dt", text: "Team lead").ancestor(".govuk-summary-list__row") }
 
@@ -36,7 +36,7 @@ RSpec.feature "Team leaders can assign users to project roles" do
   end
 
   scenario "Team leader assigns a user to the regional delivery officer role" do
-    visit project_internal_contacts_path(project_id)
+    visit conversions_voluntary_project_internal_contacts_path(project_id)
 
     regional_delivery_officer_summary_list_row = -> { page.find("dt", text: "Regional delivery officer").ancestor(".govuk-summary-list__row") }
 
@@ -58,7 +58,7 @@ RSpec.feature "Team leaders can assign users to project roles" do
   end
 
   scenario "Team leader assigns a user to the caseworker role" do
-    visit project_internal_contacts_path(project_id)
+    visit conversions_voluntary_project_internal_contacts_path(project_id)
 
     caseworker_summary_list_row = -> { page.find("dt", text: "Caseworker").ancestor(".govuk-summary-list__row") }
 

--- a/spec/features/team_leaders_can_assign_users_to_project_roles_spec.rb
+++ b/spec/features/team_leaders_can_assign_users_to_project_roles_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Team leaders can assign users to project roles" do
   end
 
   scenario "Team leader assigns a user to the team leader role" do
-    visit project_information_path(project_id)
+    visit project_internal_contacts_path(project_id)
 
     team_leader_summary_list_row = -> { page.find("dt", text: "Team lead").ancestor(".govuk-summary-list__row") }
 
@@ -36,7 +36,7 @@ RSpec.feature "Team leaders can assign users to project roles" do
   end
 
   scenario "Team leader assigns a user to the regional delivery officer role" do
-    visit project_information_path(project_id)
+    visit project_internal_contacts_path(project_id)
 
     regional_delivery_officer_summary_list_row = -> { page.find("dt", text: "Regional delivery officer").ancestor(".govuk-summary-list__row") }
 
@@ -58,7 +58,7 @@ RSpec.feature "Team leaders can assign users to project roles" do
   end
 
   scenario "Team leader assigns a user to the caseworker role" do
-    visit project_information_path(project_id)
+    visit project_internal_contacts_path(project_id)
 
     caseworker_summary_list_row = -> { page.find("dt", text: "Caseworker").ancestor(".govuk-summary-list__row") }
 

--- a/spec/features/users_can_view_internal_contacts_spec.rb
+++ b/spec/features/users_can_view_internal_contacts_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Users can view internal contacts for a project" do
   before do
     mock_successful_api_responses(urn: 123456, ukprn: 10061021)
     sign_in_with_user(user)
-    visit project_internal_contacts_path(project_id)
+    visit conversions_voluntary_project_internal_contacts_path(project_id)
   end
 
   context "when the caseworker, team lead and regional delivery officer have been assigned" do

--- a/spec/features/users_can_view_internal_contacts_spec.rb
+++ b/spec/features/users_can_view_internal_contacts_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.feature "Users can view internal contacts for a project" do
+  include ActionView::Helpers::TextHelper
+
+  let(:user) { create(:user, :caseworker) }
+  let(:project) { create(:conversion_project, :with_conditions, caseworker: user) }
+  let(:project_id) { project.id }
+
+  before do
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    sign_in_with_user(user)
+    visit project_internal_contacts_path(project_id)
+  end
+
+  context "when the caseworker, team lead and regional delivery officer have been assigned" do
+    let(:project) { create(:conversion_project, :with_team_lead_and_regional_delivery_officer_assigned, caseworker: user) }
+
+    scenario "they can view the users names and email addresses assigned to the project" do
+      within("#projectInternalContacts") do
+        expect(page).to have_content(user.full_name)
+        expect(page).to have_link("Email caseworker", href: "mailto:#{user.email}")
+
+        expect(page).to have_content(project.team_leader.full_name)
+        expect(page).to have_link("Email team leader", href: "mailto:#{project.team_leader.email}")
+
+        expect(page).to have_content(project.regional_delivery_officer.full_name)
+        expect(page).to have_link("Email regional delivery officer", href: "mailto:#{project.regional_delivery_officer.email}")
+      end
+    end
+  end
+
+  context "when a project does not have an assigned caseworker" do
+    let(:project) { create(:conversion_project) }
+
+    scenario "the project page shows an unassigned caseworker" do
+      expect(page).to have_content(I18n.t("project.summary.caseworker.unassigned"))
+    end
+  end
+end

--- a/spec/features/users_can_view_project_information_spec.rb
+++ b/spec/features/users_can_view_project_information_spec.rb
@@ -55,23 +55,6 @@ RSpec.feature "Users can view project information" do
     end
   end
 
-  context "when the caseworker, team lead and regional delivery officer have been assigned" do
-    let(:project) { create(:conversion_project, :with_team_lead_and_regional_delivery_officer_assigned, caseworker: user) }
-
-    scenario "they can view the users names and email addresses assigned to the project" do
-      within("#projectDetails") do
-        expect(page).to have_content(user.full_name)
-        expect(page).to have_link("Email caseworker", href: "mailto:#{user.email}")
-
-        expect(page).to have_content(project.team_leader.full_name)
-        expect(page).to have_link("Email team leader", href: "mailto:#{project.team_leader.email}")
-
-        expect(page).to have_content(project.regional_delivery_officer.full_name)
-        expect(page).to have_link("Email regional delivery officer", href: "mailto:#{project.regional_delivery_officer.email}")
-      end
-    end
-  end
-
   context "when there are conditions from the advisory board" do
     let(:project) { create(:conversion_project, :with_conditions, caseworker: user) }
 

--- a/spec/features/users_can_view_projects_spec.rb
+++ b/spec/features/users_can_view_projects_spec.rb
@@ -162,14 +162,4 @@ RSpec.feature "Users can view a single project" do
     click_on establishment.name
     expect(page).to have_content(single_project.urn.to_s)
   end
-
-  context "when a project does not have an assigned caseworker" do
-    scenario "the project page shows an unassigned caseworker" do
-      sign_in_with_user(create(:user, :team_leader))
-      single_project = create(:conversion_project, urn: urn)
-
-      visit project_information_path(single_project)
-      expect(page).to have_content(I18n.t("project.summary.caseworker.unassigned"))
-    end
-  end
 end

--- a/spec/requests/assignments_controller_spec.rb
+++ b/spec/requests/assignments_controller_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe AssignmentsController, type: :request do
       response
     end
 
-    it "assigns the project team lead and redirefcts with a message" do
-      expect(perform_request).to redirect_to(conversions_voluntary_project_information_path(project))
+    it "assigns the project team lead and redirects with a message" do
+      expect(perform_request).to redirect_to(project_internal_contacts_path(project))
       expect(request.flash[:notice]).to eq(I18n.t("project.assign.team_leader.success"))
 
       expect(project.reload.team_leader).to eq team_leader
@@ -84,7 +84,7 @@ RSpec.describe AssignmentsController, type: :request do
     end
 
     it "assigns the project regional delivery officer and redirefcts with a message" do
-      expect(perform_request).to redirect_to(conversions_voluntary_project_information_path(project))
+      expect(perform_request).to redirect_to(project_internal_contacts_path(project))
       expect(request.flash[:notice]).to eq(I18n.t("project.assign.regional_delivery_officer.success"))
 
       expect(project.reload.regional_delivery_officer).to eq regional_delivery_officer
@@ -138,8 +138,8 @@ RSpec.describe AssignmentsController, type: :request do
       end
     end
 
-    it "assigns the project caseworker and redirefcts with a message" do
-      expect(perform_request).to redirect_to(conversions_voluntary_project_information_path(project))
+    it "assigns the project caseworker and redirects with a message" do
+      expect(perform_request).to redirect_to(project_internal_contacts_path(project))
       expect(request.flash[:notice]).to eq(I18n.t("project.assign.caseworker.success"))
 
       expect(project.reload.caseworker).to eq caseworker

--- a/spec/requests/assignments_controller_spec.rb
+++ b/spec/requests/assignments_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe AssignmentsController, type: :request do
     end
 
     it "assigns the project team lead and redirects with a message" do
-      expect(perform_request).to redirect_to(project_internal_contacts_path(project))
+      expect(perform_request).to redirect_to(conversions_voluntary_project_internal_contacts_path(project))
       expect(request.flash[:notice]).to eq(I18n.t("project.assign.team_leader.success"))
 
       expect(project.reload.team_leader).to eq team_leader
@@ -84,7 +84,7 @@ RSpec.describe AssignmentsController, type: :request do
     end
 
     it "assigns the project regional delivery officer and redirefcts with a message" do
-      expect(perform_request).to redirect_to(project_internal_contacts_path(project))
+      expect(perform_request).to redirect_to(conversions_voluntary_project_internal_contacts_path(project))
       expect(request.flash[:notice]).to eq(I18n.t("project.assign.regional_delivery_officer.success"))
 
       expect(project.reload.regional_delivery_officer).to eq regional_delivery_officer
@@ -139,7 +139,7 @@ RSpec.describe AssignmentsController, type: :request do
     end
 
     it "assigns the project caseworker and redirects with a message" do
-      expect(perform_request).to redirect_to(project_internal_contacts_path(project))
+      expect(perform_request).to redirect_to(conversions_voluntary_project_internal_contacts_path(project))
       expect(request.flash[:notice]).to eq(I18n.t("project.assign.caseworker.success"))
 
       expect(project.reload.caseworker).to eq caseworker

--- a/spec/requests/internal_contacts_controller_spec.rb
+++ b/spec/requests/internal_contacts_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AssignmentsController, type: :request do
     let(:project_id) { project.id }
 
     subject(:perform_request) do
-      get project_internal_contacts_path(project_id)
+      get conversions_voluntary_project_internal_contacts_path(project_id)
       response
     end
 

--- a/spec/requests/internal_contacts_controller_spec.rb
+++ b/spec/requests/internal_contacts_controller_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe AssignmentsController, type: :request do
+  let(:user) { create(:user, team_leader: true) }
+
+  before do
+    sign_in_with(user)
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+  end
+
+  describe "#show" do
+    let(:project) { create(:voluntary_conversion_project) }
+    let(:project_id) { project.id }
+
+    subject(:perform_request) do
+      get project_internal_contacts_path(project_id)
+      response
+    end
+
+    describe "links to assign users to project roles" do
+      let(:change_links) do
+        [
+          project_assign_team_lead_path(project),
+          project_assign_regional_delivery_officer_path(project),
+          project_assign_caseworker_path(project)
+        ]
+      end
+
+      before { perform_request }
+
+      subject { response.body }
+
+      context "when team leader" do
+        it "has change links" do
+          expect(subject).to include(*change_links)
+        end
+      end
+
+      context "when regional delivery officer" do
+        let(:user) { create(:user, :regional_delivery_officer) }
+
+        it "does not have change links" do
+          expect(subject).to_not include(*change_links)
+        end
+      end
+
+      context "when caseworker" do
+        let(:user) { create(:user, :caseworker) }
+
+        it "does not have change links" do
+          expect(subject).to_not include(*change_links)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/project_information_controller_spec.rb
+++ b/spec/requests/project_information_controller_spec.rb
@@ -26,41 +26,5 @@ RSpec.describe ProjectInformationController, type: :request do
     it "returns a successful response" do
       expect(perform_request).to have_http_status :success
     end
-
-    describe "links to assign users to project roles" do
-      let(:change_links) do
-        [
-          project_assign_team_lead_path(project),
-          project_assign_regional_delivery_officer_path(project),
-          project_assign_caseworker_path(project)
-        ]
-      end
-
-      before { perform_request }
-
-      subject { response.body }
-
-      context "when team leader" do
-        it "has change links" do
-          expect(subject).to include(*change_links)
-        end
-      end
-
-      context "when regional delivery officer" do
-        let(:user) { create(:user, :regional_delivery_officer) }
-
-        it "does not have change links" do
-          expect(subject).to_not include(*change_links)
-        end
-      end
-
-      context "when caseworker" do
-        let(:user) { create(:user, :caseworker) }
-
-        it "does not have change links" do
-          expect(subject).to_not include(*change_links)
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
## Changes

Move the Caseworker, Team leader and Regional delivery officer to a new "Internal contacts" tab on the project details. These users can be assigned from this tab as usual.

Rename the Contacts tab External contacts, and alias the routes for `contacts`.

<img width="1079" alt="Screenshot 2023-02-06 at 14 42 18" src="https://user-images.githubusercontent.com/1089521/217004267-4baedc27-8d95-49d5-abda-ec39308a0d06.png">
<img width="1103" alt="Screenshot 2023-02-06 at 14 42 08" src="https://user-images.githubusercontent.com/1089521/217004272-b5ec4bac-10f7-484b-993c-57b049105f19.png">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
