### PR TITLE
User can view statistics page for all project statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - New views at `/projects/regional/:region/in-progress` and
   `/projects/regional/:region/completed` to show projects NOT assigned to
   Regional caseworker services, filtered by region
+- User can view statistics page for all project statistics
 
 ## [Release 19][release-19]
 

--- a/app/controllers/all/statistics/projects_controller.rb
+++ b/app/controllers/all/statistics/projects_controller.rb
@@ -1,0 +1,5 @@
+class All::Statistics::ProjectsController < ApplicationController
+  def index
+    @project_statistics = ProjectStatistics.new
+  end
+end

--- a/app/models/project_statistics.rb
+++ b/app/models/project_statistics.rb
@@ -62,4 +62,184 @@ class ProjectStatistics
   def completed_projects_not_with_regional_casework_services
     @projects.not_assigned_to_regional_caseworker_team.completed.count
   end
+
+  def total_projects_within_london_region
+    @projects.by_region("london").count
+  end
+
+  def voluntary_projects_within_london_region
+    @projects.by_region("london").voluntary.count
+  end
+
+  def sponsored_projects_within_london_region
+    @projects.by_region("london").sponsored.count
+  end
+
+  def in_progress_projects_within_london_region
+    @projects.by_region("london").in_progress.count
+  end
+
+  def completed_projects_within_london_region
+    @projects.by_region("london").completed.count
+  end
+
+  def total_projects_within_south_east_region
+    @projects.by_region("south_east").count
+  end
+
+  def voluntary_projects_within_south_east_region
+    @projects.by_region("south_east").voluntary.count
+  end
+
+  def sponsored_projects_within_south_east_region
+    @projects.by_region("south_east").sponsored.count
+  end
+
+  def in_progress_projects_within_south_east_region
+    @projects.by_region("south_east").in_progress.count
+  end
+
+  def completed_projects_within_south_east_region
+    @projects.by_region("south_east").completed.count
+  end
+
+  def total_projects_within_yorkshire_and_the_humber_region
+    @projects.by_region("yorkshire_and_the_humber").count
+  end
+
+  def voluntary_projects_within_yorkshire_and_the_humber_region
+    @projects.by_region("yorkshire_and_the_humber").voluntary.count
+  end
+
+  def sponsored_projects_within_yorkshire_and_the_humber_region
+    @projects.by_region("yorkshire_and_the_humber").sponsored.count
+  end
+
+  def in_progress_projects_within_yorkshire_and_the_humber_region
+    @projects.by_region("yorkshire_and_the_humber").in_progress.count
+  end
+
+  def completed_projects_within_yorkshire_and_the_humber_region
+    @projects.by_region("yorkshire_and_the_humber").completed.count
+  end
+
+  def total_projects_within_north_west_region
+    @projects.by_region("north_west").count
+  end
+
+  def voluntary_projects_within_north_west_region
+    @projects.by_region("north_west").voluntary.count
+  end
+
+  def sponsored_projects_within_north_west_region
+    @projects.by_region("north_west").sponsored.count
+  end
+
+  def in_progress_projects_within_north_west_region
+    @projects.by_region("north_west").in_progress.count
+  end
+
+  def completed_projects_within_north_west_region
+    @projects.by_region("north_west").completed.count
+  end
+
+  def total_projects_within_east_of_england_region
+    @projects.by_region("east_of_england").count
+  end
+
+  def voluntary_projects_within_east_of_england_region
+    @projects.by_region("east_of_england").voluntary.count
+  end
+
+  def sponsored_projects_within_east_of_england_region
+    @projects.by_region("east_of_england").sponsored.count
+  end
+
+  def in_progress_projects_within_east_of_england_region
+    @projects.by_region("east_of_england").in_progress.count
+  end
+
+  def completed_projects_within_east_of_england_region
+    @projects.by_region("east_of_england").completed.count
+  end
+
+  def total_projects_within_west_midlands_region
+    @projects.by_region("west_midlands").count
+  end
+
+  def voluntary_projects_within_west_midlands_region
+    @projects.by_region("west_midlands").voluntary.count
+  end
+
+  def sponsored_projects_within_west_midlands_region
+    @projects.by_region("west_midlands").sponsored.count
+  end
+
+  def in_progress_projects_within_west_midlands_region
+    @projects.by_region("west_midlands").in_progress.count
+  end
+
+  def completed_projects_within_west_midlands_region
+    @projects.by_region("west_midlands").completed.count
+  end
+
+  def total_projects_within_north_east_region
+    @projects.by_region("north_east").count
+  end
+
+  def voluntary_projects_within_north_east_region
+    @projects.by_region("north_east").voluntary.count
+  end
+
+  def sponsored_projects_within_north_east_region
+    @projects.by_region("north_east").sponsored.count
+  end
+
+  def in_progress_projects_within_north_east_region
+    @projects.by_region("north_east").in_progress.count
+  end
+
+  def completed_projects_within_north_east_region
+    @projects.by_region("north_east").completed.count
+  end
+
+  def total_projects_within_south_west_region
+    @projects.by_region("south_west").count
+  end
+
+  def voluntary_projects_within_south_west_region
+    @projects.by_region("south_west").voluntary.count
+  end
+
+  def sponsored_projects_within_south_west_region
+    @projects.by_region("south_west").sponsored.count
+  end
+
+  def in_progress_projects_within_south_west_region
+    @projects.by_region("south_west").in_progress.count
+  end
+
+  def completed_projects_within_south_west_region
+    @projects.by_region("south_west").completed.count
+  end
+
+  def total_projects_within_east_midlands_region
+    @projects.by_region("east_midlands").count
+  end
+
+  def voluntary_projects_within_east_midlands_region
+    @projects.by_region("east_midlands").voluntary.count
+  end
+
+  def sponsored_projects_within_east_midlands_region
+    @projects.by_region("east_midlands").sponsored.count
+  end
+
+  def in_progress_projects_within_east_midlands_region
+    @projects.by_region("east_midlands").in_progress.count
+  end
+
+  def completed_projects_within_east_midlands_region
+    @projects.by_region("east_midlands").completed.count
+  end
 end

