### PR TITLE
Basic auhorisation policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Updated success messages for notification banners
+- Users who are not assigned to the project can no longer update the task list
+  actions
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Users who are not assigned to the project can no longer complete it
 - External contacts can no longer be added, updated of deleted from projects
   that are completed
+- Notes can no longer be added, update or deleted from projects that are
+  completed
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Users who are not assigned to the project can no longer change the conversion
   date
 - Users who are not assigned to the project can no longer complete it
+- External contacts can no longer be added, updated of deleted from projects
+  that are completed
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated success messages for notification banners
 - Users who are not assigned to the project can no longer update the task list
   actions
+- Users who are not assigned to the project can no longer change the conversion
+  date
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   actions
 - Users who are not assigned to the project can no longer change the conversion
   date
+- Users who are not assigned to the project can no longer complete it
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Notes can no longer be added, update or deleted from projects that are
   completed
 - Tasks can no longer be updated once the project is completed
+- Internal contacts can no longer be updated once the project is completed
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   that are completed
 - Notes can no longer be added, update or deleted from projects that are
   completed
+- Tasks can no longer be updated once the project is completed
 
 ### Added
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -18,6 +18,7 @@ class AssignmentsController < ApplicationController
   end
 
   def update_regional_delivery_officer
+    authorize @project, :update_regional_delivery_officer?
     @project.update(regional_delivery_officer_params)
 
     redirect_to helpers.path_to_project_internal_contacts(@project), notice: t("project.assign.regional_delivery_officer.success")
@@ -28,6 +29,7 @@ class AssignmentsController < ApplicationController
   end
 
   def update_assigned_to
+    authorize @project, :update_assigned_to?
     @project.update(assigned_to_params.except(:return_to))
     @project.update(assigned_at: DateTime.now) if @project.assigned_at.nil?
 

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -6,10 +6,12 @@ class ContactsController < ApplicationController
   end
 
   def new
+    authorize @project, :new_contact?
     @contact = Contact.new(project: @project)
   end
 
   def create
+    authorize @project, :new_contact?
     @contact = Contact.new(project: @project, **contact_params)
 
     if @contact.valid?
@@ -23,12 +25,14 @@ class ContactsController < ApplicationController
 
   def edit
     @contact = Contact.find(params[:id])
+    authorize @contact
 
     @users = User.all
   end
 
   def update
     @contact = Contact.find(params[:id])
+    authorize @contact
 
     @contact.assign_attributes(contact_params)
 
@@ -42,6 +46,8 @@ class ContactsController < ApplicationController
 
   def destroy
     @contact = Contact.find(params[:id])
+    authorize @contact
+
     @contact.destroy
 
     redirect_to project_contacts_path(@project), notice: I18n.t("contact.destroy.success")
@@ -49,6 +55,7 @@ class ContactsController < ApplicationController
 
   def confirm_destroy
     @contact = Contact.find(params[:contact_id])
+    authorize @contact
   end
 
   private def find_project

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -2,7 +2,6 @@ class NotesController < ApplicationController
   before_action :find_project
   before_action :find_project_level_notes, only: :index
   after_action :verify_authorized, except: :index
-  after_action :verify_policy_scoped, only: :index
 
   def new
     @note = Note.new(project: @project, user_id:, task_identifier: params[:task_identifier])
@@ -74,7 +73,7 @@ class NotesController < ApplicationController
   end
 
   private def find_project_level_notes
-    @notes = policy_scope(Note).includes([:user]).project_level_notes(@project)
+    @notes = Note.project_level_notes(@project).includes(:user)
   end
 
   private def note_params

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -4,13 +4,15 @@ class NotesController < ApplicationController
   after_action :verify_authorized, except: :index
 
   def new
+    authorize @project, :new_note?
+
     @note = Note.new(project: @project, user_id:, task_identifier: params[:task_identifier])
-    authorize @note
   end
 
   def create
+    authorize @project, :new_note?
+
     @note = Note.new(project: @project, user_id:, **note_params)
-    authorize @note
 
     if @note.valid?
       @note.save
