### PR TITLE
Fix: link back to projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   once the confirmed conversion date is set
 - the user that prepared the conversion for advisory board is now shown on the
   unassigned projects table
+- after creating a new conversion that will be handed over to the regional
+  casework services team, the link back to the users projects is now fixed
 
 ## [Release 16][release-16]
 

--- a/app/views/conversions/date_histories/confirm_new.html.erb
+++ b/app/views/conversions/date_histories/confirm_new.html.erb
@@ -7,7 +7,7 @@
           urn: @project.urn,
           conversion_date: @project.conversion_date.to_formatted_s(:govuk),
           project_path: path_to_project(@project),
-          projects_path: projects_path
+          projects_path: in_progress_user_projects_path
         ) %>
   </div>
 </div>

--- a/app/views/conversions/voluntary/projects/created.html.erb
+++ b/app/views/conversions/voluntary/projects/created.html.erb
@@ -9,6 +9,6 @@
           school_name: @project.establishment.name,
           urn: @project.urn,
           contacts_link: path_to_project_contacts(@project)) %>
-    <%= govuk_button_link_to t("conversion_project.voluntary.create.assigned_to_regional_caseworker_team.button"), projects_path(@project) %>
+    <%= govuk_button_link_to t("conversion_project.voluntary.create.assigned_to_regional_caseworker_team.button"), in_progress_user_projects_path %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,7 +89,7 @@ Rails.application.routes.draw do
   end
 
   constraints(id: VALID_UUID_REGEX) do
-    resources :projects, only: %i[index show] do
+    resources :projects, only: %i[show] do
       collection do
         namespace :all do
           get "in-progress", to: "projects#in_progress"

--- a/spec/features/users_can_create_voluntary_conversion_projects_spec.rb
+++ b/spec/features/users_can_create_voluntary_conversion_projects_spec.rb
@@ -54,6 +54,7 @@ RSpec.feature "Users can create new voluntary conversion projects" do
 
         expect(page).to have_content("You have created a project for #{project.establishment.name} #{project.urn}")
         expect(page).to have_content("Another person will be assigned to this project")
+        expect(page).to have_link("Return to project list", href: in_progress_user_projects_path)
       end
     end
 


### PR DESCRIPTION
Product review for release 17 found this bug where a regional delivery
officer creates a new projec to be handed over to regional casework
services, upon creating the project the link back to their own projects
view was broken and casued an error.

We fix the link to the users in progress projects.

We also remove the route for `/projects` which has no controller action
and update any places we rely on that route.
