### PR TITLE
Update the external kick off task - involuntary route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The text for the external stakeholder kick off task on the voluntary
   conversion route has been updated, one action removed and the order of the
   actions changed slightly.
+- Amend the text for the stakeholder kick off task on the involuntary conversion
+  route.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add tab for unassigned projects just for team leaders view
 - Add a new action "Host stakeholder meeting" to the involuntary stakeholder
   kick-off task
+- Add new action Check provisional conversion date to the involuntary
+  stakeholder kick-off task
 
 ## [Release 14][release-14]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The form to create a voluntary conversion project allows the user to indicate
   if the project is being handed over to Regional Casework Services
 - Add tab for unassigned projects just for team leaders view
+- Add a new action "Host stakeholder meeting" to the involuntary stakeholder
+  kick-off task
 
 ## [Release 14][release-14]
 

--- a/app/models/conversion/involuntary/tasks/stakeholder_kick_off.rb
+++ b/app/models/conversion/involuntary/tasks/stakeholder_kick_off.rb
@@ -2,6 +2,7 @@ class Conversion::Involuntary::Tasks::StakeholderKickOff < TaskList::Task
   attribute :introductory_emails
   attribute :local_authority_proforma
   attribute :setup_meeting
+  attribute :meeting
   attribute :confirmed_conversion_date
   attribute "confirmed_conversion_date(3i)"
   attribute "confirmed_conversion_date(2i)"

--- a/app/models/conversion/involuntary/tasks/stakeholder_kick_off.rb
+++ b/app/models/conversion/involuntary/tasks/stakeholder_kick_off.rb
@@ -4,6 +4,7 @@ class Conversion::Involuntary::Tasks::StakeholderKickOff < TaskList::Task
   attribute :setup_meeting
   attribute :meeting
   attribute :confirmed_conversion_date
+  attribute :check_provisional_conversion_date
   attribute "confirmed_conversion_date(3i)"
   attribute "confirmed_conversion_date(2i)"
   attribute "confirmed_conversion_date(1i)"

--- a/app/views/conversions/involuntary/task_lists/tasks/stakeholder_kick_off.html.erb
+++ b/app/views/conversions/involuntary/task_lists/tasks/stakeholder_kick_off.html.erb
@@ -13,6 +13,17 @@
 
       <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :local_authority_proforma)) %>
 
+      <div class="govuk-checkboxes__item">
+        <%= hidden_field_tag("conversion_involuntary_tasks_stakeholder_kick_off[check_provisional_conversion_date]", "0", {id: nil}) %>
+        <%= check_box_tag("conversion_involuntary_tasks_stakeholder_kick_off[check_provisional_conversion_date]", 1, @task.check_provisional_conversion_date, {class: "govuk-checkboxes__input"}) %>
+        <%= label_tag("conversion_involuntary_tasks_stakeholder_kick_off[check_provisional_conversion_date]", t("conversion.involuntary.tasks.stakeholder_kick_off.check_provisional_conversion_date.title", date: @project.provisional_conversion_date.to_formatted_s(:govuk)), {class: "govuk-label govuk-checkboxes__label"}) %>
+        <div class="guidance">
+          <%= govuk_details(summary_text: t("conversion.involuntary.tasks.stakeholder_kick_off.check_provisional_conversion_date.guidance_link")) do %>
+            <%= t("conversion.involuntary.tasks.stakeholder_kick_off.check_provisional_conversion_date.guidance.html") %>
+          <% end %>
+        </div>
+      </div>
+
       <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :setup_meeting)) %>
       <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :meeting)) %>
 

--- a/app/views/conversions/involuntary/task_lists/tasks/stakeholder_kick_off.html.erb
+++ b/app/views/conversions/involuntary/task_lists/tasks/stakeholder_kick_off.html.erb
@@ -14,6 +14,7 @@
       <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :local_authority_proforma)) %>
 
       <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :setup_meeting)) %>
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :meeting)) %>
 
       <%= form.govuk_date_field :confirmed_conversion_date,
             omit_day: true,

--- a/app/views/conversions/involuntary/task_lists/tasks/stakeholder_kick_off.html.erb
+++ b/app/views/conversions/involuntary/task_lists/tasks/stakeholder_kick_off.html.erb
@@ -13,14 +13,14 @@
 
       <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :local_authority_proforma)) %>
 
+      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :setup_meeting)) %>
+
       <%= form.govuk_date_field :confirmed_conversion_date,
             omit_day: true,
             form_group: {classes: "app-confirmed-conversion-date"},
             legend: {text: t("conversion.involuntary.tasks.stakeholder_kick_off.confirmed_conversion_date.title"), size: "s"} do %>
         <div class="govuk-hint"><%= t("conversion.involuntary.tasks.stakeholder_kick_off.confirmed_conversion_date.hint.html") %></div>
       <% end %>
-
-      <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :setup_meeting)) %>
 
       <%= form.govuk_submit t("task_list.continue_button.text") %>
     <% end %>