@@ -73,7 +75,7 @@ class NotesController < ApplicationController
   end
 
   private def find_project_level_notes
-    @notes = Note.project_level_notes(@project).includes(:user)
+    @notes = Note.project_level_notes(@project).includes([:user, :project])
   end
 
   private def note_params

--- a/app/controllers/projects_complete_controller.rb
+++ b/app/controllers/projects_complete_controller.rb
@@ -1,6 +1,8 @@
 class ProjectsCompleteController < ApplicationController
   def complete
     @project = Project.find(project_id)
+    authorize @project, :update?
+
     set_project_completed_at
 
     render :completed

--- a/app/controllers/task_lists_controller.rb
+++ b/app/controllers/task_lists_controller.rb
@@ -41,6 +41,6 @@ class TaskListsController < ApplicationController
   end
 
   private def find_task_notes
-    @notes = Note.includes([:user]).where(project: @project, task_identifier: @task.class.identifier)
+    @notes = Note.includes([:user, :project]).where(project: @project, task_identifier: @task.class.identifier)
   end
 end

--- a/app/controllers/task_lists_controller.rb
+++ b/app/controllers/task_lists_controller.rb
@@ -11,6 +11,7 @@ class TaskListsController < ApplicationController
   end
 
   def update
+    authorize @task_list, policy_class: TaskListPolicy
     @task.assign_attributes task_params
 
     if @task.valid?

--- a/app/policies/contact_policy.rb
+++ b/app/policies/contact_policy.rb
@@ -1,0 +1,29 @@
+class ContactPolicy
+  attr_reader :user, :contact
+
+  def initialize(user, contact)
+    @user = user
+    @contact = contact
+    @project = @contact.project
+  end
+
+  def edit?
+    return false if @project.completed?
+
+    true
+  end
+
+  def update?
+    edit?
+  end
+
+  def destroy?
+    return false if @project.completed?
+
+    true
+  end
+
+  def confirm_destroy?
+    destroy?
+  end
+end

--- a/app/policies/note_policy.rb
+++ b/app/policies/note_policy.rb
@@ -29,19 +29,4 @@ class NotePolicy
   def confirm_destroy?
     edit?
   end
-
-  class Scope
-    def initialize(user, scope)
-      @user = user
-      @scope = scope
-    end
-
-    def resolve
-      scope.all
-    end
-
-    private
-
-    attr_reader :user, :scope
-  end
 end

--- a/app/policies/note_policy.rb
+++ b/app/policies/note_policy.rb
@@ -3,19 +3,14 @@ class NotePolicy
 
   def initialize(user, note)
     @user = user
-    @record = note
-  end
-
-  def create?
-    true
-  end
-
-  def new?
-    create?
+    @note = note
+    @project = @note.project
   end
 
   def edit?
-    @record.user == @user
+    return false if @project.completed?
+
+    @note.user == @user
   end
 
   def update?

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -43,15 +43,29 @@ class ProjectPolicy
   end
 
   def new_note?
-    return true unless @record.completed?
+    edit_project_closed?
   end
 
   def new_contact?
-    return true unless @record.completed?
+    edit_project_closed?
+  end
+
+  def update_assigned_to?
+    edit_project_closed?
+  end
+
+  def update_regional_delivery_officer?
+    edit_project_closed?
   end
 
   private def project_assigned_to_user?
     @record.assigned_to == @user
+  end
+
+  private def edit_project_closed?
+    return false if @record.completed?
+
+    true
   end
 
   class Scope

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -42,6 +42,14 @@ class ProjectPolicy
     project_assigned_to_user?
   end
 
+  def new_note?
+    return true unless @record.completed?
+  end
+
+  def new_contact?
+    return true unless @record.completed?
+  end
+
   private def project_assigned_to_user?
     @record.assigned_to == @user
   end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -31,7 +31,9 @@ class ProjectPolicy
   end
 
   def change_conversion_date?
-    @record.conversion_date_provisional? == false
+    return false if @record.conversion_date_provisional?
+
+    @record.assigned_to == @user
   end
 
   class Scope

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -26,6 +26,12 @@ class ProjectPolicy
     create?
   end
 
