### PR TITLE
Correcting Legal advisers office to Legal Adviser's Office

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Changed
 
 - remove the use of slip in the all conditions met task
+- references to Legal advisers office become Legal Adviser's Office
 - the sponsored route is only applied to a project where a directive academy
   order has been issued
 - the new project form no longer asks 'Is the school joining a Sponsor trust?'

--- a/config/locales/task_lists/conversion/involuntary/trust_modification_order.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/trust_modification_order.en.yml
@@ -29,9 +29,9 @@ en:
           received:
             title: Received
           sent_legal:
-            title: Sent to Legal advisers office
+            title: Sent to Legal Adviser's Office
           cleared:
-            title: Cleared by Legal advisers office
+            title: Cleared by Legal Adviser's Office
           saved:
             title: Saved in the school's SharePoint folder
           not_applicable:

--- a/config/locales/task_lists/conversion/voluntary/trust_modification_order.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/trust_modification_order.en.yml
@@ -29,9 +29,9 @@ en:
           received:
             title: Received
           sent_legal:
-            title: Sent to Legal advisers office
+            title: Sent to Legal Adviser's Office
           cleared:
-            title: Cleared by Legal advisers office
+            title: Cleared by Legal Adviser's Office
           saved:
             title: Saved in the school's SharePoint folder
           not_applicable:


### PR DESCRIPTION
## Changes

Correcting Legal advisers office in trust modification order task checklist to Legal Adviser's Office.

![Screenshot 2023-04-05 at 18 02 20](https://user-images.githubusercontent.com/104517016/230152247-1242838b-e55b-40a1-82df-c43ba805506e.png)

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
