### PR TITLE
Standardising capitalisation in the project kick-off tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Standardising capitalisation in the project kick-off tasks
 - Improved the summary text on the openers list and added a full stop.
 - Made project list tables headings consistent with openers list
 - Fulls stops added to empty states messages in project lists

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -6,7 +6,7 @@ en:
       route: Involuntary
       new:
         title: Add a new involuntary conversion project
-        hint_html: <p class="govuk-body">Enter the school and trust information.</p><p class="govuk-body">This will create a conversion project for a school that has been issued a Directive academy order.</p>
+        hint_html: <p class="govuk-body">Enter the school and trust information.</p><p class="govuk-body">This will create a conversion project for a school that has been issued a directive academy order.</p>
       create:
         success:
           Involuntary project successfully created

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -147,7 +147,7 @@ en:
           establishment_sharepoint_link: School SharePoint folder
           trust_sharepoint_link: Trust SharePoint folder
           directive_academy_order:
-            title: Has a Directive academy order been issued?
+            title: Has a directive academy order been issued?
             "true": "Yes"
             "false": "No"
           sponsor_trust_required:
@@ -246,6 +246,6 @@ en:
         https_only: The trust SharePoint link must have the https scheme
         host_not_allowed: Enter a trust sharepoint link in the correct format. SharePoint links start with 'https://educationgovuk.sharepoint.com' or 'https://educationgovuk-my.sharepoint.com/'
       directive_academy_order:
-        inclusion: Select yes if this project has had a Directive academy order issued
+        inclusion: Select yes if this project has had a directive academy order issued
       sponsor_trust_required:
         inclusion: Select yes if this school is joining a Sponsor trust

--- a/config/locales/task_lists/conversion/involuntary/conversion_grant.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/conversion_grant.en.yml
@@ -12,13 +12,13 @@ en:
             title: Check and confirm the school's grant eligibility
             hint:
               html:
-                <p>Confirm if the trust will receive the Fast track, Intermediate or Full sponsored grant.</p>
+                <p>Confirm if the trust will receive the fast track, intermediate or full sponsored grant.</p>
             guidance_link: How to check grant eligibility
             guidance:
               html:
-                <p>All schools that are issued a Directive academy order are allocated
+                <p>All schools that are issued a directive academy order are allocated
                 to an experienced trust. These trusts are also known as sponsors.</p>
-                <p>In most cases, the sponsor is entitled to the Fast track grant.</p>
+                <p>In most cases, the sponsor is entitled to the fast track grant.</p>
                 <p>The sponsor will get:</p>
                 <ul>
                 <li>£70,000 for primary and special schools</li>
@@ -26,7 +26,7 @@ en:
                 </ul>
                 <p>In some circumstances, the sponsor might be entitled to a larger
                 grant.</p>
-                <p>This would be the Intermediate grant, or the Full sponsored grant.</p>
+                <p>This would be the intermediate grant, or the full sponsored grant.</p>
                 <p>Intermediate grant amounts are:</p>
                 <ul>
                 <li>£90,000 for primary and special schools</li>
@@ -42,7 +42,7 @@ en:
                 conversion costs have been paid for should be used for school
                 improvements.</p>
                 <p>A business case must be approved at advisory board, or by the regional
-                director, for a trust to get the Intermediate or Full sponsored grant.</p>
+                director, for a trust to get the intermediate or full sponsored grant.</p>
                 <p>There is more <a href="https://www.gov.uk/government/publications/sponsored-academies-funding-guidance-for-sponsors" class="govuk-link" target="_blank">guidance on grant eligibility and spending (opens in
                 new tab)</a> on GOV.UK.</p>
 
@@ -51,12 +51,12 @@ en:
             guidance_link: How to claim different grants
             guidance:
               html:
-                <p>The sponsor can claim for the Fast track grant first, then apply for
-                a top-up later through an Intermediate or Full sponsored grant.</p>
+                <p>The sponsor can claim for the fast track grant first, then apply for
+                a top-up later through an intermediate or full sponsored grant.</p>
                 <p>The trust will need to complete and return the <a href="https://educationgovuk.sharepoint.com/:w:/r/sites/lvedfe00116/WorkplaceDocuments/ARDG%20Internal%20Guidance/Archive_April_2020/Pre-Opening_Funding_Grant_Letter_Claim_Form_Annex_1.docx?d=w6bce8b5b84d841dd977af39eb2191afd&amp;csf=1&amp;web=1&amp;e=h02JhV" class="govuk-link" target="_blank">grant claim form
