### PR TITLE
Users can change the conversion date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- users can now change the conversion date beyond the initial confirmed date
+
 ### Changed
 
 - Involuntary/Sponsored > External Stakeholder Kickoff guidance iteration and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - users can now change the conversion date beyond the initial confirmed date
+- the conversion date cannot be changed unless it has been confirmed in the
+  External stakeholder kick off task
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - users can now change the conversion date beyond the initial confirmed date
 - the conversion date cannot be changed unless it has been confirmed in the
   External stakeholder kick off task
+- when changing the conversion date, users now see a confirmation page when the
+  change was successful
 
 ### Changed
 

--- a/app/controllers/conversions/date_histories_controller.rb
+++ b/app/controllers/conversions/date_histories_controller.rb
@@ -1,0 +1,21 @@
+class Conversions::DateHistoriesController < ApplicationController
+  def new
+    @project = Project.find(params[:project_id])
+    @form = Conversion::NewDateHistoryForm.new
+  end
+
+  def create
+    @project = Project.find(params[:project_id])
+    @form = Conversion::NewDateHistoryForm.new(**conversion_date_history_params, project_id: @project.id, user_id: current_user.id)
+
+    if @form.save
+      redirect_to helpers.path_to_project(@project), notice: t("conversion_new_date_history_form.success")
+    else
+      render :new
+    end
+  end
+
+  private def conversion_date_history_params
+    params.require(:conversion_new_date_history_form).permit(:revised_date, :note_body)
+  end
+end

--- a/app/controllers/conversions/date_histories_controller.rb
+++ b/app/controllers/conversions/date_histories_controller.rb
@@ -11,7 +11,7 @@ class Conversions::DateHistoriesController < ApplicationController
     @form = Conversion::NewDateHistoryForm.new(**conversion_date_history_params, project_id: @project.id, user_id: current_user.id)
 
     if @form.save
-      redirect_to helpers.path_to_project(@project), notice: t("conversion_new_date_history_form.success")
+      render "confirm_new"
     else
       render :new
     end

--- a/app/controllers/conversions/date_histories_controller.rb
+++ b/app/controllers/conversions/date_histories_controller.rb
@@ -1,11 +1,13 @@
 class Conversions::DateHistoriesController < ApplicationController
   def new
     @project = Project.find(params[:project_id])
+    authorize(@project, :change_conversion_date?)
     @form = Conversion::NewDateHistoryForm.new
   end
 
   def create
     @project = Project.find(params[:project_id])
+    authorize(@project, :change_conversion_date?)
     @form = Conversion::NewDateHistoryForm.new(**conversion_date_history_params, project_id: @project.id, user_id: current_user.id)
 
     if @form.save

--- a/app/forms/conversion/new_date_history_form.rb
+++ b/app/forms/conversion/new_date_history_form.rb
@@ -1,0 +1,61 @@
+class Conversion::NewDateHistoryForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  CONVERSION_DATE_DAY = 1
+
+  attribute :project_id
+  attribute :user_id
+  attribute :note_body
+  attribute :revised_date
+  attribute "revised_date(3i)"
+  attribute "revised_date(2i)"
+  attribute "revised_date(1i)"
+
+  validates :project_id, :user_id, :note_body, presence: true
+
+  validate :revised_date_format
+
+  def save
+    return false unless valid?
+
+    project = Project.find(project_id)
+    previous_date = project.conversion_date
+    revised_date = date_from_attributes
+
+    ActiveRecord::Base.transaction do
+      conversion_date_history_note = Note.create!(project_id: project_id, user_id: user_id, body: note_body)
+      date_history = Conversion::DateHistory.create!(project_id: project_id, previous_date: previous_date, revised_date: revised_date, note: conversion_date_history_note)
+      project.update!(conversion_date: revised_date)
+
+      raise ActiveRecord::RecordInvalid unless conversion_date_history_note.persisted? && project.persisted? && date_history.persisted?
+    rescue ActiveRecord::RecordInvalid
+      errors.add(:revised_date, :transaction)
+      return false
+    end
+
+    true
+  end
+
+  private def revised_date_format
+    errors.add(:revised_date, :format) if month.blank? || year.blank?
+    errors.add(:revised_date, :format) unless (1..12).cover?(month.to_i)
+    errors.add(:revised_date, :format) unless (2000..2500).cover?(year.to_i)
+  end
+
+  private def day
+    CONVERSION_DATE_DAY.to_i
+  end
+
+  private def month
+    attributes["revised_date(2i)"].to_i
+  end
+
+  private def year
+    attributes["revised_date(1i)"].to_i
+  end
+
+  private def date_from_attributes
+    Date.new(year, month, day)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,56 +26,6 @@ module ApplicationHelper
     end
   end
 