--- a/app/models/project_statistics.rb
+++ b/app/models/project_statistics.rb
@@ -242,4 +242,13 @@ class ProjectStatistics
   def completed_projects_within_east_midlands_region
     @projects.by_region("east_midlands").completed.count
   end
+
+  def opener_date_and_project_total
+    hash = {}
+    (1..6).each do |i|
+      date = Date.today + i.month
+      hash["#{Date::MONTHNAMES[date.month]} #{date.year}"] = Project.opening_by_month_year(date.month, date.year).count
+    end
+    hash
+  end
 end

--- a/app/models/project_statistics.rb
+++ b/app/models/project_statistics.rb
@@ -1,0 +1,25 @@
+class ProjectStatistics
+  def initialize
+    @projects = Project.all
+  end
+
+  def total_number_of_projects
+    @projects.count
+  end
+
+  def total_number_of_voluntary_projects
+    @projects.voluntary.count
+  end
+
+  def total_number_of_sponsored_projects
+    @projects.sponsored.count
+  end
+
+  def total_number_of_in_progress_projects
+    @projects.in_progress.count
+  end
+
+  def total_number_of_completed_projects
+    @projects.completed.count
+  end
+end

--- a/app/models/project_statistics.rb
+++ b/app/models/project_statistics.rb
@@ -42,4 +42,24 @@ class ProjectStatistics
   def completed_projects_with_regional_casework_services
     @projects.assigned_to_regional_caseworker_team.completed.count
   end
+
+  def total_projects_not_with_regional_casework_services
+    @projects.not_assigned_to_regional_caseworker_team.count
+  end
+
+  def voluntary_projects_not_with_regional_casework_services
+    @projects.not_assigned_to_regional_caseworker_team.voluntary.count
+  end
+
+  def sponsored_projects_not_with_regional_casework_services
+    @projects.not_assigned_to_regional_caseworker_team.sponsored.count
+  end
+
+  def in_progress_projects_not_with_regional_casework_services
+    @projects.not_assigned_to_regional_caseworker_team.in_progress.count
+  end
+
+  def completed_projects_not_with_regional_casework_services
+    @projects.not_assigned_to_regional_caseworker_team.completed.count
+  end
 end

--- a/app/models/project_statistics.rb
+++ b/app/models/project_statistics.rb
@@ -22,4 +22,24 @@ class ProjectStatistics
   def total_number_of_completed_projects
     @projects.completed.count
   end
+
+  def total_projects_with_regional_casework_services
+    @projects.assigned_to_regional_caseworker_team.count
+  end
+
+  def voluntary_projects_with_regional_casework_services
+    @projects.assigned_to_regional_caseworker_team.voluntary.count
+  end
+
+  def sponsored_projects_with_regional_casework_services
+    @projects.assigned_to_regional_caseworker_team.sponsored.count
+  end
+
+  def in_progress_projects_with_regional_casework_services
+    @projects.assigned_to_regional_caseworker_team.in_progress.count
+  end
+
+  def completed_projects_with_regional_casework_services
+    @projects.assigned_to_regional_caseworker_team.completed.count
+  end
 end

