### PR TITLE
Refactor provisional conversion date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   school details on the project information tab
 - the trust address from Get information about schools is now shown in the trust
   details on the project information tab
+- add a Project Openers table view
+- Add email validation to the user model
 
 ### Changed
 
@@ -46,14 +48,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Removed the Caseworker and Team Leader fields from the internal contact tab
 - Started tracking when a project is assigned to a person via the `assigned_at`
   database column
-- when confirming the conversion date in the external stakeholder kick off task,
-  a date history is added that records the change, users will see a note to this
-  effect on the project notes view
-
-### Added
-
-- add a Project Openers table view
-- Add email validation to the user model
+- the openers list now only shows conversion projects where the conversion date
+  has been confirmed i.e. not provisional
 
 ## [Release 15][release-15]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Removed the Caseworker and Team Leader fields from the internal contact tab
 - Started tracking when a project is assigned to a person via the `assigned_at`
   database column
+- when confirming the conversion date in the external stakeholder kick off task,
+  a date history is added that records the change, users will see a note to this
+  effect on the project notes view
 
 ### Added
 

--- a/app/controllers/conversions/date_histories_controller.rb
+++ b/app/controllers/conversions/date_histories_controller.rb
@@ -8,7 +8,7 @@ class Conversions::DateHistoriesController < ApplicationController
   def create
     @project = Project.find(params[:project_id])
     authorize(@project, :change_conversion_date?)
-    @form = Conversion::NewDateHistoryForm.new(**conversion_date_history_params, project_id: @project.id, user_id: current_user.id)
+    @form = Conversion::NewDateHistoryForm.new(**conversion_date_history_params, project: @project, user: current_user)
 
     if @form.save
       @project.reload

--- a/app/controllers/conversions/date_histories_controller.rb
+++ b/app/controllers/conversions/date_histories_controller.rb
@@ -11,6 +11,7 @@ class Conversions::DateHistoriesController < ApplicationController
     @form = Conversion::NewDateHistoryForm.new(**conversion_date_history_params, project_id: @project.id, user_id: current_user.id)
 
     if @form.save
+      @project.reload
       render "confirm_new"
     else
       render :new

--- a/app/controllers/task_lists_controller.rb
+++ b/app/controllers/task_lists_controller.rb
@@ -14,6 +14,7 @@ class TaskListsController < ApplicationController
     @task.assign_attributes task_params
 
     if @task.valid?
+      @task_list.user = current_user
       @task_list.save_task(@task)
 
       redirect_to action: :index

--- a/app/forms/conversion/involuntary/create_project_form.rb
+++ b/app/forms/conversion/involuntary/create_project_form.rb
@@ -7,6 +7,7 @@ class Conversion::Involuntary::CreateProjectForm < Conversion::CreateProjectForm
       trust_sharepoint_link: trust_sharepoint_link,
       advisory_board_conditions: advisory_board_conditions,
       provisional_conversion_date: provisional_conversion_date,
+      conversion_date: provisional_conversion_date,
       advisory_board_date: advisory_board_date,
       regional_delivery_officer_id: user.id,
       task_list: Conversion::Involuntary::TaskList.new

--- a/app/forms/conversion/voluntary/create_project_form.rb
+++ b/app/forms/conversion/voluntary/create_project_form.rb
@@ -17,7 +17,6 @@ class Conversion::Voluntary::CreateProjectForm < Conversion::CreateProjectForm
       trust_sharepoint_link: trust_sharepoint_link,
       advisory_board_conditions: advisory_board_conditions,
       conversion_date: provisional_conversion_date,
-      provisional_conversion_date: provisional_conversion_date,
       advisory_board_date: advisory_board_date,
       regional_delivery_officer_id: user.id,
       task_list: Conversion::Voluntary::TaskList.new,

--- a/app/forms/conversion/voluntary/create_project_form.rb
+++ b/app/forms/conversion/voluntary/create_project_form.rb
@@ -16,6 +16,7 @@ class Conversion::Voluntary::CreateProjectForm < Conversion::CreateProjectForm
       establishment_sharepoint_link: establishment_sharepoint_link,
       trust_sharepoint_link: trust_sharepoint_link,
       advisory_board_conditions: advisory_board_conditions,
+      conversion_date: provisional_conversion_date,
       provisional_conversion_date: provisional_conversion_date,
       advisory_board_date: advisory_board_date,
       regional_delivery_officer_id: user.id,

--- a/app/helpers/project_helper.rb
+++ b/app/helpers/project_helper.rb
@@ -16,7 +16,7 @@ module ProjectHelper
   end
 
   def converting_on_date(project)
-    return project.conversion_date.to_formatted_s(:govuk) unless project.conversion_date.nil?
+    return project.conversion_date.to_formatted_s(:govuk) unless project.conversion_date_provisional?
 
     date = project.provisional_conversion_date.to_formatted_s(:govuk)
     tag = govuk_tag(text: "provisional", colour: "grey")

--- a/app/helpers/project_helper.rb
+++ b/app/helpers/project_helper.rb
@@ -18,7 +18,7 @@ module ProjectHelper
   def converting_on_date(project)
     return project.conversion_date.to_formatted_s(:govuk) unless project.conversion_date_provisional?
 
-    date = project.provisional_conversion_date.to_formatted_s(:govuk)
+    date = project.conversion_date.to_formatted_s(:govuk)
     tag = govuk_tag(text: "provisional", colour: "grey")
 
     "#{date} #{tag}".html_safe

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -7,8 +7,14 @@ class Conversion::Involuntary::TaskList < TaskList::Base
     return if project.nil?
     return unless project.conversion_date_provisional?
 
-    project.update(conversion_date: stakeholder_kick_off_confirmed_conversion_date, conversion_date_provisional: false)
+    raise TaskListUserError.new("You must set the `user` attribute on #{self}") if user.nil?
+
+    revised_date = stakeholder_kick_off_confirmed_conversion_date
+    note_body = I18n.t("conversion.involuntary.tasks.stakeholder_kick_off.confirmed_conversion_date.note")
+
+    ConversionDateUpdater.new(project: project, revised_date: revised_date, note_body: note_body, user: user).update!
   end