-  def path_to_project(project)
-    return conversions_voluntary_project_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
-    return conversions_involuntary_project_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
-  end
-
-  def path_to_project_task_list(project)
-    return conversions_voluntary_project_task_list_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
-    return conversions_involuntary_project_task_list_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
-  end
-
-  def path_to_project_notes(project)
-    return conversions_voluntary_project_notes_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
-    return conversions_involuntary_project_notes_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
-  end
-
-  def path_to_project_information(project)
-    return conversions_voluntary_project_information_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
-    return conversions_involuntary_project_information_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
-  end
-
-  def path_to_project_contacts(project)
-    return conversions_voluntary_project_contacts_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
-    return conversions_involuntary_project_contacts_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
-  end
-
-  def path_to_project_internal_contacts(project)
-    return conversions_voluntary_project_internal_contacts_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
-    return conversions_involuntary_project_internal_contacts_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
-  end
-
-  def path_to_team_lead_project_assignment(project)
-    return conversions_voluntary_project_assign_team_lead_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
-    return conversions_involuntary_project_assign_team_lead_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
-  end
-
-  def path_to_regional_delivery_officer_project_assignment(project)
-    return conversions_voluntary_project_assign_regional_delivery_officer_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
-    return conversions_involuntary_project_assign_regional_delivery_officer_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
-  end
-
-  def path_to_caseworker_project_assignment(project)
-    return conversions_voluntary_project_assign_caseworker_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
-    return conversions_involuntary_project_assign_caseworker_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
-  end
-
-  def path_to_assigned_to_project_assignment(project)
-    return conversions_voluntary_project_assign_assigned_to_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
-    return conversions_involuntary_project_assign_assigned_to_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
-  end
-
   def optional_cookies_set?
     cookies[:ACCEPT_OPTIONAL_COOKIES].present?
   end

--- a/app/helpers/project_path_helper.rb
+++ b/app/helpers/project_path_helper.rb
@@ -1,0 +1,56 @@
+module ProjectPathHelper
+  def path_to_project(project)
+    return conversions_voluntary_project_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
+  def path_to_project_task_list(project)
+    return conversions_voluntary_project_task_list_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_task_list_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
+  def path_to_project_notes(project)
+    return conversions_voluntary_project_notes_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_notes_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
+  def path_to_project_information(project)
+    return conversions_voluntary_project_information_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_information_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
+  def path_to_project_contacts(project)
+    return conversions_voluntary_project_contacts_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_contacts_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
+  def path_to_project_internal_contacts(project)
+    return conversions_voluntary_project_internal_contacts_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_internal_contacts_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
+  def path_to_team_lead_project_assignment(project)
+    return conversions_voluntary_project_assign_team_lead_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_assign_team_lead_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
+  def path_to_regional_delivery_officer_project_assignment(project)
+    return conversions_voluntary_project_assign_regional_delivery_officer_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_assign_regional_delivery_officer_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
+  def path_to_caseworker_project_assignment(project)
+    return conversions_voluntary_project_assign_caseworker_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_assign_caseworker_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
+  def path_to_assigned_to_project_assignment(project)
+    return conversions_voluntary_project_assign_assigned_to_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_assign_assigned_to_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+
+  def path_to_new_conversion_date(project)
+    return conversions_voluntary_project_conversion_date_path(project) if project.task_list_type == "Conversion::Voluntary::TaskList"
+    return conversions_involuntary_project_conversion_date_path(project) if project.task_list_type == "Conversion::Involuntary::TaskList"
+  end
+end

--- a/app/models/conversion/date_history.rb
+++ b/app/models/conversion/date_history.rb
@@ -1,0 +1,8 @@
+class Conversion::DateHistory < ApplicationRecord
+  self.table_name = "conversion_date_histories"
+
+  belongs_to :project, class_name: "Conversion::Project"
+  has_one :note, dependent: :destroy, foreign_key: :conversion_date_history_id
+
+  validates :previous_date, :revised_date, presence: true
+end

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -3,6 +3,8 @@ class Conversion::Project < Project
     ProjectPolicy
   end
 
+  has_many :conversion_dates, dependent: :destroy, class_name: "Conversion::DateHistory"
+
   def route
     return :voluntary if task_list_type == "Conversion::Voluntary::TaskList"
     return :involuntary if task_list_type == "Conversion::Involuntary::TaskList"

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,6 +1,7 @@
 class Note < ApplicationRecord
   belongs_to :project
   belongs_to :user
+  belongs_to :conversion_date_history, class_name: "Conversion::DateHistory", optional: true
 
   validates :body, presence: true, allow_blank: false
 

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -34,6 +34,10 @@ class ProjectPolicy
     true
   end
 
