### PR TITLE
Release 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release 17][release-17]
+
 ### Changed
 
 - Updated success messages for notification banners
@@ -648,7 +650,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-16...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-17...HEAD
+[release-17]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-16...release-17
 [release-16]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-15...release-16
 [release-15]:


### PR DESCRIPTION
## [Release 17][release-17]

### Changed

- Updated success messages for notification banners
- Users who are not assigned to the project can no longer update the task list
  actions
- Users who are not assigned to the project can no longer change the conversion
  date
- Users who are not assigned to the project can no longer complete it
- External contacts can no longer be added, updated of deleted from projects
  that are completed
- Notes can no longer be added, update or deleted from projects that are
  completed
- Tasks can no longer be updated once the project is completed
- Internal contacts can no longer be updated once the project is completed
- The Voluntary Process conversion grant task is now optional
- Remove "Create a new involuntary project" button
- the number of items on tabular views has been increased from 10 to 20
- the sharepoint links have been removed from the Project details section in
  Project information, they are available in the project summary as before
- the advisory board details are now separated form the Project details on
  project information
- when a users should not update a project, the save and continue button is no
  longer shown on the task view
- the unassigned tab has moved to the start for Regional casework services team
  leads
- the Regional casework service team leads now see new views for in progress and
  completed that show all the projects handed over to their team

### Added

- a new view that shows all in-progress projects at `/projects/all/in-progress`
- a new view that shows all in-progress projects assigned to Regional casework
  services at `/projects/regional-casework-services/in-progress`
- a new view that shows all completed projects at `/projects/all/completed`, the
  new view switches to a specific table that is focused on showing completed
  projects which is sorted by completion date
- a new view that shows all completed projects assigned to Regional casework
- a new view that shows a user the project they are assigned and that are
  in-progress at `/projects/user/in-progress`
- a new view that shows a user the project they are assigned and that are
  completed at `/projects/user/completed`
- a new view that shows all projects that have not been assigned to a user, but
  have been assigned to Regional casework services at
  `/projects/regional-casework-services`
- Add Directive academy order radio buttons to Create project form
- Show the project's Directive academy order information in the project
  information tab
- Add Sponsor trust required radio buttons to Create project form
- Show the project's Sponsor trust required information in the project
  information tab
- New Process the Sponsored support grant task added to the Voluntary task list
- when viewing a completed project, a banner is shown to inform users why they
  cannot change the project
- when viewing a project to which users are not assigned, a banner is shown to
  inform users why they cannot change the project
- the user that prepared the conversion for advisory board is now shown on the
  unassigned projects table

### Fixed

- users can submit changes on the involuntary external stakeholder kick off task
  once the confirmed conversion date is set
- users can submit changes on the voluntary external stakeholder kick off task
  once the confirmed conversion date is set

