### PR TITLE
Capture the user that is assigned to a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - group projects in project list by their provisional conversion date
+- Any user can now assign a project to any other user, via the "Assign to" row
+  on the project's "Internal contacts" tab.
 
 ## [Release 14][release-14]
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -36,6 +36,16 @@ class AssignmentsController < ApplicationController
     redirect_to helpers.path_to_project_internal_contacts(@project), notice: t("project.assign.caseworker.success")
   end
 
+  def assign_assigned_to
+    @all_eligible_users = helpers.all_eligible_users
+  end
+
+  def update_assigned_to
+    @project.update(assigned_to_params)
+
+    redirect_to helpers.path_to_project_internal_contacts(@project), notice: t("project.assign.assigned_to.success")
+  end
+
   private def authorize_user
     authorize :assignment
   end
@@ -50,6 +60,10 @@ class AssignmentsController < ApplicationController
 
   private def caseworker_params
     params.require(:conversion_project).permit(:caseworker_id)
+  end
+
+  private def assigned_to_params
+    params.require(:conversion_project).permit(:assigned_to_id)
   end
 
   private def find_project

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -71,6 +71,11 @@ module ApplicationHelper
     return conversions_involuntary_project_assign_caseworker_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
   end
 
+  def path_to_assigned_to_project_assignment(project)
+    return conversions_voluntary_project_assign_assigned_to_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_assign_assigned_to_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
   def optional_cookies_set?
     cookies[:ACCEPT_OPTIONAL_COOKIES].present?
   end

--- a/app/helpers/assignments_helper.rb
+++ b/app/helpers/assignments_helper.rb
@@ -2,4 +2,8 @@ module AssignmentsHelper
   def full_name_and_email(user)
     "#{user.full_name} (#{user.email})"
   end
+
+  def all_eligible_users
+    [User.caseworkers, User.regional_delivery_officers, User.team_leaders].flatten.uniq
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -25,6 +25,7 @@ class Project < ApplicationRecord
   belongs_to :caseworker, class_name: "User", optional: true
   belongs_to :team_leader, class_name: "User", optional: true
   belongs_to :regional_delivery_officer, class_name: "User", optional: true
+  belongs_to :assigned_to, class_name: "User", optional: true
 
   scope :by_provisional_conversion_date, -> { order(provisional_conversion_date: :asc) }
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -36,6 +36,9 @@ class Project < ApplicationRecord
   scope :completed, -> { where.not(completed_at: nil) }
   scope :open, -> { where(completed_at: nil) }
 
+  scope :assigned_to_caseworker, ->(user) { where(assigned_to: user).or(where(caseworker: user)) }
+  scope :assigned_to_regional_delivery_officer, ->(user) { where(assigned_to: user).or(where(regional_delivery_officer: user)) }
+
   def establishment
     @establishment ||= fetch_establishment(urn)
   end

--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -28,4 +28,12 @@ class AssignmentPolicy
   def update_caseworker?
     assign_caseworker?
   end
+
+  def assign_assigned_to?
+    true
+  end
+
+  def update_assigned_to?
+    assign_assigned_to?
+  end
 end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -36,9 +36,9 @@ class ProjectPolicy
       if user.team_leader?
         scope.by_provisional_conversion_date
       elsif user.regional_delivery_officer?
-        scope.by_provisional_conversion_date.where(regional_delivery_officer: user)
+        scope.by_provisional_conversion_date.assigned_to_regional_delivery_officer(user)
       else
-        scope.by_provisional_conversion_date.where(caseworker: user)
+        scope.by_provisional_conversion_date.assigned_to_caseworker(user)
       end
     end
 

--- a/app/views/assignments/assign_assigned_to.html.erb
+++ b/app/views/assignments/assign_assigned_to.html.erb
@@ -1,0 +1,24 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @project, url: path_to_assigned_to_project_assignment(@project), method: :post do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <span class="govuk-caption-m">URN <%= @project.urn %></span>
+      <%= form.govuk_collection_select :assigned_to_id,
+            @all_eligible_users,
+            :id,
+            ->(user) { full_name_and_email(user) },
+            label: {text: t("assignment.assign_assigned_to.title", school_name: @project.establishment.name),
+                    tag: "h1",
+                    size: "l"},
+            class: "accessible-autocomplete-target",
+            options: {include_blank: true, selected: @project.assigned_to&.id} %>
+
+      <%= form.govuk_submit do %>
+        <%= govuk_link_to "Cancel", path_to_project_information(@project) %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<%= render partial: "shared/autocomplete", locals: {selector: ".accessible-autocomplete-target"} %>