+  def change_conversion_date?
+    @record.conversion_date.present?
+  end
+
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -4,6 +4,8 @@
 
 <%= render partial: "projects/shared/project_summary" %>
 
+<%= render partial: "projects/shared/project_actions" %>
+
 <%= render partial: "projects/shared/project_sub_navigation" %>
 
 <div class="govuk-grid-row govuk-body">

--- a/app/views/conversions/date_histories/confirm_new.html.erb
+++ b/app/views/conversions/date_histories/confirm_new.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_panel(title_text: t("conversion_new_date_history_form.success.panel.title")) %>
+    <%= t(
+          "conversion_new_date_history_form.success.body_html",
+          school_name: @project.establishment.name,
+          urn: @project.urn,
+          conversion_date: @project.conversion_date.to_formatted_s(:govuk),
+          project_path: path_to_project(@project),
+          projects_path: projects_path
+        ) %>
+  </div>
+</div>

--- a/app/views/conversions/date_histories/new.html.erb
+++ b/app/views/conversions/date_histories/new.html.erb
@@ -1,0 +1,29 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: path_to_new_conversion_date(@project) do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <h1 class="govuk-fieldset__heading">
+            <%= t(
+                  "conversion_new_date_history_form.title",
+                  school_name: @project.establishment.name,
+                  urn: @project.urn, conversion_date:
+              @project.conversion_date.to_formatted_s(:govuk)
+                ) %>
+          </h1>
+        </legend>
+
+        <%= form.govuk_date_field :revised_date, omit_day: true %>
+
+        <%= form.govuk_text_area :note_body, label: {size: "m"} %>
+
+        <div class="govuk-button-group">
+          <%= form.govuk_submit(t("conversion_new_date_history_form.submit")) %>
+          <%= govuk_link_to(t("conversion_new_date_history_form.cancel"), path_to_project(@project)) %>
+        </div>
+      </fieldset>
+    <% end %>
+  </div>
+</div>

--- a/app/views/conversions/voluntary/task_lists/index.html.erb
+++ b/app/views/conversions/voluntary/task_lists/index.html.erb
@@ -3,6 +3,7 @@
 <% end %>
 
 <%= render partial: "projects/shared/project_summary" %>
+<%= render partial: "projects/shared/project_actions" %>
 <%= render partial: "projects/shared/project_sub_navigation" %>
 
 <h2 class="govuk-heading-l"><%= t("project.show.title") %></h2>

--- a/app/views/internal_contacts/show.html.erb
+++ b/app/views/internal_contacts/show.html.erb
@@ -4,6 +4,8 @@
 
 <%= render partial: "projects/shared/project_summary" %>
 
+<%= render partial: "projects/shared/project_actions" %>
+
 <%= render partial: "projects/shared/project_sub_navigation" %>
 
 <div id="projectInternalContacts">

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -4,6 +4,8 @@
 
 <%= render partial: "projects/shared/project_summary" %>
 
+<%= render partial: "projects/shared/project_actions" %>
+
 <%= render partial: "projects/shared/project_sub_navigation" %>
 
 <div class="govuk-grid-row govuk-body">

--- a/app/views/project_information/show.html.erb
+++ b/app/views/project_information/show.html.erb
@@ -4,6 +4,8 @@
 
 <%= render partial: "projects/shared/project_summary" %>
 
+<%= render partial: "projects/shared/project_actions" %>
+
 <%= render partial: "projects/shared/project_sub_navigation" %>
 
 <div class="govuk-grid-row govuk-body">

--- a/app/views/projects/shared/_project_actions.html.erb
+++ b/app/views/projects/shared/_project_actions.html.erb
@@ -1,0 +1,1 @@
+<%= govuk_button_link_to t("conversion_new_date_history_form.new"), path_to_new_conversion_date(@project), secondary: true %>

--- a/app/views/projects/shared/_project_actions.html.erb
+++ b/app/views/projects/shared/_project_actions.html.erb
@@ -1,1 +1,1 @@
-<%= govuk_button_link_to t("conversion_new_date_history_form.new"), path_to_new_conversion_date(@project), secondary: true %>
+<%= govuk_button_link_to t("conversion_new_date_history_form.new"), path_to_new_conversion_date(@project), secondary: true if policy(@project).change_conversion_date? %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -4,6 +4,8 @@
 
 <%= render partial: "projects/shared/project_summary" %>
 
+<%= render partial: "projects/shared/project_actions" %>
+
 <%= render partial: "projects/shared/project_sub_navigation" %>
 
 <%= render "projects/show/complete" unless @project.completed? %>

