### PR TITLE
View a list of projects where the conversion date has changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Projects store the school's region as a first-class attribute
 - the 'Handover with regional delivery officer' task is now optional
 
+### Added
+
+- a new view that shows project that were going to convert in the given month
+  but have sinced changed date
+
 ## [Release 18][release-18]
 
 ### Changed

--- a/app/controllers/all/conversion_date_changed/projects_controller.rb
+++ b/app/controllers/all/conversion_date_changed/projects_controller.rb
@@ -1,0 +1,23 @@
+class All::ConversionDateChanged::ProjectsController < ApplicationController
+  after_action :verify_authorized
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
+
+  def index
+    authorize Project, :index?
+
+    @projects = Project.conversion_date_revised_from(month, year)
+    @date = "#{month_name(month)} #{year}"
+  end
+
+  private def month_name(month)
+    Date::MONTHNAMES[month]
+  end
+
+  private def month
+    params[:month].to_i
+  end
+
+  private def year
+    params[:year].to_i
+  end
+end

--- a/app/views/all/conversion_date_changed/projects/index.html.erb
+++ b/app/views/all/conversion_date_changed/projects/index.html.erb
@@ -1,0 +1,11 @@
+<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">
+      <%= t("project.conversion_date_changed.title", date: @date) %>
+    </h1>
+    <%= render partial: "/projects/shared/conversion_date_changed_table", locals: {projects: @projects, date: @date} %>
+  </div>
+</div>

--- a/app/views/projects/shared/_conversion_date_changed_table.html.erb
+++ b/app/views/projects/shared/_conversion_date_changed_table.html.erb
@@ -1,0 +1,26 @@
+<% if projects.empty? %>
+  <%= govuk_inset_text(text: t("project.conversion_date_changed.empty_html")) %>
+<% else %>
+  <table class="govuk-table" name="projects_table" aria-label="Projects table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.revised_conversion_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% projects.each do |project| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+        <td class="govuk-table__cell"><%= project.urn %></td>
+        <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
+        <td class="govuk-table__cell">
+          <%= link_to t("project.table.body.view_html", school_name: project.establishment.name), path_to_project(project) %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -107,6 +107,7 @@ en:
         assign: Assign project
         added_by: Added by
         conversion_date: Conversion date
+        revised_conversion_date: Revised conversion date
       body:
         view_html: View <span class="govuk-visually-hidden">%{school_name}</span> project
         assign_html: Assign <span class="govuk-visually-hidden">%{school_name}</span> project
@@ -125,6 +126,10 @@ en:
         html:
           <p>There are currently no schools expected to become academies in %{date}.</p>
           <p>Check with your line manager if you were expecting some schools to convert in this month.</p>
+    conversion_date_changed:
+      title: Academies that were expected to convert in %{date}
+      empty_html:
+          <p>None found.</p>
       table:
         headers:
           school: School

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,10 @@ Rails.application.routes.draw do
             get "voluntary", to: "projects#voluntary"
             get "sponsored", to: "projects#sponsored"
           end
+          namespace :conversion_date_changed, path: "conversion-date-changed" do
+            get "/:month/:year", to: "projects#index", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}
+          end
+
           get "new", to: "projects#new", as: :new
         end
         namespace :regional_casework_services, path: "regional-casework-services" do

--- a/spec/factories/conversion/date_history_factory.rb
+++ b/spec/factories/conversion/date_history_factory.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :date_history, class: Conversion::DateHistory do
+    project { association :project }
+    previous_date { Date.today.at_beginning_of_month - 1.month }
+    revised_date { previous_date + 2.months }
+    note { association :note, project: project }
+  end
+end

--- a/spec/features/projects/conversion_date_changed/viewing_projects_with_a_revised_converison_date_spec.rb
+++ b/spec/features/projects/conversion_date_changed/viewing_projects_with_a_revised_converison_date_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.feature "Viewing projects with a revised conversion date" do
+  scenario "Users can view the projects that were due to convert for a given month and year" do
+    user = create(:user)
+
+    sign_in_with_user(user)
+    mock_successful_api_response_to_create_any_project
+
+    project_with_confirmed_date = create(:conversion_project, assigned_to: user, conversion_date_provisional: false, urn: 121813)
+    create(:date_history, project: project_with_confirmed_date, previous_date: Date.today.at_beginning_of_month, revised_date: Date.today.at_beginning_of_month)
+
+    project_with_other_date = create(:conversion_project, assigned_to: user, conversion_date_provisional: false, urn: 121102)
+    create(:date_history, project: project_with_other_date, previous_date: Date.today.at_beginning_of_month + 1.month, revised_date: Date.today.at_beginning_of_month + 4.months)
+
+    project_with_matching_date = create(:conversion_project, assigned_to: user, conversion_date_provisional: false, urn: 101133)
+    create(:date_history, project: project_with_matching_date, previous_date: Date.today.at_beginning_of_month, revised_date: Date.today.at_beginning_of_month + 3.months)
+
+    visit "/projects/all/conversion-date-changed/#{Date.today.month}/#{Date.today.year}"
+
+    expect(page).to have_content I18n.t("project.conversion_date_changed.title", date: Date.today.to_fs(:govuk_month))
+    expect(page).to have_content project_with_matching_date.urn
+    expect(page).not_to have_content project_with_confirmed_date.urn
+    expect(page).not_to have_content project_with_other_date.urn
+  end
+end


### PR DESCRIPTION
This work covers the concept of 'slipped' projects. Projects that were going to convert in a given month but have since changed their conversion date.

The complexity here is in the scope for these projects, there is an extensive commit message there, but in summary:

- for all in progress projects
- for a given month and year
- get the conversion date histories ordered by creation date
- get the last conversion date history item
- if the previous_date in that item is the same month and year as the given ones, included it

Much of the work is already done with existing scopes, the main work comes from the join to the converison date histories.

With the scope in place, we add a simple view to the application to render matching projects, we'll use this view to see how many projects match the criteria and test this with real world data.

![Screenshot 2023-04-03 at 10-56-38 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/229477635-38b9ddd0-1301-4b01-b72f-8652d3e8f0b8.png)
