### PR TITLE
Fixed casing on project list page and sponsored support grant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fulls stops added to empty states messages in project lists
 - Corrected guidance in the commercial transfer agreement tasks. It now says
   solicitors, not schools or trusts
+- Made Sponsored support grant sentence case, not title case
 - Corrected guidance in 125 year lease task. Now tells user to contact
   solicitor, not school
 - Updated the dev & test URLs in the README

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -33,11 +33,11 @@ en:
           title: All voluntary completed projects
     regional_casework_services:
       in_progress:
-        title: Regional casework services projects in progress
+        title: Regional Casework Services projects in progress
       completed:
-        title: Regional casework services completed projects
+        title: Regional Casework Services completed projects
       unassigned:
-        title: Regional casework services unassigned projects
+        title: Regional Casework Services unassigned projects
     user:
       in_progress:
         title: Assigned projects in progress

--- a/config/locales/task_lists/conversion/involuntary/conversion_grant.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/conversion_grant.en.yml
@@ -3,7 +3,7 @@ en:
     involuntary:
       tasks:
         conversion_grant:
-          title: Process the Sponsored support grant
+          title: Process the sponsored support grant
           hint:
             html:
               <p>Start this as soon as possible. Trusts can start getting charged by solicitors and the local authority early in the process.</p>

--- a/config/locales/task_lists/conversion/voluntary/sponsored_support_grant.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/sponsored_support_grant.en.yml
@@ -3,7 +3,7 @@ en:
     voluntary:
       tasks:
         sponsored_support_grant:
-          title: Process the Sponsored support grant
+          title: Process the sponsored support grant
           hint:
             html:
               <p>Start this as soon as possible. Trusts can start getting charged by solicitors and the local authority early in the process.</p>


### PR DESCRIPTION
## Changes

Switch Regional caseworker Services to title case on project lists.

Changed Sponsored support grant to sentence case on task list and in the task itself.

<img width="1069" alt="Screenshot 2023-03-29 at 09 21 14" src="https://user-images.githubusercontent.com/104517016/228472126-c231f32d-d22a-4e2c-bd23-4f095cf1f993.png">

<img width="1065" alt="Screenshot 2023-03-29 at 09 20 33" src="https://user-images.githubusercontent.com/104517016/228471965-bd4c184b-62f0-4429-beca-e3d0ce04b665.png">

<img width="1040" alt="Screenshot 2023-03-29 at 09 20 52" src="https://user-images.githubusercontent.com/104517016/228472048-cecf5794-ae49-4832-bb39-4cc46ebbeb31.png">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