--- a/app/views/all/statistics/projects/index.html.erb
+++ b/app/views/all/statistics/projects/index.html.erb
@@ -66,4 +66,37 @@
       </tbody>
     </table>
   </div>
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">Projects not with Regional casework services</h2>
+    <table class="govuk-table" name="not_with_regional_casework_services_statistics_table" aria-label="Not with Regional casework services statistics">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Detail</th>
+          <th class="govuk-table__header" scope="col">Total number</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body" id="voluntary_projects">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">Voluntary projects</td>
+          <td class="govuk-table__cell"><%= @project_statistics.voluntary_projects_not_with_regional_casework_services %></td>
+        </tr>
+        <tr class="govuk-table__row" id="sponsored_projects">
+          <td class="govuk-table__cell">Sponsored projects</td>
+          <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_not_with_regional_casework_services %></td>
+        </tr>
+        <tr class="govuk-table__row" id="in_progress">
+          <td class="govuk-table__cell">In progress projects</td>
+          <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_not_with_regional_casework_services %></td>
+        </tr>
+        <tr class="govuk-table__row" id="completed">
+          <td class="govuk-table__cell">Completed projects</td>
+          <td class="govuk-table__cell"><%= @project_statistics.completed_projects_not_with_regional_casework_services %></td>
+        </tr>
+        <tr class="govuk-table__row" id="all_projects">
+          <td class="govuk-table__cell">All projects not with Regional casework services</td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_projects_not_with_regional_casework_services %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/app/views/all/statistics/projects/index.html.erb
+++ b/app/views/all/statistics/projects/index.html.erb
@@ -99,4 +99,93 @@
       </tbody>
     </table>
   </div>
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">Projects per region</h2>
+    <table class="govuk-table" name="not_with_regional_casework_services_statistics_table" aria-label="Not with Regional casework services statistics">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Region</th>
+          <th class="govuk-table__header" scope="col">Voluntary projects</th>
+          <th class="govuk-table__header" scope="col">Sponsored projects</th>
+          <th class="govuk-table__header" scope="col">In-progress projects</th>
+          <th class="govuk-table__header" scope="col">Completed projects</th>
+          <th class="govuk-table__header" scope="col">All projects</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body" id="london">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">London</td>
+          <td class="govuk-table__cell"><%= @project_statistics.voluntary_projects_within_london_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_london_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_london_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_london_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_london_region %></td>
+        </tr>
+        <tr class="govuk-table__row" id="south_east">
+          <td class="govuk-table__cell">South East</td>
+          <td class="govuk-table__cell"><%= @project_statistics.voluntary_projects_within_south_east_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_south_east_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_south_east_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_south_east_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_south_east_region %></td>
+        </tr>
+        <tr class="govuk-table__row" id="yorkshire_and_the_humber">
+          <td class="govuk-table__cell">Yorkshire and the Humber</td>
+          <td class="govuk-table__cell"><%= @project_statistics.voluntary_projects_within_yorkshire_and_the_humber_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_yorkshire_and_the_humber_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_yorkshire_and_the_humber_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_yorkshire_and_the_humber_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_yorkshire_and_the_humber_region %></td>
+        </tr>
+        <tr class="govuk-table__row" id="north_west">
+          <td class="govuk-table__cell">North West</td>
+          <td class="govuk-table__cell"><%= @project_statistics.voluntary_projects_within_north_west_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_north_west_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_north_west_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_north_west_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_north_west_region %></td>
+        </tr>
+        <tr class="govuk-table__row" id="east_of_england">
+          <td class="govuk-table__cell">East of England West</td>
+          <td class="govuk-table__cell"><%= @project_statistics.voluntary_projects_within_east_of_england_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_east_of_england_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_east_of_england_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_east_of_england_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_east_of_england_region %></td>
+        </tr>
+        <tr class="govuk-table__row" id="west_midlands">
+          <td class="govuk-table__cell">West Midlands</td>
+          <td class="govuk-table__cell"><%= @project_statistics.voluntary_projects_within_west_midlands_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_west_midlands_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_west_midlands_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_west_midlands_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_west_midlands_region %></td>
+        </tr>
+        <tr class="govuk-table__row" id="north_east">
+          <td class="govuk-table__cell">North East</td>
+          <td class="govuk-table__cell"><%= @project_statistics.voluntary_projects_within_north_east_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_north_east_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_north_east_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_north_east_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_north_east_region %></td>
+        </tr>
+        <tr class="govuk-table__row" id="south_west">
+          <td class="govuk-table__cell">South West</td>
+          <td class="govuk-table__cell"><%= @project_statistics.voluntary_projects_within_south_west_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_south_west_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_south_west_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_south_west_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_south_west_region %></td>
+        </tr>
+        <tr class="govuk-table__row" id="east_midlands">
+          <td class="govuk-table__cell">East Midlands</td>
+          <td class="govuk-table__cell"><%= @project_statistics.voluntary_projects_within_east_midlands_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_east_midlands_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_east_midlands_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_east_midlands_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_east_midlands_region %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/app/views/all/statistics/projects/index.html.erb
+++ b/app/views/all/statistics/projects/index.html.erb
@@ -1,0 +1,36 @@
+<div class="govuk-grid-row govuk-body">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Statistics Page</h1>
+    <h2 class="govuk-heading-l">Overview of all projects</h2>
+    <table class="govuk-table" name="statistics_table" aria-label="Project statistics">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Detail</th>
+          <th class="govuk-table__header" scope="col">Total number</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row" id="voluntary_projects">
+          <td class="govuk-table__cell">Voluntary projects</td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_number_of_voluntary_projects %></td>
+        </tr>
+        <tr class="govuk-table__row" id="sponsored_projects">
+          <td class="govuk-table__cell">Sponsored projects</td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_number_of_sponsored_projects %></td>
+        </tr>
+        <tr class="govuk-table__row" id="in_progress">
+          <td class="govuk-table__cell">In progress projects</td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_number_of_in_progress_projects %></td>
+        </tr>
+        <tr class="govuk-table__row" id="completed">
+          <td class="govuk-table__cell">Completed projects</td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_number_of_completed_projects %></td>
+        </tr>
+        <tr class="govuk-table__row" id="all_projects">
+          <td class="govuk-table__cell">All projects</td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_number_of_projects %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/all/statistics/projects/index.html.erb
+++ b/app/views/all/statistics/projects/index.html.erb
@@ -188,4 +188,23 @@
       </tbody>
     </table>
   </div>
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">6 month view of all project openers</h2>
+    <table class="govuk-table" name="statistics_table" aria-label="Project statistics">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Project opener date</th>
+          <th class="govuk-table__header" scope="col">Total number</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      <% @project_statistics.opener_date_and_project_total.each do |key, value| %>
+        <tr class="govuk-table__row" id="<%= key.tr(" ", "_") %>">
+          <td class="govuk-table__cell"><%= key %></td>
+          <td class="govuk-table__cell"><%= value %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/app/views/all/statistics/projects/index.html.erb
+++ b/app/views/all/statistics/projects/index.html.erb
@@ -33,4 +33,37 @@
       </tbody>
     </table>
   </div>
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">Projects with Regional casework services</h2>
+    <table class="govuk-table" name="regional_casework_services_statistics_table" aria-label="Regional casework services statistics">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Detail</th>
+          <th class="govuk-table__header" scope="col">Total number</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body" id="voluntary_projects">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">Voluntary projects</td>
+          <td class="govuk-table__cell"><%= @project_statistics.voluntary_projects_with_regional_casework_services %></td>
+        </tr>
+        <tr class="govuk-table__row" id="sponsored_projects">
+          <td class="govuk-table__cell">Sponsored projects</td>
+          <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_with_regional_casework_services %></td>
+        </tr>
+        <tr class="govuk-table__row" id="in_progress">
+          <td class="govuk-table__cell">In progress projects</td>
+          <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_with_regional_casework_services %></td>
+        </tr>
+        <tr class="govuk-table__row" id="completed">
+          <td class="govuk-table__cell">Completed projects</td>
+          <td class="govuk-table__cell"><%= @project_statistics.completed_projects_with_regional_casework_services %></td>
+        </tr>
+        <tr class="govuk-table__row" id="all_projects">
+          <td class="govuk-table__cell">All projects with Regional casework services</td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_projects_with_regional_casework_services %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,9 @@ Rails.application.routes.draw do
           namespace :conversion_date_changed, path: "conversion-date-changed" do
             get "/:month/:year", to: "projects#index", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}
           end
