### PR TITLE
Users can view projects filtered by region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   order has been issued
 - the new project form no longer asks 'Is the school joining a Sponsor trust?'
 
+### Added
+
+- New views at `/projects/regional/in-progress` and
+  `/projects/regional/completed` to show projects NOT assigned to Regional
+  caseworker services
+
 ## [Release 19][release-19]
 
-### Added
+### Added
 
 - a new view at `/projects/all/new` that shows all conversion projects that
   require the new Academy URN to be provided

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - New views at `/projects/regional/in-progress` and
   `/projects/regional/completed` to show projects NOT assigned to Regional
   caseworker services
+- New views at `/projects/regional/:region/in-progress` and
+  `/projects/regional/:region/completed` to show projects NOT assigned to
+  Regional caseworker services, filtered by region
 
 ## [Release 19][release-19]
 

--- a/app/controllers/regional/projects_controller.rb
+++ b/app/controllers/regional/projects_controller.rb
@@ -10,9 +10,33 @@ class Regional::ProjectsController < ApplicationController
     pre_fetch_incoming_trusts(@projects)
   end
 
+  def in_progress_by_region
+    authorize Project, :index?
+    return not_found_error unless valid_region?
+
+    @pager, @projects = pagy(Project.not_assigned_to_regional_caseworker_team.by_region(region).in_progress.includes(:assigned_to))
+    @region = region
+    @region_string = I18n.t("project.region.#{region}")
+
+    pre_fetch_establishments(@projects)
+    pre_fetch_incoming_trusts(@projects)
+  end
+
   def completed
     authorize Project, :index?
     @pager, @projects = pagy(Project.not_assigned_to_regional_caseworker_team.completed)
+
+    pre_fetch_establishments(@projects)
+    pre_fetch_incoming_trusts(@projects)
+  end
+
+  def completed_by_region
+    authorize Project, :index?
+    return not_found_error unless valid_region?
+
+    @pager, @projects = pagy(Project.not_assigned_to_regional_caseworker_team.by_region(region).completed)
+    @region = region
+    @region_string = I18n.t("project.region.#{region}")
 
     pre_fetch_establishments(@projects)
     pre_fetch_incoming_trusts(@projects)
@@ -24,5 +48,13 @@ class Regional::ProjectsController < ApplicationController
 
   private def pre_fetch_incoming_trusts(projects)
     IncomingTrustsFetcher.new.call(projects)
+  end
+
+  private def valid_region?
+    Project.regions.include?(region)
+  end
+
+  private def region
+    params[:region].tr("-", "_")
   end
 end

--- a/app/controllers/regional/projects_controller.rb
+++ b/app/controllers/regional/projects_controller.rb
@@ -1,0 +1,28 @@
+class Regional::ProjectsController < ApplicationController
+  after_action :verify_authorized
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
+
+  def in_progress
+    authorize Project, :index?
+    @pager, @projects = pagy(Project.not_assigned_to_regional_caseworker_team.in_progress.includes(:assigned_to))
+
+    pre_fetch_establishments(@projects)
+    pre_fetch_incoming_trusts(@projects)
+  end
+
+  def completed
+    authorize Project, :index?
+    @pager, @projects = pagy(Project.not_assigned_to_regional_caseworker_team.completed)
+
+    pre_fetch_establishments(@projects)
+    pre_fetch_incoming_trusts(@projects)
+  end
+
+  private def pre_fetch_establishments(projects)
+    EstablishmentsFetcher.new.call(projects)
+  end
+
+  private def pre_fetch_incoming_trusts(projects)
+    IncomingTrustsFetcher.new.call(projects)
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -56,6 +56,8 @@ class Project < ApplicationRecord
 
   scope :assigned_to, ->(user) { where(assigned_to_id: user.id) }
 
