### PR TITLE
Remove button to create an involuntary conversion project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Tasks can no longer be updated once the project is completed
 - Internal contacts can no longer be updated once the project is completed
 - The Voluntary Process conversion grant task is now optional
+- Remove "Create a new involuntary project" button
 
 ### Added
 

--- a/app/views/projects/shared/_new_projects.html.erb
+++ b/app/views/projects/shared/_new_projects.html.erb
@@ -4,9 +4,5 @@
           new_conversions_voluntary_project_path,
           class: "govuk-button",
           data: {module: "govuk-button"} %>
-    <%= link_to t("conversion_project.involuntary.new.title"),
-          new_conversions_involuntary_project_path,
-          class: "govuk-button",
-          data: {module: "govuk-button"} %>
   </div>
 <% end %>

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -13,7 +13,7 @@ en:
     voluntary:
       route: Voluntary
       new:
-        title: Add a new voluntary conversion project
+        title: Add a new conversion project
         hint_html: <p class="govuk-body">Enter the school and trust information.</p><p class="govuk-body">This will create a conversion project for a school that has been granted an Academy order.</p>
       create:
         assigned_to_regional_delivery_officer:

--- a/spec/features/regional_delivery_officers_can_create_new_projects_spec.rb
+++ b/spec/features/regional_delivery_officers_can_create_new_projects_spec.rb
@@ -6,18 +6,11 @@ RSpec.feature "Regional delivery officers can create new projects" do
   context "when the user is a regional delivery officer" do
     let(:user) { create(:user, :regional_delivery_officer) }
 
-    it "shows a button that adds a new voluntary conversion" do
+    it "shows a button that adds a new conversion" do
       visit root_path
 
       expect(page)
         .to have_link I18n.t("conversion_project.voluntary.new.title"), href: new_conversions_voluntary_project_path
-    end
-
-    it "shows a button that adds a new involuntary conversion" do
-      visit root_path
-
-      expect(page)
-        .to have_link I18n.t("conversion_project.involuntary.new.title"), href: new_conversions_involuntary_project_path
     end
   end
 end


### PR DESCRIPTION

## Changes

We are removing the concept of "voluntary" and "involuntary" conversions.

We want all conversion projects from here on to use the "voluntary" route, and to choose tasks which reflect the project's status. In previous commits we amended the voluntary task list to support more conversion types.

We now remove the "Create new involuntary conversion" button.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