+          namespace :statistics do
+            get "/", to: "projects#index"
+          end
 
           get "new", to: "projects#new", as: :new
         end

--- a/spec/features/projects/statistics/users_can_view_project_statistics_spec.rb
+++ b/spec/features/projects/statistics/users_can_view_project_statistics_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.feature "Statistics page" do
+  before do
+    user = create(:user, :caseworker)
+    sign_in_with_user(user)
+    mock_successful_api_response_to_create_any_project
+    mock_pre_fetched_api_responses_for_any_establishment_and_trust
+  end
+
+  scenario "users can view the statistics page" do
+    visit all_statistics_projects_path
+
+    expect(page).to have_content("Statistics Page")
+  end
+end

--- a/spec/models/project_statistics_spec.rb
+++ b/spec/models/project_statistics_spec.rb
@@ -114,4 +114,348 @@ RSpec.describe ProjectStatistics, type: :model do
       end
     end
   end
+
+  describe "Projects per region" do
+    context "within the London region" do
+      let!(:voluntary_project_within_london_region_1) { create(:conversion_project, region: "london", completed_at: nil) }
+      let!(:voluntary_project_within_london_region_2) { create(:conversion_project, region: "london", completed_at: Date.today + 2.years) }
+      let!(:voluntary_project_within_south_east_region_1) { create(:conversion_project, region: "south_east") }
+      let!(:involuntary_project_within_london_region_1) { create(:involuntary_conversion_project, region: "london", completed_at: Date.today + 2.years) }
+      let!(:involuntary_project_within_london_region_2) { create(:involuntary_conversion_project, region: "london", completed_at: nil) }
+
+      describe "#total_projects_within_london_region" do
+        it "returns the total number of projects within the London region" do
+          expect(subject.total_projects_within_london_region).to eql(4)
+        end
+      end
+
+      describe "#voluntary_projects_within_london_region" do
+        it "returns the total number of voluntary projects within the London region" do
+          expect(subject.voluntary_projects_within_london_region).to eql(2)
+        end
+      end
+
+      describe "#sponsored_projects_within_london_region" do
+        it "returns the total number of sponsored projects within London region" do
+          expect(subject.sponsored_projects_within_london_region).to eql(2)
+        end
+      end
+
+      describe "#in_progress_projects_within_london_region" do
+        it "returns the total number of in-progress projects within London region" do
+          expect(subject.in_progress_projects_within_london_region).to eql(2)
+        end
+      end
+
+      describe "#completed_projects_within_london_region" do
+        it "returns the total number of completed projects within London regions" do
+          expect(subject.completed_projects_within_london_region).to eql(2)
+        end
+      end
+    end
+
+    context "within the South East region" do
+      let!(:voluntary_project_within_south_east_region_1) { create(:conversion_project, region: "south_east", completed_at: nil) }
+      let!(:voluntary_project_within_south_east_region_2) { create(:conversion_project, region: "south_east", completed_at: Date.today + 2.years) }
+      let!(:voluntary_project_within_north_west_region_1) { create(:conversion_project, region: "north_west") }
+      let!(:involuntary_project_within_south_east_region_1) { create(:involuntary_conversion_project, region: "south_east", completed_at: Date.today + 2.years) }
+      let!(:involuntary_project_within_south_east_region_2) { create(:involuntary_conversion_project, region: "south_east", completed_at: nil) }
+
+      describe "#total_projects_within_south_east_region" do
+        it "returns the total number of projects within the South East region" do
+          expect(subject.total_projects_within_south_east_region).to eql(4)
+        end
+      end
+
+      describe "#voluntary_projects_within_south_east_region" do
+        it "returns the total number of voluntary projects within the South East region" do
+          expect(subject.voluntary_projects_within_south_east_region).to eql(2)
+        end
+      end
+
+      describe "#sponsored_projects_within_south_east_region" do
+        it "returns the total number of sponsored projects within South East region" do
+          expect(subject.sponsored_projects_within_south_east_region).to eql(2)
+        end
+      end
+
+      describe "#in_progress_projects_within_south_east_region" do
+        it "returns the total number of in-progress projects within South East region" do
+          expect(subject.in_progress_projects_within_south_east_region).to eql(2)
+        end
+      end
+
+      describe "#completed_projects_within_south_east_region" do
+        it "returns the total number of completed projects within South East regions" do
+          expect(subject.completed_projects_within_south_east_region).to eql(2)
+        end
+      end
+    end
+
+    context "within the Yorkshire and the Humber region" do
+      let!(:voluntary_project_within_yorkshire_and_the_humber_region_1) { create(:conversion_project, region: "yorkshire_and_the_humber", completed_at: nil) }
+      let!(:voluntary_project_within_yorkshire_and_the_humber_region_2) { create(:conversion_project, region: "yorkshire_and_the_humber", completed_at: Date.today + 2.years) }
+      let!(:voluntary_project_within_north_west_region_1) { create(:conversion_project, region: "north_west") }
+      let!(:involuntary_project_within_yorkshire_and_the_humber_region_1) { create(:involuntary_conversion_project, region: "yorkshire_and_the_humber", completed_at: Date.today + 2.years) }
+      let!(:involuntary_project_within_yorkshire_and_the_humber_region_2) { create(:involuntary_conversion_project, region: "yorkshire_and_the_humber", completed_at: nil) }
+
+      describe "#total_projects_within_yorkshire_and_the_humber_region" do
+        it "returns the total number of projects within the Yorkshire and the Humber region" do
+          expect(subject.total_projects_within_yorkshire_and_the_humber_region).to eql(4)
+        end
+      end
+
+      describe "#voluntary_projects_within_yorkshire_and_the_humber_region" do
+        it "returns the total number of voluntary projects within the Yorkshire and the Humber region" do
+          expect(subject.voluntary_projects_within_yorkshire_and_the_humber_region).to eql(2)
+        end
+      end
+
+      describe "#sponsored_projects_within_yorkshire_and_the_humber_region" do
+        it "returns the total number of sponsored projects within Yorkshire and the Humber region" do
+          expect(subject.sponsored_projects_within_yorkshire_and_the_humber_region).to eql(2)
+        end
+      end
+
+      describe "#in_progress_projects_within_yorkshire_and_the_humber_region" do
+        it "returns the total number of in-progress projects within Yorkshire and the Humber region" do
+          expect(subject.in_progress_projects_within_yorkshire_and_the_humber_region).to eql(2)
+        end
+      end
+
+      describe "#completed_projects_within_yorkshire_and_the_humber_region" do
+        it "returns the total number of completed projects within Yorkshire and the Humber regions" do
+          expect(subject.completed_projects_within_yorkshire_and_the_humber_region).to eql(2)
+        end
+      end
+    end
+
+    context "within the North West region" do
+      let!(:voluntary_project_within_north_west_region_1) { create(:conversion_project, region: "north_west", completed_at: nil) }
+      let!(:voluntary_project_within_north_west_region_2) { create(:conversion_project, region: "north_west", completed_at: Date.today + 2.years) }
+      let!(:voluntary_project_within_london_region_1) { create(:conversion_project, region: "london") }
+      let!(:involuntary_project_within_north_west_region_1) { create(:involuntary_conversion_project, region: "north_west", completed_at: Date.today + 2.years) }
+      let!(:involuntary_project_within_north_west_region_2) { create(:involuntary_conversion_project, region: "north_west", completed_at: nil) }
+
+      describe "#total_projects_within_north_west_region" do
+        it "returns the total number of projects within the North West region" do
+          expect(subject.total_projects_within_north_west_region).to eql(4)
+        end
+      end
+
+      describe "#voluntary_projects_within_north_west_region" do
+        it "returns the total number of voluntary projects within the North West region" do
+          expect(subject.voluntary_projects_within_north_west_region).to eql(2)
+        end
+      end
+
+      describe "#sponsored_projects_within_north_west_region" do
+        it "returns the total number of sponsored projects within North West region" do
+          expect(subject.sponsored_projects_within_north_west_region).to eql(2)
+        end
+      end
+
+      describe "#in_progress_projects_within_north_west_region" do
+        it "returns the total number of in-progress projects within North West region" do
+          expect(subject.in_progress_projects_within_north_west_region).to eql(2)
+        end
+      end
+
+      describe "#completed_projects_within_north_west_region" do
+        it "returns the total number of completed projects within North West regions" do
+          expect(subject.completed_projects_within_north_west_region).to eql(2)
+        end
+      end
+    end
+
+    context "within the East of England region" do
+      let!(:voluntary_project_within_east_of_england_region_1) { create(:conversion_project, region: "east_of_england", completed_at: nil) }
+      let!(:voluntary_project_within_east_of_england_region_2) { create(:conversion_project, region: "east_of_england", completed_at: Date.today + 2.years) }
+      let!(:voluntary_project_within_london_region_1) { create(:conversion_project, region: "london") }
+      let!(:involuntary_project_within_east_of_england_region_1) { create(:involuntary_conversion_project, region: "east_of_england", completed_at: Date.today + 2.years) }
+      let!(:involuntary_project_within_east_of_england_region_2) { create(:involuntary_conversion_project, region: "east_of_england", completed_at: nil) }
+
+      describe "#total_projects_within_east_of_england_region" do
+        it "returns the total number of projects within the East of England region" do
+          expect(subject.total_projects_within_east_of_england_region).to eql(4)
+        end
+      end
+
+      describe "#voluntary_projects_within_east_of_england_region" do
+        it "returns the total number of voluntary projects within the East of England region" do
+          expect(subject.voluntary_projects_within_east_of_england_region).to eql(2)
+        end
+      end
+
+      describe "#sponsored_projects_within_east_of_england_region" do
+        it "returns the total number of sponsored projects within East of England region" do
+          expect(subject.sponsored_projects_within_east_of_england_region).to eql(2)
+        end
+      end
+
+      describe "#in_progress_projects_within_east_of_england_region" do
+        it "returns the total number of in-progress projects within East of England region" do
+          expect(subject.in_progress_projects_within_east_of_england_region).to eql(2)
+        end
+      end
+
+      describe "#completed_projects_within_east_of_england_region" do
+        it "returns the total number of completed projects within East of England regions" do
+          expect(subject.completed_projects_within_east_of_england_region).to eql(2)
+        end
+      end
+    end
+
+    context "within the West Midlands region" do
+      let!(:voluntary_project_within_west_midlands_region_1) { create(:conversion_project, region: "west_midlands", completed_at: nil) }
+      let!(:voluntary_project_within_west_midlands_region_2) { create(:conversion_project, region: "west_midlands", completed_at: Date.today + 2.years) }
+      let!(:voluntary_project_within_london_region_1) { create(:conversion_project, region: "london") }
+      let!(:involuntary_project_within_west_midlands_region_1) { create(:involuntary_conversion_project, region: "west_midlands", completed_at: Date.today + 2.years) }
+      let!(:involuntary_project_within_west_midlands_region_2) { create(:involuntary_conversion_project, region: "west_midlands", completed_at: nil) }
+
+      describe "#total_projects_within_west_midlands_region" do
+        it "returns the total number of projects within the West Midlands region" do
+          expect(subject.total_projects_within_west_midlands_region).to eql(4)
+        end
+      end
+
+      describe "#voluntary_projects_within_west_midlands_region" do
+        it "returns the total number of voluntary projects within the West Midlands region" do
+          expect(subject.voluntary_projects_within_west_midlands_region).to eql(2)
+        end
+      end
+
+      describe "#sponsored_projects_within_west_midlands_region" do
+        it "returns the total number of sponsored projects within West Midlands region" do
+          expect(subject.sponsored_projects_within_west_midlands_region).to eql(2)
+        end
+      end
+
+      describe "#in_progress_projects_within_west_midlands_region" do
+        it "returns the total number of in-progress projects within West Midlands region" do
+          expect(subject.in_progress_projects_within_west_midlands_region).to eql(2)
+        end
+      end
+
+      describe "#completed_projects_within_west_midlands_region" do
+        it "returns the total number of completed projects within West Midlands regions" do
+          expect(subject.completed_projects_within_west_midlands_region).to eql(2)
+        end
+      end
+    end
+
+    context "within the North East region" do
+      let!(:voluntary_project_within_north_east_region_1) { create(:conversion_project, region: "north_east", completed_at: nil) }
+      let!(:voluntary_project_within_north_east_region_2) { create(:conversion_project, region: "north_east", completed_at: Date.today + 2.years) }
+      let!(:voluntary_project_within_london_region_1) { create(:conversion_project, region: "london") }
+      let!(:involuntary_project_within_north_east_region_1) { create(:involuntary_conversion_project, region: "north_east", completed_at: Date.today + 2.years) }
+      let!(:involuntary_project_within_north_east_region_2) { create(:involuntary_conversion_project, region: "north_east", completed_at: nil) }
+
+      describe "#total_projects_within_north_east_region" do
+        it "returns the total number of projects within the North East region" do
+          expect(subject.total_projects_within_north_east_region).to eql(4)
+        end
+      end
+
+      describe "#voluntary_projects_within_north_east_region" do
+        it "returns the total number of voluntary projects within the North East region" do
+          expect(subject.voluntary_projects_within_north_east_region).to eql(2)
+        end
+      end
+
+      describe "#sponsored_projects_within_north_east_region" do
+        it "returns the total number of sponsored projects within North East region" do
+          expect(subject.sponsored_projects_within_north_east_region).to eql(2)
+        end
+      end
+
+      describe "#in_progress_projects_within_north_east_region" do
+        it "returns the total number of in-progress projects within North East region" do
+          expect(subject.in_progress_projects_within_north_east_region).to eql(2)
+        end
+      end
+
+      describe "#completed_projects_within_north_east_region" do
+        it "returns the total number of completed projects within North East regions" do
+          expect(subject.completed_projects_within_north_east_region).to eql(2)
+        end
+      end
+    end
+
+    context "within the South West region" do
+      let!(:voluntary_project_within_south_west_region_1) { create(:conversion_project, region: "south_west", completed_at: nil) }
+      let!(:voluntary_project_within_south_west_region_2) { create(:conversion_project, region: "south_west", completed_at: Date.today + 2.years) }
+      let!(:voluntary_project_within_london_region_1) { create(:conversion_project, region: "london") }
+      let!(:involuntary_project_within_south_west_region_1) { create(:involuntary_conversion_project, region: "south_west", completed_at: Date.today + 2.years) }
+      let!(:involuntary_project_within_south_west_region_2) { create(:involuntary_conversion_project, region: "south_west", completed_at: nil) }
+
+      describe "#total_projects_within_south_west_region" do
+        it "returns the total number of projects within the South West region" do
+          expect(subject.total_projects_within_south_west_region).to eql(4)
+        end
+      end
+
+      describe "#voluntary_projects_within_south_west_region" do
+        it "returns the total number of voluntary projects within the South West region" do
+          expect(subject.voluntary_projects_within_south_west_region).to eql(2)
+        end
+      end
+
+      describe "#sponsored_projects_within_south_west_region" do
+        it "returns the total number of sponsored projects within South West region" do
+          expect(subject.sponsored_projects_within_south_west_region).to eql(2)
+        end
+      end
+
+      describe "#in_progress_projects_within_south_west_region" do
+        it "returns the total number of in-progress projects within South West region" do
+          expect(subject.in_progress_projects_within_south_west_region).to eql(2)
+        end
+      end
+
+      describe "#completed_projects_within_south_west_region" do
+        it "returns the total number of completed projects within South West regions" do
+          expect(subject.completed_projects_within_south_west_region).to eql(2)
+        end
+      end
+    end
+
+    context "within the East Midlands region" do
+      let!(:voluntary_project_within_east_midlands_region_1) { create(:conversion_project, region: "east_midlands", completed_at: nil) }
+      let!(:voluntary_project_within_east_midlands_region_2) { create(:conversion_project, region: "east_midlands", completed_at: Date.today + 2.years) }
+      let!(:voluntary_project_within_london_region_1) { create(:conversion_project, region: "london") }
+      let!(:involuntary_project_within_east_midlands_region_1) { create(:involuntary_conversion_project, region: "east_midlands", completed_at: Date.today + 2.years) }
+      let!(:involuntary_project_within_east_midlands_region_2) { create(:involuntary_conversion_project, region: "east_midlands", completed_at: nil) }
+
+      describe "#total_projects_within_east_midlands_region" do
+        it "returns the total number of projects within the East Midlands region" do
+          expect(subject.total_projects_within_east_midlands_region).to eql(4)
+        end
+      end
+
+      describe "#voluntary_projects_within_east_midlands_region" do
+        it "returns the total number of voluntary projects within the East Midlands region" do
+          expect(subject.voluntary_projects_within_east_midlands_region).to eql(2)
+        end
+      end
+
+      describe "#sponsored_projects_within_east_midlands_region" do
+        it "returns the total number of sponsored projects within East Midlands region" do
+          expect(subject.sponsored_projects_within_east_midlands_region).to eql(2)
+        end
+      end
+
+      describe "#in_progress_projects_within_east_midlands_region" do
+        it "returns the total number of in-progress projects within East Midlands region" do
+          expect(subject.in_progress_projects_within_east_midlands_region).to eql(2)
+        end
+      end
+
+      describe "#completed_projects_within_east_midlands_region" do
+        it "returns the total number of completed projects within East Midlands regions" do
+          expect(subject.completed_projects_within_east_midlands_region).to eql(2)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/project_statistics_spec.rb
+++ b/spec/models/project_statistics_spec.rb
@@ -458,4 +458,20 @@ RSpec.describe ProjectStatistics, type: :model do
       end
     end
   end
