### PR TITLE
Update what constitutes sponsored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## Changed
+
+- the sponsored route is only applied to a project where a directive academy
+  order has been issued
+
 ## [Release 19][release-19]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - the sponsored route is only applied to a project where a directive academy
   order has been issued
+- the new project form no longer asks 'Is the school joining a Sponsor trust?'
 
 ## [Release 19][release-19]
 

--- a/app/controllers/conversions/involuntary/projects_controller.rb
+++ b/app/controllers/conversions/involuntary/projects_controller.rb
@@ -43,8 +43,7 @@ class Conversions::Involuntary::ProjectsController < Conversions::ProjectsContro
       :establishment_sharepoint_link,
       :trust_sharepoint_link,
       :note_body,
-      :directive_academy_order,
-      :sponsor_trust_required
+      :directive_academy_order
     )
   end
 end

--- a/app/controllers/conversions/voluntary/projects_controller.rb
+++ b/app/controllers/conversions/voluntary/projects_controller.rb
@@ -49,8 +49,7 @@ class Conversions::Voluntary::ProjectsController < Conversions::ProjectsControll
       :trust_sharepoint_link,
       :note_body,
       :assigned_to_regional_caseworker_team,
-      :directive_academy_order,
-      :sponsor_trust_required
+      :directive_academy_order
     )
   end
 end

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -44,7 +44,6 @@ class Conversion::CreateProjectForm
   validate :urn_unique_for_in_progress_conversions, if: -> { urn.present? }
 
   validates :directive_academy_order, inclusion: {in: %w[true false]}
-  validates :sponsor_trust_required, inclusion: {in: %w[true false]}
 
   def initialize(params = {})
     @attributes_with_invalid_values = []

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -5,7 +5,6 @@ class Conversion::CreateProjectForm
 
   SHAREPOINT_URLS = %w[educationgovuk-my.sharepoint.com educationgovuk.sharepoint.com].freeze
   DIRECTIVE_ACADEMY_ORDER_RESPONSES = [OpenStruct.new(id: true, name: I18n.t("yes")), OpenStruct.new(id: false, name: I18n.t("no"))]
-  SPONSOR_TRUST_REQUIRED_RESPONSES = [OpenStruct.new(id: true, name: I18n.t("yes")), OpenStruct.new(id: false, name: I18n.t("no"))]
 
   class NegativeValueError < StandardError; end
 
@@ -17,7 +16,6 @@ class Conversion::CreateProjectForm
   attribute :note_body
   attribute :user
   attribute :directive_academy_order
-  attribute :sponsor_trust_required
   attribute :region
 
   attr_reader :provisional_conversion_date,
@@ -52,10 +50,6 @@ class Conversion::CreateProjectForm
 
   def directive_academy_order_responses
     DIRECTIVE_ACADEMY_ORDER_RESPONSES
-  end
-
-  def sponsor_trust_required_responses
-    SPONSOR_TRUST_REQUIRED_RESPONSES
   end
 
   def provisional_conversion_date=(hash)

--- a/app/forms/conversion/involuntary/create_project_form.rb
+++ b/app/forms/conversion/involuntary/create_project_form.rb
@@ -12,7 +12,6 @@ class Conversion::Involuntary::CreateProjectForm < Conversion::CreateProjectForm
       regional_delivery_officer_id: user.id,
       task_list: Conversion::Involuntary::TaskList.new,
       directive_academy_order: directive_academy_order,
-      sponsor_trust_required: sponsor_trust_required,
       region: region
     )
 

--- a/app/forms/conversion/voluntary/create_project_form.rb
+++ b/app/forms/conversion/voluntary/create_project_form.rb
@@ -25,7 +25,6 @@ class Conversion::Voluntary::CreateProjectForm < Conversion::CreateProjectForm
       assigned_to: assigned_to,
       assigned_at: assigned_at,
       directive_academy_order: directive_academy_order,
-      sponsor_trust_required: directive_academy_order,
       region: region
     )
 

--- a/app/forms/conversion/voluntary/create_project_form.rb
+++ b/app/forms/conversion/voluntary/create_project_form.rb
@@ -25,7 +25,7 @@ class Conversion::Voluntary::CreateProjectForm < Conversion::CreateProjectForm
       assigned_to: assigned_to,
       assigned_at: assigned_at,
       directive_academy_order: directive_academy_order,