+  def update?
+    return false if @record.completed?
+
+    project_assigned_to_user?
+  end
+
   def openers?
     true
   end
@@ -33,6 +39,10 @@ class ProjectPolicy
   def change_conversion_date?
     return false if @record.conversion_date_provisional?
 
+    project_assigned_to_user?
+  end
+
+  private def project_assigned_to_user?
     @record.assigned_to == @user
   end
 
@@ -52,8 +62,6 @@ class ProjectPolicy
       end
     end
 
-    private
-
-    attr_reader :user, :scope
+    private attr_reader :user, :scope
   end
 end

--- a/app/policies/task_list_policy.rb
+++ b/app/policies/task_list_policy.rb
@@ -1,0 +1,16 @@
+class TaskListPolicy
+  attr_reader :user, :task_list
+
+  def initialize(user, task_list)
+    @user = user
+    @task_list = task_list
+  end
+
+  def edit?
+    true
+  end
+
+  def update?
+    @task_list.project.assigned_to == @user
+  end
+end

--- a/app/policies/task_list_policy.rb
+++ b/app/policies/task_list_policy.rb
@@ -4,6 +4,7 @@ class TaskListPolicy
   def initialize(user, task_list)
     @user = user
     @task_list = task_list
+    @project = task_list.project
   end
 
   def edit?
@@ -11,6 +12,8 @@ class TaskListPolicy
   end
 
   def update?
+    return false if @project.completed?
+
     @task_list.project.assigned_to == @user
   end
 end

--- a/spec/accessibility/projects_spec.rb
+++ b/spec/accessibility/projects_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Test projects accessibility", driver: :headless_firefox, accessib
   end
 
   scenario "project completed page" do
-    project = create(:conversion_project, regional_delivery_officer: user)
+    project = create(:conversion_project, regional_delivery_officer: user, assigned_to: user)
     visit project_path(project)
 
     click_on I18n.t("project.complete.submit_button")

--- a/spec/features/conversions/users_can_change_the_conversion_date_spec.rb
+++ b/spec/features/conversions/users_can_change_the_conversion_date_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Users can change the conversion date" do
 
   scenario "they can change the date on a conversion project and see a confirmation view" do
     revised_conversion_date = (Date.today + 6.months).at_beginning_of_month
-    project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false)
+    project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false, assigned_to: user)
 
     visit conversions_voluntary_project_path(project)
 
@@ -30,7 +30,7 @@ RSpec.feature "Users can change the conversion date" do
 
   context "Involuntary conversions" do
     scenario "the Change conversion date button is also available on involuntary conversions" do
-      project = create(:involuntary_conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false)
+      project = create(:involuntary_conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false, assigned_to: user)
 
       visit conversions_involuntary_project_path(project)
 
@@ -39,7 +39,7 @@ RSpec.feature "Users can change the conversion date" do
   end
 
   scenario "they can cancel the change if needed" do
-    project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false)
+    project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false, assigned_to: user)
 
     visit conversions_voluntary_project_path(project)
 
@@ -54,7 +54,7 @@ RSpec.feature "Users can change the conversion date" do
   end
 
   scenario "they can view the conversion date change note on the projects notes view" do
-    project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false)
+    project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false, assigned_to: user)
     revised_conversion_date = (Date.today + 6.months).at_beginning_of_month
     note = "This is a test note."
 
@@ -75,7 +75,7 @@ RSpec.feature "Users can change the conversion date" do
 
   context "when the project conversion date is provisional" do
     scenario "they cannot change the conversion date" do
-      project = create(:conversion_project)
+      project = create(:conversion_project, assigned_to: user)
 
       visit conversions_voluntary_project_path(project)
 

--- a/spec/features/users_can_complete_a_project_spec.rb
+++ b/spec/features/users_can_complete_a_project_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Users can complete a project" do
   let(:user) { create(:user, :caseworker) }
-  let(:project) { create(:conversion_project, caseworker: user) }
+  let(:project) { create(:conversion_project, assigned_to: user) }
 
   before do
     mock_successful_api_responses(urn: 123456, ukprn: 10061021)

