### PR TITLE
Capture if a project is being handed over to Regional Caseworker Team 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   new "Internal contacts" tab.
 - The notification banner shown to users after a successful operation has a new
   visual style.
+- If a voluntary project is being handed over to Regional Casework Services,
+  send the team leader notification; if it is not, assign the current user to
+  the project and do not send the notification.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Any user can now assign a project to any other user, via the "Assign to" row
   on the project's "Internal contacts" tab.
 - add healthcheck endpoint
+- The form to create a voluntary conversion project allows the user to indicate
+  if the project is being handed over to Regional Casework Services
 
 ## [Release 14][release-14]
 

--- a/app/controllers/conversions/voluntary/projects_controller.rb
+++ b/app/controllers/conversions/voluntary/projects_controller.rb
@@ -42,7 +42,8 @@ class Conversions::Voluntary::ProjectsController < Conversions::ProjectsControll
       :advisory_board_conditions,
       :establishment_sharepoint_link,
       :trust_sharepoint_link,
-      :note_body
+      :note_body,
+      :assigned_to_regional_caseworker_team
     )
   end
 end

--- a/app/forms/conversion/voluntary/create_project_form.rb
+++ b/app/forms/conversion/voluntary/create_project_form.rb
@@ -1,4 +1,12 @@
 class Conversion::Voluntary::CreateProjectForm < Conversion::CreateProjectForm
+  attribute :assigned_to_regional_caseworker_team, :boolean
+
+  CASEWORKER_TEAM_RESPONSES = [OpenStruct.new(id: true, name: I18n.t("yes")), OpenStruct.new(id: false, name: I18n.t("no"))]
+
+  def assigned_to_regional_caseworker_team_responses
+    CASEWORKER_TEAM_RESPONSES
+  end
+
   def save
     @project = Conversion::Project.new(
       urn: urn,
@@ -9,7 +17,8 @@ class Conversion::Voluntary::CreateProjectForm < Conversion::CreateProjectForm
       provisional_conversion_date: provisional_conversion_date,
       advisory_board_date: advisory_board_date,
       regional_delivery_officer_id: user.id,
-      task_list: Conversion::Voluntary::TaskList.new
+      task_list: Conversion::Voluntary::TaskList.new,
+      assigned_to_regional_caseworker_team: assigned_to_regional_caseworker_team
     )
 
     return nil unless valid?

--- a/app/forms/conversion/voluntary/create_project_form.rb
+++ b/app/forms/conversion/voluntary/create_project_form.rb
@@ -8,6 +8,8 @@ class Conversion::Voluntary::CreateProjectForm < Conversion::CreateProjectForm
   end
 
   def save
+    assigned_to = assigned_to_regional_caseworker_team ? nil : user
+
     @project = Conversion::Project.new(
       urn: urn,
       incoming_trust_ukprn: incoming_trust_ukprn,
@@ -18,7 +20,8 @@ class Conversion::Voluntary::CreateProjectForm < Conversion::CreateProjectForm
       advisory_board_date: advisory_board_date,
       regional_delivery_officer_id: user.id,
       task_list: Conversion::Voluntary::TaskList.new,
-      assigned_to_regional_caseworker_team: assigned_to_regional_caseworker_team
+      assigned_to_regional_caseworker_team: assigned_to_regional_caseworker_team,
+      assigned_to: assigned_to
     )
 
     return nil unless valid?
@@ -26,7 +29,7 @@ class Conversion::Voluntary::CreateProjectForm < Conversion::CreateProjectForm
     ActiveRecord::Base.transaction do
       @project.save
       @note = Note.create(body: note_body, project: @project, user: user) if note_body
-      notify_team_leaders(@project)
+      notify_team_leaders(@project) if assigned_to_regional_caseworker_team
     end
 
     @project

--- a/app/views/conversions/voluntary/projects/new.html.erb
+++ b/app/views/conversions/voluntary/projects/new.html.erb
@@ -20,6 +20,7 @@
       <%= form.govuk_text_area :note_body,
             label: {text: t("project.new.handover_comments_label"), size: "m"},
             hint: {text: t("project.new.handover_comments_hint").html_safe} %>
+      <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, @project.assigned_to_regional_caseworker_team_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")} %>
 
       <%= form.govuk_submit %>
     <% end %>

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -53,6 +53,7 @@ en:
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
+        assigned_to_regional_caseworker_team: Are you handing this project over to Regional Casework Services?
   errors:
     attributes:
       provisional_conversion_date:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,8 @@
 en:
   service_name: Complete conversions, transfers and changes
   support_email_subject: "Complete conversions, transfers and changes: support query"
+  "yes": "Yes"
+  "no": "No"
   phase_banner:
     phase: Beta
     phase_notice:

--- a/db/migrate/20230210105741_add_assigned_to_regional_caseworker_team_to_projects.rb
+++ b/db/migrate/20230210105741_add_assigned_to_regional_caseworker_team_to_projects.rb
@@ -1,0 +1,5 @@
+class AddAssignedToRegionalCaseworkerTeamToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :assigned_to_regional_caseworker_team, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_03_161446) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_10_105741) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -263,6 +263,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_03_161446) do
     t.uuid "task_list_id"
     t.string "task_list_type"
     t.uuid "assigned_to_id"
+    t.boolean "assigned_to_regional_caseworker_team", default: false
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"