-      sponsor_trust_required: sponsor_trust_required,
+      sponsor_trust_required: directive_academy_order,
       region: region
     )
 

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -6,7 +6,7 @@ class Conversion::Project < Project
   has_many :conversion_dates, dependent: :destroy, class_name: "Conversion::DateHistory"
 
   def route
-    return :sponsored if sponsor_trust_required?
+    return :sponsored if directive_academy_order?
     :voluntary
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -33,8 +33,8 @@ class Project < ApplicationRecord
   scope :conversions, -> { where(type: "Conversion::Project") }
   scope :conversions_voluntary, -> { conversions.where(task_list_type: "Conversion::Voluntary::TaskList") }
   scope :conversions_involuntary, -> { conversions.where(task_list_type: "Conversion::Involuntary::TaskList") }
-  scope :sponsored, -> { where(sponsor_trust_required: true) }
-  scope :voluntary, -> { where(sponsor_trust_required: false) }
+  scope :sponsored, -> { where(directive_academy_order: true) }
+  scope :voluntary, -> { where(directive_academy_order: false) }
 
   scope :no_academy_urn, -> { where(academy_urn: nil) }
   scope :provisional, -> { where(conversion_date_provisional: true) }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -20,7 +20,6 @@ class Project < ApplicationRecord
   validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
   validates :trust_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
   validates :directive_academy_order, inclusion: {in: [true, false]}
-  validates :sponsor_trust_required, inclusion: {in: [true, false]}
 
   validate :establishment_exists, if: -> { urn.present? }
   validate :trust_exists, if: -> { incoming_trust_ukprn.present? }

--- a/app/views/conversions/involuntary/projects/new.html.erb
+++ b/app/views/conversions/involuntary/projects/new.html.erb
@@ -21,7 +21,6 @@
             label: {text: t("project.new.handover_comments_label"), size: "m"},
             hint: {text: t("project.new.handover_comments_hint").html_safe} %>
       <%= form.govuk_collection_radio_buttons :directive_academy_order, @project.directive_academy_order_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.directive_academy_order")}, form_group: {id: "directive-academy-order"} %>
-      <%= form.govuk_collection_radio_buttons :sponsor_trust_required, @project.sponsor_trust_required_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.sponsor_trust_required")}, form_group: {id: "sponsor-trust-required"} %>
 
       <%= form.govuk_submit %>
     <% end %>

--- a/app/views/conversions/voluntary/projects/new.html.erb
+++ b/app/views/conversions/voluntary/projects/new.html.erb
@@ -22,7 +22,6 @@
             hint: {text: t("project.new.handover_comments_hint").html_safe} %>
       <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, @project.assigned_to_regional_caseworker_team_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>
       <%= form.govuk_collection_radio_buttons :directive_academy_order, @project.directive_academy_order_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.directive_academy_order")}, form_group: {id: "directive-academy-order"} %>
-      <%= form.govuk_collection_radio_buttons :sponsor_trust_required, @project.sponsor_trust_required_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.sponsor_trust_required")}, form_group: {id: "sponsor-trust-required"} %>
 
       <%= form.govuk_submit %>
     <% end %>

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -5,10 +5,6 @@
       row.key { t('project_information.show.project_details.rows.directive_academy_order.title') }
       row.value { t("project_information.show.project_details.rows.directive_academy_order.#{@project.directive_academy_order}") }
     end
-    summary_list.row do |row|
-      row.key { t('project_information.show.project_details.rows.sponsor_trust_required.title') }
-      row.value { t("project_information.show.project_details.rows.sponsor_trust_required.#{@project.sponsor_trust_required}") }
-    end
   end %>
 </div>
 

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -72,7 +72,6 @@ en:
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
         assigned_to_regional_caseworker_team: Are you handing this project over to Regional Casework Services?
         directive_academy_order: Has a Directive academy order been issued?
-        sponsor_trust_required: Is the school joining a Sponsor trust?
   errors:
     attributes:
       conversion_date:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -170,10 +170,6 @@ en:
             title: Has a directive academy order been issued?
             "true": "Yes"
             "false": "No"
