### PR TITLE
Release 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
-## Changed
+## [Release 20][release-20]
+
+### Changed
 
 - remove the use of slip in the all conditions met task
 - references to Legal advisers office become Legal Adviser's Office
@@ -738,7 +740,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-19...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-20...HEAD
+[release-20]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-19...release-20
 [release-19]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-18...release-19
 [release-18]:


### PR DESCRIPTION
### Changed

- remove the use of slip in the all conditions met task
- references to Legal advisers office become Legal Adviser's Office
- the sponsored route is only applied to a project where a directive academy order has been issued
- the new project form no longer asks 'Is the school joining a Sponsor trust?'

### Added

- New views at `/projects/regional/in-progress` and `/projects/regional/completed` to show projects NOT assigned to Regional caseworker services
- New views at `/projects/regional/:region/in-progress` and `/projects/regional/:region/completed` to show projects NOT assigned to Regional caseworker services, filtered by region

## Checklist

- [x] Check that this pull request has the correct version number.
- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` to move Unreleased changes into a new version.
- [x] Update the release links at the bottom of `CHANGELOG.md` to reflect the
      new version.