--- a/config/locales/conversion_history.en.yml
+++ b/config/locales/conversion_history.en.yml
@@ -1,0 +1,8 @@
+en:
+  errors:
+    attributes:
+      revised_date:
+        format: Enter a valid month and year
+        transaction: Conversion date could not be saved
+      note_body:
+        blank: Enter a reason

--- a/config/locales/conversion_history.en.yml
+++ b/config/locales/conversion_history.en.yml
@@ -4,7 +4,19 @@ en:
     new: Change conversion date
     cancel: Cancel
     submit: Confirm new conversion date
-    success: Conversion date has been updated
+    success:
+      panel:
+        title: Conversion date changed
+      body_html:
+        <p>You have changed the conversion date for %{school_name} %{urn}.</p>
+        <h2 class="govuk-heading-m">New conversion date</h2>
+        <p>The new conversion date is %{conversion_date}.</p>
+        <h2 class="govuk-heading-m">What happens next</h2>
+        <p>The conversion has moved to the new month in your project list.</p>
+        <p>You can <a href="%{project_path}">continue working on this conversion</a>, or <a href="%{projects_path}">choose another project to work on</a> from your list.</p>
+        <h2 class="govuk-heading-m">Need to change the conversion date?</h2>
+        <p>You can change the conversion date as many times as you need.</p>
+        <p>If you made a mistake, go back and enter the correct date.</p>
   errors:
     attributes:
       revised_date:

--- a/config/locales/conversion_history.en.yml
+++ b/config/locales/conversion_history.en.yml
@@ -1,4 +1,10 @@
 en:
+  conversion_new_date_history_form:
+    title: Change conversion date for %{school_name}, URN%{urn}, from %{conversion_date}
+    new: Change conversion date
+    cancel: Cancel
+    submit: Confirm new conversion date
+    success: Conversion date has been updated
   errors:
     attributes:
       revised_date:
@@ -6,3 +12,13 @@ en:
         transaction: Conversion date could not be saved
       note_body:
         blank: Enter a reason
+  helpers:
+    label:
+      conversion_new_date_history_form:
+        note_body: Why is a new conversion date needed?
+    legend:
+      conversion_new_date_history_form:
+        revised_date: Enter new conversion date
+    hint:
+      conversion_new_date_history_form:
+        revised_date: You should agree the new conversion date with relevant parties. You only need to enter a month and year as all schools convert on the first day of the month.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,11 @@ Rails.application.routes.draw do
     get "internal_contacts", to: "/internal_contacts#show"
   end
 
+  concern :conversion_date_historyable do
+    get "conversion-date", to: "/conversions/date_histories#new"
+    post "conversion-date", to: "/conversions/date_histories#create"
+  end
+
   namespace :conversions do
     get "/", to: "/conversions/projects#index"
     namespace :voluntary do
@@ -73,7 +78,7 @@ Rails.application.routes.draw do
 
       resources :projects,
         only: %i[new create],
-        concerns: %i[task_listable contactable notable assignable informationable completable internal_contactable]
+        concerns: %i[task_listable contactable notable assignable informationable completable internal_contactable conversion_date_historyable]
     end
     namespace :involuntary do
       get "/", to: "/conversions/involuntary/projects#index"
@@ -81,7 +86,7 @@ Rails.application.routes.draw do
 
       resources :projects,
         only: %i[new create],
-        concerns: %i[task_listable contactable notable assignable informationable completable internal_contactable]
+        concerns: %i[task_listable contactable notable assignable informationable completable internal_contactable conversion_date_historyable]
     end
   end
 

--- a/db/migrate/20230301171454_create_conversion_date_histories.rb
+++ b/db/migrate/20230301171454_create_conversion_date_histories.rb
@@ -1,0 +1,12 @@
+class CreateConversionDateHistories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :conversion_date_histories, id: :uuid do |t|
+      t.date :revised_date
+      t.date :previous_date
+      t.uuid :project_id
+      t.timestamps
+    end
+
+    add_column :notes, :conversion_date_history_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,6 +25,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_02_151008) do
     t.index ["project_id"], name: "index_contacts_on_project_id"
   end
 
+  create_table "conversion_date_histories", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+    t.date "revised_date"
+    t.date "previous_date"
+    t.uuid "project_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "conversion_involuntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.boolean "handover_review"
     t.datetime "created_at", null: false
@@ -242,6 +250,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_02_151008) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "task_identifier"
+    t.uuid "conversion_date_history_id"
     t.index ["project_id"], name: "index_notes_on_project_id"
     t.index ["user_id"], name: "index_notes_on_user_id"
   end

