### PR TITLE
Changed the guidance in commercial transfer agreement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Corrected guidance in the commercial transfer agreement tasks. It now says 
+  solicitors, not schools or trusts
 - Updated the dev & test URLs in the README
 - users can no longer create a new project with a school URN that already has a
   project in progress, this prevents duplicate projects being created by mistake

--- a/config/locales/task_lists/conversion/involuntary/commercial_transfer_agreement.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/commercial_transfer_agreement.en.yml
@@ -8,8 +8,8 @@ en:
             html: <p>The Commercial transfer agreement is essential for all conversion projects.</p>
 
           email_signed:
-            title: Email the trust to ask if all relevant parties have agreed and signed the Commercial transfer agreement
+            title: Email the solicitors to ask if all relevant parties have agreed and signed the Commercial transfer agreement
           receive_signed:
-            title: Receive email from the trust confirming all relevant parties have agreed and signed the Commercial transfer agreement
+            title: Receive email from the solicitors confirming all relevant parties have agreed and signed the Commercial transfer agreement
           save_signed:
             title: Save a copy of the confirmation email in the school's SharePoint folder

--- a/config/locales/task_lists/conversion/voluntary/commercial_transfer_agreement.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/commercial_transfer_agreement.en.yml
@@ -8,8 +8,8 @@ en:
             html: <p>The Commercial transfer agreement is essential for all conversion projects.</p>
 
           email_signed:
-            title: Email the school to ask if all relevant parties have agreed and signed the Commercial transfer agreement
+            title: Email the solicitors to ask if all relevant parties have agreed and signed the Commercial transfer agreement
           receive_signed:
-            title: Receive email from the school confirming all relevant parties have agreed and signed the Commercial transfer agreement
+            title: Receive email from the solicitors confirming all relevant parties have agreed and signed the Commercial transfer agreement
           save_signed:
             title: Save a copy of the confirmation email in the school's SharePoint folder


### PR DESCRIPTION
## Changes

Tasks now reference solicitors instead of school or trust.

<img width="698" alt="Screenshot 2023-03-27 at 14 31 39" src="https://user-images.githubusercontent.com/104517016/227952622-3839a4fa-58c1-4ff6-98c8-82d59675a779.png">

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
