### PR TITLE
Group projects in project list by their provisional conversion date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - moved the Caseworker, Team Leader and Regional Delivery Officer details to a
   new "Internal contacts" tab.
 
+### Added
+
+- group projects in project list by their provisional conversion date
+
 ## [Release 14][release-14]
 
 ### Changed

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -5,7 +5,7 @@ class ProjectsController < ApplicationController
 
   def index
     authorize Project
-    @pagy, @projects = pagy(policy_scope(Project.includes(:task_list).open))
+    @pagy, @projects = pagy(policy_scope(Project.open))
 
     EstablishmentsFetcher.new.call(@projects)
     IncomingTrustsFetcher.new.call(@projects)
@@ -13,7 +13,7 @@ class ProjectsController < ApplicationController
 
   def completed
     authorize Project
-    @pagy, @projects = pagy(policy_scope(Project.includes(:task_list).completed))
+    @pagy, @projects = pagy(policy_scope(Project.completed))
   end
 
   def show

--- a/app/views/projects/index/_project_summary.html.erb
+++ b/app/views/projects/index/_project_summary.html.erb
@@ -2,25 +2,18 @@
 
   <div class="row-container">
     <%= render partial: "projects/index/project_summary_item",
-          locals: {label: t("project_information.show.school_details.rows.school_type"), content: project.establishment.type} %>
-
-    <%= render partial: "projects/index/project_summary_item",
-          locals: {label: t("project.summary.converting_on.title"), content: converting_on_date(project)} %>
-  </div>
-
-  <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
-
-  <div class="row-container">
-    <%= render partial: "projects/index/project_summary_item",
           locals: {label: t("project.summary.incoming_trust.title"), content: project.incoming_trust.name} %>
 
     <%= render partial: "projects/index/project_summary_item",
-          locals: {label: t("project.summary.local_authority.title"), content: project.establishment.local_authority} %>
+          locals: {label: t("project_information.show.school_details.rows.school_type"), content: project.establishment.type} %>
   </div>
 
   <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
 
   <div class="row-container">
+    <%= render partial: "projects/index/project_summary_item",
+          locals: {label: t("project.summary.local_authority.title"), content: project.establishment.local_authority} %>
+
     <%= render partial: "projects/index/project_summary_item",
           locals: {label: t("conversion_project.summary.route.title"), content: t("conversion_project.#{project.route}.route")} %>
   </div>

--- a/app/views/shared/projects/_list.html.erb
+++ b/app/views/shared/projects/_list.html.erb
@@ -2,15 +2,18 @@
   <%= govuk_inset_text(text: t("project.index.empty")) %>
 <% else %>
   <ul class="projects-list list-style-none govuk-!-padding-0">
-    <% @projects.each do |project| %>
-      <li>
-        <span class="govuk-caption-m">URN <%= project.urn %></span>
-        <h2 class="govuk-heading-m govuk-heading-m--school-name">
-          <%= link_to project.establishment.name, path_to_project(project) %>
-        </h2>
-
-        <%= render partial: "projects/index/project_summary", locals: {project: project} %>
-      </li>
+    <% grouped_project = @projects.group_by { |project| project.provisional_conversion_date.strftime("%B %Y openers") } %>
+      <% grouped_project.each do |opening_date, projects| %>
+        <h2 class="govuk-heading-m"><%= opening_date %></h2>
+        <% projects.each do |project| %>
+          <li>
+            <span class="govuk-caption-m">URN <%= project.urn %></span>
+            <h3 class="govuk-heading-m govuk-heading-m--school-name">
+              <%= link_to project.establishment.name, path_to_project(project) %>
+            </h3>
+            <%= render partial: "projects/index/project_summary", locals: {project: project} %>
+          </li>
+      <% end %>
     <% end %>
   </ul>
 <% end %>

--- a/spec/features/users_can_view_projects_spec.rb
+++ b/spec/features/users_can_view_projects_spec.rb
@@ -140,7 +140,6 @@ RSpec.feature "Users can view a list of projects" do
 
     within urn.ancestor("li") do
       expect(page).to have_content("School type: #{project.establishment.type}")
-      expect(page).to have_content("Converting on: #{project.provisional_conversion_date.to_formatted_s(:govuk)}")
       expect(page).to have_content("Incoming trust: #{project.incoming_trust.name}")
       expect(page).to have_content("Local authority: #{project.establishment.local_authority}")
     end

--- a/spec/features/users_can_view_projects_spec.rb
+++ b/spec/features/users_can_view_projects_spec.rb
@@ -78,6 +78,14 @@ RSpec.feature "Users can view a list of projects" do
       expect(page.find("ul.projects-list > li:nth-of-type(2)")).to have_content("100002")
       expect(page.find("ul.projects-list > li:nth-of-type(3)")).to have_content("100001")
     end
+
+    scenario "projects are grouped under conversion date headings" do
+      three_years_time = Date.today.beginning_of_month + 3.years
+
+      visit projects_path
+
+      expect(page).to have_css("h2", text: three_years_time.strftime("%B %Y openers"))
+    end
   end
 
   context "when the user is a regional delivery officer" do


### PR DESCRIPTION
## Changes

Projects are now grouped by their `provisional_conversion_date` within hte project list
The `provisional_conversion_date` has also been removed from the individual project, as this now sits as the header for all the projects with that same date.

## Screenshots 

### Before

<img width="1163" alt="Screenshot 2023-02-08 at 14 35 36" src="https://user-images.githubusercontent.com/59832893/217560576-0e45a937-4239-4a24-8963-03d3cef5b176.png">

### After

<img width="1163" alt="Screenshot 2023-02-08 at 14 38 38" src="https://user-images.githubusercontent.com/59832893/217561206-c94bbc70-5d1c-46c3-b79a-718fbe007e8b.png">

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
