### PR TITLE
Add "Process the sponsored support grant" task to the voluntary conversion task list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add Sponsor trust required radio buttons to Create project form
 - Show the project's Sponsor trust required information in the project
   information tab
+- New Process the Sponsored support grant task added to the Voluntary task list
 
 ## [Release 16][release-16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   completed
 - Tasks can no longer be updated once the project is completed
 - Internal contacts can no longer be updated once the project is completed
+- The Voluntary Process conversion grant task is now optional
 
 ### Added
 

--- a/app/models/conversion/voluntary/task_list.rb
+++ b/app/models/conversion/voluntary/task_list.rb
@@ -21,7 +21,8 @@ class Conversion::Voluntary::TaskList < TaskList::Base
       tasks: [
         Conversion::Voluntary::Tasks::Handover,
         Conversion::Voluntary::Tasks::StakeholderKickOff,
-        Conversion::Voluntary::Tasks::ConversionGrant
+        Conversion::Voluntary::Tasks::ConversionGrant,
+        Conversion::Voluntary::Tasks::SponsoredSupportGrant
       ]
     },
     {

--- a/app/models/conversion/voluntary/tasks/conversion_grant.rb
+++ b/app/models/conversion/voluntary/tasks/conversion_grant.rb
@@ -1,4 +1,4 @@
-class Conversion::Voluntary::Tasks::ConversionGrant < TaskList::Task
+class Conversion::Voluntary::Tasks::ConversionGrant < TaskList::OptionalTask
   attribute :check_vendor_account
   attribute :payment_form
   attribute :send_information

--- a/app/models/conversion/voluntary/tasks/sponsored_support_grant.rb
+++ b/app/models/conversion/voluntary/tasks/sponsored_support_grant.rb
@@ -1,0 +1,7 @@
+class Conversion::Voluntary::Tasks::SponsoredSupportGrant < TaskList::OptionalTask
+  attribute :eligibility
+  attribute :payment_amount
+  attribute :payment_form
+  attribute :send_information
+  attribute :inform_trust
+end

--- a/app/views/conversions/voluntary/task_lists/tasks/conversion_grant.html.erb
+++ b/app/views/conversions/voluntary/task_lists/tasks/conversion_grant.html.erb
@@ -10,6 +10,10 @@
       <%= form.govuk_error_summary %>
 
       <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
+      <div class="govuk-form-group">
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :check_vendor_account)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :payment_form)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :send_information)) %>

--- a/app/views/conversions/voluntary/task_lists/tasks/sponsored_support_grant.html.erb
+++ b/app/views/conversions/voluntary/task_lists/tasks/sponsored_support_grant.html.erb
@@ -1,0 +1,35 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: task_list_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: conversions_voluntary_project_update_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :eligibility)) %>
+
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :payment_amount)) %>
+
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :payment_form)) %>
+
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :send_information)) %>
+
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :inform_trust)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversions/shared/task_notes" %>
+  </div>
+</div>

--- a/config/locales/task_lists/conversion/voluntary/conversion_grant.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/conversion_grant.en.yml
@@ -61,3 +61,5 @@ en:
 
           share_payment_date:
             title: Tell the school or trust the grant information has been sent
+          not_applicable:
+            title: Not applicable