--- a/spec/features/conversions/users_can_change_the_conversion_date_spec.rb
+++ b/spec/features/conversions/users_can_change_the_conversion_date_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.feature "Users can change the conversion date" do
+  let(:user) { create(:user, :caseworker) }
+
+  before do
+    mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    sign_in_with_user(user)
+  end
+
+  scenario "they can change the date on a conversion project" do
+    revised_conversion_date = (Date.today + 6.months).at_beginning_of_month
+    project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+
+    visit conversions_voluntary_project_path(project)
+
+    click_on(I18n.t("conversion_new_date_history_form.new"))
+
+    expect(page).to have_content(I18n.t("helpers.legend.conversion_new_date_history_form.revised_date"))
+    expect(page).to have_content(I18n.t("helpers.label.conversion_new_date_history_form.note_body"))
+
+    fill_in("Month", with: revised_conversion_date.month)
+    fill_in("Year", with: revised_conversion_date.year)
+    fill_in(I18n.t("helpers.label.conversion_new_date_history_form.note_body"), with: "This is a test note being added.")
+
+    click_button(I18n.t("conversion_new_date_history_form.submit"))
+
+    expect(page).to have_content("Success")
+    expect(page).to have_content(revised_conversion_date.to_formatted_s(:govuk))
+  end
+
+  scenario "they can cancel the change if needed" do
+    project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+
+    visit conversions_voluntary_project_path(project)
+
+    click_on(I18n.t("conversion_new_date_history_form.new"))
+
+    expect(page).to have_content(I18n.t("helpers.legend.conversion_new_date_history_form.revised_date"))
+    expect(page).to have_content(I18n.t("helpers.label.conversion_new_date_history_form.note_body"))
+
+    click_on(I18n.t("conversion_new_date_history_form.cancel"))
+
+    expect(page).to have_content(project.conversion_date.to_formatted_s(:govuk))
+  end
+
+  scenario "they can view the conversion date change note on the projects notes view" do
+    project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+    revised_conversion_date = (Date.today + 6.months).at_beginning_of_month
+    note = "This is a test note."
+
+    visit conversions_voluntary_project_path(project)
+
+    click_on(I18n.t("conversion_new_date_history_form.new"))
+
+    fill_in("Month", with: revised_conversion_date.month)
+    fill_in("Year", with: revised_conversion_date.year)
+    fill_in(I18n.t("helpers.label.conversion_new_date_history_form.note_body"), with: note)
+    click_button(I18n.t("conversion_new_date_history_form.submit"))
+
+    click_on("Notes")
+
+    expect(page).to have_content(note)
+  end
+end

--- a/spec/features/conversions/users_can_change_the_conversion_date_spec.rb
+++ b/spec/features/conversions/users_can_change_the_conversion_date_spec.rb
@@ -62,4 +62,14 @@ RSpec.feature "Users can change the conversion date" do
 
     expect(page).to have_content(note)
   end
+
+  context "when the project conversion date is provisional" do
+    scenario "they cannot change the conversion date" do
+      project = create(:conversion_project)
+
+      visit conversions_voluntary_project_path(project)
+
+      expect(page).not_to have_link(I18n.t("conversion_new_date_history_form.new"))
+    end
+  end
 end

--- a/spec/features/conversions/users_can_change_the_conversion_date_spec.rb
+++ b/spec/features/conversions/users_can_change_the_conversion_date_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Users can change the conversion date" do
     sign_in_with_user(user)
   end
 
-  scenario "they can change the date on a conversion project" do
+  scenario "they can change the date on a conversion project and see a confirmation view" do
     revised_conversion_date = (Date.today + 6.months).at_beginning_of_month
     project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
 
@@ -25,8 +25,7 @@ RSpec.feature "Users can change the conversion date" do
 
     click_button(I18n.t("conversion_new_date_history_form.submit"))
 
-    expect(page).to have_content("Success")
-    expect(page).to have_content(revised_conversion_date.to_formatted_s(:govuk))
+    expect(page).to have_content(I18n.t("conversion_new_date_history_form.success.panel.title"))
   end
 
   scenario "they can cancel the change if needed" do
@@ -58,6 +57,7 @@ RSpec.feature "Users can change the conversion date" do
     fill_in(I18n.t("helpers.label.conversion_new_date_history_form.note_body"), with: note)
     click_button(I18n.t("conversion_new_date_history_form.submit"))
 
+    click_on("continue working on this conversion")
     click_on("Notes")
 
     expect(page).to have_content(note)