+
   TASK_LIST_LAYOUT = [
     {
       identifier: :project_kick_off,

--- a/app/models/conversion/involuntary/task_list.rb
+++ b/app/models/conversion/involuntary/task_list.rb
@@ -5,9 +5,9 @@ class Conversion::Involuntary::TaskList < TaskList::Base
 
   def set_conversion_date
     return if project.nil?
-    return if project.conversion_date.present?
+    return unless project.conversion_date_provisional?
 
-    project.update(conversion_date: stakeholder_kick_off_confirmed_conversion_date)
+    project.update(conversion_date: stakeholder_kick_off_confirmed_conversion_date, conversion_date_provisional: false)
   end
   TASK_LIST_LAYOUT = [
     {

--- a/app/models/conversion/voluntary/task_list.rb
+++ b/app/models/conversion/voluntary/task_list.rb
@@ -4,9 +4,9 @@ class Conversion::Voluntary::TaskList < TaskList::Base
 
   def set_conversion_date
     return if project.nil?
-    return if project.conversion_date.present?
+    return unless project.conversion_date_provisional?
 
-    project.update(conversion_date: stakeholder_kick_off_confirmed_conversion_date)
+    project.update(conversion_date: stakeholder_kick_off_confirmed_conversion_date, conversion_date_provisional: false)
   end
 
   TASK_LIST_LAYOUT = [

--- a/app/models/conversion/voluntary/task_list.rb
+++ b/app/models/conversion/voluntary/task_list.rb
@@ -1,12 +1,18 @@
 class Conversion::Voluntary::TaskList < TaskList::Base
   self.table_name = "conversion_voluntary_task_lists"
+
   after_save :set_conversion_date
 
   def set_conversion_date
     return if project.nil?
     return unless project.conversion_date_provisional?
 
-    project.update(conversion_date: stakeholder_kick_off_confirmed_conversion_date, conversion_date_provisional: false)
+    raise TaskListUserError.new("You must set the `user` attribute on #{self}") if user.nil?
+
+    revised_date = stakeholder_kick_off_confirmed_conversion_date
+    note_body = I18n.t("conversion.voluntary.tasks.stakeholder_kick_off.confirmed_conversion_date.note")
+
+    ConversionDateUpdater.new(project: project, revised_date: revised_date, note_body: note_body, user: user).update!
   end
 
   TASK_LIST_LAYOUT = [

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -27,8 +27,6 @@ class Project < ApplicationRecord
   belongs_to :regional_delivery_officer, class_name: "User", optional: true
   belongs_to :assigned_to, class_name: "User", optional: true
 
-  scope :by_provisional_conversion_date, -> { order(provisional_conversion_date: :asc) }
-
   scope :conversions, -> { where(type: "Conversion::Project") }
   scope :conversions_voluntary, -> { conversions.where(task_list_type: "Conversion::Voluntary::TaskList") }
   scope :conversions_involuntary, -> { conversions.where(task_list_type: "Conversion::Involuntary::TaskList") }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -12,8 +12,8 @@ class Project < ApplicationRecord
   validates :urn, urn: true
   validates :incoming_trust_ukprn, presence: true
   validates :incoming_trust_ukprn, ukprn: true
-  validates :provisional_conversion_date, presence: true
-  validates :provisional_conversion_date, first_day_of_month: true
+  validates :conversion_date, presence: true
+  validates :conversion_date, first_day_of_month: true
   validates :advisory_board_date, presence: true
   validates :advisory_board_date, date_in_the_past: true
   validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -45,7 +45,7 @@ class Project < ApplicationRecord
   scope :unassigned_to_user, -> { where assigned_to: nil }
   scope :assigned_to_regional_caseworker_team, -> { where(assigned_to_regional_caseworker_team: true) }
 
-  scope :opening_by_month_year, ->(month, year) { includes(:task_list).where.not(conversion_date: nil).and(where("YEAR(conversion_date) = ?", year)).and(where("MONTH(conversion_date) = ?", month)) }
+  scope :opening_by_month_year, ->(month, year) { includes(:task_list).where(conversion_date_provisional: false).and(where("YEAR(conversion_date) = ?", year)).and(where("MONTH(conversion_date) = ?", month)) }
 
   def establishment
     @establishment ||= fetch_establishment(urn)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -33,6 +33,11 @@ class Project < ApplicationRecord
   scope :conversions_voluntary, -> { conversions.where(task_list_type: "Conversion::Voluntary::TaskList") }
   scope :conversions_involuntary, -> { conversions.where(task_list_type: "Conversion::Involuntary::TaskList") }
 
+  scope :provisional, -> { where(conversion_date_provisional: true) }
+  scope :confirmed, -> { where(conversion_date_provisional: false) }
+
+  scope :by_conversion_date, -> { order(conversion_date: :asc) }
+
   scope :completed, -> { where.not(completed_at: nil) }
   scope :open, -> { where(completed_at: nil) }
 

--- a/app/models/task_list/base.rb
+++ b/app/models/task_list/base.rb
@@ -1,6 +1,10 @@
 class TaskList::Base < ActiveRecord::Base
   include TaskList
 
+  class TaskListUserError < StandardError; end
+
+  attr_accessor :user
+
   self.abstract_class = true
 
   def sections

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -35,7 +35,7 @@ class ProjectPolicy
   end
 
   def change_conversion_date?
-    @record.conversion_date.present?
+    @record.conversion_date_provisional? == false
   end
 
   class Scope

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -46,11 +46,11 @@ class ProjectPolicy
 
     def resolve
       if user.team_leader?
-        scope.by_provisional_conversion_date
+        scope.conversions.by_conversion_date
       elsif user.regional_delivery_officer?
-        scope.by_provisional_conversion_date.assigned_to_regional_delivery_officer(user)
+        scope.conversions.by_conversion_date.assigned_to_regional_delivery_officer(user)
       else
-        scope.by_provisional_conversion_date.assigned_to_caseworker(user)
+        scope.conversions.by_conversion_date.assigned_to_caseworker(user)
       end
     end
 

--- a/app/services/conversion_date_updater.rb
+++ b/app/services/conversion_date_updater.rb
@@ -1,0 +1,23 @@
+class ConversionDateUpdater
+  def initialize(project:, revised_date:, note_body:, user:)
+    @project = project
+    @previous_date = project.conversion_date
+    @revised_date = revised_date
+    @user = user
+    @note_body = note_body
+  end
+
+  def update!
+    ActiveRecord::Base.transaction do
+      conversion_date_history_note = Note.create!(project_id: @project.id, user_id: @user.id, body: @note_body)
+      date_history = Conversion::DateHistory.create!(project_id: @project.id, previous_date: @previous_date, revised_date: @revised_date, note: conversion_date_history_note)
+      @project.update!(conversion_date: @revised_date, conversion_date_provisional: false)
+
+      raise ActiveRecord::RecordInvalid unless conversion_date_history_note.persisted? && @project.persisted? && date_history.persisted?
+    rescue ActiveRecord::RecordInvalid
+      return false
+    end
+
+    true
+  end
+end

--- a/app/services/project_conversion_date_migrator.rb
+++ b/app/services/project_conversion_date_migrator.rb
@@ -1,0 +1,23 @@
+class ProjectConversionDateMigrator
+  def initialize(project)
+    @project = project
+  end
+
+  def migrate_up!
+    if @project.conversion_date.nil? && @project.conversion_date_provisional? && @project.task_list.stakeholder_kick_off_confirmed_conversion_date.nil?
+      @project.update!(conversion_date: @project.provisional_conversion_date)
+    else
+      note_body = "Conversion date confirmed as part of external stakeholder kick off task."
+
+      user = if @project.assigned_to.present?
+        User.find(@project.assigned_to.id)
+      else
+        User.find(@project.regional_delivery_officer.id)
+      end
+
+      conversion_date_history_note = Note.create!(project_id: @project.id, user_id: user.id, body: note_body)
+      Conversion::DateHistory.create!(project_id: @project.id, previous_date: @project.provisional_conversion_date, revised_date: @project.conversion_date, note: conversion_date_history_note)
+      @project.update!(conversion_date_provisional: false)
+    end
+  end
+end

--- a/app/views/conversions/involuntary/task_lists/tasks/stakeholder_kick_off.html.erb
+++ b/app/views/conversions/involuntary/task_lists/tasks/stakeholder_kick_off.html.erb
@@ -30,7 +30,7 @@
       <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :setup_meeting)) %>
       <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :meeting)) %>
 
-      <% if @project.conversion_date.nil? %>
+      <% if @project.conversion_date_provisional? %>
         <%= form.govuk_date_field :confirmed_conversion_date,
               omit_day: true,
               form_group: {classes: "app-confirmed-conversion-date"},

--- a/app/views/conversions/voluntary/task_lists/tasks/stakeholder_kick_off.html.erb
+++ b/app/views/conversions/voluntary/task_lists/tasks/stakeholder_kick_off.html.erb
@@ -15,7 +15,7 @@
         <div class="govuk-checkboxes__item">
           <%= hidden_field_tag("conversion_voluntary_tasks_stakeholder_kick_off[check_provisional_conversion_date]", "0", {id: nil}) %>
           <%= check_box_tag("conversion_voluntary_tasks_stakeholder_kick_off[check_provisional_conversion_date]", 1, @task.check_provisional_conversion_date, {class: "govuk-checkboxes__input"}) %>
-          <%= label_tag("conversion_voluntary_tasks_stakeholder_kick_off[check_provisional_conversion_date]", t("conversion.voluntary.tasks.stakeholder_kick_off.check_provisional_conversion_date.title", date: @project.provisional_conversion_date.strftime("01 %B %Y")), {class: "govuk-label govuk-checkboxes__label"}) %>
+          <%= label_tag("conversion_voluntary_tasks_stakeholder_kick_off[check_provisional_conversion_date]", t("conversion.voluntary.tasks.stakeholder_kick_off.check_provisional_conversion_date.title", date: @project.conversion_date.strftime("01 %B %Y")), {class: "govuk-label govuk-checkboxes__label"}) %>
           <div class="hint">
             <%= t("conversion.voluntary.tasks.stakeholder_kick_off.check_provisional_conversion_date.hint.html") %>
           </div>

--- a/app/views/conversions/voluntary/task_lists/tasks/stakeholder_kick_off.html.erb
+++ b/app/views/conversions/voluntary/task_lists/tasks/stakeholder_kick_off.html.erb
@@ -29,7 +29,7 @@
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :setup_meeting)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :meeting)) %>
 
