### PR TITLE
Users can view the trust address in the application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   establishment name
 - the school address from Get information about schools is now shown in the
   school details on the project information tab
+- the trust address from Get information about schools is now shown in the trust
+  details on the project information tab
 
 ### Changed
 

--- a/app/models/academies_api/trust.rb
+++ b/app/models/academies_api/trust.rb
@@ -2,7 +2,13 @@ class AcademiesApi::Trust < AcademiesApi::BaseApiModel
   attr_accessor(
     :ukprn,
     :original_name,
-    :companies_house_number
+    :companies_house_number,
+    :address_street,
+    :address_locality,
+    :address_additional,
+    :address_town,
+    :address_county,
+    :address_postcode
   )
 
   def name
@@ -13,7 +19,24 @@ class AcademiesApi::Trust < AcademiesApi::BaseApiModel
     {
       ukprn: "giasData.ukprn",
       original_name: "giasData.groupName",
-      companies_house_number: "giasData.companiesHouseNumber"
+      companies_house_number: "giasData.companiesHouseNumber",
+      address_street: "giasData.groupContactAddress.street",
+      address_locality: "giasData.groupContactAddress.locality",
+      address_additional: "giasData.groupContactAddress.additionalLine",
+      address_town: "giasData.groupContactAddress.town",
+      address_county: "giasData.groupContactAddress.country",
+      address_postcode: "giasData.groupContactAddress.postcode"
     }
+  end
+
+  def address
+    [
+      address_street,
+      address_locality,
+      address_additional,
+      address_town,
+      address_county,
+      address_postcode
+    ]
   end
 end

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -62,6 +62,10 @@
       row.value { (@project.incoming_trust.name + "<br/>" + link_to_trust_on_gias(@project.incoming_trust_ukprn)).html_safe }
     end
     summary_list.row do |row|
+      row.key { t('project_information.show.trust_details.rows.address') }
+      row.value { address_markup(@project.incoming_trust.address) }
+    end
+    summary_list.row do |row|
       row.key { t('project_information.show.trust_details.rows.ukprn') }
       row.value { @project.incoming_trust_ukprn.to_s }
     end

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -123,6 +123,7 @@ en:
         rows:
           incoming_trust_name: Incoming trust name
           view_in_gias: View the trust information in GIAS (opens in new tab)
+          address: Address
           ukprn: UK Provider Reference Number
           companies_house_number: Companies House number
       local_authority_details:

--- a/spec/factories/academies_api/trust.rb
+++ b/spec/factories/academies_api/trust.rb
@@ -3,5 +3,11 @@ FactoryBot.define do
     ukprn { "10061021" }
     original_name { "THE ROMERO CATHOLIC ACADEMY" }
     companies_house_number { "09702162" }
+    address_street { "The Street" }
+    address_locality { "Locality" }
+    address_additional { "Additional" }
+    address_town { "Town" }
+    address_county { "County" }
+    address_postcode { "PC1 PC2" }
   end
 end

--- a/spec/features/project_information/users_can_view_trust_details_spec.rb
+++ b/spec/features/project_information/users_can_view_trust_details_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Users can view school details" do
+RSpec.feature "Users can view trust details" do
   let(:user) { create(:user, :caseworker) }
   let(:project) { create(:conversion_project, :with_conditions, caseworker: user) }
 
@@ -15,6 +15,17 @@ RSpec.feature "Users can view school details" do
       expect(page).to have_content(project.incoming_trust.name)
       expect(page).to have_content(project.incoming_trust_ukprn)
       expect(page).to have_content(project.incoming_trust.companies_house_number)
+    end
+  end
+
+  scenario "the trust address is shown" do
+    within("#trustDetails") do
+      expect(page).to have_content(project.incoming_trust.address_street)
+      expect(page).to have_content(project.incoming_trust.address_additional)
+      expect(page).to have_content(project.incoming_trust.address_locality)
+      expect(page).to have_content(project.incoming_trust.address_town)
+      expect(page).to have_content(project.incoming_trust.address_county)
+      expect(page).to have_content(project.incoming_trust.address_postcode)
     end
   end
 end

--- a/spec/helpers/project_helper_spec.rb
+++ b/spec/helpers/project_helper_spec.rb
@@ -140,15 +140,30 @@ RSpec.describe ProjectHelper, type: :helper do
   end
 
   describe "#address_markup" do
-    it "returns the address on mutiple lines wrapped in the <address> tag" do
-      establishment = build(:academies_api_establishment)
-      markup = address_markup(establishment.address)
+    context "within school details" do
+      it "returns the address on mutiple lines wrapped in the <address> tag" do
+        establishment = build(:academies_api_establishment)
+        markup = address_markup(establishment.address)
 
-      expect(markup).to include("address")
-      expect(markup).to include("/address")
-      expect(markup).to include("#{establishment.address_street}<br/>")
-      expect(markup).to include("#{establishment.address_additional}<br/>")
-      expect(markup).to include(establishment.address_postcode.to_s)
+        expect(markup).to include("address")
+        expect(markup).to include("/address")
+        expect(markup).to include("#{establishment.address_street}<br/>")
+        expect(markup).to include("#{establishment.address_additional}<br/>")
+        expect(markup).to include(establishment.address_postcode.to_s)
+      end
+    end
+
+    context "within trust details" do
+      it "returns the address on mutiple lines wrapped in the <address> tag" do
+        trust = build(:academies_api_trust)
+        markup = address_markup(trust.address)
+
+        expect(markup).to include("address")
+        expect(markup).to include("/address")
+        expect(markup).to include("#{trust.address_street}<br/>")
+        expect(markup).to include("#{trust.address_additional}<br/>")
+        expect(markup).to include(trust.address_postcode.to_s)
+      end
     end
   end
 end


### PR DESCRIPTION
## Changes

The trust address from Get information about schools is now shown in the trust details on the project information tab
This mirrors the work done for fetching and displaying the schools address from Get information about schools.

![Screenshot 2023-03-14 at 09 17 37](https://user-images.githubusercontent.com/59832893/224953904-e11d8d78-2321-4312-becd-7f02882c0be3.png)

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