--- a/app/views/internal_contacts/show.html.erb
+++ b/app/views/internal_contacts/show.html.erb
@@ -10,6 +10,16 @@
   <h2 class="govuk-heading-l"><%= t("contact.index.internal_contacts") %></h2>
   <%= govuk_summary_list do |summary_list|
         summary_list.row do |row|
+          row.key { t("project_information.show.project_details.rows.assigned_to") }
+          row.value { display_name(@project.assigned_to) }
+          if @project.assigned_to.present?
+            row.action(text: "Email", href: mail_to_path(@project.assigned_to.email), visually_hidden_text: "assigned to")
+          end
+          if policy(:assignment).assign_assigned_to?
+            row.action(href: path_to_assigned_to_project_assignment(@project), visually_hidden_text: "assigned to")
+          end
+        end
+        summary_list.row do |row|
           row.key { t("project_information.show.project_details.rows.caseworker") }
           row.value { display_name(@project.caseworker) }
           if @project.caseworker.present?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,6 +68,8 @@ en:
       title: Change regional delivery officer for %{school_name}
     assign_caseworker:
       title: Change caseworker for %{school_name}
+    assign_assigned_to:
+      title: Change assigned person for %{school_name}
 
   subnavigation:
     project_task_list: Task list

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -69,6 +69,8 @@ en:
         success: Regional delivery officer has been assigned successfully
       caseworker:
         success: Caseworker has been assigned successfully
+      assigned_to:
+        success: Project has been assigned successfully
   project_information:
     show:
       side_navigation:
@@ -79,6 +81,7 @@ en:
           caseworker: Caseworker
           team_lead: Team lead
           regional_delivery_officer: Regional delivery officer
+          assigned_to: Assigned to
           unassigned: Not yet assigned
           advisory_board_date: Date of advisory board
           establishment_sharepoint_link: School SharePoint folder

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,8 @@ Rails.application.routes.draw do
       post "regional-delivery-officer", action: :update_regional_delivery_officer
       get "caseworker", action: :assign_caseworker
       post "caseworker", action: :update_caseworker
+      get "assigned_to", action: :assign_assigned_to
+      post "assigned_to", action: :update_assigned_to
     end
   end
 
@@ -93,6 +95,8 @@ Rails.application.routes.draw do
       post "regional-delivery-officer", action: :update_regional_delivery_officer
       get "caseworker", action: :assign_caseworker
       post "caseworker", action: :update_caseworker
+      get "assigned_to", action: :assign_assigned_to
+      post "assigned_to", action: :update_assigned_to
     end
   end
 

--- a/db/migrate/20230203161446_add_assigned_to_to_projects.rb
+++ b/db/migrate/20230203161446_add_assigned_to_to_projects.rb
@@ -1,0 +1,13 @@
+class AddAssignedToToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :projects, :assigned_to, foreign_key: {to_table: :users}, type: :uuid
+
+    Project.all.each do |project|
+      if project.caseworker_id
+        project.update!(assigned_to_id: project.caseworker_id)
+      elsif project.regional_delivery_officer_id
+        project.update!(assigned_to_id: project.regional_delivery_officer_id)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_02_123106) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_03_161446) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -262,6 +262,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_02_123106) do
     t.string "type"
     t.uuid "task_list_id"
     t.string "task_list_type"
+    t.uuid "assigned_to_id"
+    t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"
     t.index ["team_leader_id"], name: "index_projects_on_team_leader_id"
@@ -284,6 +286,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_02_123106) do
   add_foreign_key "contacts", "projects"
   add_foreign_key "notes", "projects"
   add_foreign_key "notes", "users"
+  add_foreign_key "projects", "users", column: "assigned_to_id"
   add_foreign_key "projects", "users", column: "caseworker_id"
   add_foreign_key "projects", "users", column: "regional_delivery_officer_id"
   add_foreign_key "projects", "users", column: "team_leader_id"

