### PR TITLE
Add academy urn to project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- a new view at `/projects/all/new` that shows all conversion projects that
+  require the new Academy URN to be provided
+
 ### Changed
 
 - Standardised capitalisation in supplemental funding agreement voluntary and

--- a/app/controllers/all/projects_controller.rb
+++ b/app/controllers/all/projects_controller.rb
@@ -1,0 +1,20 @@
+class All::ProjectsController < ApplicationController
+  after_action :verify_authorized
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
+
+  def new
+    authorize Project, :index?
+    @pager, @projects = pagy(Project.no_academy_urn.by_conversion_date)
+
+    pre_fetch_establishments(@projects)
+    pre_fetch_incoming_trusts(@projects)
+  end
+
+  private def pre_fetch_establishments(projects)
+    EstablishmentsFetcher.new.call(projects)
+  end
+
+  private def pre_fetch_incoming_trusts(projects)
+    IncomingTrustsFetcher.new.call(projects)
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -36,6 +36,7 @@ class Project < ApplicationRecord
   scope :sponsored, -> { where(sponsor_trust_required: true) }
   scope :voluntary, -> { where(sponsor_trust_required: false) }
 
+  scope :no_academy_urn, -> { where(academy_urn: nil) }
   scope :provisional, -> { where(conversion_date_provisional: true) }
   scope :confirmed, -> { where(conversion_date_provisional: false) }
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -10,6 +10,7 @@ class Project < ApplicationRecord
 
   validates :urn, presence: true
   validates :urn, urn: true
+  validates :academy_urn, urn: true, if: -> { academy_urn.present? }
   validates :incoming_trust_ukprn, presence: true
   validates :incoming_trust_ukprn, ukprn: true
   validates :conversion_date, presence: true

--- a/app/views/all/projects/new.html.erb
+++ b/app/views/all/projects/new.html.erb
@@ -1,0 +1,11 @@
+<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t("project.all.new.title") %>
+    </h1>
+
+    <%= render partial: "/projects/shared/new_table", locals: {projects: @projects, pager: @pager} %>
+  </div>
+</div>

--- a/app/views/projects/shared/_new_table.html.erb
+++ b/app/views/projects/shared/_new_table.html.erb
@@ -1,0 +1,36 @@
+<% if projects.empty? %>
+  <%= govuk_inset_text(text: t("project.table.new.empty")) %>
+<% else %>
+  <table class="govuk-table" name="projects_table" aria-label="Projects table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_type") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_phase") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.route") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% projects.each do |project| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+        <td class="govuk-table__cell"><%= project.urn %></td>
+        <td class="govuk-table__cell"><%= project.establishment.type %></td>
+        <td class="govuk-table__cell"><%= project.establishment.phase %></td>
+        <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
+        <td class="govuk-table__cell"><%= t("project.table.body.#{project.route}") %></td>
+        <td class="govuk-table__cell">
+          <a href="<%= path_to_project(project) %>">
+            <%= t("project.table.body.view_html", school_name: project.establishment.name) %>
+          </a>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<%= govuk_pagination(pagy: pager) %>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -31,6 +31,8 @@ en:
           title: All sponsored completed projects
         voluntary:
           title: All voluntary completed projects
+      new:
+        title: All conversions without an academy URN
     regional_casework_services:
       in_progress:
         title: Regional Casework Services projects in progress
@@ -104,6 +106,7 @@ en:
         view: View project
         assign: Assign project
         added_by: Added by
+        conversion_date: Conversion date
       body:
         view_html: View <span class="govuk-visually-hidden">%{school_name}</span> project
         assign_html: Assign <span class="govuk-visually-hidden">%{school_name}</span> project
@@ -113,6 +116,8 @@ en:
         empty: There are no completed projects.
       unassigned:
         empty: There are no unassigned projects.
+      new:
+        empty: There are no conversions without an academy URN
     openers:
       title: Academies opening in %{date}
       subtitle: Schools that are expected to become academies.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,7 @@ Rails.application.routes.draw do
             get "voluntary", to: "projects#voluntary"
             get "sponsored", to: "projects#sponsored"
           end
+          get "new", to: "projects#new", as: :new
         end
         namespace :regional_casework_services, path: "regional-casework-services" do
           get "in-progress", to: "projects#in_progress"

--- a/db/migrate/20230403140609_add_academy_urn_to_project.rb
+++ b/db/migrate/20230403140609_add_academy_urn_to_project.rb
@@ -1,0 +1,5 @@
+class AddAcademyUrnToProject < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :academy_urn, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_03_101729) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_03_140609) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -286,6 +286,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_03_101729) do
     t.boolean "directive_academy_order", default: false
     t.boolean "sponsor_trust_required", default: false
     t.string "region"