--- a/config/locales/task_lists/conversion/voluntary/sponsored_support_grant.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/sponsored_support_grant.en.yml
@@ -1,0 +1,106 @@
+en:
+  conversion:
+    voluntary:
+      tasks:
+        sponsored_support_grant:
+          title: Process the Sponsored support grant
+          hint:
+            html:
+              <p>Start this as soon as possible. Trusts can start getting charged by solicitors and the local authority early in the process.</p>
+
+          eligibility:
+            title: Check and confirm the school's grant eligibility
+            hint:
+              html:
+                <p>Confirm if the trust will receive the Fast track, Intermediate or Full sponsored grant.</p>
+            guidance_link: How to check grant eligibility
+            guidance:
+              html:
+                <p>All schools that are issued a Directive academy order are allocated
+                to an experienced trust. These trusts are also known as sponsors.</p>
+                <p>In most cases, the sponsor is entitled to the Fast track grant.</p>
+                <p>The sponsor will get:</p>
+                <ul>
+                <li>£70,000 for primary and special schools</li>
+                <li>£80,000 for secondary and all-through schools</li>
+                </ul>
+                <p>In some circumstances, the sponsor might be entitled to a larger
+                grant.</p>
+                <p>This would be the Intermediate grant, or the Full sponsored grant.</p>
+                <p>Intermediate grant amounts are:</p>
+                <ul>
+                <li>£90,000 for primary and special schools</li>
+                <li>£115,000 for secondary and all-through schools</li>
+                </ul>
+                <p>Full sponsored grant amounts are:</p>
+                <ul>
+                <li>£110,000 for primary and special schools</li>
+                <li>£150,000 secondary and all-through schools</li>
+                </ul>
+                <p>All grants include the £25,000 conversion grant. This is used to fund
+                conversion costs, such as legal expenses. Any amount left after
+                conversion costs have been paid for should be used for school
+                improvements.</p>
+                <p>A business case must be approved at advisory board, or by the regional
+                director, for a trust to get the Intermediate or Full sponsored grant.</p>
+                <p>There is more <a href="https://www.gov.uk/government/publications/sponsored-academies-funding-guidance-for-sponsors" class="govuk-link" target="_blank">guidance on grant eligibility and spending (opens in
+                new tab)</a> on GOV.UK.</p>
+
+          payment_amount:
+            title: Tell the trust how much they are entitled to and how to claim the grant
+            guidance_link: How to claim different grants
+            guidance:
+              html:
+                <p>The sponsor can claim for the Fast track grant first, then apply for
+                a top-up later through an Intermediate or Full sponsored grant.</p>
+                <p>The trust will need to complete and return the <a href="https://educationgovuk.sharepoint.com/:w:/r/sites/lvedfe00116/WorkplaceDocuments/ARDG%20Internal%20Guidance/Archive_April_2020/Pre-Opening_Funding_Grant_Letter_Claim_Form_Annex_1.docx?d=w6bce8b5b84d841dd977af39eb2191afd&amp;csf=1&amp;web=1&amp;e=h02JhV" class="govuk-link" target="_blank">grant claim form
+                (opens in new tab)</a> to claim the Fast track grant. Share the form with them.</p>
+                <p>There is <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Funding-and-Finance.aspx?xsdata=MDV8MDF8fGIzMTZmYzk3NGM2NjQ5OTg0NTNlMDhkYWQ4NTcyMjc2fGZhZDI3N2M5YzYwYTRkYTFiNWYzYjNiOGIzNGE4MmY5fDB8MHw2MzgwNjAxNjU5NzgyNzcxODJ8VW5rbm93bnxWR1ZoYlhOVFpXTjFjbWwwZVZObGNuWnBZMlY4ZXlKV0lqb2lNQzR3TGpBd01EQWlMQ0pRSWpvaVYybHVNeklpTENKQlRpSTZJazkwYUdWeUlpd2lWMVFpT2pFeGZRPT18MXxNVFkzTURReE9UYzVOamcwTnpzeE5qY3dOREU1TnprMk9EUTNPekU1T20xbFpYUnBibWRmVFhwck1GcHFhRzFPYWxWMFRYcHJNMWxUTURCTk1sSnBURmRGTWsxcVRYUmFSMVV6VGtSRmQxbDZSbTFaTWxFMFFIUm9jbVZoWkM1Mk1nPT18Y2I5OTQ1ODRkNzdiNDY3ODQ1M2UwOGRhZDg1NzIyNzZ8NDA4ZDc0YWZkZmYyNDY2MWIxNzU3OTYzNmQ0MGRkMmE%3D&amp;sdata=SFhTMGxCRWVUQkxvTHRTQmp0emVrUlNHREVQdTlEQjFCMlYzSEY3WlR4dz0%3D&amp;ovuser=fad277c9-c60a-4da1-b5f3-b3b8b34a82f9%2CJoanna.EVANS%40EDUCATION.GOV.UK&amp;OR=Teams-HL&amp;CT=1670513971254&amp;clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiIxNDE1LzIyMTEzMDA0MTAwIiwiSGFzRmVkZXJhdGVkVXNlciI6ZmFsc2V9" class="govuk-link" target="_blank">guidance about how to claim different grants (opens in new
+                tab)</a> in SharePoint that explains how a trust can claim the Intermediate and Full sponsored grants.</p>
+
+          payment_form:
+            title: Receive, check and save the converter support grant claim form in the school's SharePoint folder
+            hint:
+              html:
+                <p>Make sure no information is missing.</p>
+            guidance_link: How to check and save the form
+            guidance:
+              html:
+                <p>The trust must send you the grant claim form.</p>
+                <p>Check it's complete and save it in the school's SharePoint folder.</p>
+
+          send_information:
+            title: Send the grant information to the payments team
+            hint:
+              html:
+                <p>Send them the Academy order and Grant claim form.</p>
+            guidance_link: Guidance on what information to send
+            guidance:
+              html:
+                <p>You'll find the Directive academy order and Grant claim form in the
+                school's SharePoint folder.</p>
+                <p>You should send the documents to the Grant Payments team by email at
+                <a href="mailto:cfugrantpayments.regionsgroup@education.gov.uk" class="govuk-link" target="_blank">cfugrantpayments.regionsgroup@education.gov.uk</a>.</p>
+                <p>The subject line of the email must include the:</p>
+                <ul class="govuk-list govuk-list--bullet">
+                <li>region the school is in</li>
+                <li>converter grant type</li>
+                <li>support grant type</li>
+                <li>school's name</li>
+                </ul>
+                <p>The content of the email must include the:</p>
+                <ul class="govuk-list govuk-list--bullet">
+                <li>type of grant, or grants, needed</li>
+                <li>amount of money the school is eligible for</li>
+                <li>school's name</li>
+                <li>trust it's joining</li>
+                <li>provisional conversion date</li>
+                </ul>
+                <p>It's helpful to include the school or trust's vendor account number
+                too. The Grant Payments team will need this to be able to send the
+                money to whoever will receive it.</p>
+
+          inform_trust:
+            title: Tell the trust the grant information as been sent
+          not_applicable:
+            title: Not applicable

