### PR TITLE
In-progress projects does not include unassigned and is ordered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - A conversion project can now be added on the same day as the advisory board
 - Projects that have no user assigned to them no longer appear in lists of
   in-progress projects
+- In-progress projects are not orderd by their converison date, with those
+  converting soonest at the top
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Removed the "Check the baseline" task from task lists
 - Conversion projects now have a route of voluntary or sponsored
 - A conversion project can now be added on the same day as the advisory board
+- Projects that have no user assigned to them no longer appear in lists of
+  in-progress projects
 
 ### Added
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -41,7 +41,7 @@ class Project < ApplicationRecord
   scope :by_conversion_date, -> { order(conversion_date: :asc) }
 
   scope :completed, -> { where.not(completed_at: nil).order(completed_at: :desc) }
-  scope :in_progress, -> { where(completed_at: nil).assigned }
+  scope :in_progress, -> { where(completed_at: nil).assigned.by_conversion_date }
 
   scope :assigned, -> { where.not(assigned_to: nil) }
   scope :assigned_to_caseworker, ->(user) { where(assigned_to: user).or(where(caseworker: user)) }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -41,8 +41,9 @@ class Project < ApplicationRecord
   scope :by_conversion_date, -> { order(conversion_date: :asc) }
 
   scope :completed, -> { where.not(completed_at: nil).order(completed_at: :desc) }
-  scope :in_progress, -> { where(completed_at: nil) }
+  scope :in_progress, -> { where(completed_at: nil).assigned }
 
+  scope :assigned, -> { where.not(assigned_to: nil) }
   scope :assigned_to_caseworker, ->(user) { where(assigned_to: user).or(where(caseworker: user)) }
   scope :assigned_to_regional_delivery_officer, ->(user) { where(assigned_to: user).or(where(regional_delivery_officer: user)) }
 

--- a/spec/factories/conversion/involuntary/project_factory.rb
+++ b/spec/factories/conversion/involuntary/project_factory.rb
@@ -11,5 +11,6 @@ FactoryBot.define do
     task_list { association :conversion_involuntary_task_list }
     directive_academy_order { true }
     sponsor_trust_required { true }
+    assigned_to { association :user, :caseworker, email: "user.#{SecureRandom.uuid}@education.gov.uk" }
   end
 end

--- a/spec/factories/conversion/project_factory.rb
+++ b/spec/factories/conversion/project_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/establishment-folder" }
     trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }
     task_list { association :voluntary_conversion_task_list }
-    assigned_to { nil }
+    assigned_to { association :user, :caseworker, email: "user.#{SecureRandom.uuid}@education.gov.uk" }
     directive_academy_order { false }
     sponsor_trust_required { false }
     regional_delivery_officer { association :user, :regional_delivery_officer }
@@ -22,11 +22,16 @@ FactoryBot.define do
       team_leader { nil }
       regional_delivery_officer { nil }
       caseworker { nil }
+      assigned_to { nil }
     end
 
     trait :with_team_lead_and_regional_delivery_officer_assigned do
       team_leader { association :user, :team_leader }
       regional_delivery_officer { association :user, :regional_delivery_officer }
+    end
+
+    trait :unassigned do
+      assigned_to { nil }
     end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -408,6 +408,18 @@ RSpec.describe Project, type: :model do
         expect(projects).to include in_progress_project
         expect(projects).to_not include unassigned_project
       end
+
+      it "is ordered by conversion date ascending" do
+        mock_successful_api_response_to_create_any_project
+        create(:conversion_project, conversion_date: Date.today.at_beginning_of_month + 2.month)
+        project_converting_last = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month + 3.month)
+        project_converting_first = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month + 1.month)
+
+        projects = Project.in_progress
+
+        expect(projects.first).to eql project_converting_first
+        expect(projects.last).to eql project_converting_last
+      end
     end
 
     describe "assigned_to_caseworker scope" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -371,6 +371,19 @@ RSpec.describe Project, type: :model do
       end
     end
 
+    describe "#assigned" do
+      it "only includes projects assigned to a user" do
+        mock_successful_api_response_to_create_any_project
+        assigned_project = create(:conversion_project)
+        unassigned_project = create(:conversion_project, :unassigned)
+
+        projects = Project.assigned
+
+        expect(projects).to include(assigned_project)
+        expect(projects).to_not include(unassigned_project)
+      end
+    end
+
     describe "in_progress scope" do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 
@@ -383,6 +396,17 @@ RSpec.describe Project, type: :model do
 
         expect(projects).to include(open_project_1, open_project_2)
         expect(projects).to_not include(completed_project)
+      end
+
+      it "does not include unassigned projects" do
+        mock_successful_api_response_to_create_any_project
+        in_progress_project = create(:conversion_project)
+        unassigned_project = create(:conversion_project, :unassigned)
+
+        projects = Project.in_progress
+
+        expect(projects).to include in_progress_project
+        expect(projects).to_not include unassigned_project
       end
     end
 


### PR DESCRIPTION
Our current model of 'in-progress' is that the completed at time is not
set, it feels right to add to this projects that are assigned to a user,
if the project was not assigned who would do the work to make it
in-progress?

Here we address this in the in-progress scope.

We may want to add a view that exposed projects that are neither
in-progress or completed, for now we don't need to worry because:

- for regional caswork services they can already do this with the
  unassigned view
- for regional users, they are auto assigned to the project at creation
  so the risk is minimised

https://trello.com/c/Kn8FjAr0

THis work also includes setting the order of in-progress projects.

https://trello.com/c/5Ndm9aRO