### PR TITLE
Add "change conversion date" button to involuntary conversions

### DIFF
--- a/app/views/conversions/involuntary/task_lists/index.html.erb
+++ b/app/views/conversions/involuntary/task_lists/index.html.erb
@@ -3,6 +3,7 @@
 <% end %>
 
 <%= render partial: "projects/shared/project_summary" %>
+<%= render partial: "projects/shared/project_actions" %>
 <%= render partial: "projects/shared/project_sub_navigation" %>
 
 <h2 class="govuk-heading-l"><%= t("project.show.title") %></h2>

--- a/spec/features/conversions/users_can_change_the_conversion_date_spec.rb
+++ b/spec/features/conversions/users_can_change_the_conversion_date_spec.rb
@@ -28,6 +28,16 @@ RSpec.feature "Users can change the conversion date" do
     expect(page).to have_content(I18n.t("conversion_new_date_history_form.success.panel.title"))
   end
 
+  context "Involuntary conversions" do
+    scenario "the Change conversion date button is also available on involuntary conversions" do
+      project = create(:involuntary_conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false)
+
+      visit conversions_involuntary_project_path(project)
+
+      expect(page).to have_link(I18n.t("conversion_new_date_history_form.new"))
+    end
+  end
+
   scenario "they can cancel the change if needed" do
     project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false)
 


### PR DESCRIPTION

## Changes

The involuntary conversion Task list page did not show the "Change conversion date" button. This was accidentally missed from a previous commit.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
