### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - group projects in project list by their provisional conversion date
 - Any user can now assign a project to any other user, via the "Assign to" row
   on the project's "Internal contacts" tab.
+- add healthcheck endpoint
 
 ## [Release 14][release-14]
 

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,0 +1,7 @@
+class HealthcheckController < ApplicationController
+  skip_before_action :redirect_unauthenticated_user
+
+  def check
+    render json: {status: "OK"}, status: :ok
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,8 @@ Rails.application.routes.draw do
   get "cookies", to: "cookies#edit"
   post "cookies", to: "cookies#update"
 
+  get "healthcheck" => "healthcheck#check"
+
   # High voltage configuration for static pages. Matches routes from the root of the domain. Uses
   # HighVoltage::Constraints::RootRoute to validate that the view exists.
   get "/*id" => "pages#show", :as => :page, :format => false, :constraints => HighVoltage::Constraints::RootRoute.new

--- a/spec/requests/healthcheck_controller_spec.rb
+++ b/spec/requests/healthcheck_controller_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe HealthcheckController, type: :request do
+  describe "#check" do
+    it "returns status 200" do
+      get healthcheck_path
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Added in `/check` endpoint for TechOps to monitor that the app is up and responding.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
