### PR TITLE
Set the `assigned_at` DateTime when a user is keeping a project they created

### DIFF
--- a/app/forms/conversion/voluntary/create_project_form.rb
+++ b/app/forms/conversion/voluntary/create_project_form.rb
@@ -9,6 +9,7 @@ class Conversion::Voluntary::CreateProjectForm < Conversion::CreateProjectForm
 
   def save
     assigned_to = assigned_to_regional_caseworker_team ? nil : user
+    assigned_at = assigned_to_regional_caseworker_team ? nil : DateTime.now
 
     @project = Conversion::Project.new(
       urn: urn,
@@ -22,6 +23,7 @@ class Conversion::Voluntary::CreateProjectForm < Conversion::CreateProjectForm
       task_list: Conversion::Voluntary::TaskList.new,
       assigned_to_regional_caseworker_team: assigned_to_regional_caseworker_team,
       assigned_to: assigned_to,
+      assigned_at: assigned_at,
       directive_academy_order: directive_academy_order,
       sponsor_trust_required: sponsor_trust_required
     )

--- a/spec/features/users_can_create_voluntary_conversion_projects_spec.rb
+++ b/spec/features/users_can_create_voluntary_conversion_projects_spec.rb
@@ -56,6 +56,18 @@ RSpec.feature "Users can create new voluntary conversion projects" do
         expect(page).to have_content("Another person will be assigned to this project")
         expect(page).to have_link("Return to project list", href: in_progress_user_projects_path)
       end
+
+      it "does not assign the user to the project" do
+        fill_in_form
+        within("#assigned-to-regional-caseworker-team") do
+          choose("Yes")
+        end
+        click_button("Continue")
+
+        project = Project.last
+        expect(project.assigned_to).to be_nil
+        expect(project.assigned_at).to be_nil
+      end
     end
 
     scenario "there is an option to assign the project to the Regional Caseworker Team" do

--- a/spec/forms/conversion/voluntary/create_project_form_spec.rb
+++ b/spec/forms/conversion/voluntary/create_project_form_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe Conversion::Voluntary::CreateProjectForm, type: :model do
 
         expect(project.assigned_to).to_not be_nil
       end
+
+      it "sets Project.assigned_at to now" do
+        freeze_time
+        project = build(:create_voluntary_project_form, assigned_to_regional_caseworker_team: false).save
+        expect(project.assigned_at).to eq DateTime.now
+      end
     end
   end
 end


### PR DESCRIPTION

## Changes

A small bug in project creation meant that when a user creates a project and is *not* handing it over, the `assigned_at` DateTime was not being set on the project. The `assigned_at` time should reflect when someone was added to the `assigned_to` field on the project.

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