--- a/db/migrate/20230321162440_add_conversion_grant_not_applicable_to_voluntary_task_lists.rb
+++ b/db/migrate/20230321162440_add_conversion_grant_not_applicable_to_voluntary_task_lists.rb
@@ -1,0 +1,5 @@
+class AddConversionGrantNotApplicableToVoluntaryTaskLists < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_voluntary_task_lists, :conversion_grant_not_applicable, :boolean
+  end
+end

--- a/db/migrate/20230322142230_add_sponsored_support_grant_to_voluntary_task_list.rb
+++ b/db/migrate/20230322142230_add_sponsored_support_grant_to_voluntary_task_list.rb
@@ -1,0 +1,10 @@
+class AddSponsoredSupportGrantToVoluntaryTaskList < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_voluntary_task_lists, :sponsored_support_grant_eligibility, :boolean
+    add_column :conversion_voluntary_task_lists, :sponsored_support_grant_payment_amount, :boolean
+    add_column :conversion_voluntary_task_lists, :sponsored_support_grant_payment_form, :boolean
+    add_column :conversion_voluntary_task_lists, :sponsored_support_grant_send_information, :boolean
+    add_column :conversion_voluntary_task_lists, :sponsored_support_grant_inform_trust, :boolean
+    add_column :conversion_voluntary_task_lists, :sponsored_support_grant_not_applicable, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_21_112545) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_21_162440) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -241,6 +241,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_21_112545) do
     t.boolean "trust_modification_order_not_applicable"
     t.date "stakeholder_kick_off_confirmed_conversion_date"
     t.boolean "stakeholder_kick_off_check_provisional_conversion_date"
+    t.boolean "conversion_grant_not_applicable"
   end
 
   create_table "notes", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_21_162440) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_22_142230) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -242,6 +242,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_21_162440) do
     t.date "stakeholder_kick_off_confirmed_conversion_date"
     t.boolean "stakeholder_kick_off_check_provisional_conversion_date"
     t.boolean "conversion_grant_not_applicable"
+    t.boolean "sponsored_support_grant_eligibility"
+    t.boolean "sponsored_support_grant_payment_amount"
+    t.boolean "sponsored_support_grant_payment_form"
+    t.boolean "sponsored_support_grant_send_information"
+    t.boolean "sponsored_support_grant_inform_trust"
+    t.boolean "sponsored_support_grant_not_applicable"
   end
 
   create_table "notes", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/features/all_conversion_project_tasks_have_locales_spec.rb
+++ b/spec/features/all_conversion_project_tasks_have_locales_spec.rb
@@ -10,11 +10,12 @@ RSpec.feature "All task lists have a locale file & all keys are present" do
     sign_in_with_user(user)
   end
 
