### PR TITLE
Bugfix: external stakeholder kick off converison date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Show the project's Sponsor trust required information in the project
   information tab
 
+### Fixed
+
+- users can submit changes on the involuntary external stakeholder kick off task
+  once the confirmed conversion date is set
+
 ## [Release 16][release-16]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - users can submit changes on the involuntary external stakeholder kick off task
   once the confirmed conversion date is set
+- users can submit changes on the voluntary external stakeholder kick off task
+  once the confirmed conversion date is set
 
 ## [Release 16][release-16]
 

--- a/app/views/conversions/involuntary/task_lists/tasks/stakeholder_kick_off.html.erb
+++ b/app/views/conversions/involuntary/task_lists/tasks/stakeholder_kick_off.html.erb
@@ -37,6 +37,10 @@
               legend: {text: t("conversion.involuntary.tasks.stakeholder_kick_off.confirmed_conversion_date.title"), size: "s"} do %>
           <div class="govuk-hint"><%= t("conversion.involuntary.tasks.stakeholder_kick_off.confirmed_conversion_date.hint.html") %></div>
         <% end %>
+      <% else %>
+        <%= hidden_field_tag("conversion_involuntary_tasks_stakeholder_kick_off[confirmed_conversion_date(3i)]", @task.confirmed_conversion_date.day) %>
+        <%= hidden_field_tag("conversion_involuntary_tasks_stakeholder_kick_off[confirmed_conversion_date(2i)]", @task.confirmed_conversion_date.month) %>
+        <%= hidden_field_tag("conversion_involuntary_tasks_stakeholder_kick_off[confirmed_conversion_date(1i)]", @task.confirmed_conversion_date.year) %>
       <% end %>
 
       <%= form.govuk_submit t("task_list.continue_button.text") %>

--- a/app/views/conversions/voluntary/task_lists/tasks/stakeholder_kick_off.html.erb
+++ b/app/views/conversions/voluntary/task_lists/tasks/stakeholder_kick_off.html.erb
@@ -35,8 +35,11 @@
                 form_group: {classes: "app-confirmed-conversion-date"},
                 legend: {text: t("conversion.voluntary.tasks.stakeholder_kick_off.confirmed_conversion_date.title"), size: "s"} do %>
             <div class="govuk-hint"><%= t("conversion.voluntary.tasks.stakeholder_kick_off.confirmed_conversion_date.hint.html") %></div>
-
           <% end %>
+        <% else %>
+          <%= hidden_field_tag("conversion_voluntary_tasks_stakeholder_kick_off[confirmed_conversion_date(3i)]", @task.confirmed_conversion_date.day) %>
+          <%= hidden_field_tag("conversion_voluntary_tasks_stakeholder_kick_off[confirmed_conversion_date(2i)]", @task.confirmed_conversion_date.month) %>
+          <%= hidden_field_tag("conversion_voluntary_tasks_stakeholder_kick_off[confirmed_conversion_date(1i)]", @task.confirmed_conversion_date.year) %>
         <% end %>
       </div>
 

--- a/spec/features/users_can_complete_conversion_involuntary_tasks_spec.rb
+++ b/spec/features/users_can_complete_conversion_involuntary_tasks_spec.rb
@@ -34,17 +34,41 @@ RSpec.feature "Users can complete tasks in an involuntary conversion project" do
     expect(tasks_on_page).to eq tasks_we_are_testing
   end
 
-  scenario "the stakeholder kick off task" do
-    click_on "External stakeholder kick-off"
-    page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
-    within(".app-confirmed-conversion-date") do
-      completion_date = Date.today + 1.year
-      fill_in "Month", with: completion_date.month
-      fill_in "Year", with: completion_date.year
+  describe "the stakeholder kick-off task" do
+    context "when the project conversion date is provisional" do
+      let(:project) { create(:involuntary_conversion_project, assigned_to: user, conversion_date_provisional: true) }
+
+      scenario "they can set the confirmed date" do
+        visit conversions_involuntary_project_task_list_path(project)
+
+        click_on "External stakeholder kick-off"
+        page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
+        within(".app-confirmed-conversion-date") do
+          completion_date = Date.today + 1.year
+          fill_in "Month", with: completion_date.month
+          fill_in "Year", with: completion_date.year
+        end
+        click_on I18n.t("task_list.continue_button.text")
+        table_row = page.find("li.app-task-list__item", text: "External stakeholder kick-off")
+        expect(table_row).to have_content("Completed")
+      end
     end
