### PR TITLE
Add a link to the companies house information page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - a new view that show all completed conversion projects that are voluntary at
   `/projects/all/in-progress/voluntary`
 - basic telemetery is being sent to DfE Application Insights
+- Add a link to the companies house information page from the project
+  information tab
 
 ### Fixed
 

--- a/app/helpers/project_helper.rb
+++ b/app/helpers/project_helper.rb
@@ -36,6 +36,12 @@ module ProjectHelper
     link_to(t("project_information.show.trust_details.rows.view_in_gias"), "https://get-information-schools.service.gov.uk/Groups/Search?GroupSearchModel.Text=#{ukprn}", target: :_blank)
   end
 
+  def link_to_companies_house(companies_house_number)
+    raise ArgumentError if companies_house_number.nil?
+
+    link_to(t("project_information.show.trust_details.rows.view_companies_house"), "https://find-and-update.company-information.service.gov.uk/company/#{companies_house_number}", target: :_blank)
+  end
+
   def all_conditions_met_tag(project)
     tag = if project.all_conditions_met?
       govuk_tag(text: "yes", colour: "turquoise")

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -77,7 +77,8 @@
     end
     summary_list.row do |row|
       row.key { t('project_information.show.trust_details.rows.companies_house_number') }
-      row.value { @project.incoming_trust.companies_house_number } end
+      row.value { (@project.incoming_trust.companies_house_number + "<br/>" + link_to_companies_house(@project.incoming_trust.companies_house_number)).html_safe }
+    end
   end %>
 </div>
 

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -179,6 +179,7 @@ en:
           address: Address
           ukprn: UK Provider Reference Number
           companies_house_number: Companies House number
+          view_companies_house: View the Companies House information (opens in new tab)
       local_authority_details:
         title: Local authority details
         rows:

--- a/spec/helpers/project_helper_spec.rb
+++ b/spec/helpers/project_helper_spec.rb
@@ -119,6 +119,28 @@ RSpec.describe ProjectHelper, type: :helper do
     end
   end
 
+  describe "#link_to_companies_house" do
+    context "when a companies house number is provided" do
+      let(:companies_house_number) { "10768218" }
+
+      it "returns a link to the companies house information" do
+        expect(link_to_companies_house(companies_house_number)).to include("https://find-and-update.company-information.service.gov.uk/company/#{companies_house_number}")
+      end
+
+      it "opens the link in a new tab" do
+        expect(link_to_companies_house(companies_house_number)).to include("_blank")
+      end
+    end
+
+    context "when a companies house number is not provided" do
+      let(:companies_house_number) { nil }
+
+      it "returns an argument error" do
+        expect { link_to_companies_house(companies_house_number) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
   describe "#all_conditions_met_tag" do
     context "when all_conditions_met is true" do
       let(:task_list) { create(:voluntary_conversion_task_list, conditions_met_confirm_all_conditions_met: true) }


### PR DESCRIPTION
## Changes

Add a link to the companies house information page from the project information page

<img width="789" alt="Screenshot 2023-03-29 at 11 08 43" src="https://user-images.githubusercontent.com/59832893/228501760-ea534c5f-564c-41a2-9390-aa132d6a7ba0.png">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