-        <% if @project.conversion_date.nil? %>
+        <% if @project.conversion_date_provisional? %>
           <%= form.govuk_date_field :confirmed_conversion_date,
                 omit_day: true,
                 form_group: {classes: "app-confirmed-conversion-date"},

--- a/app/views/shared/projects/_list.html.erb
+++ b/app/views/shared/projects/_list.html.erb
@@ -2,7 +2,7 @@
   <%= govuk_inset_text(text: t("project.index.empty")) %>
 <% else %>
   <ul class="projects-list list-style-none govuk-!-padding-0">
-    <% grouped_project = @projects.group_by { |project| project.provisional_conversion_date.strftime("%B %Y openers") } %>
+    <% grouped_project = @projects.group_by { |project| project.conversion_date.strftime("%B %Y openers") } %>
       <% grouped_project.each do |opening_date, projects| %>
         <h2 class="govuk-heading-m"><%= opening_date %></h2>
         <% projects.each do |project| %>

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -71,7 +71,7 @@ en:
         assigned_to_regional_caseworker_team: Are you handing this project over to Regional Casework Services?
   errors:
     attributes:
-      provisional_conversion_date:
+      conversion_date:
         blank: Enter a provisional conversion date
         must_be_first_of_the_month: Provisional conversion date must be on the first day of the month
         must_be_in_the_future: Provisional conversion date must be in the future.

--- a/config/locales/task_lists/conversion/involuntary/stakeholder_kick_off.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/stakeholder_kick_off.en.yml
@@ -76,6 +76,7 @@ en:
               html:
                 <p>Everyone should have agreed to and know the confirmed conversion date.</p>
                 <p>You only need to enter a month and year. All schools convert on the first day of the month.</p>
+            note: Conversion date confirmed as part of external stakeholder kick off task.
           check_provisional_conversion_date:
             title: "Check the local authority is able to convert the school by the provisional conversion date: %{date}"
             hint:

--- a/config/locales/task_lists/conversion/voluntary/stakeholder_kick_off.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/stakeholder_kick_off.en.yml
@@ -47,6 +47,7 @@ en:
                 <p>You only need to enter a month and year. All schools convert on the first day of the month.</p>
             errors:
               format: Enter a valid confirmed conversion date
+            note: Conversion date confirmed as part of external stakeholder kick off task.
           setup_meeting:
             title: Send invites to the kick-off meeting or call
             hint:

--- a/db/migrate/20230310154404_add_conversion_date_provisional_to_projects.rb
+++ b/db/migrate/20230310154404_add_conversion_date_provisional_to_projects.rb
@@ -1,0 +1,11 @@
+class AddConversionDateProvisionalToProjects < ActiveRecord::Migration[7.0]
+  def up
+    add_column :projects, :conversion_date_provisional, :boolean, default: true
+    change_column_null :projects, :provisional_conversion_date, true
+  end
+
+  def down
+    remove_column :projects, :conversion_date_provisional
+    change_column_null :projects, :provisional_conversion_date, false
+  end
+end

--- a/db/migrate/20230314155035_migrate_provisional_conversion_dates.rb
+++ b/db/migrate/20230314155035_migrate_provisional_conversion_dates.rb
@@ -1,0 +1,7 @@
+class MigrateProvisionalConversionDates < ActiveRecord::Migration[7.0]
+  def up
+    Project.find_each do |project|
+      ProjectConversionDateMigrator.new(project).migrate_up!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_14_150625) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_14_160637) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -261,7 +261,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_14_150625) do
     t.datetime "updated_at", null: false
     t.uuid "team_leader_id"
     t.integer "incoming_trust_ukprn", null: false
-    t.date "provisional_conversion_date", null: false
     t.uuid "regional_delivery_officer_id"
     t.uuid "caseworker_id"
     t.datetime "assigned_at"
@@ -276,6 +275,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_14_150625) do
     t.uuid "assigned_to_id"
     t.boolean "assigned_to_regional_caseworker_team", default: false
     t.date "conversion_date"
