### PR TITLE
Increase page width to 1024px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- the width of the applicaiton has been increased from 960px to 1024px when
+  viewed on desktop class device.
+
 ## [Release 15][release-15]
 
 ### Changed

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,9 @@
 $govuk-font-url-function: "font-url";
 $govuk-image-url-function: "image-url";
-
 $govuk-global-styles: true;
+
+// override the default page width
+$govuk-page-width: 1024px;
 
 @import "govuk-frontend/govuk/all";
 @import "@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";


### PR DESCRIPTION
## Changes

Right now all our users are internal DfE users who have DfE provided
devices. Our analytics show that increasing the width of our viewport,
the space inside the browser window is viable as no one accesses the
service on a screen that cannot accomadte this change.

Horizontal space will place an important role in the application as we
introduce tables and these extra 64px could mean being able to show an
extra column.