+
+  describe "Projects opening in the next 6 months" do
+    describe "#opener_date_and_project_total" do
+      let!(:project_1) { create(:conversion_project, conversion_date: Date.today.at_beginning_of_month + 1.month, conversion_date_provisional: false) }
+      let!(:project_2) { create(:conversion_project, conversion_date: Date.today.at_beginning_of_month + 3.month, conversion_date_provisional: false) }
+
+      it "returns the table of openers for the next 6 months" do
+        (1..6).each do |i|
+          date = Date.today + i.month
+          within("##{Date::MONTHNAMES[date.month]}_#{date.year}") do
+            expect(page).to have_content(Project.opening_by_month_year(date.month, date.year).count)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/models/project_statistics_spec.rb
+++ b/spec/models/project_statistics_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe ProjectStatistics, type: :model do
+  subject { ProjectStatistics.new }
+  before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+  describe "all projects" do
+    let!(:voluntary_in_progress_project_1) { create(:conversion_project, completed_at: nil) }
+    let!(:sponsored_in_progress_project_2) { create(:involuntary_conversion_project, completed_at: nil) }
+    let!(:voluntary_completed_project_1) { create(:conversion_project, completed_at: Date.today + 2.years) }
+    let!(:sponsored_completed_project_2) { create(:involuntary_conversion_project, completed_at: Date.today + 2.years) }
+
+    describe "#total_number_of_projects" do
+      it "returns the total number of all projects" do
+        expect(subject.total_number_of_projects).to eql(4)
+      end
+    end
+
+    describe "#total_number_of_voluntary_projects" do
+      it "returns the total number of all voluntary projects" do
+        expect(subject.total_number_of_voluntary_projects).to eql(2)
+      end
+    end
+
+    describe "#total_number_of_sponsored_projects" do
+      it "returns the total number of all sponsored projects" do
+        expect(subject.total_number_of_sponsored_projects).to eql(2)
+      end
+    end
+
+    describe "#total_number_of_in_progress_projects" do
+      it "returns the total number of all in-progress projects" do
+        expect(subject.total_number_of_in_progress_projects).to eql(2)
+      end
+    end
+
+    describe "#total_number_of_completed_projects" do
+      it "returns the total number of all completed projects" do
+        expect(subject.total_number_of_completed_projects).to eql(2)
+      end
+    end
+  end
+end