--- a/spec/forms/conversion/new_date_form_spec.rb
+++ b/spec/forms/conversion/new_date_form_spec.rb
@@ -1,0 +1,122 @@
+require "rails_helper"
+
+RSpec.describe Conversion::NewDateHistoryForm, type: :model do
+  describe "validations" do
+    it "requires a valid year" do
+      form = create_valid_form_object
+
+      form.send(:"revised_date(1i)=", "")
+      expect(form).to be_invalid
+
+      form.send(:"revised_date(1i)=", "not a string")
+      expect(form).to be_invalid
+
+      form.send(:"revised_date(1i)=", "1901")
+      expect(form).to be_invalid
+
+      form.send(:"revised_date(1i)=", "3023")
+      expect(form).to be_invalid
+
+      form.send(:"revised_date(1i)=", "23")
+      expect(form).to be_invalid
+    end
+
+    it "requires a valid month" do
+      form = create_valid_form_object
+
+      form.send(:"revised_date(2i)=", "")
+      expect(form).to be_invalid
+
+      form.send(:"revised_date(2i)=", "not a string")
+      expect(form).to be_invalid
+
+      form.send(:"revised_date(2i)=", "0")
+      expect(form).to be_invalid
+
+      form.send(:"revised_date(2i)=", "24")
+      expect(form).to be_invalid
+    end
+
+    it "requires the note body" do
+      form = create_valid_form_object
+
+      form.note_body = ""
+      expect(form).to be_invalid
+    end
+
+    it "requires the project_id" do
+      form = create_valid_form_object
+      form.project_id = nil
+
+      expect(form).to be_invalid
+    end
+
+    it "requires the user_id" do
+      form = create_valid_form_object
+      form.user_id = nil
+
+      expect(form).to be_invalid
+    end
+  end
+
+  describe "#save" do
+    it "creates the conversion date history and note" do
+      mock_successful_api_calls(establishment: 123456, trust: 12345678)
+      project = create(:conversion_project, conversion_date: Date.today)
+      user = create(:user, :caseworker)
+      form = create_valid_form_object
+      form.project_id = project.id
+      form.user_id = user.id
+      form.note_body = "This is my note body."
+
+      expect(form.save).to be true
+      expect(project.conversion_dates.count).to eq 1
+      expect(Note.count).to eq 1
+
+      conversion_date_history = project.conversion_dates.first
+      expect(conversion_date_history.revised_date).to eql Date.new(2023, 1, 1)
+
+      note = conversion_date_history.note
+      expect(note.user).to eql user
+      expect(note.project).to eql project
+      expect(note.body).to eql "This is my note body."
+    end
+
+    it "updates the project conversion date with the revised date" do
+      mock_successful_api_calls(establishment: 123456, trust: 12345678)
+      project = create(:conversion_project, conversion_date: Date.today)
+      user = create(:user, :caseworker)
+      form = create_valid_form_object
+      form.project_id = project.id
+      form.user_id = user.id
+
+      expect(form.save).to be true
+
+      expect(project.reload.conversion_date).to eq Date.new(2023, 1, 1)
+    end
+
+    it "is transactional, it does nothing if any operation fails and returns an error" do
+      mock_successful_api_calls(establishment: 123456, trust: 12345678)
+      project = create(:conversion_project, conversion_date: Date.today)
+      form = create_valid_form_object
+      form.project_id = project.id
+
+      expect(form.save).to eq false
+      expect(project.reload.conversion_date).not_to eq Date.new(2023, 1, 1)
+      expect(Note.count).to be_zero
+      expect(project.conversion_dates.count).to be_zero
+      expect(form.errors.messages[:revised_date]).to include(I18n.t("errors.attributes.revised_date.transaction"))
+    end
+  end
+
+  def create_valid_form_object
+    described_class.new(
+      project_id: "PROJECT_ID",
+      user_id: "USER_ID",
+      note_body: "Note body",
+      "revised_date(3i)": "1",
+      "revised_date(2i)": "1",
+      "revised_date(1i)": "2023"
+    )
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -92,44 +92,6 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe "project paths" do
-    before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
-
-    context "when the project is a voluntary conversion" do
-      it "returns the correct paths" do
-        project = create(:voluntary_conversion_project)
-
-        expect(helper.path_to_project(project)).to eq conversions_voluntary_project_path(project)
-        expect(helper.path_to_project_task_list(project)).to eq conversions_voluntary_project_task_list_path(project)
-        expect(helper.path_to_project_information(project)).to eq conversions_voluntary_project_information_path(project)
-        expect(helper.path_to_project_notes(project)).to eq conversions_voluntary_project_notes_path(project)
-        expect(helper.path_to_project_contacts(project)).to eq conversions_voluntary_project_contacts_path(project)
-
-        expect(helper.path_to_team_lead_project_assignment(project)).to eq conversions_voluntary_project_assign_team_lead_path(project)
-        expect(helper.path_to_regional_delivery_officer_project_assignment(project)).to eq conversions_voluntary_project_assign_regional_delivery_officer_path(project)
-        expect(helper.path_to_caseworker_project_assignment(project)).to eq conversions_voluntary_project_assign_caseworker_path(project)
-        expect(helper.path_to_assigned_to_project_assignment(project)).to eq conversions_voluntary_project_assign_assigned_to_path(project)
-      end
-    end
-
-    context "when the project is a involuntary conversion" do
-      it "returns the correct path" do
-        project = create(:involuntary_conversion_project)
-
-        expect(helper.path_to_project(project)).to eq conversions_involuntary_project_path(project)
-        expect(helper.path_to_project_task_list(project)).to eq conversions_involuntary_project_task_list_path(project)
-        expect(helper.path_to_project_information(project)).to eq conversions_involuntary_project_information_path(project)
-        expect(helper.path_to_project_notes(project)).to eq conversions_involuntary_project_notes_path(project)
-        expect(helper.path_to_project_contacts(project)).to eq conversions_involuntary_project_contacts_path(project)
-
-        expect(helper.path_to_team_lead_project_assignment(project)).to eq conversions_involuntary_project_assign_team_lead_path(project)
-        expect(helper.path_to_regional_delivery_officer_project_assignment(project)).to eq conversions_involuntary_project_assign_regional_delivery_officer_path(project)
-        expect(helper.path_to_caseworker_project_assignment(project)).to eq conversions_involuntary_project_assign_caseworker_path(project)
-        expect(helper.path_to_assigned_to_project_assignment(project)).to eq conversions_involuntary_project_assign_assigned_to_path(project)
-      end
-    end
-  end
-
   describe "#enable_google_tag_manager?" do
     context "when not in production" do
       it "returns false" do

