### PR TITLE
1384 content tweaks full stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Made project list tables headings consistent with openers list
+- Fulls stops added to empty states messages in project lists
 - Updated the dev & test URLs in the README
 - users can no longer create a new project with a school URN that already has a
   project in progress, this prevents duplicate projects being created by mistake

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -97,8 +97,8 @@ en:
         success: Project has been assigned successfully
     table:
       headers:
-        school_name: School name
-        school_urn: School URN
+        school_name: School
+        school_urn: URN
         type: Type of project
         assigned_to: Assigned to
         view: View project

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -108,11 +108,11 @@ en:
         view_html: View <span class="govuk-visually-hidden">%{school_name}</span> project
         assign_html: Assign <span class="govuk-visually-hidden">%{school_name}</span> project
       in_progress:
-        empty: There are no projects in progress
+        empty: There are no projects in progress.
       completed:
-        empty: There are no completed projects
+        empty: There are no completed projects.
       unassigned:
-        empty: There are no unassigned projects
+        empty: There are no unassigned projects.
     openers:
       title: Academies opening in %{date}
       subtitle: A list of schools becoming academies


### PR DESCRIPTION
## Changes

Adding full stops to empty state messages in project lists. Also changing table headings to match those in openers list for consistency.

<img width="1062" alt="Screenshot 2023-03-28 at 15 33 12" src="https://user-images.githubusercontent.com/104517016/228272666-4518da6d-01ca-46ea-8a3d-bdaa88df08b3.png">

<img width="1055" alt="Screenshot 2023-03-28 at 15 33 49" src="https://user-images.githubusercontent.com/104517016/228272735-3ff835d7-2694-4bad-96b0-8527288e2701.png">

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