+  scope :by_region, ->(region) { where(region: region) }
+
   enum :region, {
     london: "H",
     south_east: "J",

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -50,6 +50,7 @@ class Project < ApplicationRecord
 
   scope :unassigned_to_user, -> { where assigned_to: nil }
   scope :assigned_to_regional_caseworker_team, -> { where(assigned_to_regional_caseworker_team: true) }
+  scope :not_assigned_to_regional_caseworker_team, -> { where.not(assigned_to_regional_caseworker_team: true) }
 
   scope :opening_by_month_year, ->(month, year) { includes(:task_list).where(conversion_date_provisional: false).and(where("YEAR(conversion_date) = ?", year)).and(where("MONTH(conversion_date) = ?", month)) }
 

--- a/app/views/regional/projects/_project_index_sub_navigation.html.erb
+++ b/app/views/regional/projects/_project_index_sub_navigation.html.erb
@@ -1,0 +1,12 @@
+<nav class="moj-sub-navigation" aria-label="Project index sub-navigation">
+  <ul class="moj-sub-navigation__list">
+    <%= render partial: "shared/sub_navigation_item",
+          locals: {name: t("subnavigation.in_progress_projects"),
+                   path: in_progress_regional_projects_path} %>
+
+    <%= render partial: "shared/sub_navigation_item",
+          locals: {name: t("subnavigation.completed_projects"),
+                   path: completed_regional_projects_path} %>
+
+  </ul>
+</nav>

--- a/app/views/regional/projects/_project_index_sub_navigation.html.erb
+++ b/app/views/regional/projects/_project_index_sub_navigation.html.erb
@@ -1,12 +1,21 @@
 <nav class="moj-sub-navigation" aria-label="Project index sub-navigation">
   <ul class="moj-sub-navigation__list">
-    <%= render partial: "shared/sub_navigation_item",
-          locals: {name: t("subnavigation.in_progress_projects"),
-                   path: in_progress_regional_projects_path} %>
+    <% if @region %>
+      <%= render partial: "shared/sub_navigation_item",
+            locals: {name: t("subnavigation.in_progress_projects"),
+                     path: in_progress_by_region_regional_projects_path(@region)} %>
 
-    <%= render partial: "shared/sub_navigation_item",
-          locals: {name: t("subnavigation.completed_projects"),
-                   path: completed_regional_projects_path} %>
+      <%= render partial: "shared/sub_navigation_item",
+            locals: {name: t("subnavigation.completed_projects"),
+                     path: completed_by_region_regional_projects_path(@region)} %>
+    <% else %>
+      <%= render partial: "shared/sub_navigation_item",
+            locals: {name: t("subnavigation.in_progress_projects"),
+                     path: in_progress_regional_projects_path} %>
 
+      <%= render partial: "shared/sub_navigation_item",
+            locals: {name: t("subnavigation.completed_projects"),
+                     path: completed_regional_projects_path} %>
+    <% end %>
   </ul>
 </nav>

--- a/app/views/regional/projects/completed.html.erb
+++ b/app/views/regional/projects/completed.html.erb
@@ -1,0 +1,15 @@
+<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">
+      <%= t("project.regional.completed.title") %>
+    </h1>
+
+    <%= render partial: "project_index_sub_navigation" %>
+
+    <%= render partial: "/projects/shared/completed_table", locals: {projects: @projects, pager: @pager} %>
+
+  </div>
+</div>

--- a/app/views/regional/projects/completed_by_region.html.erb
+++ b/app/views/regional/projects/completed_by_region.html.erb
@@ -1,0 +1,15 @@
+<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">
+      <%= t("project.regional.by_region.completed.title", region: @region_string) %>
+    </h1>
+
+    <%= render partial: "project_index_sub_navigation" %>
+
+    <%= render partial: "/projects/shared/completed_table", locals: {projects: @projects, pager: @pager} %>
+
+  </div>
+</div>

--- a/app/views/regional/projects/in_progress.html.erb
+++ b/app/views/regional/projects/in_progress.html.erb
@@ -1,0 +1,15 @@
+<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">
+      <%= t("project.regional.in_progress.title") %>
+    </h1>
+
+    <%= render partial: "project_index_sub_navigation" %>
+
+    <%= render partial: "/projects/shared/in_progress_table", locals: {projects: @projects, pager: @pager} %>
+
+  </div>
+</div>

--- a/app/views/regional/projects/in_progress_by_region.html.erb
+++ b/app/views/regional/projects/in_progress_by_region.html.erb
@@ -1,0 +1,15 @@
+<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">
+      <%= t("project.regional.by_region.in_progress.title", region: @region_string) %>
+    </h1>
+
+    <%= render partial: "project_index_sub_navigation" %>
+
+    <%= render partial: "/projects/shared/in_progress_table", locals: {projects: @projects, pager: @pager} %>
+
+  </div>
+</div>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -40,6 +40,11 @@ en:
         title: Regional Casework Services completed projects
       unassigned:
         title: Regional Casework Services unassigned projects
+    regional:
+      in_progress:
+        title: Regional projects in progress
+      completed:
+        title: Regional completed projects
     user:
       in_progress:
         title: Assigned projects in progress

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -45,6 +45,11 @@ en:
         title: Regional projects in progress
       completed:
         title: Regional completed projects
+      by_region:
+        in_progress:
+          title: Regional projects for %{region} in progress
+        completed:
+          title: Regional completed projects for %{region}
     user:
       in_progress:
         title: Assigned projects in progress

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -150,15 +150,15 @@ en:
       completed_html: <h3>Project completed<h3><p>This project was completed on %{date} and cannot be changed.</p>
       not_assigned_html: <h3>Not assigned to project</h3><p>This project is not assigned to you and cannot be changed, you can add notes or contacts if required.</p>
     region:
-      london: London,
-      south_east: South East,
-      yorkshire_and_the_humber: Yorkshire and the Humber,
-      north_west: North West,
-      east_of_england: East of England,
-      west_midlands: West Midlands,
-      north_east: North East,
-      south_west: South West,
-      east_midlands: East Midlands,
+      london: London
+      south_east: South East
+      yorkshire_and_the_humber: Yorkshire and the Humber
+      north_west: North West
+      east_of_england: East of England
+      west_midlands: West Midlands
+      north_east: North East
+      south_west: South West
+      east_midlands: East Midlands
   project_information:
     show:
       side_navigation:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,8 @@ Rails.application.routes.draw do
         namespace :regional, path: "regional" do
           get "in-progress", to: "projects#in_progress"
           get "completed", to: "projects#completed"
+          get ":region/in-progress", to: "projects#in_progress_by_region", as: :in_progress_by_region
+          get ":region/completed", to: "projects#completed_by_region", as: :completed_by_region
         end
         namespace :user do
           get "in-progress", to: "projects#in_progress"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,10 @@ Rails.application.routes.draw do
           get "completed", to: "projects#completed"
           get "unassigned", to: "projects#unassigned"
         end
+        namespace :regional, path: "regional" do
+          get "in-progress", to: "projects#in_progress"
+          get "completed", to: "projects#completed"
+        end
         namespace :user do
           get "in-progress", to: "projects#in_progress"
           get "completed", to: "projects#completed"

--- a/spec/features/projects/users_can_view_a_list_of_regional_projects_spec.rb
+++ b/spec/features/projects/users_can_view_a_list_of_regional_projects_spec.rb
@@ -7,55 +7,109 @@ RSpec.feature "Viewing regional projects" do
     sign_in_with_user(user)
   end
 
-  context "when there are no projects" do
-    scenario "they can view a helpful message" do
-      visit in_progress_regional_projects_path
+  context "projects for all regions" do
+    context "when there are no projects" do
+      scenario "they can view a helpful message" do
+        visit in_progress_regional_projects_path
 
-      expect(page).to have_content(I18n.t("project.table.in_progress.empty"))
+        expect(page).to have_content(I18n.t("project.table.in_progress.empty"))
 
-      visit completed_regional_projects_path
+        visit completed_regional_projects_path
 
-      expect(page).to have_content(I18n.t("project.table.completed.empty"))
-    end
-  end
-
-  context "when there are projects" do
-    before do
-      mock_successful_api_response_to_create_any_project
-      mock_pre_fetched_api_responses_for_any_establishment_and_trust
-    end
-
-    let!(:completed_regional_project) { create(:conversion_project, urn: 101133, assigned_to_regional_caseworker_team: false, completed_at: Date.yesterday) }
-    let!(:in_progress_regional_project) { create(:conversion_project, urn: 126041, assigned_to_regional_caseworker_team: false, assigned_to: user) }
-
-    let!(:completed_project) { create(:conversion_project, urn: 121583, completed_at: Date.yesterday, assigned_to_regional_caseworker_team: true, assigned_to: user) }
-    let!(:in_progress_project) { create(:conversion_project, urn: 115652, assigned_to_regional_caseworker_team: true, assigned_to: user) }
-
-    scenario "they can view all in progress projects" do
-      visit in_progress_regional_projects_path
-
-      expect(page).to have_content(I18n.t("project.regional.in_progress.title"))
-
-      within("tbody") do
-        expect(page).to_not have_content(in_progress_project.urn)
-        expect(page).to have_content(in_progress_regional_project.urn)
-
-        expect(page).to_not have_content(completed_project.urn)
-        expect(page).to_not have_content(completed_regional_project.urn)
+        expect(page).to have_content(I18n.t("project.table.completed.empty"))
       end
     end
 
-    scenario "they can view all completed projects" do
-      visit completed_regional_projects_path
+    context "when there are projects" do
+      before do
+        mock_successful_api_response_to_create_any_project
+        mock_pre_fetched_api_responses_for_any_establishment_and_trust
+      end
 
-      expect(page).to have_content(I18n.t("project.regional.completed.title"))
+      let!(:completed_regional_project) { create(:conversion_project, urn: 101133, assigned_to_regional_caseworker_team: false, completed_at: Date.yesterday) }
+      let!(:in_progress_regional_project) { create(:conversion_project, urn: 126041, assigned_to_regional_caseworker_team: false, assigned_to: user) }
 
-      within("tbody") do
-        expect(page).not_to have_content(completed_project.urn)
-        expect(page).to have_content(completed_regional_project.urn)
+      let!(:completed_project) { create(:conversion_project, urn: 121583, completed_at: Date.yesterday, assigned_to_regional_caseworker_team: true, assigned_to: user) }
+      let!(:in_progress_project) { create(:conversion_project, urn: 115652, assigned_to_regional_caseworker_team: true, assigned_to: user) }
 
-        expect(page).to_not have_content(in_progress_project.urn)
-        expect(page).to_not have_content(in_progress_regional_project.urn)
+      scenario "they can view all in progress projects" do
+        visit in_progress_regional_projects_path
+
+        expect(page).to have_content(I18n.t("project.regional.in_progress.title"))
+
+        within("tbody") do
+          expect(page).to_not have_content(in_progress_project.urn)
+          expect(page).to have_content(in_progress_regional_project.urn)
+
+          expect(page).to_not have_content(completed_project.urn)
+          expect(page).to_not have_content(completed_regional_project.urn)
+        end
+      end
+
+      scenario "they can view all completed projects" do
+        visit completed_regional_projects_path
+
+        expect(page).to have_content(I18n.t("project.regional.completed.title"))
+
+        within("tbody") do
+          expect(page).not_to have_content(completed_project.urn)
+          expect(page).to have_content(completed_regional_project.urn)
+
+          expect(page).to_not have_content(in_progress_project.urn)
+          expect(page).to_not have_content(in_progress_regional_project.urn)
+        end
+      end
+    end
+  end
+
+  context "projects filtered by region" do
+    context "when there are no projects" do
+      scenario "they can view a helpful message" do
+        visit in_progress_by_region_regional_projects_path("london")
+
+        expect(page).to have_content(I18n.t("project.table.in_progress.empty"))
+
+        visit completed_by_region_regional_projects_path("london")
+
+        expect(page).to have_content(I18n.t("project.table.completed.empty"))
+      end
+    end
+
+    context "when the region parameter isn't a region" do
+      it "renders a not_found error page" do
+        visit in_progress_by_region_regional_projects_path("paris")
+
+        expect(page).to have_content("not found")
+      end
+    end
+
+    context "when there are projects" do
+      before do
+        mock_successful_api_response_to_create_any_project
+        mock_pre_fetched_api_responses_for_any_establishment_and_trust
+      end
+
+      let!(:west_midlands_project) { create(:conversion_project, urn: 123456, region: Project.regions["west_midlands"]) }
+      let!(:london_project) { create(:conversion_project, urn: 100001, region: Project.regions["london"]) }
+
+      it "shows projects from the desired region" do
+        visit in_progress_by_region_regional_projects_path("west_midlands")
+
+        within("tbody") do
+          expect(page).to have_content(west_midlands_project.urn)
+          expect(page).to_not have_content(london_project.urn)
+        end
+      end
+
+      context "when the region parameter has hyphens instead of underscores" do
+        it "still interprets the region name correctly" do
+          visit in_progress_by_region_regional_projects_path("west-midlands")
+
+          within("tbody") do
+            expect(page).to have_content(west_midlands_project.urn)
+            expect(page).to_not have_content(london_project.urn)
+          end
+        end
       end
     end
   end

--- a/spec/features/projects/users_can_view_a_list_of_regional_projects_spec.rb
+++ b/spec/features/projects/users_can_view_a_list_of_regional_projects_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.feature "Viewing regional projects" do
+  let(:user) { create(:user, :caseworker) }
+
+  before do
+    sign_in_with_user(user)
+  end
+
+  context "when there are no projects" do
+    scenario "they can view a helpful message" do
+      visit in_progress_regional_projects_path
+
+      expect(page).to have_content(I18n.t("project.table.in_progress.empty"))
+
+      visit completed_regional_projects_path
+
+      expect(page).to have_content(I18n.t("project.table.completed.empty"))
+    end
+  end
+
+  context "when there are projects" do
+    before do
+      mock_successful_api_response_to_create_any_project
+      mock_pre_fetched_api_responses_for_any_establishment_and_trust
+    end
+
+    let!(:completed_regional_project) { create(:conversion_project, urn: 101133, assigned_to_regional_caseworker_team: false, completed_at: Date.yesterday) }
+    let!(:in_progress_regional_project) { create(:conversion_project, urn: 126041, assigned_to_regional_caseworker_team: false, assigned_to: user) }
+
+    let!(:completed_project) { create(:conversion_project, urn: 121583, completed_at: Date.yesterday, assigned_to_regional_caseworker_team: true, assigned_to: user) }
+    let!(:in_progress_project) { create(:conversion_project, urn: 115652, assigned_to_regional_caseworker_team: true, assigned_to: user) }
+
+    scenario "they can view all in progress projects" do
+      visit in_progress_regional_projects_path
+
+      expect(page).to have_content(I18n.t("project.regional.in_progress.title"))
+
+      within("tbody") do
+        expect(page).to_not have_content(in_progress_project.urn)
+        expect(page).to have_content(in_progress_regional_project.urn)
+
+        expect(page).to_not have_content(completed_project.urn)
+        expect(page).to_not have_content(completed_regional_project.urn)
+      end
+    end
+
+    scenario "they can view all completed projects" do
+      visit completed_regional_projects_path
+
+      expect(page).to have_content(I18n.t("project.regional.completed.title"))
+
+      within("tbody") do
+        expect(page).not_to have_content(completed_project.urn)
+        expect(page).to have_content(completed_regional_project.urn)
+
+        expect(page).to_not have_content(in_progress_project.urn)
+        expect(page).to_not have_content(in_progress_regional_project.urn)
+      end
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -616,6 +616,17 @@ RSpec.describe Project, type: :model do
         expect(projects).not_to include(existing_project)
       end
     end
+
+    describe "by_region scope" do
+      it "returns only projects for the given region" do
+        mock_successful_api_response_to_create_any_project
+        london_project = create(:conversion_project, region: Project.regions["london"])
+        west_mids_project = create(:conversion_project, region: Project.regions["west_midlands"])
+
+        expect(Project.by_region("london")).to include(london_project)
+        expect(Project.by_region("london")).to_not include(west_mids_project)
+      end
+    end
   end
 
   describe "region" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -488,6 +488,19 @@ RSpec.describe Project, type: :model do
       end
     end
 
+    describe "not_assigned_to_regional_casework_team scope" do
+      before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+      it "returns projects which have `assigned_to_regional_casework_team` set to `false`" do
+        not_assigned_to_regional_caseworker = create(:conversion_project, assigned_to_regional_caseworker_team: false)
+        assigned_to_regional_caseworker = create(:conversion_project, assigned_to_regional_caseworker_team: true)
+
+        projects = Project.not_assigned_to_regional_caseworker_team
+        expect(projects).to include(not_assigned_to_regional_caseworker)
+        expect(projects).to_not include(assigned_to_regional_caseworker)
+      end
+    end
+
     describe "opening_by_month_year scope" do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 


### PR DESCRIPTION
## Changes

<img width="1209" alt="Screenshot 2023-04-05 at 11 24 17" src="https://user-images.githubusercontent.com/1089521/230054162-de0077f8-d720-4a78-8192-e3fde42c7797.png">

<img width="1085" alt="Screenshot 2023-04-05 at 11 25 35" src="https://user-images.githubusercontent.com/1089521/230054397-fc57451f-2a43-4175-a20e-886d588a5c07.png">

Add views for all Regional projects (i.e. projects not assigned to Regional caseworker services), and Regional projects filtered by region. 

The region keys have underscores (e.g. `west_midlands`) and the URLs to view regional projects use these keys (e.g. `/projects/regional/west_midlands/in-progress`). However if a user decides to manually type the URL, they can use hyphens instead (`/projects/regional/west-midlands/in-progress`) and the URL will still work. 

If the user attempts to view an unrecognised region (e.g. `/projects/regional/paris/in-progress`) then they will be redirected to a Not Found page.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