--- a/app/views/conversions/involuntary/task_lists/tasks/stakeholder_kick_off.html.erb
+++ b/app/views/conversions/involuntary/task_lists/tasks/stakeholder_kick_off.html.erb
@@ -16,13 +16,8 @@
       <%= form.govuk_date_field :confirmed_conversion_date,
             omit_day: true,
             form_group: {classes: "app-confirmed-conversion-date"},
-            legend: {text: t("conversion.voluntary.tasks.stakeholder_kick_off.confirmed_conversion_date.title"), size: "s"} do %>
-        <div class="govuk-hint"><%= t("conversion.voluntary.tasks.stakeholder_kick_off.confirmed_conversion_date.hint.html") %></div>
-
-        <%= govuk_details(
-              summary_text: t("conversion.voluntary.tasks.stakeholder_kick_off.confirmed_conversion_date.guidance_link"),
-              text: t("conversion.voluntary.tasks.stakeholder_kick_off.confirmed_conversion_date.guidance.html")
-            ) %>
+            legend: {text: t("conversion.involuntary.tasks.stakeholder_kick_off.confirmed_conversion_date.title"), size: "s"} do %>
+        <div class="govuk-hint"><%= t("conversion.involuntary.tasks.stakeholder_kick_off.confirmed_conversion_date.hint.html") %></div>
       <% end %>
 
       <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :setup_meeting)) %>

--- a/config/locales/task_lists/conversion/involuntary/stakeholder_kick_off.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/stakeholder_kick_off.en.yml
@@ -59,6 +59,16 @@ en:
                 <p>You should have included possible dates for the kick-off meeting in your introductory email.</p>
                 <p>Once the trust have got back to you with a suitable date and list of attendees, send out invites to arrange the time, date and location of the meeting. It's likely to be a video call over Microsoft Teams.</p>
                 <p>Some trusts may prefer to have a one-to-one call with you, rather than a meeting involving all stakeholders.</p>
+          meeting:
+            title: Host the kick-off meeting or call
+            hint:
+              html: <p>Make sure all attendees understand what they need to do, and when they need to do it by.</p>
+            guidance_link: What to talk about in the meeting
+            guidance:
+              html:
+                <p>You should discuss and record issues that might complicate or delay the project.</p>
+                <p>You can <a href="https://educationgovuk.sharepoint.com/:w:/s/ServiceDeliveryDirectorate/EZx-RuHD_JxEuaCF68ZXpe8BvSQ3ITlysjfNJ28t0_xzfQ?e=hxRZxt" target="_blank">use the conversion checklist (opens in new tab)</a> to guide the conversation and make sure you talk about everything you need to.</p>
+
           confirmed_conversion_date:
             title: Enter the confirmed conversion date
             hint:

--- a/config/locales/task_lists/conversion/involuntary/stakeholder_kick_off.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/stakeholder_kick_off.en.yml
@@ -6,16 +6,14 @@ en:
           title: External stakeholder kick-off
           hint:
             html:
-              <p>You should start this work after you've had the handover with the regional delivery officer. This is a good opportunity for you to talk about common problems and how to avoid them.</p>
+              <p>This is where you make sure everyone involved in the conversion knows what they need to do, and when to do it, so the school can become an academy on time.</p>
+              <p>This is also a good opportunity to talk about common problems and how to avoid them.</p>
           introductory_emails:
             title: Send introductory emails to the trust and solicitors
-            hint:
-              html:
-                <p>You should also contact the local authority, but do this separately.</p>
             guidance_link: What to include in introductory emails
             guidance:
               html:
-                <p>You can <a href="https://educationgovuk.sharepoint.com/sites/ServiceDeliveryDirectorate/Shared%20Documents/Forms/AllItems.aspx?FolderCTID=0x012000265B42F1C27524438F6B1CC14FCF9E05&id=%2Fsites%2FServiceDeliveryDirectorate%2FShared%20Documents%2FOperational%20Delivery%2FGuidance%2C%20Training%20and%20Resources%2F%281%29%20CONVERSIONS%20%2D%20Guidance%20and%20Templates%2FCONVERSIONS%20%2D%20Template%20Emails%20%26%20Documents&viewid=84d1a8e7%2D052b%2D4a94%2D8d1b%2D850c4e6f284f" target="blank">choose an email template (opens in new tab)</a> to help you write your introductory emails. There are templates for the school or trust, their solicitors and the local authority.</p>
+                <p>You can <a href="https://educationgovuk.sharepoint.com/sites/ServiceDeliveryDirectorate/Shared%20Documents/Forms/AllItems.aspx?FolderCTID=0x012000265B42F1C27524438F6B1CC14FCF9E05&id=%2Fsites%2FServiceDeliveryDirectorate%2FShared%20Documents%2FOperational%20Delivery%2FGuidance%2C%20Training%20and%20Resources%2F%281%29%20CONVERSIONS%20%2D%20Guidance%20and%20Templates%2FCONVERSIONS%20%2D%20Template%20Emails%20%26%20Documents&viewid=84d1a8e7%2D052b%2D4a94%2D8d1b%2D850c4e6f284f" target="blank">choose an email template (opens in new tab)</a> to help you write your introductory emails. There are templates for the trust and their solicitors.</p>
 
                 <p>This will help you to:</p>
 