-                (opens in new tab)</a> to claim the Fast track grant. Share the form with them.</p>
+                (opens in new tab)</a> to claim the fast track grant. Share the form with them.</p>
                 <p>There is <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Funding-and-Finance.aspx?xsdata=MDV8MDF8fGIzMTZmYzk3NGM2NjQ5OTg0NTNlMDhkYWQ4NTcyMjc2fGZhZDI3N2M5YzYwYTRkYTFiNWYzYjNiOGIzNGE4MmY5fDB8MHw2MzgwNjAxNjU5NzgyNzcxODJ8VW5rbm93bnxWR1ZoYlhOVFpXTjFjbWwwZVZObGNuWnBZMlY4ZXlKV0lqb2lNQzR3TGpBd01EQWlMQ0pRSWpvaVYybHVNeklpTENKQlRpSTZJazkwYUdWeUlpd2lWMVFpT2pFeGZRPT18MXxNVFkzTURReE9UYzVOamcwTnpzeE5qY3dOREU1TnprMk9EUTNPekU1T20xbFpYUnBibWRmVFhwck1GcHFhRzFPYWxWMFRYcHJNMWxUTURCTk1sSnBURmRGTWsxcVRYUmFSMVV6VGtSRmQxbDZSbTFaTWxFMFFIUm9jbVZoWkM1Mk1nPT18Y2I5OTQ1ODRkNzdiNDY3ODQ1M2UwOGRhZDg1NzIyNzZ8NDA4ZDc0YWZkZmYyNDY2MWIxNzU3OTYzNmQ0MGRkMmE%3D&amp;sdata=SFhTMGxCRWVUQkxvTHRTQmp0emVrUlNHREVQdTlEQjFCMlYzSEY3WlR4dz0%3D&amp;ovuser=fad277c9-c60a-4da1-b5f3-b3b8b34a82f9%2CJoanna.EVANS%40EDUCATION.GOV.UK&amp;OR=Teams-HL&amp;CT=1670513971254&amp;clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiIxNDE1LzIyMTEzMDA0MTAwIiwiSGFzRmVkZXJhdGVkVXNlciI6ZmFsc2V9" class="govuk-link" target="_blank">guidance about how to claim different grants (opens in new
-                tab)</a> in SharePoint that explains how a trust can claim the Intermediate and Full sponsored grants.</p>
+                tab)</a> in SharePoint that explains how a trust can claim the intermediate and full sponsored grants.</p>
 
           payment_form:
             title: Receive, check and save the converter support grant claim form in the school's SharePoint folder
@@ -73,11 +73,11 @@ en:
             title: Send the grant information to the payments team
             hint:
               html:
-                <p>Send them the Academy order and Grant claim form.</p>
+                <p>Send them the academy order and grant claim form.</p>
             guidance_link: Guidance on what information to send
             guidance:
               html:
-                <p>You'll find the Directive academy order and Grant claim form in the
+                <p>You'll find the directive academy order and grant claim form in the
                 school's SharePoint folder.</p>
                 <p>You should send the documents to the Grant Payments team by email at
                 <a href="mailto:cfugrantpayments.regionsgroup@education.gov.uk" class="govuk-link" target="_blank">cfugrantpayments.regionsgroup@education.gov.uk</a>.</p>

--- a/config/locales/task_lists/conversion/voluntary/conversion_grant.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/conversion_grant.en.yml
@@ -24,7 +24,7 @@ en:
                 <p>It can take 15 to 20 days for an account to be created.</p>
 
           payment_form:
-            title: Receive, check and save the Grant claim form in the school's SharePoint folder
+            title: Receive, check and save the grant claim form in the school's SharePoint folder
             hint:
               html:
                 <p>Make sure no information is missing.</p>
@@ -37,11 +37,11 @@ en:
           send_information:
             title: Send the grant information to the payments team
             hint:
-              html: <p>Send them the Application to convert, Academy order and Grant claim form.</p>
+              html: <p>Send them the application to convert, academy order and grant claim form.</p>
             guidance_link: Guidance on what information to send
             guidance:
               html:
-                <p>You'll find the Academy order, Application to convert and Grant claim form in the school's SharePoint folder.</p>
+                <p>You'll find the academy order, application to convert and grant claim form in the school's SharePoint folder.</p>
                 <p>You should send the documents to the Grant Payments team by email at <a href="mailto:cfugrantpayments.regionsgroup@education.gov.uk" target="_blank">cfugrantpayments.regionsgroup@education.gov.uk</a>.</p>
                 <p>The subject line of the email must include the:</p>
                 <ul>