--- a/spec/features/users_can_complete_conversion_involuntary_tasks_spec.rb
+++ b/spec/features/users_can_complete_conversion_involuntary_tasks_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Users can complete tasks in an involuntary conversion project" do
   let(:user) { create(:user, :regional_delivery_officer) }
-  let(:involuntary_project) { create(:involuntary_conversion_project) }
+  let(:involuntary_project) { create(:involuntary_conversion_project, assigned_to: user) }
 
   before do
     mock_successful_api_responses(urn: any_args, ukprn: any_args)

--- a/spec/features/users_can_complete_conversion_voluntary_tasks_spec.rb
+++ b/spec/features/users_can_complete_conversion_voluntary_tasks_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Users can complete tasks in a voluntary conversion project" do
   let(:user) { create(:user, :regional_delivery_officer) }
-  let(:voluntary_project) { create(:voluntary_conversion_project) }
+  let(:voluntary_project) { create(:voluntary_conversion_project, assigned_to: user) }
 
   before do
     mock_successful_api_responses(urn: any_args, ukprn: any_args)

--- a/spec/policies/contact_policy_spec.rb
+++ b/spec/policies/contact_policy_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe ContactPolicy do
+  subject { described_class }
+  before { mock_successful_api_response_to_create_any_project }
+
+  let(:application_user) { build(:user, email: "application.user@education.gov.uk") }
+
+  permissions :edit?, :update?, :destroy?, :confirm_destroy? do
+    it "grants access if project is not completed" do
+      project = build(:conversion_project, assigned_to: application_user, completed_at: nil)
+      expect(subject).to permit(application_user, build(:contact, project: project))
+    end
+
+    it "denies access if project is completed" do
+      project = build(:conversion_project, assigned_to: application_user, completed_at: Date.yesterday)
+      expect(subject).not_to permit(application_user, build(:contact, project: project))
+    end
+  end
+end

--- a/spec/policies/note_policy_spec.rb
+++ b/spec/policies/note_policy_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe NotePolicy do
+  subject { described_class }
+  before { mock_successful_api_response_to_create_any_project }
+
+  let(:application_user) { build(:user, email: "application.user@education.gov.uk") }
+
+  permissions :edit?, :update?, :destroy? do
+    context "when the note was created by the user" do
+      it "grants access if project is not completed" do
+        project = build(:conversion_project, assigned_to: application_user, completed_at: nil)
+        expect(subject).to permit(application_user, build(:note, project: project, user: application_user))
+      end
+
+      it "denies access if project is completed" do
+        project = build(:conversion_project, assigned_to: application_user, completed_at: Date.yesterday)
+        expect(subject).not_to permit(application_user, build(:note, project: project, user: application_user))
+      end
+    end
+
+    context "when the note was not created by the user" do
+      it "denies access if project is completed" do
+        project = build(:conversion_project, assigned_to: application_user, completed_at: Date.yesterday)
+        expect(subject).not_to permit(application_user, build(:note, project: project))
+      end
+
+      it "denies access if project is not completed" do
+        project = build(:conversion_project, assigned_to: application_user, completed_at: nil)
+        expect(subject).not_to permit(application_user, build(:note, project: project))
+      end
+    end
+  end
+end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -54,4 +54,16 @@ RSpec.describe ProjectPolicy do
       end
     end
   end
+
+  permissions :new_note?, :new_contact? do
+    it "grants access if project is not completed" do
+      project = build(:conversion_project, assigned_to: application_user, completed_at: nil)
+      expect(subject).to permit(application_user, project)
+    end
+
+    it "denies access if project is completed" do
+      project = build(:conversion_project, assigned_to: application_user, completed_at: Date.yesterday)
+      expect(subject).not_to permit(application_user, project)
+    end
+  end
 end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -66,4 +66,28 @@ RSpec.describe ProjectPolicy do
       expect(subject).not_to permit(application_user, project)
     end
   end
