### PR TITLE
Split the advisory board details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The Voluntary Process conversion grant task is now optional
 - Remove "Create a new involuntary project" button
 - the number of items on tabular views has been increased from 10 to 20
+- the sharepoint links have been removed from the Project details section in
+  Project information, they are available in the project summary as before
+- the advisory board details are now separated form the Project details on
+  project information
 
 ### Added
 

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -2,22 +2,6 @@
   <h2 class="govuk-heading-l"><%= t('project_information.show.project_details.title') %></h2>
   <%= govuk_summary_list do |summary_list|
     summary_list.row do |row|
-      row.key { t('project_information.show.project_details.rows.advisory_board_date') }
-      row.value { @project.advisory_board_date.to_date.to_formatted_s(:govuk) }
-    end
-    summary_list.row do |row|
-      row.key { t('project_information.show.project_details.rows.advisory_board_conditions') }
-      row.value { simple_format(@project.advisory_board_conditions, class: "govuk-body") }
-    end
-    summary_list.row do |row|
-      row.key { t('project_information.show.project_details.rows.establishment_sharepoint_link') }
-      row.value { safe_link_to(t("project.summary.establishment_sharepoint_link.value"), @project.establishment_sharepoint_link) }
-    end
-    summary_list.row do |row|
-      row.key { t('project_information.show.project_details.rows.trust_sharepoint_link') }
-      row.value { safe_link_to(t("project.summary.trust_sharepoint_link.value"), @project.trust_sharepoint_link) }
-    end
-    summary_list.row do |row|
       row.key { t('project_information.show.project_details.rows.directive_academy_order.title') }
       row.value { t("project_information.show.project_details.rows.directive_academy_order.#{@project.directive_academy_order}") }
     end
@@ -27,6 +11,20 @@
     end
   end %>
 </div>
+
+<div id="advisoryBoardDetails">
+  <h2 class="govuk-heading-l"><%= t('project_information.show.advisory_board_details.title') %></h2>
+  <%= govuk_summary_list do |summary_list|
+    summary_list.row do |row|
+      row.key { t('project_information.show.advisory_board_details.rows.advisory_board_date') }
+      row.value { @project.advisory_board_date.to_date.to_formatted_s(:govuk) }
+    end
+    summary_list.row do |row|
+      row.key { t('project_information.show.advisory_board_details.rows.advisory_board_conditions') }
+      row.value { simple_format(@project.advisory_board_conditions, class: "govuk-body") }
+    end
+  end %>
+  </div>
 
 <div id="schoolDetails">
   <h2 class="govuk-heading-l"><%= t('project_information.show.school_details.title') %></h2>

--- a/app/views/project_information/show/_side_navigation.html.erb
+++ b/app/views/project_information/show/_side_navigation.html.erb
@@ -2,6 +2,7 @@
   <h2 class="govuk-heading-m"><%= t("project_information.show.side_navigation.title") %></h2>
   <ul class="list-style-none govuk-!-padding-0">
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.project_details.title"), path: "#projectDetails"} %>
+    <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.advisory_board_details.title"), path: "#advisoryBoardDetails"} %>
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.school_details.title"), path: "#schoolDetails"} %>
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.trust_details.title"), path: "#trustDetails"} %>
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.local_authority_details.title"), path: "#localAuthorityDetails"} %>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -131,10 +131,8 @@ en:
           regional_delivery_officer: Regional delivery officer
           assigned_to: Assigned to
           unassigned: Not yet assigned
-          advisory_board_date: Date of advisory board
           establishment_sharepoint_link: School SharePoint folder
           trust_sharepoint_link: Trust SharePoint folder
-          advisory_board_conditions: Conditions from advisory board
           directive_academy_order:
             title: Has a Directive academy order been issued?
             "true": "Yes"
@@ -143,6 +141,12 @@ en:
             title: Is the school joining a Sponsor trust?
             "true": "Yes"
             "false": "No"
+      advisory_board_details:
+        title: Advisory board details
+        rows:
+          advisory_board_date: Date of advisory board
+          advisory_board_conditions: Conditions from advisory board
+
       school_details:
         title: School details
         rows:

--- a/spec/features/project_information/users_can_view_advisory_board_details_spec.rb
+++ b/spec/features/project_information/users_can_view_advisory_board_details_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.feature "Users can view school advisory board details" do
+  let(:user) { create(:user, :caseworker) }
+  let(:project) { create(:conversion_project, :with_conditions, caseworker: user) }
+
+  before do
+    mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    sign_in_with_user(user)
+    visit project_information_path(project)
+  end
+
+  context "when there are conditions from the advisory board" do
+    let(:project) { create(:conversion_project, :with_conditions, caseworker: user) }
+
+    scenario "they can view the advisory board details" do
+      within("#advisoryBoardDetails") do
+        expect(page).to have_content(project.advisory_board_date.to_formatted_s(:govuk))
+      end
+    end
+  end
+end

--- a/spec/features/project_information/users_can_view_project_details_spec.rb
+++ b/spec/features/project_information/users_can_view_project_details_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
-RSpec.feature "Users can view school details" do
+RSpec.feature "Users can view project details" do
   let(:user) { create(:user, :caseworker) }
-  let(:project) { create(:conversion_project, :with_conditions, caseworker: user) }
+  let(:project) { create(:conversion_project, directive_academy_order: true, sponsor_trust_required: true) }
 
   before do
     mock_successful_api_responses(urn: any_args, ukprn: any_args)
@@ -10,25 +10,15 @@ RSpec.feature "Users can view school details" do
     visit project_information_path(project)
   end
 
-  scenario "they can view the School SharePoint link" do
-    within("#projectDetails") do
-      expect(page).to have_link(I18n.t("project.summary.establishment_sharepoint_link.value"), href: project.establishment_sharepoint_link)
+  scenario "they can see if it has had a directive academy order issued" do
+    within("#projectDetails .govuk-summary-list__row:first-of-type") do
+      expect(page).to have_content("Yes")
     end
   end
 
-  scenario "they can view the Trust SharePoint link" do
-    within("#projectDetails") do
-      expect(page).to have_link(I18n.t("project.summary.trust_sharepoint_link.value"), href: project.trust_sharepoint_link)
-    end
-  end
-
-  context "when there are conditions from the advisory board" do
-    let(:project) { create(:conversion_project, :with_conditions, caseworker: user) }
-
-    scenario "they can view the advisory board details" do
-      within("#projectDetails") do
-        expect(page).to have_content(project.advisory_board_date.to_formatted_s(:govuk))
-      end
+  scenario "they can see if it requires a sponsor trust" do
+    within("#projectDetails .govuk-summary-list__row:last-of-type") do
+      expect(page).to have_content("Yes")
     end
   end
 end


### PR DESCRIPTION
The advisory board is a significant event and is a natural grouping of
information, here we split it out.

We also remove the sharepoint links as they are always available in the
project summary.

![image](https://user-images.githubusercontent.com/480578/227215195-86243389-7a11-4e1c-8189-e134331431c6.png)