-          sponsor_trust_required:
-            title: Is the school joining a Sponsor trust?
-            "true": "Yes"
-            "false": "No"
       advisory_board_details:
         title: Advisory board details
         rows:
@@ -268,5 +264,3 @@ en:
         host_not_allowed: Enter a trust sharepoint link in the correct format. SharePoint links start with 'https://educationgovuk.sharepoint.com' or 'https://educationgovuk-my.sharepoint.com/'
       directive_academy_order:
         inclusion: Select yes if this project has had a directive academy order issued
-      sponsor_trust_required:
-        inclusion: Select yes if this school is joining a Sponsor trust

--- a/db/migrate/20230404144130_remove_sponsor_trust_required.rb
+++ b/db/migrate/20230404144130_remove_sponsor_trust_required.rb
@@ -1,0 +1,5 @@
+class RemoveSponsorTrustRequired < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :projects, :sponsor_trust_required, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_03_140609) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_04_144130) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -284,7 +284,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_03_140609) do
     t.boolean "conversion_date_provisional", default: true
     t.date "provisional_conversion_date"
     t.boolean "directive_academy_order", default: false
-    t.boolean "sponsor_trust_required", default: false
     t.string "region"
     t.integer "academy_urn"
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"

--- a/spec/factories/conversion/create_project_form_factory.rb
+++ b/spec/factories/conversion/create_project_form_factory.rb
@@ -9,7 +9,6 @@ FactoryBot.define do
     user { association :user, :regional_delivery_officer }
     note_body { "A note" }
     directive_academy_order { "false" }
-    sponsor_trust_required { "false" }
   end
 
   factory :create_involuntary_project_form, parent: :create_project_form, class: "Conversion::Involuntary::CreateProjectForm" do

--- a/spec/factories/conversion/involuntary/project_factory.rb
+++ b/spec/factories/conversion/involuntary/project_factory.rb
@@ -10,7 +10,6 @@ FactoryBot.define do
     trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }
     task_list { association :conversion_involuntary_task_list }
     directive_academy_order { true }
-    sponsor_trust_required { true }
     assigned_to { association :user, :caseworker, email: "user.#{SecureRandom.uuid}@education.gov.uk" }
   end
 end

--- a/spec/factories/conversion/project_factory.rb
+++ b/spec/factories/conversion/project_factory.rb
@@ -11,7 +11,6 @@ FactoryBot.define do
     task_list { association :voluntary_conversion_task_list }
     assigned_to { association :user, :caseworker, email: "user.#{SecureRandom.uuid}@education.gov.uk" }
     directive_academy_order { false }
-    sponsor_trust_required { false }
     region { Project.regions["london"] }
     regional_delivery_officer { association :user, :regional_delivery_officer }
 

--- a/spec/features/project_information/users_can_view_project_details_spec.rb
+++ b/spec/features/project_information/users_can_view_project_details_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Users can view project details" do
   let(:user) { create(:user, :caseworker) }
-  let(:project) { create(:conversion_project, directive_academy_order: true, sponsor_trust_required: true) }
+  let(:project) { create(:conversion_project, directive_academy_order: true) }
 
   before do
     mock_successful_api_responses(urn: any_args, ukprn: any_args)
@@ -12,12 +12,6 @@ RSpec.feature "Users can view project details" do
 
   scenario "they can see if it has had a directive academy order issued" do
     within("#projectDetails .govuk-summary-list__row:first-of-type") do
-      expect(page).to have_content("Yes")
-    end
-  end
-
-  scenario "they can see if it requires a sponsor trust" do
-    within("#projectDetails .govuk-summary-list__row:last-of-type") do
       expect(page).to have_content("Yes")
     end
   end

--- a/spec/features/projects/completed/users_can_view_a_list_of_all_projects_spec.rb
+++ b/spec/features/projects/completed/users_can_view_a_list_of_all_projects_spec.rb
@@ -30,8 +30,8 @@ RSpec.feature "Viewing all completed projects" do
     end
 
     let!(:completed_project) { create(:conversion_project, urn: 121583, completed_at: Date.yesterday) }
