### PR TITLE
Add Project Openers table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - the width of the application has been increased from 960px to 1024px when
   viewed on desktop class device.
 
+### Added
+
+- add a Project Openers table view
+
 ## [Release 15][release-15]
 
 ### Changed

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,10 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
   rescue_from AcademiesApi::Client::Error, with: :client_error
 
+  def not_found_error
+    render "pages/page_not_found", status: :not_found
+  end
+
   private def user_not_authorized
     flash[:alert] = I18n.t("unauthorised_action.message")
     redirect_back(fallback_location: root_path)
@@ -16,9 +20,5 @@ class ApplicationController < ActionController::Base
 
   private def client_error
     render "pages/api_client_timeout", status: 500
-  end
-
-  private def not_found_error
-    render "pages/page_not_found", status: :not_found
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -32,8 +32,7 @@ class ProjectsController < ApplicationController
     year = params[:year]
     month = params[:month]
 
-    # TODO: add a scope for projects with a conversion date of this month & year
-    @projects = Project.all
+    @projects = Project.opening_by_month_year(month, year)
     @date = "#{Date::MONTHNAMES[month.to_i]} #{year}"
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -25,4 +25,15 @@ class ProjectsController < ApplicationController
     @project = Project.find(params[:id])
     authorize @project
   end
+
+  def openers
+    authorize Project
+
+    year = params[:year]
+    month = params[:month]
+
+    # TODO: add a scope for projects with a conversion date of this month & year
+    @projects = Project.all
+    @date = "#{Date::MONTHNAMES[month.to_i]} #{year}"
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -42,6 +42,8 @@ class Project < ApplicationRecord
   scope :unassigned_to_user, -> { where assigned_to: nil }
   scope :assigned_to_regional_caseworker_team, -> { where(assigned_to_regional_caseworker_team: true) }
 
+  scope :opening_by_month_year, ->(month, year) { where.not(conversion_date: nil).and(where("YEAR(conversion_date) = ?", year)).and(where("MONTH(conversion_date) = ?", month)) }
+
   def establishment
     @establishment ||= fetch_establishment(urn)
   end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -30,6 +30,10 @@ class ProjectPolicy
     create?
   end
 
+  def openers?
+    true
+  end
+
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/views/projects/openers.html.erb
+++ b/app/views/projects/openers.html.erb
@@ -1,0 +1,13 @@
+<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">
+      <%= t("project.openers.title", date: @date) %>
+    </h1>
+    <p><%= t("project.openers.subtitle") %></p>
+
+    <%= render partial: "/shared/projects/table", locals: {projects: @projects, date: @date} %>
+  </div>
+</div>

--- a/app/views/shared/projects/_table.html.erb
+++ b/app/views/shared/projects/_table.html.erb
@@ -1,0 +1,30 @@
+<% if projects.empty? %>
+  <%= govuk_inset_text(text: t("project.openers.empty.html", date: date)) %>
+<% else %>
+  <table class="govuk-table" name="projects_table" aria-label="Projects table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><%= t("project.openers.table.headers.school") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.openers.table.headers.urn") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.openers.table.headers.incoming_trust") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.openers.table.headers.ukprn") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.openers.table.headers.view") %></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% projects.each do |project| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+        <td class="govuk-table__cell"><%= project.urn %></td>
+        <td class="govuk-table__cell"><%= project.incoming_trust.name %></td>
+        <td class="govuk-table__cell"><%= project.incoming_trust.ukprn %></td>
+       <td class="govuk-table__cell">
+         <a href="<%= path_to_project(project) %>">
+           <%= t("project.openers.table.headers.open.html", school_name: project.establishment.name) %>
+         </a>
+       </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -73,6 +73,23 @@ en:
         success: Caseworker has been assigned successfully
       assigned_to:
         success: Project has been assigned successfully
+    openers:
+      title: Academies opening in %{date}
+      subtitle: A list of schools becoming academies
+      empty:
+        html:
+          <p>There are currently no schools expected to become academies in %{date}.</p>
+          <p>Check with your line manager if you were expecting some schools to convert in this month.</p>
+      table:
+        headers:
+          school: School
+          urn: URN
+          incoming_trust: Incoming trust
+          ukprn: UKPRN
+          view: View project
+          open:
+            html:
+              Open <span class="govuk-visually-hidden">%{school_name}</span> project
   project_information:
     show:
       side_navigation:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