-    click_on I18n.t("task_list.continue_button.text")
-    table_row = page.find("li.app-task-list__item", text: "External stakeholder kick-off")
-    expect(table_row).to have_content("Completed")
+
+    context "when the project conversion date is confirmed" do
+      let(:project) { create(:involuntary_conversion_project, assigned_to: user, conversion_date_provisional: false) }
+
+      scenario "they can continue to submit the task form" do
+        project.task_list.stakeholder_kick_off_confirmed_conversion_date = Date.today.at_beginning_of_month + 3.months
+        project.task_list.save!
+        visit conversions_involuntary_project_task_list_path(project)
+
+        click_on "External stakeholder kick-off"
+        page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
+        click_on I18n.t("task_list.continue_button.text")
+        table_row = page.find("li.app-task-list__item", text: "External stakeholder kick-off")
+        expect(table_row).to have_content("Completed")
+      end
+    end
   end
 
   context "when the project has a confirmed conversion date" do

--- a/spec/features/users_can_complete_conversion_voluntary_tasks_spec.rb
+++ b/spec/features/users_can_complete_conversion_voluntary_tasks_spec.rb
@@ -35,17 +35,41 @@ RSpec.feature "Users can complete tasks in a voluntary conversion project" do
     expect(tasks_on_page).to eq tasks_we_are_testing
   end
 
-  scenario "the stakeholder kick off task" do
-    click_on "External stakeholder kick-off"
-    page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
-    within(".app-confirmed-conversion-date") do
-      completion_date = Date.today + 1.year
-      fill_in "Month", with: completion_date.month
-      fill_in "Year", with: completion_date.year
+  describe "the stakeholder kick-off task" do
+    context "when the project conversion date is provisional" do
+      let(:project) { create(:voluntary_conversion_project, assigned_to: user, conversion_date_provisional: true) }
+
+      scenario "they can set the confirmed date" do
+        visit conversions_voluntary_project_task_list_path(project)
+
+        click_on "External stakeholder kick-off"
+        page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
+        within(".app-confirmed-conversion-date") do
+          completion_date = Date.today + 1.year
+          fill_in "Month", with: completion_date.month
+          fill_in "Year", with: completion_date.year
+        end
+        click_on I18n.t("task_list.continue_button.text")
+        table_row = page.find("li.app-task-list__item", text: "External stakeholder kick-off")
+        expect(table_row).to have_content("Completed")
+      end
     end
-    click_on I18n.t("task_list.continue_button.text")
-    table_row = page.find("li.app-task-list__item", text: "External stakeholder kick-off")
-    expect(table_row).to have_content("Completed")
+
+    context "when the project conversion date is confirmed" do
+      let(:project) { create(:voluntary_conversion_project, assigned_to: user, conversion_date_provisional: false) }
+
+      scenario "they can continue to submit the task form" do
+        project.task_list.stakeholder_kick_off_confirmed_conversion_date = Date.today.at_beginning_of_month + 3.months
+        project.task_list.save!
+        visit conversions_voluntary_project_task_list_path(project)
+
+        click_on "External stakeholder kick-off"
+        page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
+        click_on I18n.t("task_list.continue_button.text")
+        table_row = page.find("li.app-task-list__item", text: "External stakeholder kick-off")
+        expect(table_row).to have_content("Completed")
+      end
+    end
   end
 
   context "when the project has a confirmed conversion date" do


### PR DESCRIPTION
When the projects conversion date is confrimed we do not show the
conversion date fields on the external stakeholder kick off task.

When submitted the task list attempts to save the task expecting all of
the attributes to be present for mass assignment, but because the form
does not show the date fields this fails.

We saw this in production, here is a link to the exception in Sentry:

https://sdd-n7.sentry.io/issues/4001605117/?project=6684508

The solution is tricky, mostly because of our reliance on mass
assignment on the task list.

However as we have this issus in production, this is a proposed qucik
fix.

Once the conversion date is confirmed we add hidden fields to the form
to ensure all attributes are passed along correctly.

At this point, we are not sure what the long term fix will be for
this issue, but we do need this quick fix.