--- a/spec/features/users_can_assign_a_project_spec.rb
+++ b/spec/features/users_can_assign_a_project_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+RSpec.feature "Any user can assign any other user to a project" do
+  let!(:team_leader) { create(:user, team_leader: true, first_name: "Bobbie") }
+  let!(:regional_delivery_officer) { create(:user, :regional_delivery_officer, first_name: "Chris") }
+  let!(:caseworker) { create(:user, :caseworker, first_name: "Alex") }
+
+  let(:project) { create(:conversion_project) }
+  let(:project_id) { project.id }
+
+  before do
+    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    sign_in_with_user(user)
+  end
+
+  context "The user is a caseworker" do
+    let(:user) { caseworker }
+
+    scenario "The caseworker can assign another user to a project" do
+      visit conversions_voluntary_project_internal_contacts_path(project_id)
+
+      assigned_to_summary_list_row = -> { page.find("dt", text: "Assigned to").ancestor(".govuk-summary-list__row") }
+
+      within assigned_to_summary_list_row.call do
+        expect(page).to have_content "Not yet assigned"
+
+        click_on "Change"
+      end
+
+      expect(page).to have_current_path(conversions_voluntary_project_assign_assigned_to_path(project))
+
+      select team_leader.full_name, from: I18n.t("assignment.assign_assigned_to.title", school_name: project.establishment.name)
+
+      click_on "Continue"
+
+      within assigned_to_summary_list_row.call do
+        expect(page).to have_content team_leader.full_name
+      end
+    end
+  end
+
+  context "The user is a team leader" do
+    let(:user) { team_leader }
+
+    scenario "The team leader can assign another user to a project" do
+      visit conversions_voluntary_project_internal_contacts_path(project_id)
+
+      assigned_to_summary_list_row = -> { page.find("dt", text: "Assigned to").ancestor(".govuk-summary-list__row") }
+
+      within assigned_to_summary_list_row.call do
+        expect(page).to have_content "Not yet assigned"
+
+        click_on "Change"
+      end
+
+      expect(page).to have_current_path(conversions_voluntary_project_assign_assigned_to_path(project))
+
+      select regional_delivery_officer.full_name, from: I18n.t("assignment.assign_assigned_to.title", school_name: project.establishment.name)
+
+      click_on "Continue"
+
+      within assigned_to_summary_list_row.call do
+        expect(page).to have_content regional_delivery_officer.full_name
+      end
+    end
+  end
+
+  context "The user is a regional delivery officer" do
+    let(:user) { regional_delivery_officer }
+
+    scenario "The regional delivery officer can assign another user to a project" do
+      visit conversions_voluntary_project_internal_contacts_path(project_id)
+
+      assigned_to_summary_list_row = -> { page.find("dt", text: "Assigned to").ancestor(".govuk-summary-list__row") }
+
+      within assigned_to_summary_list_row.call do
+        expect(page).to have_content "Not yet assigned"
+
+        click_on "Change"
+      end
+
+      expect(page).to have_current_path(conversions_voluntary_project_assign_assigned_to_path(project))
+
+      select caseworker.full_name, from: I18n.t("assignment.assign_assigned_to.title", school_name: project.establishment.name)
+
+      click_on "Continue"
+
+      within assigned_to_summary_list_row.call do
+        expect(page).to have_content caseworker.full_name
+      end
+    end
+  end
+end

--- a/spec/features/users_can_view_projects_spec.rb
+++ b/spec/features/users_can_view_projects_spec.rb
@@ -15,8 +15,8 @@ RSpec.feature "Users can view a list of projects" do
   let(:mock_trusts_fetcher) { double(IncomingTrustsFetcher, call: true) }
   let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
   let(:regional_delivery_officer) { create(:user, :regional_delivery_officer, email: "regionaldeliveryofficer@education.gov.uk") }
-  let(:user_1) { create(:user, email: "user1@education.gov.uk") }
-  let(:user_2) { create(:user, email: "user2@education.gov.uk") }
+  let(:caseworker) { create(:user, :caseworker, email: "caseworker@education.gov.uk") }
+  let(:user) { create(:user, email: "user@education.gov.uk") }
   let!(:unassigned_project) {
     create(
       :conversion_project,
@@ -24,29 +24,29 @@ RSpec.feature "Users can view a list of projects" do
       provisional_conversion_date: Date.today.beginning_of_month + 3.years
     )
   }