-    let!(:sponsored_completed_project) { create(:conversion_project, urn: 121102, completed_at: Date.yesterday, sponsor_trust_required: true) }
-    let!(:voluntary_completed_project) { create(:conversion_project, urn: 114067, completed_at: Date.yesterday, sponsor_trust_required: false) }
+    let!(:sponsored_completed_project) { create(:conversion_project, urn: 121102, completed_at: Date.yesterday, directive_academy_order: true) }
+    let!(:voluntary_completed_project) { create(:conversion_project, urn: 114067, completed_at: Date.yesterday, directive_academy_order: false) }
     let!(:in_progress_project) { create(:conversion_project, urn: 115652) }
 
     context "when signed in as a Regional caseworker" do

--- a/spec/features/projects/in_progress/users_can_view_a_list_of_all_projects_spec.rb
+++ b/spec/features/projects/in_progress/users_can_view_a_list_of_all_projects_spec.rb
@@ -31,8 +31,8 @@ RSpec.feature "Viewing all in-progress projects" do
 
     let!(:completed_project) { create(:conversion_project, urn: 121583, completed_at: Date.yesterday) }
     let!(:in_progress_project) { create(:conversion_project, urn: 115652) }
-    let!(:sponsored_in_progress_project) { create(:conversion_project, urn: 112209, sponsor_trust_required: true) }
-    let!(:voluntary_in_progress_project) { create(:conversion_project, urn: 103835, sponsor_trust_required: false) }
+    let!(:sponsored_in_progress_project) { create(:conversion_project, urn: 112209, directive_academy_order: true) }
+    let!(:voluntary_in_progress_project) { create(:conversion_project, urn: 103835, directive_academy_order: false) }
 
     context "when signed in as a Regional caseworker" do
       let(:user) { create(:user, :caseworker) }

--- a/spec/features/users_can_create_involuntary_conversion_projects_spec.rb
+++ b/spec/features/users_can_create_involuntary_conversion_projects_spec.rb
@@ -43,10 +43,6 @@ RSpec.feature "Users can create new involuntary conversion projects" do
         choose "Yes"
       end
 
-      within("#sponsor-trust-required") do
-        choose "Yes"
-      end
-
       click_button("Continue")
 
       expect(page).to have_content(I18n.t("project.show.title"))

--- a/spec/features/users_can_create_voluntary_conversion_projects_spec.rb
+++ b/spec/features/users_can_create_voluntary_conversion_projects_spec.rb
@@ -103,8 +103,5 @@ RSpec.feature "Users can create new voluntary conversion projects" do
     within("#directive-academy-order") do
       choose "No"
     end
-    within("#sponsor-trust-required") do
-      choose "No"
-    end
   end
 end

--- a/spec/features/users_can_view_a_project_summary_spec.rb
+++ b/spec/features/users_can_view_a_project_summary_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Users can view a project summary" do
 
   context "when they view a single sponsored conversion project" do
     scenario "they see the route" do
-      project = create(:voluntary_conversion_project, caseworker: user, sponsor_trust_required: true)
+      project = create(:voluntary_conversion_project, caseworker: user, directive_academy_order: true)
       visit project_path(project)
 
       within("#project-summary") do

--- a/spec/forms/conversion/voluntary/create_project_form_spec.rb
+++ b/spec/forms/conversion/voluntary/create_project_form_spec.rb
@@ -60,5 +60,19 @@ RSpec.describe Conversion::Voluntary::CreateProjectForm, type: :model do
         expect(project.assigned_at).to eq DateTime.now
       end
     end
+
+    describe "#sponsor_trust_required" do
+      it "has the same value as directive_academy_order" do
+        mock_successful_api_response_to_create_any_project
+
+        project = build(:create_voluntary_project_form, urn: 121813, directive_academy_order: "false").save
+
+        expect(project.sponsor_trust_required).to eql false
+
+        project = build(:create_voluntary_project_form, urn: 101133, directive_academy_order: "true").save
+
+        expect(project.sponsor_trust_required).to eql true
+      end
+    end
   end
 end

--- a/spec/forms/conversion/voluntary/create_project_form_spec.rb
+++ b/spec/forms/conversion/voluntary/create_project_form_spec.rb
@@ -60,19 +60,5 @@ RSpec.describe Conversion::Voluntary::CreateProjectForm, type: :model do
         expect(project.assigned_at).to eq DateTime.now
       end
     end
