### PR TITLE
Tidy up copy on external stakeholder kick-off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Involuntary/Sponsored > External Stakeholder Kickoff guidance iteration and
+  fix incorrect guidance
 - Involuntary/Sponsored > External Stakeholder Kickoff > Send introductory
   emails copy changes to improve words and handle faith schools/diocese
 - the conversion date can now only be set once on involuntary conversion

--- a/app/views/conversions/involuntary/task_lists/tasks/stakeholder_kick_off.html.erb
+++ b/app/views/conversions/involuntary/task_lists/tasks/stakeholder_kick_off.html.erb
@@ -17,6 +17,9 @@
         <%= hidden_field_tag("conversion_involuntary_tasks_stakeholder_kick_off[check_provisional_conversion_date]", "0", {id: nil}) %>
         <%= check_box_tag("conversion_involuntary_tasks_stakeholder_kick_off[check_provisional_conversion_date]", 1, @task.check_provisional_conversion_date, {class: "govuk-checkboxes__input"}) %>
         <%= label_tag("conversion_involuntary_tasks_stakeholder_kick_off[check_provisional_conversion_date]", t("conversion.involuntary.tasks.stakeholder_kick_off.check_provisional_conversion_date.title", date: @project.provisional_conversion_date.to_formatted_s(:govuk)), {class: "govuk-label govuk-checkboxes__label"}) %>
+        <div class="hint">
+            <%= t("conversion.voluntary.tasks.stakeholder_kick_off.check_provisional_conversion_date.hint.html") %>
+          </div>
         <div class="guidance">
           <%= govuk_details(summary_text: t("conversion.involuntary.tasks.stakeholder_kick_off.check_provisional_conversion_date.guidance_link")) do %>
             <%= t("conversion.involuntary.tasks.stakeholder_kick_off.check_provisional_conversion_date.guidance.html") %>

--- a/app/views/conversions/voluntary/task_lists/tasks/stakeholder_kick_off.html.erb
+++ b/app/views/conversions/voluntary/task_lists/tasks/stakeholder_kick_off.html.erb
@@ -36,10 +36,6 @@
                 legend: {text: t("conversion.voluntary.tasks.stakeholder_kick_off.confirmed_conversion_date.title"), size: "s"} do %>
             <div class="govuk-hint"><%= t("conversion.voluntary.tasks.stakeholder_kick_off.confirmed_conversion_date.hint.html") %></div>
 
-          <%= govuk_details(
-                summary_text: t("conversion.voluntary.tasks.stakeholder_kick_off.confirmed_conversion_date.guidance_link"),
-                text: t("conversion.voluntary.tasks.stakeholder_kick_off.confirmed_conversion_date.guidance.html")
-              ) %>
           <% end %>
         <% end %>
       </div>

--- a/config/locales/task_lists/conversion/involuntary/stakeholder_kick_off.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/stakeholder_kick_off.en.yml
@@ -11,7 +11,7 @@ en:
           introductory_emails:
             title: Send introductory emails
             hint:
-              html: <p>Email the trust and solicitors. Also email the diocese if this is a faith school. You should email the local authority separately.</p>
+              html: <p>Email the trust and solicitors. Also email the diocese if this is a faith school.</p>
             guidance_link: What to include in introductory emails
             guidance:
               html:
@@ -40,6 +40,7 @@ en:
                 <p>However, some local authorities will not share the proforma until after the directive academy order has been issued.</p>
                 <p>If it is not in SharePoint, check if the person who prepared the project has asked for it.</p>
                 <p>If they have not, ask the local authority to send the proforma to you and save it in SharePoint.</p>