--- a/spec/models/project_statistics_spec.rb
+++ b/spec/models/project_statistics_spec.rb
@@ -77,4 +77,41 @@ RSpec.describe ProjectStatistics, type: :model do
       end
     end
   end
+
+  describe "Regional projects that are not with regional casework services" do
+    let!(:voluntary_in_progress_project_not_with_regional_casework_services_1) { create(:conversion_project, assigned_to_regional_caseworker_team: false, completed_at: nil) }
+    let!(:voluntary_completed_project_not_with_regional_casework_services_2) { create(:conversion_project, assigned_to_regional_caseworker_team: false, completed_at: Date.today + 2.years) }
+    let!(:sponsored_in_progress_project_not_with_regional_casework_services_1) { create(:involuntary_conversion_project, assigned_to_regional_caseworker_team: false, completed_at: nil) }
+    let!(:sponsored_completed_project_not_with_regional_casework_services_2) { create(:involuntary_conversion_project, assigned_to_regional_caseworker_team: false, completed_at: Date.today + 2.years) }
+
+    describe "#total_projects_not_with_regional_casework_services" do
+      it "returns the total number of projects not with regional casework services" do
+        expect(subject.total_projects_not_with_regional_casework_services).to eql(4)
+      end
+    end
+
+    describe "#voluntary_projects_not_with_regional_casework_services" do
+      it "returns the total number of voluntary projects not with regional casework services" do
+        expect(subject.voluntary_projects_not_with_regional_casework_services).to eql(2)
+      end
+    end
+
+    describe "#sponsored_projects_not_with_regional_casework_services" do
+      it "returns the total number of sponsored projects not with regional casework services" do
+        expect(subject.sponsored_projects_not_with_regional_casework_services).to eql(2)
+      end
+    end
+
+    describe "#in_progress_projects_not_with_regional_casework_services" do
+      it "returns the total number of in-progress projects not with regional casework services" do
+        expect(subject.in_progress_projects_not_with_regional_casework_services).to eql(2)
+      end
+    end
+
+    describe "#completed_projects_not_with_regional_casework_services" do
+      it "returns the total number of completed projects not with regional casework services" do
+        expect(subject.completed_projects_not_with_regional_casework_services).to eql(2)
+      end
+    end
+  end
 end