+    t.boolean "conversion_date_provisional", default: true
+    t.date "provisional_conversion_date"
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"

--- a/spec/factories/conversion/involuntary/project_factory.rb
+++ b/spec/factories/conversion/involuntary/project_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     urn { 123456 }
     incoming_trust_ukprn { 10061021 }
     provisional_conversion_date { (Date.today + 2.years).at_beginning_of_month }
+    conversion_date { (Date.today + 2.years).at_beginning_of_month }
     advisory_board_date { (Date.today - 2.weeks) }
     establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/establishment-folder" }
     trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }

--- a/spec/factories/conversion/project_factory.rb
+++ b/spec/factories/conversion/project_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     urn { 123456 }
     incoming_trust_ukprn { 10061021 }
     provisional_conversion_date { (Date.today + 2.years).at_beginning_of_month }
-    conversion_date { nil }
+    conversion_date { (Date.today + 2.years).at_beginning_of_month }
     advisory_board_date { (Date.today - 2.weeks) }
     establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/establishment-folder" }
     trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }

--- a/spec/features/conversions/users_can_change_the_conversion_date_spec.rb
+++ b/spec/features/conversions/users_can_change_the_conversion_date_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Users can change the conversion date" do
 
   scenario "they can change the date on a conversion project and see a confirmation view" do
     revised_conversion_date = (Date.today + 6.months).at_beginning_of_month
-    project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+    project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false)
 
     visit conversions_voluntary_project_path(project)
 
@@ -29,7 +29,7 @@ RSpec.feature "Users can change the conversion date" do
   end
 
   scenario "they can cancel the change if needed" do
-    project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+    project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false)
 
     visit conversions_voluntary_project_path(project)
 
@@ -44,7 +44,7 @@ RSpec.feature "Users can change the conversion date" do
   end
 
   scenario "they can view the conversion date change note on the projects notes view" do
-    project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+    project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false)
     revised_conversion_date = (Date.today + 6.months).at_beginning_of_month
     note = "This is a test note."
 

--- a/spec/features/users_can_complete_conversion_involuntary_tasks_spec.rb
+++ b/spec/features/users_can_complete_conversion_involuntary_tasks_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature "Users can complete tasks in an involuntary conversion project" do
   end
 
   context "when the project does not have a confirmed conversion date" do
-    let(:involuntary_project) { create(:involuntary_conversion_project, provisional_conversion_date: Date.new(2023, 12, 1)) }
+    let(:involuntary_project) { create(:involuntary_conversion_project, conversion_date: Date.new(2023, 12, 1), conversion_date_provisional: true) }
 
     scenario "the Conditions met task shows the provisional conversion date in the hint text" do
       click_on "Confirm all conditions have been met"

--- a/spec/features/users_can_complete_conversion_voluntary_tasks_spec.rb
+++ b/spec/features/users_can_complete_conversion_voluntary_tasks_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Users can complete tasks in a voluntary conversion project" do
   end
 
   context "when the project does not have a confirmed conversion date" do
-    let(:voluntary_project) { create(:voluntary_conversion_project, provisional_conversion_date: Date.new(2023, 12, 1)) }
+    let(:voluntary_project) { create(:voluntary_conversion_project, conversion_date: Date.new(2023, 12, 1), conversion_date_provisional: true) }
 
     scenario "the Conditions met task shows the provisional conversion date in the hint text" do
       click_on "Confirm all conditions have been met"

--- a/spec/features/users_can_create_involuntary_conversion_projects_spec.rb
+++ b/spec/features/users_can_create_involuntary_conversion_projects_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Users can create new involuntary conversion projects" do
       fill_in "Incoming trust UK Provider Reference Number (UKPRN)", with: ukprn
 
       within("#provisional-conversion-date") do
-        completion_date = Date.today + 1.year
+        completion_date = Date.today.at_beginning_of_month + 1.year
         fill_in "Month", with: completion_date.month
         fill_in "Year", with: completion_date.year
       end

--- a/spec/features/users_can_view_a_table_of_project_openers_spec.rb
+++ b/spec/features/users_can_view_a_table_of_project_openers_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Users can view project openers in table form" do
     context "when a project has all conditions met" do
       it "shows the correct tag" do
         task_list = create(:voluntary_conversion_task_list, conditions_met_confirm_all_conditions_met: true)
-        _project = create(:conversion_project, task_list: task_list, conversion_date: Date.new(2023, 1, 1))
+        _project = create(:conversion_project, task_list: task_list, conversion_date: Date.new(2023, 1, 1), conversion_date_provisional: false)
 
         visit openers_projects_path(1, 2023)
         expect(page).to have_css("strong.govuk-tag--turquoise", text: "yes")
@@ -25,7 +25,7 @@ RSpec.feature "Users can view project openers in table form" do
     context "when a project does not have all conditions met" do
       it "shows the correct tag" do
         task_list = create(:voluntary_conversion_task_list, conditions_met_confirm_all_conditions_met: nil)
-        _project = create(:conversion_project, task_list: task_list, conversion_date: Date.new(2023, 1, 1))
+        _project = create(:conversion_project, task_list: task_list, conversion_date: Date.new(2023, 1, 1), conversion_date_provisional: false)
 
         visit openers_projects_path(1, 2023)
         expect(page).to have_css("strong.govuk-tag--blue", text: "not started")

--- a/spec/features/users_can_view_projects_spec.rb
+++ b/spec/features/users_can_view_projects_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Users can view a list of projects" do
     create(
       :conversion_project,
       urn: 100001,
-      provisional_conversion_date: Date.today.beginning_of_month + 3.years
+      conversion_date: Date.today.beginning_of_month + 3.years
     )
   }
   let!(:user_project) {
@@ -28,7 +28,7 @@ RSpec.feature "Users can view a list of projects" do
       :conversion_project,
       urn: 100002,
       caseworker: user,
-      provisional_conversion_date: Date.today.beginning_of_month + 2.year
+      conversion_date: Date.today.beginning_of_month + 2.year
     )
   }
   let!(:completed_project) {
@@ -37,7 +37,7 @@ RSpec.feature "Users can view a list of projects" do
       urn: 100004,
       caseworker: caseworker,
       regional_delivery_officer: regional_delivery_officer,
-      provisional_conversion_date: Date.today.beginning_of_month + 6.months,
+      conversion_date: Date.today.beginning_of_month + 6.months,
       completed_at: Date.today.beginning_of_month + 7.months
     )
   }
@@ -47,7 +47,7 @@ RSpec.feature "Users can view a list of projects" do
       urn: 100003,
       caseworker: caseworker,
       regional_delivery_officer: regional_delivery_officer,
