### PR TITLE
Projects can be added the same day as the board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project in progress, this prevents duplicate projects being created by mistake
 - Removed the "Check the baseline" task from task lists
 - Conversion projects now have a route of voluntary or sponsored
+- A conversion project can now be added on the same day as the advisory board
 
 ### Added
 

--- a/app/validators/date_in_the_past_validator.rb
+++ b/app/validators/date_in_the_past_validator.rb
@@ -2,7 +2,7 @@ class DateInThePastValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return unless value.present?
 
-    unless value.past?
+    unless value.past? || value.today?
       record.errors.add(attribute, :must_be_in_the_past)
     end
   end

--- a/spec/validators/date_in_the_past_validator_spec.rb
+++ b/spec/validators/date_in_the_past_validator_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe DateInThePastValidator do
   end
 
   context "when the date is today" do
-    it "is invalid" do
+    it "is valid" do
       subject.date = Date.today
-      expect(subject).to be_invalid
+      expect(subject).to be_valid
     end
   end
 end


### PR DESCRIPTION
We had a user attempting to create a new project on the same day as the
advisory board, our validation was in the past so this was not possible.

Here we allow todays date as well.