--- a/spec/helpers/project_path_helper_spec.rb
+++ b/spec/helpers/project_path_helper_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe ProjectPathHelper, type: :helper do
       expect(helper.path_to_regional_delivery_officer_project_assignment(project)).to eq conversions_voluntary_project_assign_regional_delivery_officer_path(project)
       expect(helper.path_to_caseworker_project_assignment(project)).to eq conversions_voluntary_project_assign_caseworker_path(project)
       expect(helper.path_to_assigned_to_project_assignment(project)).to eq conversions_voluntary_project_assign_assigned_to_path(project)
+      expect(helper.path_to_new_conversion_date(project)).to eq conversions_voluntary_project_conversion_date_path(project)
     end
   end
 
@@ -34,6 +35,7 @@ RSpec.describe ProjectPathHelper, type: :helper do
       expect(helper.path_to_regional_delivery_officer_project_assignment(project)).to eq conversions_involuntary_project_assign_regional_delivery_officer_path(project)
       expect(helper.path_to_caseworker_project_assignment(project)).to eq conversions_involuntary_project_assign_caseworker_path(project)
       expect(helper.path_to_assigned_to_project_assignment(project)).to eq conversions_involuntary_project_assign_assigned_to_path(project)
+      expect(helper.path_to_new_conversion_date(project)).to eq conversions_involuntary_project_conversion_date_path(project)
     end
   end
 end

--- a/spec/helpers/project_path_helper_spec.rb
+++ b/spec/helpers/project_path_helper_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe ProjectPathHelper, type: :helper do
+  before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+  context "when the project is a voluntary conversion" do
+    it "returns the correct paths" do
+      project = create(:voluntary_conversion_project)
+
+      expect(helper.path_to_project(project)).to eq conversions_voluntary_project_path(project)
+      expect(helper.path_to_project_task_list(project)).to eq conversions_voluntary_project_task_list_path(project)
+      expect(helper.path_to_project_information(project)).to eq conversions_voluntary_project_information_path(project)
+      expect(helper.path_to_project_notes(project)).to eq conversions_voluntary_project_notes_path(project)
+      expect(helper.path_to_project_contacts(project)).to eq conversions_voluntary_project_contacts_path(project)
+
+      expect(helper.path_to_team_lead_project_assignment(project)).to eq conversions_voluntary_project_assign_team_lead_path(project)
+      expect(helper.path_to_regional_delivery_officer_project_assignment(project)).to eq conversions_voluntary_project_assign_regional_delivery_officer_path(project)
+      expect(helper.path_to_caseworker_project_assignment(project)).to eq conversions_voluntary_project_assign_caseworker_path(project)
+      expect(helper.path_to_assigned_to_project_assignment(project)).to eq conversions_voluntary_project_assign_assigned_to_path(project)
+    end
+  end
+
+  context "when the project is a involuntary conversion" do
+    it "returns the correct path" do
+      project = create(:involuntary_conversion_project)
+
+      expect(helper.path_to_project(project)).to eq conversions_involuntary_project_path(project)
+      expect(helper.path_to_project_task_list(project)).to eq conversions_involuntary_project_task_list_path(project)
+      expect(helper.path_to_project_information(project)).to eq conversions_involuntary_project_information_path(project)
+      expect(helper.path_to_project_notes(project)).to eq conversions_involuntary_project_notes_path(project)
+      expect(helper.path_to_project_contacts(project)).to eq conversions_involuntary_project_contacts_path(project)
+
+      expect(helper.path_to_team_lead_project_assignment(project)).to eq conversions_involuntary_project_assign_team_lead_path(project)
+      expect(helper.path_to_regional_delivery_officer_project_assignment(project)).to eq conversions_involuntary_project_assign_regional_delivery_officer_path(project)
+      expect(helper.path_to_caseworker_project_assignment(project)).to eq conversions_involuntary_project_assign_caseworker_path(project)
+      expect(helper.path_to_assigned_to_project_assignment(project)).to eq conversions_involuntary_project_assign_assigned_to_path(project)
+    end
+  end
+end

