### PR TITLE
Release 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release 15][release-15]
+
 ### Changed
 
 - the voluntary conversion, stakeholder kick off task had a duplicated action.
@@ -530,7 +532,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-14...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-15...HEAD
+[release-15]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-14...release-15
 [release-14]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-13...release-14
 [release-13]:


### PR DESCRIPTION
- the voluntary conversion, stakeholder kick off task had a duplicated action. This has now been corrected. Users may want to verify they have completed the action in the task.
- renamed the "Contacts" tab to "External contacts"
- moved the Caseworker, Team Leader and Regional Delivery Officer details to a new "Internal contacts" tab.
- The notification banner shown to users after a successful operation has a new visual style.
- If a voluntary project is being handed over to Regional Casework Services, send the team leader notification; if it is not, assign the current user to the project and do not send the notification.
- Update Rails to 7.0.4.2 to address some security issues.
- Tasks displayed on the task list are no longer indented.
- The text for the external stakeholder kick off task on the voluntary conversion route has been updated, one action removed and the order of the actions changed slightly.
- Amend the text for the stakeholder kick off task on the involuntary conversion route.

- group projects in project list by their provisional conversion date
- Any user can now assign a project to any other user, via the "Assign to" row on the project's "Internal contacts" tab.
- add healthcheck endpoint
- The form to create a voluntary conversion project allows the user to indicate if the project is being handed over to Regional Casework Services
- Add tab for unassigned projects just for team leaders view
- Add a new action "Host stakeholder meeting" to the involuntary stakeholder kick-off task
- Add new action Check provisional conversion date to the involuntary stakeholder kick-off task
- Add Assign button to projects on the Unassigned projects tab

## Checklist

- [x] Check that this pull request has the correct version number.
- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` to move Unreleased changes into a new version.
- [x] Update the release links at the bottom of `CHANGELOG.md` to reflect the
      new version.
