### PR TITLE
Add Assign button to the Unassigned project view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   kick-off task
 - Add new action Check provisional conversion date to the involuntary
   stakeholder kick-off task
+- Add Assign button to projects on the Unassigned projects tab
 
 ## [Release 14][release-14]
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -41,9 +41,10 @@ class AssignmentsController < ApplicationController
   end
 
   def update_assigned_to
-    @project.update(assigned_to_params)
+    @project.update(assigned_to_params.except(:return_to))
+    return_to = assigned_to_params[:return_to] || helpers.path_to_project_internal_contacts(@project)
 
-    redirect_to helpers.path_to_project_internal_contacts(@project), notice: t("project.assign.assigned_to.success")
+    redirect_to return_to, notice: t("project.assign.assigned_to.success")
   end
 
   private def authorize_user
@@ -63,7 +64,7 @@ class AssignmentsController < ApplicationController
   end
 
   private def assigned_to_params
-    params.require(:conversion_project).permit(:assigned_to_id)
+    params.require(:conversion_project).permit(:assigned_to_id, :return_to)
   end
 
   private def find_project

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -18,7 +18,7 @@ class ProjectsController < ApplicationController
 
   def unassigned
     authorize Project
-    @pagy, @projects = pagy(policy_scope(Project.unassigned))
+    @pagy, @projects = pagy(policy_scope(Project.unassigned_to_user.assigned_to_regional_caseworker_team))
   end
 
   def show

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -5,7 +5,7 @@ class ProjectsController < ApplicationController
 
   def index
     authorize Project
-    @pagy, @projects = pagy(policy_scope(Project.open))
+    @pagy, @projects = pagy(policy_scope(Project.open.includes(:assigned_to)))
 
     EstablishmentsFetcher.new.call(@projects)
     IncomingTrustsFetcher.new.call(@projects)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -54,6 +54,10 @@ class Project < ApplicationRecord
     completed_at.present?
   end
 
+  def unassigned_to_user?
+    assigned_to.nil?
+  end
+
   private def fetch_establishment(urn)
     result = AcademiesApi::Client.new.get_establishment(urn)
     raise result.error if result.error.present?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -39,7 +39,8 @@ class Project < ApplicationRecord
   scope :assigned_to_caseworker, ->(user) { where(assigned_to: user).or(where(caseworker: user)) }
   scope :assigned_to_regional_delivery_officer, ->(user) { where(assigned_to: user).or(where(regional_delivery_officer: user)) }
 
-  scope :unassigned, -> { where(assigned_to: nil).and(where(assigned_to_regional_caseworker_team: true)) }
+  scope :unassigned_to_user, -> { where assigned_to: nil }
+  scope :assigned_to_regional_caseworker_team, -> { where(assigned_to_regional_caseworker_team: true) }
 
   def establishment
     @establishment ||= fetch_establishment(urn)

--- a/app/views/assignments/assign_assigned_to.html.erb
+++ b/app/views/assignments/assign_assigned_to.html.erb
@@ -13,6 +13,7 @@
                     size: "l"},
             class: "accessible-autocomplete-target",
             options: {include_blank: true, selected: @project.assigned_to&.id} %>
+      <%= form.hidden_field :return_to, value: request.referrer %>
 
       <%= form.govuk_submit do %>
         <%= govuk_link_to "Cancel", path_to_project_information(@project) %>

--- a/app/views/projects/index/_project_summary.html.erb
+++ b/app/views/projects/index/_project_summary.html.erb
@@ -16,9 +16,17 @@
 
     <%= render partial: "projects/index/project_summary_item",
           locals: {label: t("conversion_project.summary.route.title"), content: t("conversion_project.#{project.route}.route")} %>
+
   </div>
 
   <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
+
+  <% if project.unassigned_to_user? && policy(:assignment).assign_assigned_to? && current_page?("/projects/unassigned") %>
+    <%= link_to t("conversion_project.summary.assign"),
+          path_to_assigned_to_project_assignment(project),
+          class: "govuk-button govuk-button--secondary",
+          data: {module: "govuk-button"} %>
+  <% end %>
 
   <% if project.completed? %>
     <%= render partial: "projects/index/project_summary_item",
@@ -26,5 +34,4 @@
 
     <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
   <% end %>
-
 </div>

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -24,6 +24,10 @@ en:
     summary:
       route:
         title: Route
+      completed_by:
+        title: Completed by
+      unassigned: Unassigned
+      assign: Assign
   helpers:
     label:
       conversion_project:

--- a/spec/features/users_can_assign_a_project_spec.rb
+++ b/spec/features/users_can_assign_a_project_spec.rb
@@ -13,80 +13,146 @@ RSpec.feature "Any user can assign any other user to a project" do
     sign_in_with_user(user)
   end
 
