### PR TITLE
Update sponsored kickoff call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Involuntary/Sponsored > External Stakeholder Kickoff > Send introductory
+  emails copy changes to improve words and handle faith schools/diocese
 - Voluntary > External Stakeholder Kickoff > Send introductory emails copy
   changes to improve words and handle faith schools/diocese
 - the width of the applicaiton has been increased from 960px to 1024px when

--- a/config/locales/task_lists/conversion/involuntary/stakeholder_kick_off.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/stakeholder_kick_off.en.yml
@@ -9,7 +9,9 @@ en:
               <p>This is where you make sure everyone involved in the conversion knows what they need to do, and when to do it, so the school can become an academy on time.</p>
               <p>This is also a good opportunity to talk about common problems and how to avoid them.</p>
           introductory_emails:
-            title: Send introductory emails to the trust and solicitors
+            title: Send introductory emails
+            hint:
+              html: <p>Email the trust and solicitors. Also email the diocese if this is a faith school. You should email the local authority separately.</p>
             guidance_link: What to include in introductory emails
             guidance:
               html:


### PR DESCRIPTION
## Changes

- Send introductory emails task does not mention who to email
- Send introductory emails hint informs who to emails and to contact LA separately this is now consistent with voluntary conversions

![image](https://user-images.githubusercontent.com/13239597/222384366-53f106d9-4763-4374-b1a7-5279f3d07e72.png)


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