--- a/spec/models/project_statistics_spec.rb
+++ b/spec/models/project_statistics_spec.rb
@@ -40,4 +40,41 @@ RSpec.describe ProjectStatistics, type: :model do
       end
     end
   end
+
+  describe "Regional casework services projects" do
+    let!(:voluntary_in_progress_project_with_regional_casework_services_1) { create(:conversion_project, assigned_to_regional_caseworker_team: true, completed_at: nil) }
+    let!(:voluntary_completed_project_with_regional_casework_services_2) { create(:conversion_project, assigned_to_regional_caseworker_team: true, completed_at: Date.today + 2.years) }
+    let!(:sponsored_in_progress_project_with_regional_casework_services_1) { create(:involuntary_conversion_project, assigned_to_regional_caseworker_team: true, completed_at: nil) }
+    let!(:sponsored_completed_project_with_regional_casework_services_2) { create(:involuntary_conversion_project, assigned_to_regional_caseworker_team: true, completed_at: Date.today + 2.years) }
+
+    describe "#total_projects_with_regional_casework_services" do
+      it "returns the total number of all projects within regional casework services" do
+        expect(subject.total_projects_with_regional_casework_services).to eql(4)
+      end
+    end
+
+    describe "#voluntary_projects_with_regional_casework_services" do
+      it "returns the total number of voluntary projects within regional casework services" do
+        expect(subject.voluntary_projects_with_regional_casework_services).to eql(2)
+      end
+    end
+
+    describe "#sponsored_projects_with_regional_casework_services" do
+      it "returns the total number of sponsored projects within regional casework services" do
+        expect(subject.sponsored_projects_with_regional_casework_services).to eql(2)
+      end
+    end
+
+    describe "#in_progress_projects_with_regional_casework_services" do
+      it "returns the total number of in-progress projects within regional casework services" do
+        expect(subject.in_progress_projects_with_regional_casework_services).to eql(2)
+      end
+    end
+
+    describe "#completed_projects_with_regional_casework_services" do
+      it "returns the total number of completed projects within regional casework services" do
+        expect(subject.completed_projects_with_regional_casework_services).to eql(2)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes

We now have a statistics page which gives an overview of all projects split into different categories:

- a general overview of all projects
- Regional casework services projects
- Regional projects
- Projects per region
- a 6 month view of all project openers

page can be found at `projects/all/statistics`
## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
