### PR TITLE
Handover task is optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added full stops to project handover confirmation page. Also explicitly called
   out the URN. Removed a from opens in a new tab.
 - Projects store the school's region as a first-class attribute
+- the 'Handover with regional delivery officer' task is now optional
 
 ## [Release 18][release-18]
 

--- a/app/models/conversion/voluntary/tasks/handover.rb
+++ b/app/models/conversion/voluntary/tasks/handover.rb
@@ -1,4 +1,4 @@
-class Conversion::Voluntary::Tasks::Handover < TaskList::Task
+class Conversion::Voluntary::Tasks::Handover < TaskList::OptionalTask
   attribute :review
   attribute :notes
   attribute :meeting

--- a/app/views/conversions/voluntary/task_lists/tasks/handover.html.erb
+++ b/app/views/conversions/voluntary/task_lists/tasks/handover.html.erb
@@ -11,6 +11,10 @@
       <%= form.govuk_error_summary %>
 
       <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
+      <div class="govuk-form-group">
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :review)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :notes)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :meeting)) %>

--- a/config/locales/task_lists/conversion/voluntary/handover.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/handover.en.yml
@@ -5,6 +5,9 @@ en:
         handover:
           title: Handover with regional delivery officer
 
+          not_applicable:
+            title: Not applicable
+
           review:
             title: Review the project information, check the documents and carry out research
             hint:

--- a/db/migrate/20230403101729_handover_task_is_optional.rb
+++ b/db/migrate/20230403101729_handover_task_is_optional.rb
@@ -1,0 +1,5 @@
+class HandoverTaskIsOptional < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_voluntary_task_lists, :handover_not_applicable, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_30_125747) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_03_101729) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -246,6 +246,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_30_125747) do
     t.boolean "sponsored_support_grant_send_information"
     t.boolean "sponsored_support_grant_inform_trust"
     t.boolean "sponsored_support_grant_not_applicable"
+    t.boolean "handover_not_applicable"
   end
 
   create_table "notes", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/features/users_can_complete_conversion_voluntary_tasks_spec.rb
+++ b/spec/features/users_can_complete_conversion_voluntary_tasks_spec.rb
@@ -11,14 +11,14 @@ RSpec.feature "Users can complete tasks in a voluntary conversion project" do
   end
 
   mandatory_tasks = %w[commercial_transfer_agreement
-    conditions_met handover
+    conditions_met
     land_questionnaire land_registry
     receive_grant_payment_certificate redact_and_send
     school_completed share_information single_worksheet
     supplemental_funding_agreement
     tell_regional_delivery_officer update_esfa]
 
-  optional_tasks = %w[articles_of_association church_supplemental_agreement
+  optional_tasks = %w[handover articles_of_association church_supplemental_agreement
     deed_of_variation direction_to_transfer master_funding_agreement
     one_hundred_and_twenty_five_year_lease subleases tenancy_at_will
     trust_modification_order conversion_grant sponsored_support_grant]


### PR DESCRIPTION
As we work to make the voluntary project route work for both voluntary
and sponsored converisons we will need the 'Handover with regional
delivery officer' task optional so that when a regional delivery officer
is completed the a sponsored conversion (which is currently always)
they can skip this task.

https://trello.com/c/vcdEuEY0