-      provisional_conversion_date: Date.today.beginning_of_month + 1.years
+      conversion_date: Date.today.beginning_of_month + 1.years
     )
   }
   let!(:assigned_to_project_for_rdo) {
@@ -57,7 +57,7 @@ RSpec.feature "Users can view a list of projects" do
       caseworker: caseworker,
       regional_delivery_officer: nil,
       assigned_to: regional_delivery_officer,
-      provisional_conversion_date: Date.today.beginning_of_month + 4.years
+      conversion_date: Date.today.beginning_of_month + 4.years
     )
   }
   let!(:assigned_to_project_for_caseworker) {
@@ -67,7 +67,7 @@ RSpec.feature "Users can view a list of projects" do
       caseworker: nil,
       regional_delivery_officer: nil,
       assigned_to: caseworker,
-      provisional_conversion_date: Date.today.beginning_of_month + 5.years
+      conversion_date: Date.today.beginning_of_month + 5.years
     )
   }
 

--- a/spec/forms/conversion/new_date_form_spec.rb
+++ b/spec/forms/conversion/new_date_form_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Conversion::NewDateHistoryForm, type: :model do
   describe "#save" do
     it "creates the conversion date history and note" do
       mock_successful_api_calls(establishment: 123456, trust: 12345678)
-      project = create(:conversion_project, conversion_date: Date.today)
+      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
       user = create(:user, :caseworker)
       form = create_valid_form_object
       form.project_id = project.id
@@ -84,7 +84,7 @@ RSpec.describe Conversion::NewDateHistoryForm, type: :model do
 
     it "updates the project conversion date with the revised date" do
       mock_successful_api_calls(establishment: 123456, trust: 12345678)
-      project = create(:conversion_project, conversion_date: Date.today)
+      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
       user = create(:user, :caseworker)
       form = create_valid_form_object
       form.project_id = project.id
@@ -97,7 +97,7 @@ RSpec.describe Conversion::NewDateHistoryForm, type: :model do
 
     it "is transactional, it does nothing if any operation fails and returns an error" do
       mock_successful_api_calls(establishment: 123456, trust: 12345678)
-      project = create(:conversion_project, conversion_date: Date.today)
+      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
       form = create_valid_form_object
       form.project_id = project.id
 

--- a/spec/forms/conversion/new_date_form_spec.rb
+++ b/spec/forms/conversion/new_date_form_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Conversion::NewDateHistoryForm, type: :model do
+  let(:form) { create_valid_form_object }
+
   describe "validations" do
     it "requires a valid year" do
       form = create_valid_form_object
@@ -44,75 +46,50 @@ RSpec.describe Conversion::NewDateHistoryForm, type: :model do
       expect(form).to be_invalid
     end
 
-    it "requires the project_id" do
+    it "requires the project" do
       form = create_valid_form_object
-      form.project_id = nil
+      form.project = nil
 
       expect(form).to be_invalid
     end
 
-    it "requires the user_id" do
+    it "requires the user" do
       form = create_valid_form_object
-      form.user_id = nil
+      form.user = nil
 
       expect(form).to be_invalid
     end
   end
 
   describe "#save" do
-    it "creates the conversion date history and note" do
-      mock_successful_api_calls(establishment: 123456, trust: 12345678)
-      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
-      user = create(:user, :caseworker)
-      form = create_valid_form_object
-      form.project_id = project.id
-      form.user_id = user.id
+    let(:project) { create(:conversion_project, conversion_date: Date.today.at_beginning_of_month) }
+    let(:user) { create(:user, :caseworker) }
+
+    before { mock_successful_api_calls(establishment: any_args, trust: any_args) }
+
+    it "returns true when successful" do
+      form.project = project
+      form.user = user
       form.note_body = "This is my note body."
 
       expect(form.save).to be true
-      expect(project.conversion_dates.count).to eq 1
-      expect(Note.count).to eq 1
-
-      conversion_date_history = project.conversion_dates.first
-      expect(conversion_date_history.revised_date).to eql Date.new(2023, 1, 1)
-
-      note = conversion_date_history.note
-      expect(note.user).to eql user
-      expect(note.project).to eql project
-      expect(note.body).to eql "This is my note body."
     end
 
-    it "updates the project conversion date with the revised date" do
-      mock_successful_api_calls(establishment: 123456, trust: 12345678)
-      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
-      user = create(:user, :caseworker)
-      form = create_valid_form_object
-      form.project_id = project.id
-      form.user_id = user.id
+    it "adds an error and returns false if unsuccessful" do
+      form.project = project
+      form.user = user
 
-      expect(form.save).to be true
-
-      expect(project.reload.conversion_date).to eq Date.new(2023, 1, 1)
-    end
-
-    it "is transactional, it does nothing if any operation fails and returns an error" do
-      mock_successful_api_calls(establishment: 123456, trust: 12345678)
-      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
-      form = create_valid_form_object
-      form.project_id = project.id
+      allow_any_instance_of(ConversionDateUpdater).to receive("update!").and_return(false)
 
       expect(form.save).to eq false
-      expect(project.reload.conversion_date).not_to eq Date.new(2023, 1, 1)
-      expect(Note.count).to be_zero
-      expect(project.conversion_dates.count).to be_zero
       expect(form.errors.messages[:revised_date]).to include(I18n.t("errors.attributes.revised_date.transaction"))
     end
   end
 
   def create_valid_form_object
     described_class.new(
-      project_id: "PROJECT_ID",
-      user_id: "USER_ID",
+      project: build(:conversion_project),
+      user: build(:user),
       note_body: "Note body",
       "revised_date(3i)": "1",
       "revised_date(2i)": "1",

--- a/spec/helpers/project_helper_spec.rb
+++ b/spec/helpers/project_helper_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe ProjectHelper, type: :helper do
 
     context "when the conversion date is confirmed" do
       it "returns the formatted date and a provisional tag" do
-        project = build(:conversion_project, conversion_date: Date.today)
+        project = build(:conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false)
 
         expect(helper.converting_on_date(project)).to include project.conversion_date.to_formatted_s(:govuk)
         expect(helper.converting_on_date(project)).not_to include "provisional"

--- a/spec/models/conversion/involuntary/task_list_spec.rb
+++ b/spec/models/conversion/involuntary/task_list_spec.rb
@@ -21,21 +21,20 @@ RSpec.describe Conversion::Involuntary::TaskList do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 
       it "syncs the conversion date with the project" do
-        project = create(:involuntary_conversion_project)
+        project = create(:involuntary_conversion_project, conversion_date: Date.today.at_beginning_of_month - 6.months, conversion_date_provisional: true)
 
-        expect(project.reload.conversion_date).to be_nil
+        project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: Date.today.at_beginning_of_month)
 
-        project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: Date.today)
-
-        expect(project.reload.conversion_date).to eq Date.today
+        expect(project.reload.conversion_date).to eq Date.today.at_beginning_of_month
+        expect(project.reload.conversion_date_provisional).to eq false
       end
 
       it "can only sync once" do
-        project = create(:involuntary_conversion_project, conversion_date: Date.today)
+        project = create(:involuntary_conversion_project, conversion_date: Date.today.at_beginning_of_month - 6.months, conversion_date_provisional: false)
 