-
-    describe "#sponsor_trust_required" do
-      it "has the same value as directive_academy_order" do
-        mock_successful_api_response_to_create_any_project
-
-        project = build(:create_voluntary_project_form, urn: 121813, directive_academy_order: "false").save
-
-        expect(project.sponsor_trust_required).to eql false
-
-        project = build(:create_voluntary_project_form, urn: 101133, directive_academy_order: "true").save
-
-        expect(project.sponsor_trust_required).to eql true
-      end
-    end
   end
 end

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -4,19 +4,31 @@ RSpec.describe Conversion::Project do
   describe "#route" do
     before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 
-    context "when the project is a voluntary conversion" do
-      let(:project) { create(:conversion_project, sponsor_trust_required: false) }
+    context "when a directive academy order has been issued" do
+      context "and the school is joining a sponsor trust" do
+        let(:project) { create(:conversion_project, directive_academy_order: true, sponsor_trust_required: true) }
 
-      it "returns the correct route" do
-        expect(project.route).to eq :voluntary
+        it "the route is sponsored" do
+          expect(project.route).to eq :sponsored
+        end
       end
     end
 
-    context "when the project is a sponsored conversion" do
-      let(:project) { create(:conversion_project, sponsor_trust_required: true) }
+    context "when the project has not been issued a directive academy order" do
+      context "and the school is joining a sponsor trust" do
+        let(:project) { create(:conversion_project, directive_academy_order: false, sponsor_trust_required: true) }
 
-      it "returns the correct route" do
-        expect(project.route).to eq :sponsored
+        it "the route is voluntary" do
+          expect(project.route).to eq :voluntary
+        end
+      end
+
+      context "and the school is not joining a sponsor trust" do
+        let(:project) { create(:conversion_project, directive_academy_order: false, sponsor_trust_required: false) }
+
+        it "the route is voluntary" do
+          expect(project.route).to eq :voluntary
+        end
       end
     end
   end

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Conversion::Project do
 
     context "when a directive academy order has been issued" do
       context "and the school is joining a sponsor trust" do
-        let(:project) { create(:conversion_project, directive_academy_order: true, sponsor_trust_required: true) }
+        let(:project) { create(:conversion_project, directive_academy_order: true) }
 
         it "the route is sponsored" do
           expect(project.route).to eq :sponsored
@@ -16,7 +16,7 @@ RSpec.describe Conversion::Project do
 
     context "when the project has not been issued a directive academy order" do
       context "and the school is joining a sponsor trust" do
-        let(:project) { create(:conversion_project, directive_academy_order: false, sponsor_trust_required: true) }
+        let(:project) { create(:conversion_project, directive_academy_order: false) }
 
         it "the route is voluntary" do
           expect(project.route).to eq :voluntary
@@ -24,7 +24,7 @@ RSpec.describe Conversion::Project do
       end
 
       context "and the school is not joining a sponsor trust" do
-        let(:project) { create(:conversion_project, directive_academy_order: false, sponsor_trust_required: false) }
+        let(:project) { create(:conversion_project, directive_academy_order: false) }
 
         it "the route is voluntary" do
           expect(project.route).to eq :voluntary

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -584,10 +584,10 @@ RSpec.describe Project, type: :model do
     end
 
     describe "#voluntary" do
-      it "returns only projects where sponsor_trust_required is false" do
+      it "returns only projects where directive_academy_order is false" do
         mock_successful_api_response_to_create_any_project
-        voluntary_project = create(:conversion_project, sponsor_trust_required: false)
-        sponsored_project = create(:conversion_project, sponsor_trust_required: true)
+        voluntary_project = create(:conversion_project, directive_academy_order: false)
+        sponsored_project = create(:conversion_project, directive_academy_order: true)
         projects = Project.voluntary
 
         expect(projects).to include(voluntary_project)
@@ -596,10 +596,10 @@ RSpec.describe Project, type: :model do
     end
 
     describe "#sponsored" do
-      it "returns only projects where sponsor_trust_required is true" do
+      it "returns only projects where directive_academy_order is true" do
         mock_successful_api_response_to_create_any_project