-  context "The user is a caseworker" do
-    let(:user) { caseworker }
+  context "Assigning a project from the project internal contacts tab" do
+    context "The user is a caseworker" do
+      let(:user) { caseworker }
 
-    scenario "The caseworker can assign another user to a project" do
-      visit conversions_voluntary_project_internal_contacts_path(project_id)
+      scenario "The caseworker can assign another user to a project" do
+        visit conversions_voluntary_project_internal_contacts_path(project_id)
 
-      assigned_to_summary_list_row = -> { page.find("dt", text: "Assigned to").ancestor(".govuk-summary-list__row") }
+        assigned_to_summary_list_row = -> { page.find("dt", text: "Assigned to").ancestor(".govuk-summary-list__row") }
 
-      within assigned_to_summary_list_row.call do
-        expect(page).to have_content "Not yet assigned"
+        within assigned_to_summary_list_row.call do
+          expect(page).to have_content "Not yet assigned"
 
-        click_on "Change"
+          click_on "Change"
+        end
+
+        expect(page).to have_current_path(conversions_voluntary_project_assign_assigned_to_path(project))
+
+        select team_leader.full_name, from: I18n.t("assignment.assign_assigned_to.title", school_name: project.establishment.name)
+
+        click_on "Continue"
+
+        within assigned_to_summary_list_row.call do
+          expect(page).to have_content team_leader.full_name
+        end
       end
+    end
 
-      expect(page).to have_current_path(conversions_voluntary_project_assign_assigned_to_path(project))
+    context "The user is a team leader" do
+      let(:user) { team_leader }
 
-      select team_leader.full_name, from: I18n.t("assignment.assign_assigned_to.title", school_name: project.establishment.name)
+      scenario "The team leader can assign another user to a project" do
+        visit conversions_voluntary_project_internal_contacts_path(project_id)
 
-      click_on "Continue"
+        assigned_to_summary_list_row = -> { page.find("dt", text: "Assigned to").ancestor(".govuk-summary-list__row") }
 
-      within assigned_to_summary_list_row.call do
-        expect(page).to have_content team_leader.full_name
+        within assigned_to_summary_list_row.call do
+          expect(page).to have_content "Not yet assigned"
+
+          click_on "Change"
+        end
+
+        expect(page).to have_current_path(conversions_voluntary_project_assign_assigned_to_path(project))
+
+        select regional_delivery_officer.full_name, from: I18n.t("assignment.assign_assigned_to.title", school_name: project.establishment.name)
+
+        click_on "Continue"
+
+        within assigned_to_summary_list_row.call do
+          expect(page).to have_content regional_delivery_officer.full_name
+        end
+      end
+    end
+
+    context "The user is a regional delivery officer" do
+      let(:user) { regional_delivery_officer }
+
+      scenario "The regional delivery officer can assign another user to a project" do
+        visit conversions_voluntary_project_internal_contacts_path(project_id)
+
+        assigned_to_summary_list_row = -> { page.find("dt", text: "Assigned to").ancestor(".govuk-summary-list__row") }
+
+        within assigned_to_summary_list_row.call do
+          expect(page).to have_content "Not yet assigned"
+
+          click_on "Change"
+        end
+
+        expect(page).to have_current_path(conversions_voluntary_project_assign_assigned_to_path(project))
+
+        select caseworker.full_name, from: I18n.t("assignment.assign_assigned_to.title", school_name: project.establishment.name)
+
+        click_on "Continue"
+
+        within assigned_to_summary_list_row.call do
+          expect(page).to have_content caseworker.full_name
+        end
       end
     end
   end
 
-  context "The user is a team leader" do
-    let(:user) { team_leader }
+  context "Assigning a project from the Unassigned projects list" do
+    context "The user is a caseworker" do
+      let(:user) { caseworker }
 
-    scenario "The team leader can assign another user to a project" do
-      visit conversions_voluntary_project_internal_contacts_path(project_id)
+      scenario "The user cannot view the Unassigned projects list" do
+        visit root_path
 
-      assigned_to_summary_list_row = -> { page.find("dt", text: "Assigned to").ancestor(".govuk-summary-list__row") }
-
-      within assigned_to_summary_list_row.call do
-        expect(page).to have_content "Not yet assigned"
-
-        click_on "Change"
-      end
-
-      expect(page).to have_current_path(conversions_voluntary_project_assign_assigned_to_path(project))
-
-      select regional_delivery_officer.full_name, from: I18n.t("assignment.assign_assigned_to.title", school_name: project.establishment.name)
-
-      click_on "Continue"
-
-      within assigned_to_summary_list_row.call do
-        expect(page).to have_content regional_delivery_officer.full_name
+        expect(page).to_not have_content(I18n.t("subnavigation.unassigned_projects"))
       end
     end
-  end
 