-        project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: Date.tomorrow)
+        project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: Date.tomorrow.at_beginning_of_month)
 
-        expect(project.reload.conversion_date).to eq Date.today
+        expect(project.reload.conversion_date).to eq Date.today.at_beginning_of_month - 6.months
       end
     end
   end

--- a/spec/models/conversion/involuntary/task_list_spec.rb
+++ b/spec/models/conversion/involuntary/task_list_spec.rb
@@ -17,24 +17,50 @@ RSpec.describe Conversion::Involuntary::TaskList do
   end
 
   describe "conversion date" do
+    let(:user) { create(:user, :caseworker) }
+
     context "when the projects task list is saved" do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 
-      it "syncs the conversion date with the project" do
-        project = create(:involuntary_conversion_project, conversion_date: Date.today.at_beginning_of_month - 6.months, conversion_date_provisional: true)
+      it "syncs the conversion date with the project and creates a date history" do
+        conversion_date = Date.today.at_beginning_of_month - 6.months
+        revised_conversion_date = Date.today.at_beginning_of_month
+        project = create(:involuntary_conversion_project, conversion_date: conversion_date, conversion_date_provisional: true)
 
-        project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: Date.today.at_beginning_of_month)
+        project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: revised_conversion_date, user: user)
+        project.reload
 
-        expect(project.reload.conversion_date).to eq Date.today.at_beginning_of_month
-        expect(project.reload.conversion_date_provisional).to eq false
+        expect(project.conversion_date).to eq revised_conversion_date
+        expect(project.conversion_date_provisional).to eq false
+
+        conversion_date_history = project.conversion_dates.first
+        expect(conversion_date_history.revised_date).to eql revised_conversion_date
+        expect(conversion_date_history.previous_date).to eql conversion_date
+
+        note = conversion_date_history.note
+        expect(note.user).to eql user
+        expect(note.project).to eql project
+        expect(note.body).to eql I18n.t("conversion.voluntary.tasks.stakeholder_kick_off.confirmed_conversion_date.note")
       end
 
-      it "can only sync once" do
-        project = create(:involuntary_conversion_project, conversion_date: Date.today.at_beginning_of_month - 6.months, conversion_date_provisional: false)
+      it "only syncs when the conversion date is provisional" do
+        conversion_date = Date.today.at_beginning_of_month - 6.months
+        revised_conversion_date = Date.today.at_beginning_of_month
+        project = create(:voluntary_conversion_project, conversion_date: conversion_date, conversion_date_provisional: false)
 
-        project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: Date.tomorrow.at_beginning_of_month)
+        project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: revised_conversion_date, user: user)
 
-        expect(project.reload.conversion_date).to eq Date.today.at_beginning_of_month - 6.months
+        expect(project.reload.conversion_date).to eq conversion_date
+      end
+
+      it "raises an error if no user is set on the task list" do
+        conversion_date = Date.today.at_beginning_of_month - 6.months
+        revised_conversion_date = Date.today.at_beginning_of_month
+        project = create(:voluntary_conversion_project, conversion_date: conversion_date, conversion_date_provisional: true)
+
+        expect {
+          project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: revised_conversion_date, user: nil)
+        }.to raise_error(TaskList::Base::TaskListUserError)
       end
     end
   end

--- a/spec/models/conversion/voluntary/task_list_spec.rb
+++ b/spec/models/conversion/voluntary/task_list_spec.rb
@@ -21,21 +21,20 @@ RSpec.describe Conversion::Voluntary::TaskList do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 
       it "syncs the conversion date with the project" do
-        project = create(:voluntary_conversion_project)
+        project = create(:voluntary_conversion_project, conversion_date: Date.today.at_beginning_of_month - 6.months, conversion_date_provisional: true)
 
-        expect(project.reload.conversion_date).to be_nil
+        project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: Date.today.at_beginning_of_month)
 
-        project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: Date.today)
-
-        expect(project.reload.conversion_date).to eq Date.today
+        expect(project.reload.conversion_date).to eq Date.today.at_beginning_of_month
+        expect(project.reload.conversion_date_provisional).to eq false
       end
 
       it "can only sync once" do
-        project = create(:voluntary_conversion_project, conversion_date: Date.today)
+        project = create(:voluntary_conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false)
 
-        project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: Date.tomorrow)
+        project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: Date.today.at_beginning_of_month + 6.months)
 
-        expect(project.reload.conversion_date).to eq Date.today
+        expect(project.reload.conversion_date).to eq Date.today.at_beginning_of_month
       end
     end
   end

--- a/spec/models/conversion/voluntary/task_list_spec.rb
+++ b/spec/models/conversion/voluntary/task_list_spec.rb
@@ -17,24 +17,50 @@ RSpec.describe Conversion::Voluntary::TaskList do
   end
 
   describe "conversion date" do
+    let(:user) { create(:user, :caseworker) }
+
     context "when the projects task list is saved" do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 
-      it "syncs the conversion date with the project" do
-        project = create(:voluntary_conversion_project, conversion_date: Date.today.at_beginning_of_month - 6.months, conversion_date_provisional: true)
+      it "syncs the conversion date with the project and creates a date history" do
+        conversion_date = Date.today.at_beginning_of_month - 6.months
+        revised_conversion_date = Date.today.at_beginning_of_month
+        project = create(:voluntary_conversion_project, conversion_date: conversion_date, conversion_date_provisional: true)
 
-        project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: Date.today.at_beginning_of_month)
+        project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: revised_conversion_date, user: user)
+        project.reload
 
-        expect(project.reload.conversion_date).to eq Date.today.at_beginning_of_month
-        expect(project.reload.conversion_date_provisional).to eq false
+        expect(project.conversion_date).to eq revised_conversion_date
+        expect(project.conversion_date_provisional).to eq false
+
+        conversion_date_history = project.conversion_dates.first
+        expect(conversion_date_history.revised_date).to eql revised_conversion_date
+        expect(conversion_date_history.previous_date).to eql conversion_date
+
+        note = conversion_date_history.note
+        expect(note.user).to eql user
+        expect(note.project).to eql project
+        expect(note.body).to eql I18n.t("conversion.voluntary.tasks.stakeholder_kick_off.confirmed_conversion_date.note")
       end
 
-      it "can only sync once" do
-        project = create(:voluntary_conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false)
+      it "only syncs when the conversion date is provisional" do
+        conversion_date = Date.today.at_beginning_of_month - 6.months
+        revised_conversion_date = Date.today.at_beginning_of_month
+        project = create(:voluntary_conversion_project, conversion_date: conversion_date, conversion_date_provisional: false)
 
-        project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: Date.today.at_beginning_of_month + 6.months)
+        project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: revised_conversion_date)
 