-        voluntary_project = create(:conversion_project, sponsor_trust_required: false)
-        sponsored_project = create(:conversion_project, sponsor_trust_required: true)
+        voluntary_project = create(:conversion_project, directive_academy_order: false)
+        sponsored_project = create(:conversion_project, directive_academy_order: true)
         projects = Project.sponsored
 
         expect(projects).to include(sponsored_project)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_db_column(:type).of_type :string }
     it { is_expected.to have_db_column(:assigned_to_regional_caseworker_team).of_type :boolean }
     it { is_expected.to have_db_column(:directive_academy_order).of_type :boolean }
-    it { is_expected.to have_db_column(:sponsor_trust_required).of_type :boolean }
     it { is_expected.to have_db_column(:region).of_type :string }
     it { is_expected.to have_db_column(:academy_urn).of_type :integer }
   end
@@ -130,20 +129,6 @@ RSpec.describe Project, type: :model do
           subject.assign_attributes(directive_academy_order: nil)
           subject.valid?
           expect(subject.errors[:directive_academy_order]).to include("Select yes if this project has had a directive academy order issued")
-        end
-      end
-    end
-
-    describe "#sponsor_trust_required" do
-      it { is_expected.to allow_value(true).for(:sponsor_trust_required) }
-      it { is_expected.to allow_value(false).for(:sponsor_trust_required) }
-      it { is_expected.to_not allow_value(nil).for(:sponsor_trust_required) }
-
-      context "error messages" do
-        it "adds an appropriate error message if the value is nil" do
-          subject.assign_attributes(sponsor_trust_required: nil)
-          subject.valid?
-          expect(subject.errors[:sponsor_trust_required]).to include("Select yes if this school is joining a Sponsor trust")
         end
       end
     end

--- a/spec/requests/conversions/involuntary/projects_controller_spec.rb
+++ b/spec/requests/conversions/involuntary/projects_controller_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe Conversions::Involuntary::ProjectsController do
       "advisory_board_date(3i)": "1",
       "advisory_board_date(2i)": "1",
       "advisory_board_date(1i)": "2022",
-      regional_delivery_officer: nil,
-      sponsor_trust_required: "false")
+      regional_delivery_officer: nil)
   }
 
   before do

--- a/spec/requests/conversions/voluntary/projects_controller_spec.rb
+++ b/spec/requests/conversions/voluntary/projects_controller_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe Conversions::Voluntary::ProjectsController do
       "advisory_board_date(2i)": "1",
       "advisory_board_date(1i)": "2022",
       regional_delivery_officer: nil,
-      directive_academy_order: "false",
-      sponsor_trust_required: "false")
+      directive_academy_order: "false")
   }
 
   before do

--- a/spec/support/shared_examples/create_conversion_project_form.rb
+++ b/spec/support/shared_examples/create_conversion_project_form.rb
@@ -169,17 +169,6 @@ RSpec.shared_examples "a conversion project FormObject" do
         expect(form.errors[:directive_academy_order]).to include("Select yes if this project has had a directive academy order issued")
       end
     end
-
-    describe "sponsor_trust_required" do
-      it "validates the presence of sponsor_trust_required" do
-        form = build(
-          form_factory.to_sym,
-          sponsor_trust_required: nil
-        )
-        expect(form).to be_invalid
-        expect(form.errors[:sponsor_trust_required]).to include("Select yes if this school is joining a Sponsor trust")
-      end
-    end
   end
 
   describe "urn" do


### PR DESCRIPTION
After we deployed the new `sponsor_trust_required` attribute, we quickly learnt that the way we wored the quesiton and the reality of projects let to not needing to collect this attribute.

There is a case where a school is converting voluntarily by joining a trust that can be a sponsor, but this would not be considered a 'sponsored' conversion. We came to this conclusion after seeing a real project meet this criteria:

https://www.complete.education.gov.uk/conversions/voluntary/projects/E22A0D59-CE7C-486E-A6DB-B3F781CEDC4E/information

(not project will show as voluntary once this work is merged!)

Armed with the confidence this brings, this works redefines what constitutes a 'sponsored' conversion - the issuing of a directive academy order and then goes on to remove the `sponsored_trust_required` attribute.

https://trello.com/c/GPg2EnmX