+
+  permissions :update_assigned_to? do
+    it "grants access if project is not completed" do
+      project = build(:conversion_project, assigned_to: application_user, completed_at: nil)
+      expect(subject).to permit(application_user, project)
+    end
+
+    it "denies access if project is completed" do
+      project = build(:conversion_project, assigned_to: application_user, completed_at: Date.yesterday)
+      expect(subject).not_to permit(application_user, project)
+    end
+  end
+
+  permissions :update_regional_delivery_officer? do
+    it "grants access if project is not completed" do
+      project = build(:conversion_project, assigned_to: application_user, completed_at: nil)
+      expect(subject).to permit(application_user, project)
+    end
+
+    it "denies access if project is completed" do
+      project = build(:conversion_project, assigned_to: application_user, completed_at: Date.yesterday)
+      expect(subject).not_to permit(application_user, project)
+    end
+  end
 end

--- a/spec/policies/task_list_policy_spec.rb
+++ b/spec/policies/task_list_policy_spec.rb
@@ -4,33 +4,58 @@ RSpec.describe TaskListPolicy do
   subject { described_class }
   before { mock_successful_api_response_to_create_any_project }
 
-  let(:application_user) { create(:user, email: "application.user@education.gov.uk") }
+  let(:application_user) { build(:user, email: "application.user@education.gov.uk") }
 
   permissions :edit? do
     it "grants access if project is assigned to the same user" do
-      expect(subject).to permit(application_user, create(:conversion_project, assigned_to: application_user).task_list)
+      task_list = create(:conversion_project, assigned_to: application_user).task_list
+      expect(subject).to permit(application_user, task_list)
     end
 
     it "grants access if project is assigned to a different user" do
-      expect(subject).to permit(application_user, create(:conversion_project, assigned_to: create(:user)).task_list)
+      task_list = create(:conversion_project, assigned_to: build(:user)).task_list
+      expect(subject).to permit(application_user, task_list)
     end
 
     it "grants access if project is assigned to nil" do
-      expect(subject).to permit(create(:user), create(:conversion_project, assigned_to: nil).task_list)
+      task_list = create(:conversion_project, assigned_to: nil).task_list
+      expect(subject).to permit(create(:user), task_list)
     end
   end
 
   permissions :update? do
-    it "grants access if project is assigned to the same user" do
-      expect(subject).to permit(application_user, create(:conversion_project, assigned_to: application_user).task_list)
+    context "when the project is in progress" do
+      it "grants access if project is assigned to the same user" do
+        task_list = create(:conversion_project, assigned_to: application_user).task_list
+        expect(subject).to permit(application_user, task_list)
+      end
+
+      it "denies access if project is assigned to a different user" do
+        task_list = create(:conversion_project, assigned_to: build(:user)).task_list
+        expect(subject).not_to permit(application_user, task_list)
+      end
+
+      it "denies access if project is assigned to nil" do
+        task_list = create(:conversion_project, assigned_to: nil).task_list
+        expect(subject).not_to permit(application_user, task_list)
+      end
     end
 
-    it "denies access if project is assigned to a different user" do
-      expect(subject).not_to permit(application_user, create(:conversion_project, assigned_to: create(:user)).task_list)
-    end
+    context "when the project is completed" do
+      it "denies access if project is assigned to the same user" do
+        task_list = create(:conversion_project, assigned_to: application_user, completed_at: Date.yesterday).task_list
+        expect(subject).not_to permit(application_user, task_list)
+      end
 
-    it "denies access if project is assigned to nil" do
-      expect(subject).not_to permit(application_user, create(:conversion_project, assigned_to: nil).task_list)
+      it "denies access if project is assigned to a different user" do
+        task_list = create(:conversion_project, assigned_to: build(:user), completed_at: Date.yesterday).task_list
+        expect(subject).not_to permit(application_user, task_list)
+      end
+
+      it "denies access if project is assigned to nil" do
+        task_list = create(:conversion_project, assigned_to: nil, completed_at: Date.yesterday).task_list
+        expect(subject).not_to permit(application_user, task_list)
+      end
     end
   end
 end