--- a/spec/factories/conversion/create_project_form_factory.rb
+++ b/spec/factories/conversion/create_project_form_factory.rb
@@ -14,5 +14,6 @@ FactoryBot.define do
   end
 
   factory :create_voluntary_project_form, parent: :create_project_form, class: "Conversion::Voluntary::CreateProjectForm" do
+    assigned_to_regional_caseworker_team { false }
   end
 end

--- a/spec/factories/conversion/project_factory.rb
+++ b/spec/factories/conversion/project_factory.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/establishment-folder" }
     trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }
     task_list { association :voluntary_conversion_task_list }
+    assigned_to { nil }
 
     trait :with_conditions do
       advisory_board_conditions { "The following must be met:\n 1. Must be red\n2. Must be blue\n" }

--- a/spec/features/users_can_create_involuntary_conversion_projects_spec.rb
+++ b/spec/features/users_can_create_involuntary_conversion_projects_spec.rb
@@ -48,5 +48,9 @@ RSpec.feature "Users can create new involuntary conversion projects" do
 
       expect(page).to have_content(two_weeks_ago.to_formatted_s(:govuk))
     end
+
+    scenario "there is no option to assign the project to the Regional Caseworker Team" do
+      expect(page).to_not have_content(I18n.t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team"))
+    end
   end
 end

--- a/spec/features/users_can_create_voluntary_conversion_projects_spec.rb
+++ b/spec/features/users_can_create_voluntary_conversion_projects_spec.rb
@@ -48,5 +48,9 @@ RSpec.feature "Users can create new voluntary conversion projects" do
 
       expect(page).to have_content(two_weeks_ago.to_formatted_s(:govuk))
     end
+
+    scenario "there is an option to assign the project to the Regional Caseworker Team" do
+      expect(page).to have_content(I18n.t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team"))
+    end
   end
 end

--- a/spec/forms/conversion/voluntary/create_project_form_spec.rb
+++ b/spec/forms/conversion/voluntary/create_project_form_spec.rb
@@ -16,18 +16,43 @@ RSpec.describe Conversion::Voluntary::CreateProjectForm, type: :model do
       ActiveJob::Base.queue_adapter.enqueued_jobs.clear
     end
 
-    it "sends a notification to team leaders" do
-      team_leader = create(:user, :team_leader)
-      another_team_leader = create(:user, :team_leader)
+    context "when the project is being assigned to the Regional Caseworker Team" do
+      it "sends a notification to team leaders" do
+        team_leader = create(:user, :team_leader)
+        another_team_leader = create(:user, :team_leader)
 
-      project = build(:create_voluntary_project_form).save
+        project = build(:create_voluntary_project_form, assigned_to_regional_caseworker_team: true).save
 
-      expect(ActionMailer::MailDeliveryJob)
-        .to(have_been_enqueued.on_queue("default")
-        .with("TeamLeaderMailer", "new_project_created", "deliver_now", args: [team_leader, project]))
-      expect(ActionMailer::MailDeliveryJob)
-        .to(have_been_enqueued.on_queue("default")
-        .with("TeamLeaderMailer", "new_project_created", "deliver_now", args: [another_team_leader, project]))
+        expect(ActionMailer::MailDeliveryJob)
+          .to(have_been_enqueued.on_queue("default")
+                                .with("TeamLeaderMailer", "new_project_created", "deliver_now", args: [team_leader, project]))
+        expect(ActionMailer::MailDeliveryJob)
+          .to(have_been_enqueued.on_queue("default")
+                                .with("TeamLeaderMailer", "new_project_created", "deliver_now", args: [another_team_leader, project]))
+      end
+
+      it "does not set Project.assigned_to" do
+        project = build(:create_voluntary_project_form, assigned_to_regional_caseworker_team: true).save
+
+        expect(project.assigned_to).to be_nil
+      end
+    end
+
+    context "when the project is NOT being assigned to the Regional Caseworker Team" do
+      it "does not send a notification to team leaders" do
+        _team_leader = create(:user, :team_leader)
+        _another_team_leader = create(:user, :team_leader)
+
+        _project = build(:create_voluntary_project_form, assigned_to_regional_caseworker_team: false).save
+
+        expect(ActionMailer::MailDeliveryJob).to_not(have_been_enqueued)
+      end
+
+      it "sets Project.assigned_to the current user" do
+        project = build(:create_voluntary_project_form, assigned_to_regional_caseworker_team: false).save
+
+        expect(project.assigned_to).to_not be_nil
+      end
     end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_db_column(:trust_sharepoint_link).of_type :text }
     it { is_expected.to have_db_column(:completed_at).of_type :datetime }
     it { is_expected.to have_db_column(:type).of_type :string }
+    it { is_expected.to have_db_column(:assigned_to_regional_caseworker_team).of_type :boolean }
   end
 
   describe "Relationships" do


### PR DESCRIPTION
## Changes

When creating a new voluntary project, allow the user to indicate if the project will be handed over to Regional Caseworker Services or not.

<img width="941" alt="Screenshot 2023-02-13 at 16 30 51" src="https://user-images.githubusercontent.com/1089521/218516793-efd5e05f-ce17-41d5-91b7-4fa1f5fae7f5.png">

If yes, the project will be created with `assigned_to` left blank, and an email will be sent to the team leaders.

If no, the creating user will be `assigned_to` the project, and no email will be sent to team leaders.

There is no visible change for involuntary projects.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
