### PR TITLE
Rename `caseworker_assigned_at` to `assigned_at`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   depending on whether the project is being handed over to Regional Caseworker
   services or not
 - Removed the Caseworker and Team Leader fields from the internal contact tab
+- Started tracking when a project is assigned to a person via the `assigned_at`
+  database column
 
 ### Added
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -29,6 +29,7 @@ class AssignmentsController < ApplicationController
 
   def update_assigned_to
     @project.update(assigned_to_params.except(:return_to))
+    @project.update(assigned_at: DateTime.now) if @project.assigned_at.nil?
 
     AssignedToMailer.assigned_notification(@project.assigned_to, @project).deliver_later
 

--- a/db/migrate/20230314150625_rename_caseworker_assigned_at.rb
+++ b/db/migrate/20230314150625_rename_caseworker_assigned_at.rb
@@ -1,0 +1,11 @@
+class RenameCaseworkerAssignedAt < ActiveRecord::Migration[7.0]
+  def change
+    Project.all.each do |project|
+      if project.caseworker_assigned_at.nil?
+        project.update!(caseworker_assigned_at: project.created_at)
+      end
+    end
+
+    rename_column :projects, :caseworker_assigned_at, :assigned_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_02_151008) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_14_150625) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -264,7 +264,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_02_151008) do
     t.date "provisional_conversion_date", null: false
     t.uuid "regional_delivery_officer_id"
     t.uuid "caseworker_id"
-    t.datetime "caseworker_assigned_at"
+    t.datetime "assigned_at"
     t.date "advisory_board_date"
     t.text "advisory_board_conditions"
     t.text "establishment_sharepoint_link"

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_db_column(:caseworker_id).of_type :uuid }
     it { is_expected.to have_db_column(:team_leader_id).of_type :uuid }
     it { is_expected.to have_db_column(:assigned_to_id).of_type :uuid }
-    it { is_expected.to have_db_column(:caseworker_assigned_at).of_type :datetime }
+    it { is_expected.to have_db_column(:assigned_at).of_type :datetime }
     it { is_expected.to have_db_column(:advisory_board_date).of_type :date }
     it { is_expected.to have_db_column(:advisory_board_conditions).of_type :text }
     it { is_expected.to have_db_column(:establishment_sharepoint_link).of_type :text }


### PR DESCRIPTION

## Changes

The `caseworker_assigned_at` attribute on Projects is now redundant, as we are assigning people to the projects in the `assigned_to` field - and they may not be caseworkers.

Rename the column `caseworker_assigned_at` to just `assigned_at` Fill this column whenever anyone is added to the `assigned_to` field on a project

If any projects already on the system are assigned but do not have an `assigned_at` value (e.g. if they are assigned to an RDO, not a caseworker), backfill the column with the project's `created_at` date (it's close enough!)

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
