### PR TITLE
Validate new projects URN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Updated the dev & test URLs in the README
+- users can no longer create a new project with a school URN that already has a
+  project in progress, this prevents duplicate projects being created by mistake
 
 ## [Release 17][release-17]
 

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -40,6 +40,8 @@ class Conversion::CreateProjectForm
   validate :establishment_exists, if: -> { urn.present? }
   validate :trust_exists, if: -> { incoming_trust_ukprn.present? }
 
+  validate :urn_unique_for_in_progress_conversions, if: -> { urn.present? }
+
   validates :directive_academy_order, inclusion: {in: %w[true false]}
   validates :sponsor_trust_required, inclusion: {in: %w[true false]}
 
@@ -101,5 +103,9 @@ class Conversion::CreateProjectForm
     raise result.error if result.error.present?
   rescue AcademiesApi::Client::NotFoundError
     errors.add(:incoming_trust_ukprn, :no_trust_found)
+  end
+
+  private def urn_unique_for_in_progress_conversions
+    errors.add(:urn, :duplicate) if Project.in_progress.where(urn: urn).any?
   end
 end

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -214,6 +214,7 @@ en:
         no_establishment_found: There's no school with that URN. Check the number you entered is correct.
         not_a_number: School URN can only contain numbers. No letters or special characters.
         wrong_length: URN must be 6 digits long. For example, 123456.
+        duplicate: There is already an in-progress project with this URN
       incoming_trust_ukprn:
         blank: Enter a UKPRN
         no_trust_found: There's no trust with that UKPRN. Check the number you entered is correct.

--- a/spec/support/shared_examples/create_conversion_project_form.rb
+++ b/spec/support/shared_examples/create_conversion_project_form.rb
@@ -204,6 +204,17 @@ RSpec.shared_examples "a conversion project FormObject" do
         expect(form).to be_invalid
       end
     end
+
+    context "when there is another in-progress project with the same urn" do
+      it "is invalid" do
+        _project_with_urn = create(:conversion_project, urn: 121813)
+        form = build(form_factory.to_sym)
+
+        form.urn = 121813
+        expect(form).to be_invalid
+        expect(form.errors.messages[:urn]).to include I18n.t("errors.attributes.urn.duplicate")
+      end
+    end
   end
 
   describe "incoming_trust_ukprn" do


### PR DESCRIPTION
The same school should never been converting more that once, we've seen
some issues in production where different users add the same project
resulting in duplicates.

This works prevents the issue by checking that a project that is in
progress does not already exist and if it does, showing a simple error
message.

https://trello.com/c/TBOAIBeo

![Screenshot 2023-03-24 at 13-14-22 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/227572853-d81a1382-100d-49c0-a15e-b3fad8526852.png)

