### PR TITLE
Removed the use of slip in all conditions met. Replaced with a referen…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Changed
 
+- remove the use of slip in the all conditions met task
 - the sponsored route is only applied to a project where a directive academy
   order has been issued
 - the new project form no longer asks 'Is the school joining a Sponsor trust?'

--- a/config/locales/task_lists/conversion/involuntary/conditions_met.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/conditions_met.en.yml
@@ -25,4 +25,4 @@ en:
             guidance_link: What to do if conditions are not met
             guidance:
               html:
-                <p>You must agree a new conversion date with all stakeholders and slip the project.</p>
+                <p>You must agree a new conversion date with all stakeholders, then change conversion date recorded in this project.</p>

--- a/config/locales/task_lists/conversion/voluntary/conditions_met.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/conditions_met.en.yml
@@ -25,4 +25,4 @@ en:
             guidance_link: What to do if conditions are not met
             guidance:
               html:
-                <p>You must agree a new conversion date with all stakeholders and slip the project.</p>
+                <p>You must agree a new conversion date with all stakeholders, then change conversion date recorded in this project.</p>


### PR DESCRIPTION
…ce to changing the conversion date.

## Changes

Removed slip and replaced with reference to changing the conversion date in the details component that gives guidance on what to do if conditions are not met.

![Screenshot 2023-04-05 at 18 17 03](https://user-images.githubusercontent.com/104517016/230155399-bc21a31f-2616-456e-ba99-c5ad361748e8.png)


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
