### PR TITLE
Change to guidance above complete project button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Update to complete project button guidance
 - Involuntary/Sponsored > External Stakeholder Kickoff guidance iteration and
   fix incorrect guidance
 - Involuntary/Sponsored > External Stakeholder Kickoff > Send introductory

--- a/app/views/projects/show/_complete.html.erb
+++ b/app/views/projects/show/_complete.html.erb
@@ -3,7 +3,7 @@
 
     <%= form_with url: project_complete_path(@project), method: :put do |form| %>
       <h3 class="govuk-heading-m"><%= t("project.complete.heading") %></h3>
-      <p class="govuk-body"><%= t("project.complete.guidance") %></p>
+      <p class="govuk-body"><%= t("project.complete.guidance.html") %></p>
 
       <%= form.govuk_submit t("project.complete.submit_button") %>
 

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -43,8 +43,10 @@ en:
     complete:
       heading: Completing a project
       guidance:
-        You should only complete the project when you have finished every task and marked any that are not needed
-        as not applicable. You will not be able to change this project once it is completed.
+        html:
+          <p>You should only complete the project when you have finished every task and marked any that are not needed
+          as not applicable.</p>
+          <p>You will not be able to change this project once it is completed.</p>
       submit_button: Complete project
       back_link: Return to project list
     summary:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -42,8 +42,10 @@ en:
       success: Project has been updated successfully
     complete:
       heading: Completing a project
-      guidance: Check all the tasks have been completed or marked as not applicable.
-      submit_button: Mark project as completed
+      guidance:
+        You should only complete the project when you have finished every task and marked any that are not needed
+        as not applicable. You will not be able to change this project once it is completed.
+      submit_button: Complete project
       back_link: Return to project list
     summary:
       incoming_trust:


### PR DESCRIPTION
## Changes

Added more guidance to be explicit about completing every task or marking as not applicable before clicking big green button. Also changed language on green button to say complete project.

<img width="723" alt="Screenshot 2023-03-15 at 11 55 32" src="https://user-images.githubusercontent.com/104517016/225301953-c803be05-042f-417d-9cc9-297345b2a487.png">

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
