### PR TITLE
Unassigned project view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - add healthcheck endpoint
 - The form to create a voluntary conversion project allows the user to indicate
   if the project is being handed over to Regional Casework Services
+- Add tab for unassigned projects just for team leaders view
 
 ## [Release 14][release-14]
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -16,6 +16,11 @@ class ProjectsController < ApplicationController
     @pagy, @projects = pagy(policy_scope(Project.completed))
   end
 
+  def unassigned
+    authorize Project
+    @pagy, @projects = pagy(policy_scope(Project.unassigned))
+  end
+
   def show
     @project = Project.find(params[:id])
     authorize @project

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -39,6 +39,8 @@ class Project < ApplicationRecord
   scope :assigned_to_caseworker, ->(user) { where(assigned_to: user).or(where(caseworker: user)) }
   scope :assigned_to_regional_delivery_officer, ->(user) { where(assigned_to: user).or(where(regional_delivery_officer: user)) }
 
+  scope :unassigned, -> { where(assigned_to: nil).and(where(assigned_to_regional_caseworker_team: true)) }
+
   def establishment
     @establishment ||= fetch_establishment(urn)
   end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -14,6 +14,10 @@ class ProjectPolicy
     true
   end
 
+  def unassigned?
+    user.team_leader?
+  end
+
   def show?
     true
   end

--- a/app/views/projects/shared/_project_index_sub_navigation.html.erb
+++ b/app/views/projects/shared/_project_index_sub_navigation.html.erb
@@ -5,5 +5,7 @@
 
     <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.completed_projects"), path: completed_projects_path} %>
 
+    <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.unassigned_projects"), path: unassigned_projects_path} if policy(:project).unassigned? %>
+
   </ul>
 </nav>

--- a/app/views/projects/unassigned.html.erb
+++ b/app/views/projects/unassigned.html.erb
@@ -1,0 +1,17 @@
+<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">
+      <%= t("project.index.unassigned.title") %>
+    </h1>
+
+    <%= render partial: "projects/shared/new_projects" if policy(:project).new? %>
+
+    <%= render partial: "projects/shared/project_index_sub_navigation" %>
+
+    <%= render partial: "/shared/projects/list", locals: {projects: @projects, pager: @pagy} %>
+
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,7 @@ en:
     project_information: Project information
     completed_projects: Completed
     in_progress_projects: In progress
+    unassigned_projects: Unassigned projects
     notes: Notes
     external_contacts: External contacts
     internal_contacts: Internal contacts

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -11,6 +11,8 @@ en:
           title: Involuntary conversion projects
       completed:
         title: Completed projects
+      unassigned:
+        title: Unassigned projects
       empty: No projects
     show:
       title: Task list

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
   resources :projects, only: %i[index show] do
     collection do
       get "completed"
+      get "unassigned"
     end
     get "information", to: "project_information#show"
 

--- a/spec/features/users_can_view_unassigned_projects_spec.rb
+++ b/spec/features/users_can_view_unassigned_projects_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.feature "Users can view a list of projects" do
+  before do
+    (100001..100006).each do |urn|
+      mock_successful_api_responses(urn: urn, ukprn: 10061021)
+    end
+
+    allow(EstablishmentsFetcher).to receive(:new).and_return(mock_establishments_fetcher)
+    allow(IncomingTrustsFetcher).to receive(:new).and_return(mock_trusts_fetcher)
+  end
+
+  let(:mock_establishments_fetcher) { double(EstablishmentsFetcher, call: true) }
+  let(:mock_trusts_fetcher) { double(IncomingTrustsFetcher, call: true) }
+  let(:team_leader) { create(:user, :team_leader, email: "teamleader@education.gov.uk") }
+  let(:regional_delivery_officer) { create(:user, :regional_delivery_officer, email: "regionaldeliveryofficer@education.gov.uk") }
+  let(:caseworker) { create(:user, :caseworker, email: "caseworker@education.gov.uk") }
+
+  let!(:unassigned_project) {
+    create(
+      :conversion_project,
+      urn: 100001,
+      assigned_to_regional_caseworker_team: true
+    )
+  }
+  let!(:assigned_project) {
+    create(
+      :conversion_project,
+      urn: 100002,
+      assigned_to: caseworker
+    )
+  }
+
+  context "When the user is a Team leader" do
+    before do
+      sign_in_with_user(team_leader)
+    end
+
+    scenario "user can see the unassigned projects tab" do
+      visit projects_path
+
+      expect(page).to have_content("Unassigned projects")
+    end
+
+    scenario "user can see the list of unassigned projects" do
+      visit projects_path
+
+      click_on "Unassigned projects"
+
+      expect(page).to have_content("URN 100001")
+      expect(page).to_not have_content("URN 100002")
+    end
+  end
+
+  context "When the user is a Regional Delivery Officer" do
+    before do
+      sign_in_with_user(regional_delivery_officer)
+    end
+
+    scenario "user cannot see the unassigned projects tab" do
+      visit projects_path
+
+      expect(page).to_not have_content("Unassigned projects")
+    end
+  end
+
+  context "When the user is a Caseworker" do
+    before do
+      sign_in_with_user(caseworker)
+    end
+
+    scenario "user cannot see the unassigned projects tab" do
+      visit projects_path
+
+      expect(page).to_not have_content("Unassigned projects")
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -362,5 +362,19 @@ RSpec.describe Project, type: :model do
         expect(projects).to_not include(other_project)
       end
     end
+
+    describe "unassigned scope" do
+      before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+      it "returns projects which do not have an `assigned_to` value" do
+        user = create(:user, :regional_delivery_officer)
+        assigned_project = create(:conversion_project, assigned_to: user)
+        unassigned_project = create(:conversion_project, assigned_to: nil, assigned_to_regional_caseworker_team: true)
+
+        projects = Project.unassigned
+        expect(projects).to include(unassigned_project)
+        expect(projects).to_not include(assigned_project)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Changes

Team leaders can now view a list of unassigned projects within a new assigned projects tabs.

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