+    t.integer "academy_urn"
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"

--- a/spec/features/projects/new/users_can_view_a_list_of_new_projects_spec.rb
+++ b/spec/features/projects/new/users_can_view_a_list_of_new_projects_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.feature "Viewing all new projects" do
+  context "when there are no projects" do
+    before do
+      user = create(:user, :caseworker)
+      sign_in_with_user(user)
+    end
+
+    scenario "they can see a helpful message" do
+      visit new_all_projects_path
+
+      expect(page).to have_content(I18n.t("project.table.new.empty"))
+    end
+  end
+
+  context "when there are projects in progress" do
+    before do
+      sign_in_with_user(user)
+      mock_successful_api_response_to_create_any_project
+      mock_pre_fetched_api_responses_for_any_establishment_and_trust
+    end
+
+    let!(:project_without_academy_urn) { create(:conversion_project, urn: 121583, academy_urn: nil) }
+    let!(:project_with_academy_urn) { create(:conversion_project, urn: 115652, academy_urn: 115654) }
+
+    context "when signed in as a Regional caseworker" do
+      let(:user) { create(:user, :caseworker) }
+
+      scenario "they can view all in progress projects" do
+        view_all_new_projects
+        table_has_the_correct_headers
+      end
+    end
+
+    context "when signed in as a Regional caseworker team lead" do
+      let(:user) { create(:user, :team_leader) }
+
+      scenario "they can view all in progress projects" do
+        view_all_new_projects
+        table_has_the_correct_headers
+      end
+    end
+
+    context "when signed in as a Regional delivery officer" do
+      let(:user) { create(:user, :regional_delivery_officer) }
+
+      scenario "they can view all in progress projects" do
+        view_all_new_projects
+        table_has_the_correct_headers
+      end
+    end
+
+    def table_has_the_correct_headers
+      visit new_all_projects_path
+
+      within("thead") do
+        expect(page).to have_content("School")
+        expect(page).to have_content("URN")
+        expect(page).to have_content("Type")
+        expect(page).to have_content("Phase")
+        expect(page).to have_content("Conversion date")
+        expect(page).to have_content("Route")
+        expect(page).to have_content("View project")
+      end
+    end
+
+    def view_all_new_projects
+      visit new_all_projects_path
+
+      expect(page).to have_content(I18n.t("project.all.new.title"))
+
+      within("tbody") do
+        expect(page).to have_content(project_without_academy_urn.academy_urn)
+
+        expect(page).not_to have_content(project_with_academy_urn.academy_urn)
+      end
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -606,6 +606,18 @@ RSpec.describe Project, type: :model do
         expect(projects).not_to include(voluntary_project)
       end
     end
+
+    describe "#no_academy_urn" do
+      it "returns only projects where academy_urn is nil" do
+        mock_successful_api_response_to_create_any_project
+        new_project = create(:conversion_project, academy_urn: nil)
+        existing_project = create(:conversion_project, academy_urn: 126041)
+        projects = Project.no_academy_urn
+
+        expect(projects).to include(new_project)
+        expect(projects).not_to include(existing_project)
+      end
+    end
   end
 
   describe "region" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -147,6 +147,28 @@ RSpec.describe Project, type: :model do
         end
       end
     end
+
+    describe "academy urn" do
+      context "when there is no academy urn" do
+        it "is valid" do
+          project = build(:conversion_project, academy_urn: nil)
+
+          expect(project).to be_valid
+        end
+      end
+
+      context "when there is an academy urn" do
+        it "the urn must be valid" do
+          project = build(:conversion_project, academy_urn: 12345678)
+
+          expect(project).to be_invalid
+
+          project = build(:conversion_project, academy_urn: 123456)
+
+          expect(project).to be_valid
+        end
+      end
+    end
   end
 
   describe "#establishment" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_db_column(:directive_academy_order).of_type :boolean }
     it { is_expected.to have_db_column(:sponsor_trust_required).of_type :boolean }
     it { is_expected.to have_db_column(:region).of_type :string }
+    it { is_expected.to have_db_column(:academy_urn).of_type :integer }
   end
 
   describe "Relationships" do


### PR DESCRIPTION
This work lays the ground work for service support users to come to the application and provide the new Academy URN.

This information will allow us to pull the new academy details from the GIAS data in the Academies database and use it.

Right now this is just a new attribute and view, it does nothing useful, but it does allow us to test the logic that includes the correct projects and build on this foundation.

![image](https://user-images.githubusercontent.com/480578/229557365-641dd3af-ab96-4696-b7df-e9b921bd0ec8.png)
