### PR TITLE
Fix the conversion date migration

### DIFF
--- a/app/services/project_conversion_date_migrator.rb
+++ b/app/services/project_conversion_date_migrator.rb
@@ -4,10 +4,12 @@ class ProjectConversionDateMigrator
   end
 
   def migrate_up!
-    if @project.conversion_date.nil? && @project.conversion_date_provisional? && @project.task_list.stakeholder_kick_off_confirmed_conversion_date.nil?
-      @project.update!(conversion_date: @project.provisional_conversion_date)
-    else
+    if @project.provisional_conversion_date.present? && @project.conversion_date.nil? && @project.task_list.stakeholder_kick_off_confirmed_conversion_date.nil?
+      @project.update!(conversion_date: @project.provisional_conversion_date, conversion_date_provisional: true)
+    elsif @project.task_list.stakeholder_kick_off_confirmed_conversion_date.present?
       note_body = "Conversion date confirmed as part of external stakeholder kick off task."
+      previous_date = @project.provisional_conversion_date
+      revised_date = @project.task_list.stakeholder_kick_off_confirmed_conversion_date
 
       user = if @project.assigned_to.present?
         User.find(@project.assigned_to.id)
@@ -16,8 +18,8 @@ class ProjectConversionDateMigrator
       end
 
       conversion_date_history_note = Note.create!(project_id: @project.id, user_id: user.id, body: note_body)
-      Conversion::DateHistory.create!(project_id: @project.id, previous_date: @project.provisional_conversion_date, revised_date: @project.conversion_date, note: conversion_date_history_note)
-      @project.update!(conversion_date_provisional: false)
+      Conversion::DateHistory.create!(project_id: @project.id, previous_date: previous_date, revised_date: revised_date, note: conversion_date_history_note)
+      @project.update!(conversion_date: revised_date, conversion_date_provisional: false)
     end
   end
 end

--- a/spec/services/project_conversion_date_migrator_spec.rb
+++ b/spec/services/project_conversion_date_migrator_spec.rb
@@ -32,9 +32,11 @@ RSpec.describe ProjectConversionDateMigrator do
           project = create(
             :conversion_project,
             assigned_to: user,
-            provisional_conversion_date: Date.today.at_beginning_of_month,
-            conversion_date: Date.today.at_beginning_of_month + 1.month
+            provisional_conversion_date: Date.today.at_beginning_of_month
           )
+          project.conversion_date = nil
+          project.save(validate: false)
+          allow(project.task_list).to receive(:stakeholder_kick_off_confirmed_conversion_date).and_return(Date.today.at_beginning_of_month + 1.month)
 
           described_class.new(project).migrate_up!
           project.reload
@@ -58,6 +60,9 @@ RSpec.describe ProjectConversionDateMigrator do
             regional_delivery_officer: user,
             provisional_conversion_date: Date.today
           )
+          project.conversion_date = nil
+          project.save(validate: false)
+          allow(project.task_list).to receive(:stakeholder_kick_off_confirmed_conversion_date).and_return(Date.today.at_beginning_of_month + 1.month)
 
           described_class.new(project).migrate_up!
           project.reload


### PR DESCRIPTION
When we attempted to run the conversion date migration in development it
failed. This was because any existing project did not get the default
value of true for the new `conversion_date_provisional` meaning the
first if case did not pass and the project fell into the else.

There the code attepmts to create a history but cannot as there is no
value to get a revised date (because it is acually provisional!)

This fixed version:

- changes the first if case to check for a nil converison date, a
  present provisional conversion date and a stake holder kick off task
  that has no value, in production this should mean a project that is
  still provisional
- we use an elsif to confirm the other case has a value for the
  stakeholder kick off task we can use before attempting to do so.
- if neither of these cases is true we do nothing, although that would
  mean a project in an unexpected state.

## Changes

_Add a summary of the changes in this pull request_

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
