### PR TITLE
Update the hint text and error message for provisional conversion date entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Update hint text and error message for provisional conversion date entry
+
 ## [Release 13][release-13]
 
 ### Changed

--- a/app/views/conversions/involuntary/projects/new.html.erb
+++ b/app/views/conversions/involuntary/projects/new.html.erb
@@ -14,7 +14,7 @@
       <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m", text: t("helpers.label.conversion_project.incoming_trust_ukprn")}, hint: {text: t("helpers.hint.project.incoming_trust_ukprn").html_safe}, width: 10 %>
       <%= form.govuk_date_field :advisory_board_date, legend: {text: t("helpers.legend.project.advisory_board_date")}, form_group: {id: "advisory-board-date"} %>
       <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m", text: t("helpers.label.conversion_project.advisory_board_conditions")} %>
-      <%= form.govuk_date_field :provisional_conversion_date, legend: {text: t("helpers.legend.project.provisional_conversion_date")}, omit_day: true, form_group: {id: "provisional-conversion-date"} %>
+      <%= form.govuk_date_field :provisional_conversion_date, legend: {text: t("helpers.legend.conversion_project.provisional_conversion_date")}, omit_day: true, form_group: {id: "provisional-conversion-date"}, hint: {text: t("helpers.hint.conversion_project.provisional_conversion_date")} %>
       <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m", text: t("helpers.label.conversion_project.establishment_sharepoint_link")} %>
       <%= form.govuk_text_field :trust_sharepoint_link, label: {size: "m", text: t("helpers.label.conversion_project.trust_sharepoint_link")} %>
       <%= form.govuk_text_area :note_body,

--- a/app/views/conversions/voluntary/projects/new.html.erb
+++ b/app/views/conversions/voluntary/projects/new.html.erb
@@ -14,7 +14,7 @@
       <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m", text: t("helpers.label.conversion_project.incoming_trust_ukprn")}, hint: {text: t("helpers.hint.project.incoming_trust_ukprn").html_safe}, width: 10 %>
       <%= form.govuk_date_field :advisory_board_date, legend: {text: t("helpers.legend.project.advisory_board_date")}, form_group: {id: "advisory-board-date"} %>
       <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m", text: t("helpers.label.conversion_project.advisory_board_conditions")} %>
-      <%= form.govuk_date_field :provisional_conversion_date, legend: {text: t("helpers.legend.project.provisional_conversion_date")}, omit_day: true, form_group: {id: "provisional-conversion-date"} %>
+      <%= form.govuk_date_field :provisional_conversion_date, legend: {text: t("helpers.legend.conversion_project.provisional_conversion_date")}, omit_day: true, form_group: {id: "provisional-conversion-date"}, hint: {text: t("helpers.hint.conversion_project.provisional_conversion_date")} %>
       <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m", text: t("helpers.label.conversion_project.establishment_sharepoint_link")} %>
       <%= form.govuk_text_field :trust_sharepoint_link, label: {size: "m", text: t("helpers.label.conversion_project.trust_sharepoint_link")} %>
       <%= form.govuk_text_area :note_body,

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -53,3 +53,9 @@ en:
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
+  errors:
+    attributes:
+      provisional_conversion_date:
+        blank: Enter a provisional conversion date
+        must_be_first_of_the_month: Provisional conversion date must be on the first day of the month
+        must_be_in_the_future: Provisional conversion date must be in the future.

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -49,7 +49,7 @@ en:
           <br /><br />
           <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in a new tab)</a>.
         caseworker_id: The caseworker responsible for this project
-        provisional_conversion_date: The provisional conversion date is always the first day of the month.
+        provisional_conversion_date: If you do not have a provisional date, enter a date that is at least six months after the advisory board. You can change this later.
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -154,7 +154,7 @@ en:
         not_a_number: UKPRN can only contain numbers. No letters or special characters.
         must_be_correct_format: UKPRN must be 8 digits long and start with a 1. For example, 12345678.
       provisional_conversion_date:
-        blank: Enter a month and year for the provisional conversion date, like 01 2023. If you do not know the provisional conversion date then enter a date that is at least six months after the advisory board.
+        blank: Enter a provisional conversion date
         must_be_first_of_the_month: Provisional conversion date must be on the first day of the month
         must_be_in_the_future: Provisional conversion date must be in the future.
       regional_delivery_officer_id:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -124,7 +124,6 @@ en:
         trust_sharepoint_link: Trust SharePoint link
     legend:
       project:
-        provisional_conversion_date: Provisional conversion date
         advisory_board_date: Date of advisory board
     hint:
       project:
@@ -137,7 +136,6 @@ en:
           <br/ ><br />
           <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in new tab)</a>.
         caseworker_id: The caseworker responsible for this project
-        provisional_conversion_date: The provisional conversion date is always the first day of the month.
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
@@ -153,10 +151,6 @@ en:
         no_trust_found: There's no trust with that UKPRN. Check the number you entered is correct.
         not_a_number: UKPRN can only contain numbers. No letters or special characters.
         must_be_correct_format: UKPRN must be 8 digits long and start with a 1. For example, 12345678.
-      provisional_conversion_date:
-        blank: Enter a provisional conversion date
-        must_be_first_of_the_month: Provisional conversion date must be on the first day of the month
-        must_be_in_the_future: Provisional conversion date must be in the future.
       regional_delivery_officer_id:
         blank: Choose a regional delivery officer
       advisory_board_date:

--- a/spec/features/new_conversion_project_has_locales_spec.rb
+++ b/spec/features/new_conversion_project_has_locales_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.feature "All new conversion projects have a locale file & all keys are present" do
+  let(:user) { create(:user, :regional_delivery_officer) }
+
+  before do
+    mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    sign_in_with_user(user)
+  end
+
+  context "voluntary projects" do
+    it "have locales when creating a new project" do
+      visit new_conversions_voluntary_project_path
+
+      expect(page).to_not have_css(".translation_missing")
+    end
+  end
+
+  context "involuntary projects" do
+    it "have locales when creating a new project" do
+      visit new_conversions_voluntary_project_path
+
+      expect(page).to_not have_css(".translation_missing")
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Update hint text and error message for provisional conversion date for both voluntary and involuntary conversion projects.
All `provisional_conversion_date` entries are now consolidated into the `conversion_projects` YAML file to be consistent with the language we use for conversion projects.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
