### PR TITLE
Add basic Application Insights support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `/projects/all/in-progress/sponsored`
 - a new view that show all completed conversion projects that are voluntary at
   `/projects/all/in-progress/voluntary`
+- basic telemetery is being sent to DfE Application Insights
 
 ## [Release 17][release-17]
 

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,9 @@ gem "faraday"
 gem "sentry-ruby"
 gem "sentry-rails"
 
+# application insights
+gem "application_insights"
+
 gem "sidekiq", "< 7.0"
 
 gem "pagy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    application_insights (0.5.6)
     ast (2.4.2)
     axe-core-api (4.5.0)
       dumb_delegator
@@ -422,6 +423,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-sqlserver-adapter
+  application_insights
   axe-core-rspec
   bootsnap
   brakeman

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,7 @@ module DfeCompleteConversionsTransfersAndChanges
 
     # use the cookie session and set the name of the cookie
     config.session_store :cookie_store, key: "SESSION"
+
+    # Application Insights
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/integer/time"
+require "application_insights"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -100,4 +101,9 @@ Rails.application.configure do
 
   # Use Sidekiq
   config.active_job.queue_adapter = :sidekiq
+
+  # Use Application Insights if a key is available
+  if (key = ENV.fetch("APPLICATION_INSIGHTS_KEY", nil))
+    config.middleware.use ApplicationInsights::Rack::TrackRequest, key, 500, 60
+  end
 end

--- a/doc/environment-variables.md
+++ b/doc/environment-variables.md
@@ -64,3 +64,7 @@ https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/bl
 Contains a range of IP addresses used by the monitoring health probes. This
 range is added to the `ALLOWED_HOSTS` on production, so that the probes can hit
 the `/healthcheck` endpoint to confirm the app is up & running.
+
+`APPLICATION_INSIGHTS_KEY`
+
+The instrumentation key for Microsoft Application Insights.


### PR DESCRIPTION
We have been asked to follow all the .NET products in the program and
use Microsoft Applcation Insights. Whilst not something the team is
familiar with, we want to try and accomadate where it does not effect
our ability to deliver value or support the live service.

The gem used here is set to archived on Github [1], but may be stable
enough for our needs, we have to test it to find out.

After a small spike, here we have the absolute minimum working version
of this, with basic stats going to Application Insights.

We have set the following options as the defaults:

- buffer size: 500
- send interval: 60

See: https://github.com/microsoft/ApplicationInsights-Ruby/blob/5db6b4ad65262d23f26b678143a4a1fd7939e5c2/lib/application_insights/rack/track_request.rb#L18

We will ship this version and let it run for a period of time to try and
better understand:

- what we can do with Application Insights
- how it aligns with what we are being asked to do AKA compared to other
  .NET products

We only load Application Insights if the key is present and in the
three 'production' environments:

- development
- test
- production

[1] https://github.com/Microsoft/ApplicationInsights-Ruby

## Changes

_Add a summary of the changes in this pull request_

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