-        expect(project.reload.conversion_date).to eq Date.today.at_beginning_of_month
+        expect(project.reload.conversion_date).to eq conversion_date
+      end
+
+      it "raises an error if no user is set on the task list" do
+        conversion_date = Date.today.at_beginning_of_month - 6.months
+        revised_conversion_date = Date.today.at_beginning_of_month
+        project = create(:voluntary_conversion_project, conversion_date: conversion_date, conversion_date_provisional: true)
+
+        expect {
+          project.task_list.update(stakeholder_kick_off_confirmed_conversion_date: revised_conversion_date, user: nil)
+        }.to raise_error(TaskList::Base::TaskListUserError)
       end
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -229,22 +229,6 @@ RSpec.describe Project, type: :model do
     end
   end
 
-  describe "by_provisional_conversion_date scope" do
-    before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
-
-    it "shows the project that will convert earliest first" do
-      last_project = create(:conversion_project, provisional_conversion_date: Date.today.beginning_of_month + 3.years)
-      middle_project = create(:conversion_project, provisional_conversion_date: Date.today.beginning_of_month + 2.years)
-      first_project = create(:conversion_project, provisional_conversion_date: Date.today.beginning_of_month + 1.year)
-
-      ordered_projects = Project.by_provisional_conversion_date
-
-      expect(ordered_projects[0].id).to eq first_project.id
-      expect(ordered_projects[1].id).to eq middle_project.id
-      expect(ordered_projects[2].id).to eq last_project.id
-    end
-  end
-
   describe "#completed?" do
     context "when the completed_at is nil, i.e. the project is active" do
       it "returns false" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -444,5 +444,47 @@ RSpec.describe Project, type: :model do
         expect(Project.opening_by_month_year(1, 2023)).to include(project_in_scope)
       end
     end
+
+    describe "provisional scope" do
+      it "only returns projects with a provisional conversion date" do
+        mock_successful_api_responses(urn: any_args, ukprn: any_args)
+        provisional_project = create(:conversion_project, conversion_date_provisional: true)
+        confirmed_project = create(:conversion_project, conversion_date_provisional: false)
+
+        scoped_projects = Project.provisional
+
+        expect(scoped_projects).to include provisional_project
+        expect(scoped_projects).not_to include confirmed_project
+      end
+    end
+
+    describe "confirmed scope" do
+      it "only returns projects with a confirmed conversion date" do
+        mock_successful_api_responses(urn: any_args, ukprn: any_args)
+        provisional_project = create(:conversion_project, conversion_date_provisional: true)
+        confirmed_project = create(:conversion_project, conversion_date_provisional: false)
+
+        scoped_projects = Project.confirmed
+
+        expect(scoped_projects).to include confirmed_project
+        expect(scoped_projects).not_to include provisional_project
+      end
+    end
+
+    describe "by_conversion_date scope" do
+      before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+      it "shows the project that will convert earliest first" do
+        last_project = create(:conversion_project, conversion_date: Date.today.beginning_of_month + 3.years)
+        middle_project = create(:conversion_project, conversion_date: Date.today.beginning_of_month + 2.years)
+        first_project = create(:conversion_project, conversion_date: Date.today.beginning_of_month + 1.year)
+
+        scoped_projects = Project.by_conversion_date
+
+        expect(scoped_projects[0].id).to eq first_project.id
+        expect(scoped_projects[1].id).to eq middle_project.id
+        expect(scoped_projects[2].id).to eq last_project.id
+      end
+    end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -95,15 +95,15 @@ RSpec.describe Project, type: :model do
       end
     end
 
-    describe "#provisional_conversion_date" do
-      it { is_expected.to validate_presence_of(:provisional_conversion_date) }
+    describe "#conversion_date" do
+      it { is_expected.to validate_presence_of(:conversion_date) }
 
       context "when the date is not on the first of the month" do
-        subject { build(:conversion_project, provisional_conversion_date: Date.today.months_since(6).at_end_of_month) }
+        subject { build(:conversion_project, conversion_date: Date.today.months_since(6).at_end_of_month) }
 
         it "is invalid" do
           expect(subject).to_not be_valid
-          expect(subject.errors[:provisional_conversion_date]).to include(I18n.t("errors.attributes.provisional_conversion_date.must_be_first_of_the_month"))
+          expect(subject.errors[:conversion_date]).to include(I18n.t("errors.attributes.conversion_date.must_be_first_of_the_month"))
         end
       end
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -420,8 +420,8 @@ RSpec.describe Project, type: :model do
       end
 
       it "only returns projects with a confirmed conversion date in that month & year" do
-        project_in_scope = create(:conversion_project, conversion_date: Date.new(2023, 1, 1))
-        project_not_in_scope = create(:conversion_project, conversion_date: Date.new(2023, 2, 1))
+        project_in_scope = create(:conversion_project, conversion_date: Date.new(2023, 1, 1), conversion_date_provisional: false)
+        project_not_in_scope = create(:conversion_project, conversion_date: Date.new(2023, 2, 1), conversion_date_provisional: true)
         project_without_conversion_date = create(:conversion_project)
 
         expect(Project.opening_by_month_year(1, 2023)).to_not include(project_not_in_scope, project_without_conversion_date)

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ProjectPolicy do
 
     context "when the conversion date is confirmed" do
       it "returns true" do
-        project = build(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+        project = build(:conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false)
         user = build(:user, :caseworker)
 
         policy = described_class.new(user, project)

--- a/spec/requests/conversions/date_histories_controller_spec.rb
+++ b/spec/requests/conversions/date_histories_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Conversions::DateHistoriesController do
       user = create(:user, :caseworker)
       sign_in_with(user)
       mock_successful_api_calls(establishment: any_args, trust: any_args)
-      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false)
       mock_successful_api_establishment_response(urn: project.urn)
 
       post conversions_involuntary_project_conversion_date_path(project), params: {conversion_new_date_history_form: {revised_date: nil, note_body: nil}}

--- a/spec/requests/projects_openers_spec.rb
+++ b/spec/requests/projects_openers_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ProjectsOpenersController, type: :request do
       end
 
       it "returns project details in table form" do