@@ -57,7 +57,7 @@ en:
                   <li>trust it's joining</li>
                   <li>provisional conversion date</li>
                 </ul>
-                <p>It's helpful to include the school or trust's vendor account number too. The Grant payments team will need this to be able to send the money to whoever will receive it.</p>
+                <p>It's helpful to include the school or trust's vendor account number too. The Grant Payments team will need this to be able to send the money to whoever will receive it.</p>
 
           share_payment_date:
             title: Tell the school or trust the grant information has been sent

--- a/config/locales/task_lists/conversion/voluntary/handover.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/handover.en.yml
@@ -22,7 +22,7 @@ en:
                 <ul>
                   <li>project information, such as advisory board conditions</li>
                   <li>school or trust website for more information about the school</li>
-                  <li>google maps for potential land issues</li>
+                  <li>Google Maps for potential land issues</li>
                 </ul>
 
           notes:

--- a/config/locales/task_lists/conversion/voluntary/sponsored_support_grant.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/sponsored_support_grant.en.yml
@@ -12,13 +12,13 @@ en:
             title: Check and confirm the school's grant eligibility
             hint:
               html:
-                <p>Confirm if the trust will receive the Fast track, Intermediate or Full sponsored grant.</p>
+                <p>Confirm if the trust will receive the fast track, intermediate or full sponsored grant.</p>
             guidance_link: How to check grant eligibility
             guidance:
               html:
-                <p>All schools that are issued a Directive academy order are allocated
+                <p>All schools that are issued a directive academy order are allocated
                 to an experienced trust. These trusts are also known as sponsors.</p>
-                <p>In most cases, the sponsor is entitled to the Fast track grant.</p>
+                <p>In most cases, the sponsor is entitled to the fast track grant.</p>
                 <p>The sponsor will get:</p>
                 <ul>
                 <li>£70,000 for primary and special schools</li>
@@ -26,7 +26,7 @@ en:
                 </ul>
                 <p>In some circumstances, the sponsor might be entitled to a larger
                 grant.</p>
-                <p>This would be the Intermediate grant, or the Full sponsored grant.</p>
+                <p>This would be the intermediate grant, or the full sponsored grant.</p>
                 <p>Intermediate grant amounts are:</p>
                 <ul>
                 <li>£90,000 for primary and special schools</li>
@@ -42,7 +42,7 @@ en:
                 conversion costs have been paid for should be used for school
                 improvements.</p>
                 <p>A business case must be approved at advisory board, or by the regional
-                director, for a trust to get the Intermediate or Full sponsored grant.</p>
+                director, for a trust to get the intermediate or full sponsored grant.</p>
                 <p>There is more <a href="https://www.gov.uk/government/publications/sponsored-academies-funding-guidance-for-sponsors" class="govuk-link" target="_blank">guidance on grant eligibility and spending (opens in
                 new tab)</a> on GOV.UK.</p>
 
@@ -51,12 +51,12 @@ en:
             guidance_link: How to claim different grants
             guidance:
               html:
-                <p>The sponsor can claim for the Fast track grant first, then apply for
-                a top-up later through an Intermediate or Full sponsored grant.</p>
+                <p>The sponsor can claim for the fast track grant first, then apply for
+                a top-up later through an intermediate or full sponsored grant.</p>
                 <p>The trust will need to complete and return the <a href="https://educationgovuk.sharepoint.com/:w:/r/sites/lvedfe00116/WorkplaceDocuments/ARDG%20Internal%20Guidance/Archive_April_2020/Pre-Opening_Funding_Grant_Letter_Claim_Form_Annex_1.docx?d=w6bce8b5b84d841dd977af39eb2191afd&amp;csf=1&amp;web=1&amp;e=h02JhV" class="govuk-link" target="_blank">grant claim form
