### PR TITLE
Release 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release 18][release-18]
+
 ### Changed
 
 - Improved the summary text on the openers list and added a full stop.
@@ -685,7 +687,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-17...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-18...HEAD
+[release-18]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-17...release-18
 [release-17]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-16...release-17
 [release-16]:


### PR DESCRIPTION
### Changed

- Improved the summary text on the openers list and added a full stop.
- Made project list tables headings consistent with openers list
- Fulls stops added to empty states messages in project lists
- Corrected guidance in the commercial transfer agreement tasks. It now says
  solicitors, not schools or trusts
- Made Sponsored support grant sentence case, not title case
- Corrected guidance in 125 year lease task. Now tells user to contact
  solicitor, not school
- Updated the dev & test URLs in the README
- users can no longer create a new project with a school URN that already has a
  project in progress, this prevents duplicate projects being created by mistake
- Removed the "Check the baseline" task from task lists
- Conversion projects now have a route of voluntary or sponsored
- A conversion project can now be added on the same day as the advisory board

### Added

- a new view that show all in-progress conversion projects that are sponsored at
  `/projects/all/in-progress/sponsored`
- a new view that show all in-progress conversion projects that are voluntary at
  `/projects/all/in-progress/voluntary`
- a new view that show all completed conversion projects that are sponsored at
  `/projects/all/in-progress/sponsored`
- a new view that show all completed conversion projects that are voluntary at
  `/projects/all/in-progress/voluntary`
- basic telemetery is being sent to DfE Application Insights

### Fixed

- Fixed a bug where every time a task list was saved, a new note was created