--- a/spec/policies/task_list_policy_spec.rb
+++ b/spec/policies/task_list_policy_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe TaskListPolicy do
+  subject { described_class }
+  before { mock_successful_api_response_to_create_any_project }
+
+  let(:application_user) { create(:user, email: "application.user@education.gov.uk") }
+
+  permissions :edit? do
+    it "grants access if project is assigned to the same user" do
+      expect(subject).to permit(application_user, create(:conversion_project, assigned_to: application_user).task_list)
+    end
+
+    it "grants access if project is assigned to a different user" do
+      expect(subject).to permit(application_user, create(:conversion_project, assigned_to: create(:user)).task_list)
+    end
+
+    it "grants access if project is assigned to nil" do
+      expect(subject).to permit(create(:user), create(:conversion_project, assigned_to: nil).task_list)
+    end
+  end
+
+  permissions :update? do
+    it "grants access if project is assigned to the same user" do
+      expect(subject).to permit(application_user, create(:conversion_project, assigned_to: application_user).task_list)
+    end
+
+    it "denies access if project is assigned to a different user" do
+      expect(subject).not_to permit(application_user, create(:conversion_project, assigned_to: create(:user)).task_list)
+    end
+
+    it "denies access if project is assigned to nil" do
+      expect(subject).not_to permit(application_user, create(:conversion_project, assigned_to: nil).task_list)
+    end
+  end
+end

--- a/spec/requests/conversions/date_histories_controller_spec.rb
+++ b/spec/requests/conversions/date_histories_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Conversions::DateHistoriesController do
       user = create(:user, :caseworker)
       sign_in_with(user)
       mock_successful_api_calls(establishment: any_args, trust: any_args)
-      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false)
+      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month, conversion_date_provisional: false, assigned_to: user)
       mock_successful_api_establishment_response(urn: project.urn)
 
       post conversions_involuntary_project_conversion_date_path(project), params: {conversion_new_date_history_form: {revised_date: nil, note_body: nil}}

--- a/spec/requests/conversions/involuntary/task_lists_controller_spec.rb
+++ b/spec/requests/conversions/involuntary/task_lists_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Conversions::Involuntary::TaskListsController do
-  let(:project) { create(:involuntary_conversion_project) }
+  let(:project) { create(:involuntary_conversion_project, assigned_to: user) }
   let(:project_id) { project.id }
   let(:index_path) { conversions_involuntary_project_task_list_path(project_id) }
   let(:task) { build(:involuntary_conversion_task_handover) }

--- a/spec/requests/conversions/voluntary/task_lists_controller_spec.rb
+++ b/spec/requests/conversions/voluntary/task_lists_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Conversions::Voluntary::TaskListsController do
-  let(:project) { create(:voluntary_conversion_project) }
+  let(:project) { create(:voluntary_conversion_project, assigned_to: user) }
   let(:project_id) { project.id }
   let(:index_path) { conversions_voluntary_project_task_list_path(project_id) }
   let(:task) { build(:voluntary_conversion_task_handover) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,9 @@ require "capybara/rspec"
 require "webmock/rspec"
 WebMock.disable_net_connect!(allow_localhost: true)
 
+# Add Pundit helpers
+require "pundit/rspec"
+
 RSpec.configure do |config|
   # Do not run specs tagged accessibility by default
   config.filter_run_excluding accessibility: true


### PR DESCRIPTION
This is our first step to add some authorisation around projects.

This works adds or updates policies so that:

#### When a user is assigned_to a project
- can update the task list
- can add, delete and update their own notes
- can add, delete and update contacts
- can change the converison date
- can complete the project
- can change the assigned_to

#### When a user is not assigned_to a project
- cannot update the task list
- can add, delete and update their own notes
- can add, delete and update contacts
- cannot change the converison date
- cannot complete the project
- can change the assigned_to

#### When a project is completed
- task list cannot be updated regardless of assigned_to
- notes cannot be added, deleted or updated
- contacts cannot be added, deleted or updated
- cannot change the assigned_to

As we are working with the authorisation, for now the applciation shows the existing 'not authorised' flash, later work will improve on this.

![image](https://user-images.githubusercontent.com/480578/226582166-d2ed225b-ce7b-4695-ba72-6284bc5ec5bd.png)
