### PR TITLE
Add link to the trust on GIAS from the project information tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add new action Check provisional conversion date to the involuntary
   stakeholder kick-off task
 - Add Assign button to projects on the Unassigned projects tab
+- Add link to the trust on GIAS from the project information tab
 
 ## [Release 14][release-14]
 

--- a/app/helpers/project_helper.rb
+++ b/app/helpers/project_helper.rb
@@ -25,4 +25,10 @@ module ProjectHelper
 
     "#{date} #{tag}".html_safe
   end
+
+  def link_to_school_on_gias(urn)
+    raise ArgumentError if urn.nil?
+
+    link_to(t("project_information.show.school_details.rows.view_in_gias"), "https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/#{urn}", target: :_blank)
+  end
 end

--- a/app/helpers/project_helper.rb
+++ b/app/helpers/project_helper.rb
@@ -31,4 +31,10 @@ module ProjectHelper
 
     link_to(t("project_information.show.school_details.rows.view_in_gias"), "https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/#{urn}", target: :_blank)
   end
+
+  def link_to_trust_on_gias(ukprn)
+    raise ArgumentError if ukprn.nil?
+
+    link_to(t("project_information.show.trust_details.rows.view_in_gias"), "https://get-information-schools.service.gov.uk/Groups/Search?GroupSearchModel.Text=#{ukprn}", target: :_blank)
+  end
 end

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -25,7 +25,7 @@
   <%= govuk_summary_list(actions: false) do |summary_list|
     summary_list.row do |row|
       row.key { t('project_information.show.school_details.rows.original_school_name') }
-      row.value { t("project_information.show.school_details.rows.school_name_link_to_gias.html", school_name: @project.establishment.name, link_to_gias: safe_link_to(t('project_information.show.school_details.rows.view_in_gias'), "https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/#{@project.urn}")) }
+      row.value { (@project.establishment.name + "<br/>" + link_to_school_on_gias(@project.urn)).html_safe }
     end
     summary_list.row do |row|
       row.key { t('project_information.show.school_details.rows.old_urn') }

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -55,7 +55,7 @@
   <%= govuk_summary_list(actions: false) do |summary_list|
     summary_list.row do |row|
       row.key { t('project_information.show.trust_details.rows.incoming_trust_name') }
-      row.value { @project.incoming_trust.name }
+      row.value { (@project.incoming_trust.name + "<br/>" + link_to_trust_on_gias(@project.incoming_trust_ukprn)).html_safe }
     end
     summary_list.row do |row|
       row.key { t('project_information.show.trust_details.rows.ukprn') }

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -103,6 +103,7 @@ en:
         title: Trust details
         rows:
           incoming_trust_name: Incoming trust name
+          view_in_gias: View the trust information in GIAS (opens in new tab)
           ukprn: UK Provider Reference Number
           companies_house_number: Companies House number
       local_authority_details:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -93,10 +93,6 @@ en:
         title: School details
         rows:
           original_school_name: Original school name
-          school_name_link_to_gias:
-            html: |
-              %{school_name}<br/>
-              %{link_to_gias}
           view_in_gias: View the school's information in GIAS (opens in new tab)
           old_urn: Old Unique Reference Number
           school_type: School type

--- a/spec/helpers/project_helper_spec.rb
+++ b/spec/helpers/project_helper_spec.rb
@@ -97,4 +97,26 @@ RSpec.describe ProjectHelper, type: :helper do
       end
     end
   end
+
+  describe "#link_to_trust_on_gias" do
+    context "when a ukprn is provided" do
+      let(:ukprn) { "101456" }
+
+      it "returns a link to the trust on gias" do
+        expect(link_to_trust_on_gias(ukprn)).to include("https://get-information-schools.service.gov.uk/Groups/Search?GroupSearchModel.Text=#{ukprn}")
+      end
+
+      it "opens the link in a new tab" do
+        expect(link_to_trust_on_gias(ukprn)).to include("_blank")
+      end
+    end
+
+    context "when a ukprn is not provided" do
+      let(:ukprn) { nil }
+
+      it "returns an argument error" do
+        expect { link_to_trust_on_gias(ukprn) }.to raise_error(ArgumentError)
+      end
+    end
+  end
 end

--- a/spec/helpers/project_helper_spec.rb
+++ b/spec/helpers/project_helper_spec.rb
@@ -75,4 +75,26 @@ RSpec.describe ProjectHelper, type: :helper do
       end
     end
   end
+
+  describe "#link_to_school_on_gias" do
+    context "when a urn is provided" do
+      let(:urn) { "12345" }
+
+      it "returns a link to the school on gias" do
+        expect(link_to_school_on_gias(urn)).to include("https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/#{urn}")
+      end
+
+      it "opens the link in a new tab" do
+        expect(link_to_school_on_gias(urn)).to include("_blank")
+      end
+    end
+
+    context "when a urn is not provided" do
+      let(:urn) { nil }
+
+      it "returns an argument error" do
+        expect { link_to_school_on_gias(urn) }.to raise_error(ArgumentError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes
Added a link to the trust on GIAS from the project information tab

![Screenshot 2023-02-22 at 17 05 22](https://user-images.githubusercontent.com/59832893/220702849-1474b9b9-68e1-4dd0-b0b5-b87727b87f99.png)

Also refactored the school's link implementation to keep the code for the two links consistent.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