-  tasks = %w[articles_of_association check_baseline church_supplemental_agreement commercial_transfer_agreement
+  involuntary_tasks = %w[articles_of_association check_baseline church_supplemental_agreement commercial_transfer_agreement
     conditions_met conversion_grant deed_of_variation direction_to_transfer handover land_questionnaire land_registry
     master_funding_agreement one_hundred_and_twenty_five_year_lease receive_grant_payment_certificate redact_and_send
     school_completed share_information single_worksheet stakeholder_kick_off subleases supplemental_funding_agreement
     tell_regional_delivery_officer tenancy_at_will trust_modification_order update_esfa]
+  voluntary_tasks = involuntary_tasks + %w[sponsored_support_grant]
 
   context "involuntary project" do
     describe "has locales for all tasks" do
@@ -23,11 +24,11 @@ RSpec.feature "All task lists have a locale file & all keys are present" do
       end
 
       it "has all the links for the involuntary tasks" do
-        expect(page.find_all("ol.app-task-list ul li a").count).to eq tasks.count
+        expect(page.find_all("ol.app-task-list ul li a").count).to eq involuntary_tasks.count
         expect(page).to_not have_css(".translation_missing")
       end
 
-      tasks.each do |task|
+      involuntary_tasks.each do |task|
         it "has locales for #{I18n.t("conversion.involuntary.tasks.#{task}.title")}" do
           click_on I18n.t("conversion.involuntary.tasks.#{task}.title")
           expect(page).to_not have_css(".translation_missing")
@@ -43,11 +44,11 @@ RSpec.feature "All task lists have a locale file & all keys are present" do
       end
 
       it "has all the links for the voluntary tasks" do
-        expect(page.find_all("ol.app-task-list ul li a").count).to eq tasks.count
+        expect(page.find_all("ol.app-task-list ul li a").count).to eq voluntary_tasks.count
         expect(page).to_not have_css(".translation_missing")
       end
 
-      tasks.each do |task|
+      voluntary_tasks.each do |task|
         it "has locales for #{I18n.t("conversion.voluntary.tasks.#{task}.title")}" do
           click_on I18n.t("conversion.voluntary.tasks.#{task}.title")
           expect(page).to_not have_css(".translation_missing")

--- a/spec/features/users_can_complete_conversion_voluntary_tasks_spec.rb
+++ b/spec/features/users_can_complete_conversion_voluntary_tasks_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Users can complete tasks in a voluntary conversion project" do
   optional_tasks = %w[articles_of_association church_supplemental_agreement
     deed_of_variation direction_to_transfer master_funding_agreement
     one_hundred_and_twenty_five_year_lease subleases tenancy_at_will
-    trust_modification_order conversion_grant]
+    trust_modification_order conversion_grant sponsored_support_grant]
 
   tasks_with_collected_data = %w[
     stakeholder_kick_off

--- a/spec/features/users_can_complete_conversion_voluntary_tasks_spec.rb
+++ b/spec/features/users_can_complete_conversion_voluntary_tasks_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Users can complete tasks in a voluntary conversion project" do
   end
 
   mandatory_tasks = %w[check_baseline commercial_transfer_agreement
-    conditions_met conversion_grant handover
+    conditions_met handover
     land_questionnaire land_registry
     receive_grant_payment_certificate redact_and_send
     school_completed share_information single_worksheet
@@ -21,7 +21,7 @@ RSpec.feature "Users can complete tasks in a voluntary conversion project" do
   optional_tasks = %w[articles_of_association church_supplemental_agreement
     deed_of_variation direction_to_transfer master_funding_agreement
     one_hundred_and_twenty_five_year_lease subleases tenancy_at_will
-    trust_modification_order]
+    trust_modification_order conversion_grant]
 
   tasks_with_collected_data = %w[
     stakeholder_kick_off


### PR DESCRIPTION
## Changes

1. Make the Process conversion grant in the Voluntary task list optional

<img width="815" alt="Screenshot 2023-03-22 at 16 55 38" src="https://user-images.githubusercontent.com/1089521/226980507-7523f8c6-097c-43d9-a01d-5c38c1eca6d9.png">

2. Add a new Process the Sponsored support grant task to the Voluntary task list, with the same content as the same-named task in the Involuntary task list

<img width="815" alt="Screenshot 2023-03-22 at 16 55 11" src="https://user-images.githubusercontent.com/1089521/226980689-cb6ca6d7-8d96-456f-911d-fb0846cd183a.png">

These two changes are further steps towards removing the Involuntary conversion type of project. With these two tasks, we should be able to support all conversion types 🤞 

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
