### PR TITLE
Add new `CONTAINER_VNET` value to `config.hosts`

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -85,6 +85,7 @@ Rails.application.configure do
 
   # configure the host names
   config.hosts << ENV["HOSTNAME"]
+  config.hosts << IPAddr.new(ENV["CONTAINER_VNET"])
   config.hosts.concat ENV.fetch("ALLOWED_HOSTS", "").split(",")
 
   # configure ActionMailer

--- a/doc/environment-variables.md
+++ b/doc/environment-variables.md
@@ -58,3 +58,9 @@ the default behaviour.
 We only use this in CI to run our AXE accessibility checks. See:
 
 https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/blob/505ed05431c8398db9dd3ceb51918b77ea148761/script/all/test-accessibility#L6
+
+`CONTAINER_VNET`
+
+Contains a range of IP addresses used by the monitoring health probes. This
+range is added to the `ALLOWED_HOSTS` on production, so that the probes can hit
+the `/healthcheck` endpoint to confirm the app is up & running.


### PR DESCRIPTION
Re: https://ukgovernmentdfe.slack.com/archives/C03AANC6UJF/p1677253180105049

We added a new `/healthcheck` endpoint for monitoring.

Unfortunately when implementing the monitoring, techops encountered an error because the health probes' IP address is not in the app's allowed hosts:

```
ERROR -- : [ActionDispatch::HostAuthorization::DefaultResponseApp] Blocked host: 172.16.0.126
```

As a solution, techops are going to add a new environment variable to terraform called `CONTAINER_VNET`. This will be an IP range.

https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization

We can add this to the allowed hosts in the application via `IPAddr.new(ENV["CONTAINER_VNET"])`