+                <p>You can <a href="https://educationgovuk.sharepoint.com/sites/ServiceDeliveryDirectorate/Shared%20Documents/Forms/AllItems.aspx?FolderCTID=0x012000265B42F1C27524438F6B1CC14FCF9E05&id=%2Fsites%2FServiceDeliveryDirectorate%2FShared%20Documents%2FOperational%20Delivery%2FGuidance%2C%20Training%20and%20Resources%2F%281%29%20CONVERSIONS%20%2D%20Guidance%20and%20Templates%2FCONVERSIONS%20%2D%20Template%20Emails%20%26%20Documents&viewid=84d1a8e7%2D052b%2D4a94%2D8d1b%2D850c4e6f284f" target="blank">use a local authority email template (opens in new tab)</a> to help you write this email.</p>
           confirm_target_conversion_date:
             title: Confirm the provisional conversion date with the local authority
             hint:
@@ -50,7 +51,6 @@ en:
                 <p>The trust will have given a provisional date they want to convert on.</p>
                 <p>Tell them if the local authority cannot complete the conversion by the provisional date.</p>
                 <p>If the local authority cannot complete the conversion by the provisional date, you'll need to work with the trust and local authority to agree a new date.</p>
-
           setup_meeting:
             title: Send invites to the kick-off meeting or call
             hint:
@@ -70,7 +70,6 @@ en:
               html:
                 <p>You should discuss and record issues that might complicate or delay the project.</p>
                 <p>You can <a href="https://educationgovuk.sharepoint.com/:w:/s/ServiceDeliveryDirectorate/EZx-RuHD_JxEuaCF68ZXpe8BvSQ3ITlysjfNJ28t0_xzfQ?e=hxRZxt" target="_blank">use the conversion checklist (opens in new tab)</a> to guide the conversation and make sure you talk about everything you need to.</p>
-
           confirmed_conversion_date:
             title: Enter the confirmed conversion date
             hint:
@@ -79,6 +78,8 @@ en:
                 <p>You only need to enter a month and year. All schools convert on the first day of the month.</p>
           check_provisional_conversion_date:
             title: "Check the local authority is able to convert the school by the provisional conversion date: %{date}"
+            hint:
+              html: <p>The school or trust may have provided a provisional conversion date. Email the local authority to make sure they are able to do what they need to do by this date.</p>
             guidance_link: What to do if the local authority is not able meet the provisional conversion date
             guidance:
               html:

--- a/config/locales/task_lists/conversion/voluntary/stakeholder_kick_off.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/stakeholder_kick_off.en.yml
@@ -11,7 +11,7 @@ en:
           introductory_emails:
             title: Send introductory emails
             hint:
-              html: <p>Email the school, trust and solicitors. Also email the diocese if this is a faith school. You should email the local authority separately.</p>
+              html: <p>Email the school, trust and solicitors. Also email the diocese if this is a faith school.</p>
             guidance_link: What to include in introductory emails
             guidance:
               html:
@@ -29,7 +29,8 @@ en:
 
           local_authority_proforma:
             title: Check the local authority proforma
-            hint: Check the information is correct and there is no missing information.
+            hint:
+              html: <p>Check the information is correct and there is no missing information.</p>
             guidance_link: What to do if you don't have the local authority proforma
             guidance:
               html:
@@ -37,20 +38,15 @@ en:
                 <p>However, some local authorities will not share the proforma until after the academy order has been issued.<p>
                 <p>If it is not in SharePoint, check if the person who prepared the project has asked for it.</p>
                 <p>If they have not, ask the local authority to send the proforma to you and save it in SharePoint.</p>
-
+                <p>You can <a href="https://educationgovuk.sharepoint.com/sites/ServiceDeliveryDirectorate/Shared%20Documents/Forms/AllItems.aspx?FolderCTID=0x012000265B42F1C27524438F6B1CC14FCF9E05&id=%2Fsites%2FServiceDeliveryDirectorate%2FShared%20Documents%2FOperational%20Delivery%2FGuidance%2C%20Training%20and%20Resources%2F%281%29%20CONVERSIONS%20%2D%20Guidance%20and%20Templates%2FCONVERSIONS%20%2D%20Template%20Emails%20%26%20Documents&viewid=84d1a8e7%2D052b%2D4a94%2D8d1b%2D850c4e6f284f" target="blank">use a local authority email template (opens in new tab)</a> to help you write this email.</p>
           confirmed_conversion_date:
             title: Enter the confirmed conversion date
             hint:
-              html: <p>Check the local authority have capacity to convert the school by this date before you enter it. You only need to enter a month and year. All schools convert on the first day of the month.</p>
-            guidance_link: What to do if the local authority does not have capacity
-            guidance:
               html:
-                <p>The school and trust will have given a provisional date they want to convert on.</p>
-                <p>Tell them if the local authority cannot complete the conversion by the provisional date.</p>
-                <p>If the local authority cannot complete the conversion by the provisional date, you'll need to work with the school, trust and local authority to agree a new date.</p>
+                <p>Everyone should have agreed to and know the confirmed conversion date.</p>
+                <p>You only need to enter a month and year. All schools convert on the first day of the month.</p>
             errors:
               format: Enter a valid confirmed conversion date
-
           setup_meeting:
             title: Send invites to the kick-off meeting or call
             hint:
@@ -61,7 +57,6 @@ en:
                 <p>You should have included possible dates for the kick-off meeting in your introductory email.</p>
                 <p>Once the school have got back to you with a suitable date and list of attendees, send out invites to arrange the time, date and location of the meeting. It's likely to be a video call over Microsoft Teams.</p>
                 <p>Some schools and trusts may prefer to have a one-to-one call with you, rather than a meeting involving all stakeholders.</p>
-
           meeting:
             title: Host the kick-off meeting or call
             hint:
@@ -76,7 +71,7 @@ en:
             title: "Check the local authority is able to convert the school by the provisional conversion date: %{date}"
             hint:
               html:
-                <p>The school or trust should have provided a provisional conversion date.</p>
+                <p>The school or trust may have provided a provisional conversion date. Email the local authority to make sure they are able to do what they need to do by this date.</p>
             guidance_link: What to do if the local authority is not able meet the provisional conversion date
             guidance:
               html:


### PR DESCRIPTION
### Voluntary changes
- Check the LA proforma should have hint text saying `Check the information is correct and there is no missing information.`
- Send introductory emails hint text says `Email the school, trust and solicitors. Also email the diocese if this is a faith school.`
- Check LA proforma - details component append `You can use a local authority email template (opens in new tab) to help you write this email.` uses same link send introductory emails guidance link
- check LA can convert by conversion date: add hint text `The school or trust may have provided a provisional conversion date. Email the local authority to make sure they are able to do what they need to do by this date.`
- Enter the confirmed conversion date hint should be `Everyone should have agreed to and know the confirmed conversion date. You only need to enter a month and year. All schools convert on the first day of the month.`
- Enter the confirmed conversion date remove details component.
![localhost_3000_conversions_voluntary_projects_15F66B10-3274-4ACD-A249-80C5E0978FAC_task-list_stakeholder_kick_off](https://user-images.githubusercontent.com/13239597/223096815-2e55b884-dc8d-44bb-9d75-35a94c919ae7.png)



### Involuntary changes
- Check the LA proforma should have hint text saying `Check the information is correct and there is no missing information.`
- Send introductory emails hint text says `Email the trust and solicitors. Also email the diocese if this is a faith school.`
- Check LA proforma - details component append `You can use a local authority email template (opens in new tab) to help you write this email.` uses same link send introductory emails guidance link
- check LA can convert by conversion date: add hint text `The school or trust may have provided a provisional conversion date. Email the local authority to make sure they are able to do what they need to do by this date.`
- Enter the confirmed conversion date hint should be `Everyone should have agreed to and know the confirmed conversion date. You only need to enter a month and year. All schools convert on the first day of the month.`
- Enter the confirmed conversion date remove details component.
![localhost_3000_conversions_involuntary_projects_D218C74D-D3F3-4184-B01B-E8157287D236_task-list_stakeholder_kick_off](https://user-images.githubusercontent.com/13239597/223096896-89cbb5e9-172e-46c9-9b61-3bf6135fccfe.png)


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