-                (opens in new tab)</a> to claim the Fast track grant. Share the form with them.</p>
+                (opens in new tab)</a> to claim the fast track grant. Share the form with them.</p>
                 <p>There is <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Funding-and-Finance.aspx?xsdata=MDV8MDF8fGIzMTZmYzk3NGM2NjQ5OTg0NTNlMDhkYWQ4NTcyMjc2fGZhZDI3N2M5YzYwYTRkYTFiNWYzYjNiOGIzNGE4MmY5fDB8MHw2MzgwNjAxNjU5NzgyNzcxODJ8VW5rbm93bnxWR1ZoYlhOVFpXTjFjbWwwZVZObGNuWnBZMlY4ZXlKV0lqb2lNQzR3TGpBd01EQWlMQ0pRSWpvaVYybHVNeklpTENKQlRpSTZJazkwYUdWeUlpd2lWMVFpT2pFeGZRPT18MXxNVFkzTURReE9UYzVOamcwTnpzeE5qY3dOREU1TnprMk9EUTNPekU1T20xbFpYUnBibWRmVFhwck1GcHFhRzFPYWxWMFRYcHJNMWxUTURCTk1sSnBURmRGTWsxcVRYUmFSMVV6VGtSRmQxbDZSbTFaTWxFMFFIUm9jbVZoWkM1Mk1nPT18Y2I5OTQ1ODRkNzdiNDY3ODQ1M2UwOGRhZDg1NzIyNzZ8NDA4ZDc0YWZkZmYyNDY2MWIxNzU3OTYzNmQ0MGRkMmE%3D&amp;sdata=SFhTMGxCRWVUQkxvTHRTQmp0emVrUlNHREVQdTlEQjFCMlYzSEY3WlR4dz0%3D&amp;ovuser=fad277c9-c60a-4da1-b5f3-b3b8b34a82f9%2CJoanna.EVANS%40EDUCATION.GOV.UK&amp;OR=Teams-HL&amp;CT=1670513971254&amp;clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiIxNDE1LzIyMTEzMDA0MTAwIiwiSGFzRmVkZXJhdGVkVXNlciI6ZmFsc2V9" class="govuk-link" target="_blank">guidance about how to claim different grants (opens in new
-                tab)</a> in SharePoint that explains how a trust can claim the Intermediate and Full sponsored grants.</p>
+                tab)</a> in SharePoint that explains how a trust can claim the intermediate and full sponsored grants.</p>
 
           payment_form:
             title: Receive, check and save the converter support grant claim form in the school's SharePoint folder
@@ -73,11 +73,11 @@ en:
             title: Send the grant information to the payments team
             hint:
               html:
-                <p>Send them the Academy order and Grant claim form.</p>
+                <p>Send them the academy order and grant claim form.</p>
             guidance_link: Guidance on what information to send
             guidance:
               html:
-                <p>You'll find the Directive academy order and Grant claim form in the
+                <p>You'll find the directive academy order and grant claim form in the
                 school's SharePoint folder.</p>
                 <p>You should send the documents to the Grant Payments team by email at
                 <a href="mailto:cfugrantpayments.regionsgroup@education.gov.uk" class="govuk-link" target="_blank">cfugrantpayments.regionsgroup@education.gov.uk</a>.</p>

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Project, type: :model do
         it "adds an appropriate error message if the value is nil" do
           subject.assign_attributes(directive_academy_order: nil)
           subject.valid?
-          expect(subject.errors[:directive_academy_order]).to include("Select yes if this project has had a Directive academy order issued")
+          expect(subject.errors[:directive_academy_order]).to include("Select yes if this project has had a directive academy order issued")
         end
       end
     end

--- a/spec/support/shared_examples/create_conversion_project_form.rb
+++ b/spec/support/shared_examples/create_conversion_project_form.rb
@@ -166,7 +166,7 @@ RSpec.shared_examples "a conversion project FormObject" do
           directive_academy_order: nil
         )
         expect(form).to be_invalid
-        expect(form.errors[:directive_academy_order]).to include("Select yes if this project has had a Directive academy order issued")
+        expect(form.errors[:directive_academy_order]).to include("Select yes if this project has had a directive academy order issued")
       end
     end
 
@@ -268,7 +268,7 @@ RSpec.shared_examples "a conversion project FormObject" do
         expect(Note.last.body).to eq("Some important words")
       end
 
-      context "when the project does NOT have a Directive academy order" do
+      context "when the project does NOT have a directive academy order" do
         it "sets directive_academy_order = false on the project" do
           form = build(
             form_factory.to_sym,
@@ -279,7 +279,7 @@ RSpec.shared_examples "a conversion project FormObject" do
         end
       end
 
-      context "when the project has a Directive academy order" do
+      context "when the project has a directive academy order" do
         it "sets directive_academy_order = true on the project" do
           form = build(
             form_factory.to_sym,


### PR DESCRIPTION
# I had to amend a test. Could somebody please check that I have not broken it?

You do not need to check the content.

## Changes

- Capitalised Google Maps in handover task
- Lower cased grant claim form
- Upper cased Grant Payments team
- Fixed casing on fast track, intermediate and full sponsored grants
- Sentence cased academy order and directive academy order in grant tasks
- Sentence cased directive academy order and academy order and fixed tests to look for lower case instances

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
