### PR TITLE
1386 content tweaks misc changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   in-progress projects
 - In-progress projects are not orderd by their converison date, with those
   converting soonest at the top
+- Added full stops to project handover confirmation page. Also explicitly called
+  out the URN. Removed a from opens in a new tab.
 
 ## [Release 18][release-18]
 

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -26,14 +26,14 @@ en:
           title: Project created
           button: Return to project list
           html:
-            <p class="govuk-body">You have created a project for %{school_name} %{urn}</p>
+            <p class="govuk-body">You have created a project for %{school_name}, URN %{urn}.</p>
             <h2 class="govuk-heading-l">What happens next</h2>
-            <p class="govuk-body">Another person will be assigned to this project</p>
+            <p class="govuk-body">Another person will be assigned to this project.</p>
             <h2 class="govuk-heading-l">Add contact details</h2>
             <p class="govuk-body">You should <a href="%{contacts_link}">add any contact details</a> you have for the school, trust, solicitors, diocese and local authority.</p>
             <p class="govuk-body">This will help the person continuing this project to organise kick-off meetings.</p>
             <h2 class="govuk-heading-l">Help us improve the service</h2>
-            <p class="govuk-body">Complete this <a href="https://forms.office.com/e/xf0k4LcWVN" class="govuk-link" target="_blank">short survey (opens in a new tab)</a></p>
+            <p class="govuk-body">Complete this <a href="https://forms.office.com/e/xf0k4LcWVN" class="govuk-link" target="_blank">short survey (opens in new tab)</a>.</p>
     summary:
       route:
         title: Route

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,7 +47,7 @@ en:
     message:
       success: You have signed out. You may still be signed in to your Microsoft account.
   signed_in:
-    message: You are signed in with the email address %{email_address}
+    message: You are signed in with the email address %{email_address}.
   unknown_user:
     message: The email address %{email_address} is not registered to use this service.
   unauthorised_action:

--- a/spec/features/users_can_create_voluntary_conversion_projects_spec.rb
+++ b/spec/features/users_can_create_voluntary_conversion_projects_spec.rb
@@ -52,8 +52,8 @@ RSpec.feature "Users can create new voluntary conversion projects" do
 
         project = Project.last
 
-        expect(page).to have_content("You have created a project for #{project.establishment.name} #{project.urn}")
-        expect(page).to have_content("Another person will be assigned to this project")
+        expect(page).to have_content("You have created a project for #{project.establishment.name}, URN #{project.urn}.")
+        expect(page).to have_content("Another person will be assigned to this project.")
         expect(page).to have_link("Return to project list", href: in_progress_user_projects_path)
       end
 


### PR DESCRIPTION
## Changes

Full stops added to project handover confirmation page. Also explicitly call out the URN to make it clearer in first sentence.
<img width="1047" alt="Screenshot 2023-03-28 at 15 59 59" src="https://user-images.githubusercontent.com/104517016/228280657-1477388f-9d9c-4460-925e-3f6b4c7fe10a.png">

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