@@ -27,16 +25,19 @@ en:
                 <li>agree ways of working</li>
                 </ul>
 
-                <p>You should aim to do this in the first week of picking up the project.</p>
-                <p>Ideally the kick-off meeting should take place within the first couple of weeks.</p>
+                <p>You should aim to do this in the first week after you have been assigned the project.</p>
+                <p>Ideally the kick-off meeting should take place within the first 2 weeks.</p>
           local_authority_proforma:
-            title: Check that the local authority proforma is saved in the school's SharePoint folder
+            title: Check the local authority proforma
+            hint:
+              html: <p>Check the information is correct and there is no missing information.</p>
             guidance_link: What to do if you don't have the local authority proforma
             guidance:
               html:
-                <p>The regional delivery officer should have sent the local authority proforma to the local authority to complete.</p>
-                <p>If you haven't received it yet, check that the regional delivery officer sent it and then ask the local authority if they have completed and shared it.</p>
-
+                <p>The person who prepared this project for advisory board should have asked for the proforma from the local authority and saved it in SharePoint.</p>
+                <p>However, some local authorities will not share the proforma until after the directive academy order has been issued.</p>
+                <p>If it is not in SharePoint, check if the person who prepared the project has asked for it.</p>
+                <p>If they have not, ask the local authority to send the proforma to you and save it in SharePoint.</p>
           confirm_target_conversion_date:
             title: Confirm the provisional conversion date with the local authority
             hint:
@@ -55,6 +56,12 @@ en:
             guidance_link: How to arrange the kick-off meeting
             guidance:
               html:
-                <p>Your introductory email should have included some possible dates for a kick-off meeting.</p>
-                <p>Once the trust have got back to you with a suitable date and list of attendees, send out invites to arrange the time, date and location of the meeting. It’s likely to be a video call over Microsoft Teams.</p>
-                <p>Some trusts may prefer to have a 1-to-1 call with you, rather than a meeting involving all stakeholders.</p>
+                <p>You should have included possible dates for the kick-off meeting in your introductory email.</p>
+                <p>Once the trust have got back to you with a suitable date and list of attendees, send out invites to arrange the time, date and location of the meeting. It's likely to be a video call over Microsoft Teams.</p>
+                <p>Some trusts may prefer to have a one-to-one call with you, rather than a meeting involving all stakeholders.</p>
+          confirmed_conversion_date:
+            title: Enter the confirmed conversion date
+            hint:
+              html:
+                <p>Everyone should have agreed to and know the confirmed conversion date.</p>
+                <p>You only need to enter a month and year. All schools convert on the first day of the month.</p>

--- a/config/locales/task_lists/conversion/involuntary/stakeholder_kick_off.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/stakeholder_kick_off.en.yml
@@ -75,3 +75,10 @@ en:
               html:
                 <p>Everyone should have agreed to and know the confirmed conversion date.</p>
                 <p>You only need to enter a month and year. All schools convert on the first day of the month.</p>
+          check_provisional_conversion_date:
+            title: "Check the local authority is able to convert the school by the provisional conversion date: %{date}"
+            guidance_link: What to do if the local authority is not able meet the provisional conversion date
+            guidance:
+              html:
+                <p>Tell the trust if the local authority cannot complete the conversion by the provisional date.</p>
+                <p>If this happens you'll need to work with the trust and local authority to agree a new date.</p>

--- a/db/migrate/20230217155419_add_host_meeting_to_involuntary_conversion_projects.rb
+++ b/db/migrate/20230217155419_add_host_meeting_to_involuntary_conversion_projects.rb
@@ -1,0 +1,5 @@
+class AddHostMeetingToInvoluntaryConversionProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :stakeholder_kick_off_meeting, :boolean
+  end
+end

--- a/db/migrate/20230217160251_add_involuntary_check_provisional_conversion_date.rb
+++ b/db/migrate/20230217160251_add_involuntary_check_provisional_conversion_date.rb
@@ -1,0 +1,5 @@
+class AddInvoluntaryCheckProvisionalConversionDate < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_involuntary_task_lists, :stakeholder_kick_off_check_provisional_conversion_date, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_17_155419) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_17_160251) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -128,6 +128,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_17_155419) do
     t.boolean "direction_to_transfer_not_applicable"
     t.date "stakeholder_kick_off_confirmed_conversion_date"
     t.boolean "stakeholder_kick_off_meeting"
+    t.boolean "stakeholder_kick_off_check_provisional_conversion_date"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_15_164530) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_17_155419) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -127,6 +127,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_15_164530) do
     t.boolean "deed_of_variation_signed_secretary_state"
     t.boolean "direction_to_transfer_not_applicable"
     t.date "stakeholder_kick_off_confirmed_conversion_date"
+    t.boolean "stakeholder_kick_off_meeting"
   end
 
   create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Changes

Much like https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/517

The copy on the involuntary stakeholder kick-off task has changed.

Move the "Enter confirmed kick off date" field to the end of the page.

Add two new actions to the task - Host stakeholder meeting and Check provisional conversion date. The latter requires a variable in the action title (the conversion date) so the checkbox HTML has been added "longhand" to the template to accommodate this. 

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