+VALID_UUID_REGEX = /[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i
+MONTH_1_12_REGEX = /(?:1[0-2]|[1-9])/
+YEAR_2000_2499_REGEX = /(?:(?:20|21|23|24)[0-9]{2})/
+
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
@@ -65,7 +69,7 @@ Rails.application.routes.draw do
     get "/", to: "/conversions/projects#index"
     namespace :voluntary do
       get "/", to: "/conversions/voluntary/projects#index"
-      get "projects/:id", to: "/conversions/voluntary/projects#show", constraints: {id: /[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i}, as: :project
+      get "projects/:id", to: "/conversions/voluntary/projects#show", constraints: {id: VALID_UUID_REGEX}, as: :project
 
       resources :projects,
         only: %i[new create],
@@ -73,7 +77,7 @@ Rails.application.routes.draw do
     end
     namespace :involuntary do
       get "/", to: "/conversions/involuntary/projects#index"
-      get "projects/:id", to: "/conversions/involuntary/projects#show", constraints: {id: /[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i}, as: :project
+      get "projects/:id", to: "/conversions/involuntary/projects#show", constraints: {id: VALID_UUID_REGEX}, as: :project
 
       resources :projects,
         only: %i[new create],
@@ -81,13 +85,13 @@ Rails.application.routes.draw do
     end
   end
 
-  constraints(id: /[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i) do
+  constraints(id: VALID_UUID_REGEX) do
     resources :projects, only: %i[index show] do
       collection do
         get "completed"
         get "unassigned"
 
-        get "openers/:month/:year", to: "projects#openers", constraints: {month: /(?:1[0-2]|[1-9])/, year: /(?:(?:20|21|23|24)[0-9]{2})/}
+        get "openers/:month/:year", to: "projects#openers", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}
       end
       get "information", to: "project_information#show"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,4 +109,6 @@ Rails.application.routes.draw do
   # High voltage configuration for static pages. Matches routes from the root of the domain. Uses
   # HighVoltage::Constraints::RootRoute to validate that the view exists.
   get "/*id" => "pages#show", :as => :page, :format => false, :constraints => HighVoltage::Constraints::RootRoute.new
+
+  match "*unmatched", to: "application#not_found_error", via: :all
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Rails.application.routes.draw do
         get "completed"
         get "unassigned"
 
+        get "openers/:month/:year", to: "projects#openers", constraints: {month: /(?:1[0-2]|[1-9])/, year: /(?:(?:20|21|23|24)[0-9]{2})/}
       end
       get "information", to: "project_information#show"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,39 +65,46 @@ Rails.application.routes.draw do
     get "/", to: "/conversions/projects#index"
     namespace :voluntary do
       get "/", to: "/conversions/voluntary/projects#index"
+      get "projects/:id", to: "/conversions/voluntary/projects#show", constraints: {id: /[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i}, as: :project
+
       resources :projects,
-        only: %i[show new create],
+        only: %i[new create],
         concerns: %i[task_listable contactable notable assignable informationable completable internal_contactable]
     end
     namespace :involuntary do
       get "/", to: "/conversions/involuntary/projects#index"
+      get "projects/:id", to: "/conversions/involuntary/projects#show", constraints: {id: /[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i}, as: :project
+
       resources :projects,
-        only: %i[show new create],
+        only: %i[new create],
         concerns: %i[task_listable contactable notable assignable informationable completable internal_contactable]
     end
   end
 
-  resources :projects, only: %i[index show] do
-    collection do
-      get "completed"
-      get "unassigned"
-    end
-    get "information", to: "project_information#show"
+  constraints(id: /[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i) do
+    resources :projects, only: %i[index show] do
+      collection do
+        get "completed"
+        get "unassigned"
 
-    put "complete", to: "projects_complete#complete"
+      end
+      get "information", to: "project_information#show"
 
-    resources :notes, except: %i[show], concerns: :has_destroy_confirmation
-    resources :contacts, path: :external_contacts, except: %i[show], concerns: :has_destroy_confirmation
+      put "complete", to: "projects_complete#complete"
 
-    namespace :assign, controller: "/assignments" do
-      get "team-lead", action: :assign_team_leader
-      post "team-lead", action: :update_team_leader
-      get "regional-delivery-officer", action: :assign_regional_delivery_officer
-      post "regional-delivery-officer", action: :update_regional_delivery_officer
-      get "caseworker", action: :assign_caseworker
-      post "caseworker", action: :update_caseworker
-      get "assigned_to", action: :assign_assigned_to
-      post "assigned_to", action: :update_assigned_to
+      resources :notes, except: %i[show], concerns: :has_destroy_confirmation
+      resources :contacts, path: :external_contacts, except: %i[show], concerns: :has_destroy_confirmation
+
+      namespace :assign, controller: "/assignments" do
+        get "team-lead", action: :assign_team_leader
+        post "team-lead", action: :update_team_leader
+        get "regional-delivery-officer", action: :assign_regional_delivery_officer
+        post "regional-delivery-officer", action: :update_regional_delivery_officer
+        get "caseworker", action: :assign_caseworker
+        post "caseworker", action: :update_caseworker
+        get "assigned_to", action: :assign_assigned_to
+        post "assigned_to", action: :update_assigned_to
+      end
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -406,5 +406,23 @@ RSpec.describe Project, type: :model do
         expect(projects).to_not include(unassigned_project)
       end
     end
+
+    describe "opening_by_month_year scope" do
+      before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+      it "only returns projects with a confirmed conversion date" do
+        conversion_project = create(:conversion_project)
+        expect(Project.opening_by_month_year(1, 2023)).to_not include(conversion_project)
+      end
+
+      it "only returns projects with a confirmed conversion date in that month & year" do
+        project_in_scope = create(:conversion_project, conversion_date: Date.new(2023, 1, 1))
+        project_not_in_scope = create(:conversion_project, conversion_date: Date.new(2023, 2, 1))
+        project_without_conversion_date = create(:conversion_project)
+
+        expect(Project.opening_by_month_year(1, 2023)).to_not include(project_not_in_scope, project_without_conversion_date)
+        expect(Project.opening_by_month_year(1, 2023)).to include(project_in_scope)
+      end
+    end
   end
 end

--- a/spec/requests/projects_controller_spec.rb
+++ b/spec/requests/projects_controller_spec.rb
@@ -59,6 +59,64 @@ RSpec.describe ProjectsController, type: :request do
     end
   end
 
+  describe "#openers" do
+    context "when the month and year are missing" do
+      it "returns a 404" do
+        get "/projects/openers"
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the year is missing" do
+      it "returns a 404" do
+        get "/projects/openers/1"
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the month isn't in the scope 1..12" do
+      it "returns a 404" do
+        get "/projects/openers/13/2022"
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the year isn't in the scope 2000-2499" do
+      it "returns a 404" do
+        get "/projects/openers/12/2555"
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the month and year are present and in scope" do
+      it "shows a page title with the month & year" do
+        get "/projects/openers/1/2022"
+        expect(response.body).to include("Academies opening in January 2022")
+      end
+
+      # TODO: page currently shows all conversion projects
+      it "returns project details in table form" do
+        conversion_project = create(:conversion_project)
+        get "/projects/openers/1/2022"
+        expect(response.body).to include(
+          conversion_project.establishment.name,
+          conversion_project.urn.to_s,
+          conversion_project.incoming_trust.name,
+          conversion_project.incoming_trust.ukprn
+        )
+      end
+
+      xit "only returns projects whose confirmed conversion date is in that month & year"
+
+      context "when there are no academies opening in that month & year" do
+        xit "shows a helpful message" do
+          get "/projects/openers/01/2022"
+          expect(response.body).to include("There are currently no schools expected to become academies in January 2022")
+        end
+      end
+    end
+  end
+
   private def unset_api_data
     # Nillify any project data that comes from the API in order to best test the
     # real scenario, where loaded project data will not have associated API data until


### PR DESCRIPTION
## Changes

Add a route to a new view at `projects/openers/:month/:year`. The route is constrained by month & year being present, and within the scope of 1-12 (month) and 2000-2499 (year).

This page shows a tabular view of all projects. The list of projects is filtered to projects which have a confirmed opening date of the supplied year & month.

If a year or month are not supplied in the URL, the user is redirected to a 404. 

If the year is not in the scope of 2000-2499, or the month is not in the scope of 1-12, the user is redirected to a 404. 

If no projects fall within the scope of a correctly supplied month and year, an appropriate informational message will be shown.

<img width="1072" alt="Screenshot 2023-02-28 at 16 25 45" src="https://user-images.githubusercontent.com/1089521/221915275-e2cf39b6-fed1-4bbe-9cb7-db2054ed5c3e.png">

<img width="1127" alt="Screenshot 2023-03-06 at 15 42 46" src="https://user-images.githubusercontent.com/1089521/223159404-6ccf3ce9-28c9-42c8-a46e-3b18152c6aed.png">

As a side effect of doing this work, we now have URL constraints on the `project/:id` URLs (for "plain" projects, and voluntary/involuntary conversion projects). This is to prevent an error when a user tries to go to `projects/openers` and the application thinks the user is trying to access a project with the ID of "openers". The constraint checks that a supplied project ID is a valid UUID, and redirects the user to a 404 page if it is not.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
