### PR TITLE
View new academy details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   on gov.uk action in redact and send documents task
 - standardised capitalisation in the receive grant payment certificate task
 
+### Added
+
+- a section to project that shows the academy details, currently this will not
+  show details until the academy URN is provided
+
 ## [Release 20][release-20]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - a section to project that shows the academy details, currently this will not
   show details until the academy URN is provided
+- the academy details will be shown in full once the academy URN is supplied,
+  when the academy details cannot be found, a helpful message is shown
 
 ## [Release 20][release-20]
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -95,6 +95,14 @@ class Project < ApplicationRecord
     @incoming_trust ||= fetch_trust(incoming_trust_ukprn)
   end
 
+  def academy
+    @academy ||= fetch_academy(academy_urn).object
+  end
+
+  def academy_found?
+    academy.present?
+  end
+
   def completed?
     completed_at.present?
   end
@@ -105,6 +113,10 @@ class Project < ApplicationRecord
 
   def all_conditions_met?
     task_list.conditions_met_confirm_all_conditions_met?
+  end
+
+  private def fetch_academy(urn)
+    AcademiesApi::Client.new.get_establishment(urn)
   end
 
   private def fetch_establishment(urn)

--- a/app/views/project_information/show/_academy_details.html.erb
+++ b/app/views/project_information/show/_academy_details.html.erb
@@ -3,5 +3,50 @@
 
   <% if @project.academy_urn.nil? %>
     <%= govuk_inset_text(text: t("project_information.show.academy_details.empty")) %>
+  <% else %>
+
+    <% if @project.academy_found? %>
+      <%= govuk_summary_list(actions: false) do |summary_list|
+            summary_list.row do |row|
+              row.key { t("project_information.show.academy_details.rows.academy_name") }
+              row.value { (@project.academy.name + "<br/>" + link_to_school_on_gias(@project.academy_urn)).html_safe }
+            end
+            summary_list.row do |row|
+              row.key { t("project_information.show.academy_details.rows.address") }
+              row.value { address_markup(@project.academy.address) }
+            end
+            summary_list.row do |row|
+              row.key { t("project_information.show.academy_details.rows.urn") }
+              row.value { @project.academy_urn.to_s }
+            end
+            summary_list.row do |row|
+              row.key { t("project_information.show.academy_details.rows.school_type") }
+              row.value { @project.academy.type }
+            end
+            summary_list.row do |row|
+              row.key { t("project_information.show.academy_details.rows.age_range") }
+              row.value { age_range(@project.academy) }
+            end
+            summary_list.row do |row|
+              row.key { t("project_information.show.academy_details.rows.school_phase") }
+              row.value { @project.academy.phase }
+            end
+            summary_list.row do |row|
+              row.key { t("project_information.show.academy_details.rows.region") }
+              row.value { @project.academy.region_name }
+            end
+          end %>
+
+    <% else %>
+
+      <%= govuk_summary_list(actions: false) do |summary_list|
+            summary_list.row do |row|
+              row.key { t("project_information.show.academy_details.rows.urn") }
+              row.value { @project.academy_urn.to_s }
+            end
+          end %>
+      <%= govuk_inset_text(text: t("project_information.show.academy_details.not_found")) %>
+
+    <% end %>
   <% end %>
 </div>

--- a/app/views/project_information/show/_academy_details.html.erb
+++ b/app/views/project_information/show/_academy_details.html.erb
@@ -1,0 +1,7 @@
+<div id="academyDetails">
+  <h2 class="govuk-heading-l"><%= t("project_information.show.academy_details.title") %></h2>
+
+  <% if @project.academy_urn.nil? %>
+    <%= govuk_inset_text(text: t("project_information.show.academy_details.empty")) %>
+  <% end %>
+</div>

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -56,6 +56,8 @@
   end %>
 </div>
 
+<%= render partial: "project_information/show/academy_details" %>
+
 <div id="trustDetails">
   <h2 class="govuk-heading-l"><%= t('project_information.show.trust_details.title') %></h2>
   <%= govuk_summary_list(actions: false) do |summary_list|

--- a/app/views/project_information/show/_side_navigation.html.erb
+++ b/app/views/project_information/show/_side_navigation.html.erb
@@ -4,6 +4,7 @@
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.project_details.title"), path: "#projectDetails"} %>
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.advisory_board_details.title"), path: "#advisoryBoardDetails"} %>
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.school_details.title"), path: "#schoolDetails"} %>
+    <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.academy_details.title"), path: "#academyDetails"} %>
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.trust_details.title"), path: "#trustDetails"} %>
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.local_authority_details.title"), path: "#localAuthorityDetails"} %>
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.diocese_details.title"), path: "#dioceseDetails"} %>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -197,6 +197,9 @@ en:
           age_range: Age range
           school_phase: School phase
           region: Region
+      academy_details:
+        title: Academy details
+        empty: Academy URN has not been provided
       trust_details:
         title: Trust details
         rows:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -200,6 +200,10 @@ en:
       academy_details:
         title: Academy details
         empty: Academy URN has not been provided
+        not_found: The academy details could not be found in the Get information about schools data,
+          it can take one day for the data to be syncronised
+        rows:
+          urn: Unique reference number (URN)
       trust_details:
         title: Trust details
         rows:

--- a/spec/features/project_information/users_can_view_academy_details_spec.rb
+++ b/spec/features/project_information/users_can_view_academy_details_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.feature "Users can view academy details" do
+  let(:user) { create(:user, :caseworker) }
+  let(:project) { create(:conversion_project, assigned_to: user) }
+
+  before do
+    mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    sign_in_with_user(user)
+    visit project_information_path(project)
+  end
+
+  context "when the academy urn is not set" do
+    scenario "they see a helpful message" do
+      within("#academyDetails") do
+        expect(page).to have_content I18n.t("project_information.show.academy_details.empty")
+      end
+    end
+  end
+end

--- a/spec/features/project_information/users_can_view_academy_details_spec.rb
+++ b/spec/features/project_information/users_can_view_academy_details_spec.rb
@@ -7,13 +7,46 @@ RSpec.feature "Users can view academy details" do
   before do
     mock_successful_api_responses(urn: any_args, ukprn: any_args)
     sign_in_with_user(user)
-    visit project_information_path(project)
   end
 
   context "when the academy urn is not set" do
+    let(:project) { create(:conversion_project, assigned_to: user) }
+
     scenario "they see a helpful message" do
+      visit project_information_path(project)
+
       within("#academyDetails") do
         expect(page).to have_content I18n.t("project_information.show.academy_details.empty")
+      end
+    end
+  end
+
+  context "when the academy urn is present" do
+    let(:project) { create(:conversion_project, assigned_to: user, academy_urn: 149061) }
+
+    context "and the details are not found" do
+      before { mock_establishment_not_found(urn: project.academy_urn) }
+
+      scenario "they see the academy urn and a helpful message" do
+        visit project_information_path(project)
+
+        within("#academyDetails") do
+          expect(page).to have_content project.academy_urn
+          expect(page).to have_content I18n.t("project_information.show.academy_details.not_found")
+        end
+      end
+    end
+
+    context "and the details can be found" do
+      scenario "they see the academy details" do
+        visit project_information_path(project)
+
+        within("#academyDetails") do
+          expect(page).to have_content project.academy_urn
+          expect(page).to have_content project.academy.name
+          expect(page).to have_content project.academy.address_postcode
+          expect(page).not_to have_content I18n.t("project_information.show.academy_details.not_found")
+        end
       end
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -156,6 +156,43 @@ RSpec.describe Project, type: :model do
     end
   end
 
+  describe "#academy" do
+    it "returns an establishment object when the urn can be found" do
+      mock_successful_api_response_to_create_any_project
+
+      project = build(:conversion_project, academy_urn: 123456)
+
+      expect(project.academy).to be_a(AcademiesApi::Establishment)
+    end
+
+    it "returns nil when the urn cannot be found" do
+      mock_successful_api_response_to_create_any_project
+      mock_establishment_not_found(urn: 999999)
+
+      project = build(:conversion_project, academy_urn: 999999)
+
+      expect(project.academy).to be_nil
+    end
+  end
+
+  describe "#academy_found?" do
+    before { mock_successful_api_response_to_create_any_project }
+
+    it "returns true when the academy can be found" do
+      project = build(:conversion_project, academy_urn: 123456)
+
+      expect(project.academy_found?).to eql true
+    end
+
+    it "returns false when the academy cannot be found" do
+      project = build(:conversion_project, academy_urn: 123456)
+
+      allow_any_instance_of(Project).to receive(:academy).and_return(nil)
+
+      expect(project.academy_found?).to eql false
+    end
+  end
+
   describe "#establishment" do
     let(:urn) { 123456 }
     let(:establishment) { build(:academies_api_establishment) }

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -54,6 +54,13 @@ module AcademiesApiHelpers
     mock_timeout_api_trust_response(ukprn:)
   end
 
+  def mock_establishment_not_found(urn:)
+    mock_client = AcademiesApi::Client.new
+    not_found_result = AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError)
+    allow(mock_client).to receive(:get_establishment).with(urn).and_return(not_found_result)
+    allow(AcademiesApi::Client).to receive(:new).and_return(mock_client)
+  end
+
   def mock_timeout_api_establishment_response(urn:)
     test_client = AcademiesApi::Client.new
 


### PR DESCRIPTION
We capture the new academy URN so we can show and utilise the details.

This work introduce a way to meet this first case, showing users the academy details.

Because we fetch academy details from the Academies API, which relies on the academies database, we think there could be delay between the GIAS record being created and it showing up in the academies database, for this reason we expect this case and handle it by showing a message.

The only way to validate this now is to see it happen in the real service - this work allows us to do this.

https://trello.com/c/snQido0j

#### View when no academy URN

![Screenshot 2023-04-06 at 08-50-01 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/230366126-8c7edb86-7b09-4c01-b2dc-14be3476c219.png)

#### Vew when the URN cannot be found

![Screenshot 2023-04-06 at 11-52-53 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/230366152-69cc1111-f147-4da6-8206-2582ec620fc8.png)

#### View when the detaills are found

![Screenshot 2023-04-06 at 12-31-03 Complete conversions transfers and changes](https://user-images.githubusercontent.com/480578/230366197-f14bcdf2-0a47-4882-8a37-e053a1c37cee.png)

