### PR TITLE
Refactor: change `all_eligible_users` helper to a User scope

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -37,7 +37,7 @@ class AssignmentsController < ApplicationController
   end
 
   def assign_assigned_to
-    @all_eligible_users = helpers.all_eligible_users
+    @all_assignable_users = User.all_assignable_users
   end
 
   def update_assigned_to

--- a/app/helpers/assignments_helper.rb
+++ b/app/helpers/assignments_helper.rb
@@ -2,8 +2,4 @@ module AssignmentsHelper
   def full_name_and_email(user)
     "#{user.full_name} (#{user.email})"
   end
-
-  def all_eligible_users
-    [User.caseworkers, User.regional_delivery_officers, User.team_leaders].flatten.uniq
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
   scope :regional_delivery_officers, -> { where(regional_delivery_officer: true).order_by_first_name }
   scope :caseworkers, -> { where(caseworker: true).order_by_first_name }
 
+  scope :all_assignable_users, -> { where.not(caseworker: false).or(where.not(team_leader: false)).or(where.not(regional_delivery_officer: false)) }
+
   validates :first_name, presence: true
   validates :last_name, presence: true
 

--- a/app/views/assignments/assign_assigned_to.html.erb
+++ b/app/views/assignments/assign_assigned_to.html.erb
@@ -5,7 +5,7 @@
 
       <span class="govuk-caption-m">URN <%= @project.urn %></span>
       <%= form.govuk_collection_select :assigned_to_id,
-            @all_eligible_users,
+            @all_assignable_users,
             :id,
             ->(user) { full_name_and_email(user) },
             label: {text: t("assignment.assign_assigned_to.title", school_name: @project.establishment.name),

--- a/spec/helpers/assignments_helper_spec.rb
+++ b/spec/helpers/assignments_helper_spec.rb
@@ -10,16 +10,4 @@ RSpec.describe AssignmentsHelper, type: :helper do
       expect(subject).to eq "John Doe (user@education.gov.uk)"
     end
   end
-
-  describe "all_eligible_users" do
-    let!(:user_1) { create(:user, regional_delivery_officer: true, email: "John.Doe@email.gov.uk") }
-    let!(:user_2) { create(:user, regional_delivery_officer: true, team_leader: true, email: "Jane.Smith@email.gov.uk") }
-    let!(:user_3) { create(:user, caseworker: true, email: "Bob.Jones@email.gov.uk") }
-    let!(:user_4) { create(:user, team_leader: true, email: "Carol.Bloggs@email.gov.uk") }
-    let!(:user_5) { create(:user, team_leader: true, caseworker: true, email: "Tony.Soprano@email.gov.uk") }
-
-    it "returns a unique list of all caseworkers, team leaders and regional delivery officers" do
-      expect(helper.all_eligible_users.count).to eq 5
-    end
-  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,10 +17,11 @@ RSpec.describe User do
     let!(:team_leader_2) { create(:user, :team_leader, first_name: "Andy", email: "aaron-team-leader@education.gov.uk") }
     let!(:regional_delivery_officer) { create(:user, :regional_delivery_officer) }
     let!(:regional_delivery_officer_2) { create(:user, :regional_delivery_officer, first_name: "Adam", email: "aaron-rdo@education.gov.uk") }
+    let!(:user_without_role) { create(:user, caseworker: false, team_leader: false, regional_delivery_officer: false) }
 
     describe "order_by_first_name" do
       it "orders by first_name" do
-        expect(User.order_by_first_name.count).to be 6
+        expect(User.order_by_first_name.count).to be 7
         expect(User.order_by_first_name.first).to eq caseworker_2
         expect(User.order_by_first_name.last).to eq team_leader
       end
@@ -47,6 +48,13 @@ RSpec.describe User do
         expect(User.caseworkers.count).to be 2
         expect(User.caseworkers.first).to eq caseworker_2
         expect(User.caseworkers.last).to eq caseworker
+      end
+    end
+
+    describe "all_assignable_users" do
+      it "only includes users who have a role" do
+        expect(User.all_assignable_users.count).to eq 6
+        expect(User.all_assignable_users).to_not include(user_without_role)
       end
     end
   end


### PR DESCRIPTION

## Changes

Change `all_eligible_users` helper method to a scope on Users. This scope returns all users who have a role, and are therefore eligible to be assigned to a project. 

Also name the scope `all_assignable_users` to make it clearer what it does.

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