-  let!(:user_1_project) {
+  let!(:user_project) {
     create(
       :conversion_project,
       urn: 100002,
-      caseworker: user_1,
+      caseworker: user,
       provisional_conversion_date: Date.today.beginning_of_month + 2.year
     )
   }
-  let!(:user_2_completed_project) {
+  let!(:completed_project) {
     create(
       :conversion_project,
       urn: 100004,
-      caseworker: user_2,
+      caseworker: caseworker,
       regional_delivery_officer: regional_delivery_officer,
       provisional_conversion_date: Date.today.beginning_of_month + 6.months,
       completed_at: Date.today.beginning_of_month + 7.months
     )
   }
-  let!(:user_2_project) {
+  let!(:caseworker_project) {
     create(
       :conversion_project,
       urn: 100003,
-      caseworker: user_2,
+      caseworker: caseworker,
       regional_delivery_officer: regional_delivery_officer,
       provisional_conversion_date: Date.today.beginning_of_month + 1.years
     )
@@ -61,14 +61,14 @@ RSpec.feature "Users can view a list of projects" do
       visit projects_path
 
       page_has_project(unassigned_project)
-      page_has_project(user_1_project)
-      page_has_project(user_2_project)
+      page_has_project(user_project)
+      page_has_project(caseworker_project)
     end
 
     scenario "can see the completed project on a separate tab" do
       visit completed_projects_path
 
-      page_has_project(user_2_completed_project)
+      page_has_project(completed_project)
     end
 
     scenario "the open projects are sorted by target completion date" do
@@ -93,32 +93,46 @@ RSpec.feature "Users can view a list of projects" do
       sign_in_with_user(regional_delivery_officer)
     end
 
-    scenario "can only see assigned projects on the projects list" do
+    scenario "can see projects on which they are the regional development officer" do
       visit projects_path
 
       expect(page).to_not have_content(unassigned_project.urn.to_s)
-      expect(page).not_to have_content(user_1_project.urn.to_s)
-      page_has_project(user_2_project)
+      expect(page).to_not have_content(user_project.urn.to_s)
+      page_has_project(caseworker_project)
+    end
+  end
+
+  context "when the user is a caseworker" do
+    before do
+      sign_in_with_user(caseworker)
+    end
+
+    scenario "can see projects on which they are the caseworker" do
+      visit projects_path
+
+      expect(page).to_not have_content(unassigned_project.urn.to_s)
+      expect(page).to_not have_content(user_project.urn.to_s)
+      page_has_project(caseworker_project)
     end
   end
 
   context "when the user does not have an assigned role" do
     before(:each) do
-      sign_in_with_user(user_1)
+      sign_in_with_user(user)
     end
 
     scenario "can only see assigned projects on the projects list" do
       visit projects_path
 
       expect(page).to_not have_content(unassigned_project.urn.to_s)
-      expect(page).to have_content(user_1_project.urn.to_s)
-      expect(page).to_not have_content(user_2_project.urn.to_s)
+      expect(page).to have_content(user_project.urn.to_s)
+      expect(page).to_not have_content(caseworker_project.urn.to_s)
     end
   end
 
   context "when there are no projects in a project list" do
     before do
-      sign_in_with_user(user_1)
+      sign_in_with_user(user)
       Project.destroy_all
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -108,6 +108,7 @@ RSpec.describe ApplicationHelper, type: :helper do
         expect(helper.path_to_team_lead_project_assignment(project)).to eq conversions_voluntary_project_assign_team_lead_path(project)
         expect(helper.path_to_regional_delivery_officer_project_assignment(project)).to eq conversions_voluntary_project_assign_regional_delivery_officer_path(project)
         expect(helper.path_to_caseworker_project_assignment(project)).to eq conversions_voluntary_project_assign_caseworker_path(project)
+        expect(helper.path_to_assigned_to_project_assignment(project)).to eq conversions_voluntary_project_assign_assigned_to_path(project)
       end
     end
 
@@ -124,6 +125,7 @@ RSpec.describe ApplicationHelper, type: :helper do
         expect(helper.path_to_team_lead_project_assignment(project)).to eq conversions_involuntary_project_assign_team_lead_path(project)
         expect(helper.path_to_regional_delivery_officer_project_assignment(project)).to eq conversions_involuntary_project_assign_regional_delivery_officer_path(project)
         expect(helper.path_to_caseworker_project_assignment(project)).to eq conversions_involuntary_project_assign_caseworker_path(project)
+        expect(helper.path_to_assigned_to_project_assignment(project)).to eq conversions_involuntary_project_assign_assigned_to_path(project)
       end
     end
   end

--- a/spec/helpers/assignments_helper_spec.rb
+++ b/spec/helpers/assignments_helper_spec.rb
@@ -10,4 +10,16 @@ RSpec.describe AssignmentsHelper, type: :helper do
       expect(subject).to eq "John Doe (user@education.gov.uk)"
     end
   end
+
+  describe "all_eligible_users" do
+    let!(:user_1) { create(:user, regional_delivery_officer: true, email: "John.Doe@email.gov.uk") }
+    let!(:user_2) { create(:user, regional_delivery_officer: true, team_leader: true, email: "Jane.Smith@email.gov.uk") }
+    let!(:user_3) { create(:user, caseworker: true, email: "Bob.Jones@email.gov.uk") }
+    let!(:user_4) { create(:user, team_leader: true, email: "Carol.Bloggs@email.gov.uk") }
+    let!(:user_5) { create(:user, team_leader: true, caseworker: true, email: "Tony.Soprano@email.gov.uk") }
+
+    it "returns a unique list of all caseworkers, team leaders and regional delivery officers" do
+      expect(helper.all_eligible_users.count).to eq 5
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -331,5 +331,35 @@ RSpec.describe Project, type: :model do
         expect(projects).to_not include(completed_project)
       end
     end
+
+    describe "assigned_to_caseworker scope" do
+      before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+      it "returns projects which have the user as either the `caseworker` or `assigned_to`" do
+        user = create(:user, :caseworker)
+        other_project = create(:conversion_project)
+        caseworker_project = create(:conversion_project, caseworker: user)
+        assigned_to_project = create(:conversion_project, assigned_to: user)
+
+        projects = Project.assigned_to_caseworker(user)
+        expect(projects).to include(caseworker_project, assigned_to_project)
+        expect(projects).to_not include(other_project)
+      end
+    end
+
+    describe "assigned_to_regional_delivery_officer scope" do
+      before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+      it "returns projects which have the user as either the `regional_delivery_officer` or `assigned_to`" do
+        user = create(:user, :regional_delivery_officer)
+        other_project = create(:conversion_project)
+        rdo_project = create(:conversion_project, regional_delivery_officer: user)
+        assigned_to_project = create(:conversion_project, assigned_to: user)
+
+        projects = Project.assigned_to_regional_delivery_officer(user)
+        expect(projects).to include(rdo_project, assigned_to_project)
+        expect(projects).to_not include(other_project)
+      end
+    end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_db_column(:provisional_conversion_date).of_type :date }
     it { is_expected.to have_db_column(:caseworker_id).of_type :uuid }
     it { is_expected.to have_db_column(:team_leader_id).of_type :uuid }
+    it { is_expected.to have_db_column(:assigned_to_id).of_type :uuid }
     it { is_expected.to have_db_column(:caseworker_assigned_at).of_type :datetime }
     it { is_expected.to have_db_column(:advisory_board_date).of_type :date }
     it { is_expected.to have_db_column(:advisory_board_conditions).of_type :text }
@@ -22,6 +23,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_many(:notes).dependent(:destroy) }
     it { is_expected.to belong_to(:caseworker).required(false) }
     it { is_expected.to belong_to(:team_leader).required(false) }
+    it { is_expected.to belong_to(:assigned_to).required(false) }
     it { is_expected.to belong_to(:task_list).required(true) }
 
     describe "delete related entities" do


### PR DESCRIPTION
## Changes

We wish to capture the user who is assigned to a project. When we began this project, we had fewer user roles than we have now. With the addition of `caseworker`, `team leader` and `regional delivery officer` on projects, it's unclear who the project is *actually* assigned to. 

This PR starts off a solution by adding a new `assigned_to` relation for projects. This can hold the ID of any user. The initial database migration will copy the caseworker or regional delivery officer ID into this field for existing projects.

Any user can then visit the new "Internal contacts" tab on a project, and assign/reassign a project to another user. The list of available users is any caseworker, team leader or regional delivery officer.

Additionally, caseworkers and regional delivery officers will be able to see projects on which they are the `caseworker`/`regional_delivery_officer` OR the `assigned_to` user. Team leaders will continue to be able to view all projects.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