--- a/spec/models/conversion/date_history_spec.rb
+++ b/spec/models/conversion/date_history_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe Conversion::DateHistory do
+  describe "Attributes" do
+    it { is_expected.to have_db_column(:revised_date).of_type :date }
+    it { is_expected.to have_db_column(:previous_date).of_type :date }
+  end
+
+  describe "Associations" do
+    it { is_expected.to have_one(:note).dependent(:destroy) }
+    it { is_expected.to belong_to(:project).required(true) }
+  end
+end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Note, type: :model do
   describe "Relationships" do
     it { is_expected.to belong_to(:project) }
     it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:conversion_date_history).optional(true) }
   end
 
   describe "Validations" do

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe ProjectPolicy do
+  describe "#change_conversion_date?" do
+    context "when the conversion date is provisional" do
+      it "returns false" do
+        project = build(:conversion_project)
+        user = build(:user, :caseworker)
+
+        policy = described_class.new(user, project)
+
+        expect(policy.change_conversion_date?).to eq false
+      end
+    end
+
+    context "when the conversion date is confirmed" do
+      it "returns true" do
+        project = build(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+        user = build(:user, :caseworker)
+
+        policy = described_class.new(user, project)
+
+        expect(policy.change_conversion_date?).to eq true
+      end
+    end
+  end
+end

--- a/spec/requests/conversions/date_histories_controller_spec.rb
+++ b/spec/requests/conversions/date_histories_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Conversions::DateHistoriesController do
+  describe "#create" do
+    it "fails when the form is invalid" do
+      user = create(:user, :caseworker)
+      sign_in_with(user)
+      mock_successful_api_calls(establishment: any_args, trust: any_args)
+      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+      mock_successful_api_establishment_response(urn: project.urn)
+
+      post conversions_involuntary_project_conversion_date_path(project), params: {conversion_new_date_history_form: {revised_date: nil, note_body: nil}}
+
+      expect(response).to render_template :new
+    end
+  end
+end


### PR DESCRIPTION
We want users to be able to change the conversion date, as this is a significant event, we want the process to feel significant. We also want to record any changes to the conversion date over the life of a project.

This is our first version of this behaviour and does not adress re-surfacing the changed dates right now.

As well as the date changes, we also want users to tell us why the date had to move, for this we have used the existing Note model to keep all that narrative in one place.

This work builds on the existing `conversion_date` attribute on Project, we change the value and record the previous and revised values along with a note.

The end result gives a complete conversion date history:

- project created with provisional date
- user confirm date with all parties and records it as part of the external stakeholde kick off task
- any subsequent changes are loged as Conversion::DateHistory records

As there is not point changing the conversion date until it is confirmed, we prevent editing and hide the button unless this is the case.

We use a form object to take the submission and create the three objects in the database, this is completed in a transaction that will rollback if any of the records cannot be created.

Whilst not saving a record seems unlikely, it felt better to catch the error and surface to the user over a simple 500 error which is difficult for users to recover from.

Right now we do not resterict the new date as we have no assumptions about what the new date might be.

Once saved, we show a confrimation screen - I am not sure I agree with the content we have for this view, but it was part of the design.

https://trello.com/c/qrsCK0P8

### Showing the new button ui
![Screenshot 2023-03-06 at 17-01-08 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/223179550-eb460835-f04c-4b3b-9a06-752b3e9734ca.png)

### Showing the change conversion date form with validation errors
![Screenshot 2023-03-06 at 17-01-20 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/223179545-5c55f8ed-f8b1-44a6-9b86-b457c96b26da.png)

### Showing the confirmation page
![Screenshot 2023-03-06 at 17-01-33 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/223179532-222cb6e6-bb02-4af4-8e30-ad1ff53d4eff.png)