-        conversion_project = create(:conversion_project, conversion_date: Date.new(2022, 1, 1))
+        conversion_project = create(:conversion_project, conversion_date: Date.new(2022, 1, 1), conversion_date_provisional: false)
         get "/projects/openers/1/2022"
         expect(response.body).to include(
           conversion_project.establishment.name,
@@ -67,8 +67,8 @@ RSpec.describe ProjectsOpenersController, type: :request do
       end
 
       it "only returns projects whose confirmed conversion date is in that month & year" do
-        project_in_scope = create(:conversion_project, urn: 100001, conversion_date: Date.new(2022, 1, 1))
-        project_not_in_scope = create(:conversion_project, urn: 100002, conversion_date: Date.new(2022, 2, 1))
+        project_in_scope = create(:conversion_project, urn: 100001, conversion_date: Date.new(2022, 1, 1), conversion_date_provisional: false)
+        project_not_in_scope = create(:conversion_project, urn: 100002, conversion_date: Date.new(2022, 2, 1), conversion_date_provisional: false)
 
         get "/projects/openers/1/2022"
         expect(response.body).to include(project_in_scope.urn.to_s)

--- a/spec/services/conversion_date_updater_spec.rb
+++ b/spec/services/conversion_date_updater_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe ConversionDateUpdater do
       conversion_date_updater = described_class.new(project: project, revised_date: revised_date, note_body: note_body, user: user)
 
       expect(conversion_date_updater.update!).to be true
-
     end
 
     it "creates the conversion date history and note" do

--- a/spec/services/conversion_date_updater_spec.rb
+++ b/spec/services/conversion_date_updater_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe ConversionDateUpdater do
+  let(:user) { create(:user, :caseworker) }
+  let(:note_body) { "This is my note body." }
+
+  before do
+    mock_successful_api_calls(establishment: any_args, trust: any_args)
+  end
+
+  describe "#update!" do
+    it "returns true when successful" do
+      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+      revised_date = project.conversion_date + 2.months
+
+      conversion_date_updater = described_class.new(project: project, revised_date: revised_date, note_body: note_body, user: user)
+
+      expect(conversion_date_updater.update!).to be true
+
+    end
+
+    it "creates the conversion date history and note" do
+      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+      revised_date = project.conversion_date + 2.months
+
+      conversion_date_updater = described_class.new(project: project, revised_date: revised_date, note_body: note_body, user: user)
+
+      expect(conversion_date_updater.update!).to be true
+      expect(project.conversion_dates.count).to eql 1
+      expect(Note.count).to eql 1
+
+      conversion_date_history = project.conversion_dates.first
+      expect(conversion_date_history.revised_date).to eql revised_date
+
+      note = conversion_date_history.note
+      expect(note.user).to eql user
+      expect(note.project).to eql project
+      expect(note.body).to eql note_body
+    end
+
+    it "updates the project conversion date with the revised date" do
+      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+      revised_date = project.conversion_date + 2.months
+
+      conversion_date_updater = described_class.new(project: project, revised_date: revised_date, note_body: note_body, user: user)
+
+      expect(conversion_date_updater.update!).to be true
+
+      expect(project.reload.conversion_date).to eql revised_date
+    end
+
+    it "is transactional, it does nothing if any operation fails and returns false" do
+      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+      revised_date = project.conversion_date + 2.months
+
+      allow(project).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+
+      conversion_date_updater = ConversionDateUpdater.new(project: project, revised_date: revised_date, note_body: note_body, user: user)
+
+      expect(conversion_date_updater.update!).to be false
+      expect(project.reload.conversion_date).not_to eql revised_date
+      expect(Note.count).to be_zero
+      expect(project.conversion_dates.count).to be_zero
+    end
+  end
+end

--- a/spec/services/project_conversion_date_migrator_spec.rb
+++ b/spec/services/project_conversion_date_migrator_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe ProjectConversionDateMigrator do
+  before do
+    mock_successful_api_calls(establishment: any_args, trust: any_args)
+  end
+
+  describe "#migrate_up!" do
+    context "when the project is provisional" do
+      it "sets the conversion date to the provisional date" do
+        user = create(:user)
+        project = create(:conversion_project, provisional_conversion_date: Date.today.at_beginning_of_month)
+        project.conversion_date = nil
+        project.save(validate: false)
+
+        project.task_list.user = user
+        project.task_list.stakeholder_kick_off_confirmed_conversion_date = nil
+        project.task_list.save
+
+        described_class.new(project).migrate_up!
+        project.reload
+
+        expect(project.conversion_date).to eql project.provisional_conversion_date
+        expect(project.conversion_date_provisional?).to eql true
+      end
+    end
+
+    context "when the project is already confirmed" do
+      context "and the project is assigned to a user" do
+        it "creates a conversion date history for the user" do
+          user = create(:user)
+          project = create(
+            :conversion_project,
+            assigned_to: user,
+            provisional_conversion_date: Date.today.at_beginning_of_month,
+            conversion_date: Date.today.at_beginning_of_month + 1.month
+          )
+
+          described_class.new(project).migrate_up!
+          project.reload
+
+          expect(project.conversion_dates.count).to eql 1
+          conversion_date_history = project.conversion_dates.order(:created_at).first
+
+          expect(conversion_date_history.revised_date).to eql project.conversion_date
+          expect(conversion_date_history.previous_date).to eql project.provisional_conversion_date
+
+          expect(project.conversion_date_provisional?).to eql false
+        end
+      end
+
+      context "and the project is not assigned to a user" do
+        it "creates a conversion date history for the regional delivery officer" do
+          user = create(:user, :regional_delivery_officer)
+          project = create(
+            :conversion_project,
+            assigned_to: nil,
+            regional_delivery_officer: user,
+            provisional_conversion_date: Date.today
+          )
+
+          described_class.new(project).migrate_up!
+          project.reload
+
+          expect(project.conversion_dates.count).to eql 1
+          conversion_date_history = project.conversion_dates.last
+
+          expect(conversion_date_history.revised_date).to eql project.conversion_date
+          expect(conversion_date_history.previous_date).to eql project.provisional_conversion_date
+
+          expect(project.conversion_date_provisional?).to eql false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This work is the refactoring of how we model the conversion date.

The conversion date moves through three main states:

provisional > confirmed > changed

It can change multiple times, but it is only ever provisional once. A chagned date is still considered confirmed as it would have to be agreed by all parties.

This work is prompted by the difficulty we face building views that rely on the converison date being one column in the database when it may be represented by two, `provisional_converison_date` or `conversion_date`.

Keeping the test suite green through this means a lot has to change in single commits - apologies for that.

With the refactor done, we have one database column that can be used to sort and order projects - which makes working with them much simpler, it also resolves the bug we have where projects are always grouped by the provisional date, even after the date is no longer considered provisional.

MIgrating the projects in production has proven to be a real head scratcher (for me at least!)- I ended up writhing a small 'service' object so that I could test the result and calling that from the migration. In theory we can remove the service and migration once it is done, but I am not sure if that would have other impacts?

As far as I understand it, in production the migrations are only ever run once, unlike locally where we can rollback and forwards - so there shouldn't be a risk there.

A lot of the work here focuses on changing how the inital provisional to confirmed change happens, the approach is that all project are created with a provisional date (by defaulting `conversion_date_provisional` to true) - we can be confident the first change must be to confirmed - a service object handles all the changes so it can be called from the various places that need to trigger a change: the task list save callbacks and the change conversion date form.

We action the change using the same mechanisms we use when a user changes the date, by creating a `Conversion::DateHisotry`. Becuase a date history requires a note and a note requires a user, we have to inject a user into the task list to allow this to happen.

This work does not include removing the `provisional_conversion_date` column as I would like to see the data migration thorugh before deleting data.

Thanks for reviewing this work, it's been a really complicated one to unravel.



