### PR TITLE
Improved the summary text on the openers list and added a full stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Improved the summary text on the openers list and added a full stop.
 - Made project list tables headings consistent with openers list
 - Fulls stops added to empty states messages in project lists
 - Corrected guidance in the commercial transfer agreement tasks. It now says

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -115,7 +115,7 @@ en:
         empty: There are no unassigned projects.
     openers:
       title: Academies opening in %{date}
-      subtitle: A list of schools becoming academies
+      subtitle: Schools that are expected to become academies.
       empty:
         html:
           <p>There are currently no schools expected to become academies in %{date}.</p>


### PR DESCRIPTION
## Changes

Improved summary text on openers list and added full stop.

<img width="1050" alt="Screenshot 2023-03-29 at 10 31 01" src="https://user-images.githubusercontent.com/104517016/228491319-4a0b7316-fc4e-4cc3-8041-c6b344b8281b.png">

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