-  context "The user is a regional delivery officer" do
-    let(:user) { regional_delivery_officer }
+    context "The user is a regional delivery officer" do
+      let(:user) { regional_delivery_officer }
 
-    scenario "The regional delivery officer can assign another user to a project" do
-      visit conversions_voluntary_project_internal_contacts_path(project_id)
+      scenario "The user cannot view the Unassigned projects list" do
+        visit root_path
 
-      assigned_to_summary_list_row = -> { page.find("dt", text: "Assigned to").ancestor(".govuk-summary-list__row") }
+        expect(page).to_not have_content(I18n.t("subnavigation.unassigned_projects"))
+      end
+    end
 
-      within assigned_to_summary_list_row.call do
-        expect(page).to have_content "Not yet assigned"
+    context "The user is a team leader" do
+      let(:user) { team_leader }
+      before do
+        (100001..100006).each do |urn|
+          mock_successful_api_responses(urn: urn, ukprn: 10061021)
+        end
 
-        click_on "Change"
+        allow(EstablishmentsFetcher).to receive(:new).and_return(mock_establishments_fetcher)
+        allow(IncomingTrustsFetcher).to receive(:new).and_return(mock_trusts_fetcher)
       end
 
-      expect(page).to have_current_path(conversions_voluntary_project_assign_assigned_to_path(project))
+      let(:mock_establishments_fetcher) { double(EstablishmentsFetcher, call: true) }
+      let(:mock_trusts_fetcher) { double(IncomingTrustsFetcher, call: true) }
 
-      select caseworker.full_name, from: I18n.t("assignment.assign_assigned_to.title", school_name: project.establishment.name)
+      let!(:unassigned_project) {
+        create(
+          :conversion_project,
+          urn: 100001,
+          assigned_to: nil,
+          assigned_to_regional_caseworker_team: true
+        )
+      }
 
-      click_on "Continue"
+      scenario "The user can assign another user to an unassigned project, and is redirected to the Unassigned projects list" do
+        visit root_path
 
-      within assigned_to_summary_list_row.call do
-        expect(page).to have_content caseworker.full_name
+        click_on "Unassigned projects"
+        expect(page).to have_css("span", text: "URN 100001")
+
+        click_on "Assign"
+        expect(page).to have_current_path(conversions_voluntary_project_assign_assigned_to_path(unassigned_project))
+
+        select caseworker.full_name, from: I18n.t("assignment.assign_assigned_to.title", school_name: unassigned_project.establishment.name)
+
+        click_on "Continue"
+        expect(page).to have_current_path(unassigned_projects_path)
+
+        # The project is assigned and therefore does not appear on this page any more
+        expect(page).to_not have_css("span", text: "URN 100001")
       end
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -260,6 +260,22 @@ RSpec.describe Project, type: :model do
     end
   end
 
+  describe "unassigned_to_user?" do
+    context "when the project has an `assigned_to` value" do
+      it "returns false" do
+        project = build(:conversion_project, assigned_to: create(:user))
+        expect(project.unassigned_to_user?).to eq false
+      end
+    end
+
+    context "when the project has no `assigned_to` value" do
+      it "returns true" do
+        project = build(:conversion_project, assigned_to: nil)
+        expect(project.unassigned_to_user?).to eq true
+      end
+    end
+  end
+
   describe "Scopes" do
     describe "conversions" do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -363,17 +363,30 @@ RSpec.describe Project, type: :model do
       end
     end
 
-    describe "unassigned scope" do
+    describe "unassigned_to_user scope" do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 
       it "returns projects which do not have an `assigned_to` value" do
         user = create(:user, :regional_delivery_officer)
         assigned_project = create(:conversion_project, assigned_to: user)
-        unassigned_project = create(:conversion_project, assigned_to: nil, assigned_to_regional_caseworker_team: true)
+        unassigned_project = create(:conversion_project, assigned_to: nil)
 
-        projects = Project.unassigned
+        projects = Project.unassigned_to_user
         expect(projects).to include(unassigned_project)
         expect(projects).to_not include(assigned_project)
+      end
+    end
+
+    describe "assigned_to_regional_casework_team scope" do
+      before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+      it "returns projects which have `assigned_to_regional_casework_team` set to `true`" do
+        assigned_project = create(:conversion_project, assigned_to_regional_caseworker_team: true)
+        unassigned_project = create(:conversion_project, assigned_to_regional_caseworker_team: false)
+
+        projects = Project.assigned_to_regional_caseworker_team
+        expect(projects).to include(assigned_project)
+        expect(projects).to_not include(unassigned_project)
       end
     end
   end


### PR DESCRIPTION
## Changes

In a previous commit we added an Unassigned projects tab for Team leaders only. The projects on this tab now have an Assign button, via which the Team leaders can assign a project to another user. Once assigned, the Team leader is redirected to the project's Internal contacts tab. 

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
