### PR TITLE
Standardising capitalisation in after opening tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - the link to a project on the openers table now reads 'View Project' not 'html'
 
+### Changed
+
+- standardised capitalisation in redact and send documents task
+- removed duplicate content from send redacted docs to funding team to publish
+  on gov.uk action in redact and send documents task
+- standardised capitalisation in the receive grant payment certificate task
+
 ## [Release 20][release-20]
 
 ### Changed

--- a/config/locales/task_lists/conversion/involuntary/receive_grant_payment_certificate.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/receive_grant_payment_certificate.en.yml
@@ -5,16 +5,16 @@ en:
         receive_grant_payment_certificate:
           title: Receive grant payment certificate
           hint:
-            html: <p>You should already have sent a copy of the <a href="https://www.gov.uk/government/publications/academy-support-grant" target="_blank">Grant payment certificate (opens in new tab)</a> when you told the school or trust about the final things they need to do.</p>
+            html: <p>You should already have sent a copy of the <a href="https://www.gov.uk/government/publications/academy-support-grant" target="_blank">grant payment certificate (opens in new tab)</a> when confirming the opening date.</p>
 
           check_and_save:
-            title: Check and save the Grant payment certificate in the school's SharePoint folder
+            title: Check and save the grant payment certificate in the school's SharePoint folder
             hint:
               html: <p>Make sure the right template has been used and there is no missing information.</p>
-            guidance_link: What to do if you have not received the Grant payment certificate
+            guidance_link: What to do if you have not received the grant payment certificate
             guidance:
               html:
-                <p>You should ask the trust to send the certificate. You must record the date each time you contact them in <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&amp;file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&amp;action=default&amp;mobileredirect=true" target="_blank">the Support grant assurance report (opens in new tab)</a></p>
+                <p>You should ask the trust to send the certificate. You must record the date each time you contact them in <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&amp;file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&amp;action=default&amp;mobileredirect=true" target="_blank">the support grant assurance report (opens in new tab)</a></p>
 
           update_kim:
             title: Update KIM with date certificate is received

--- a/config/locales/task_lists/conversion/involuntary/redact_and_send.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/redact_and_send.en.yml
@@ -15,10 +15,10 @@ en:
               html:
                 <p>You need to create a redacted version of each applicable document after they've been signed by the Secretary of State:</p>
                 <ul>
-                <li>Supplemental Funding Agreement</li>
-                <li>Master Funding Agreement</li>
-                <li>Church Supplemental Agreement</li>
-                <li>Deed of Variation</li>
+                <li>supplemental funding agreement</li>
+                <li>master funding agreement</li>
+                <li>church supplemental agreement (if applicable)</li>
+                <li>deed of variation</li>
                 </ul>
                 <p>You must remove or hide:</p>
                 <ul>

--- a/config/locales/task_lists/conversion/voluntary/receive_grant_payment_certificate.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/receive_grant_payment_certificate.en.yml
@@ -5,16 +5,16 @@ en:
         receive_grant_payment_certificate:
           title: Receive grant payment certificate
           hint:
-            html: <p>You should already have sent a copy of the <a href="https://www.gov.uk/government/publications/academy-support-grant" target="_blank">Grant payment certificate (opens in new tab)</a> when confirming the school's opening date.</p>
+            html: <p>You should already have sent a copy of the <a href="https://www.gov.uk/government/publications/academy-support-grant" target="_blank">grant payment certificate (opens in new tab)</a> when confirming the school's opening date.</p>
 
           check_and_save:
-            title: Check and save the Grant payment certificate in the school's SharePoint folder
+            title: Check and save the grant payment certificate in the school's SharePoint folder
             hint:
               html: <p>Make sure the right template has been used and there is no missing information.</p>
-            guidance_link: What to do if you have not received the Grant payment certificate
+            guidance_link: What to do if you have not received the grant payment certificate
             guidance:
               html:
-                <p>You should ask the school to send the certificate. You must record the date each time you contact them in <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&amp;file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&amp;action=default&amp;mobileredirect=true" target="_blank">the Support grant assurance report (opens in new tab)</a></p>
+                <p>You should ask the school to send the certificate. You must record the date each time you contact them in <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&amp;file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&amp;action=default&amp;mobileredirect=true" target="_blank">the support grant assurance report (opens in new tab)</a></p>
 
           update_kim:
             title: Update KIM with date certificate is received
@@ -22,6 +22,6 @@ en:
               html: <p>Find this information in the ESFA handover section in KIM.</p>
 
           update_sheet:
-            title: Update the Support grant assurance report spreadsheet
+            title: Update the support grant assurance report spreadsheet
             hint:
-              html: <p>You can <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&amp;file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&amp;action=default&amp;mobileredirect=true" target="_blank">open the Support grant assurance report (opens in new tab)</a> to update it.</p>
+              html: <p>You can <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&amp;file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&amp;action=default&amp;mobileredirect=true" target="_blank">open the support grant assurance report (opens in new tab)</a> to update it.</p>

--- a/config/locales/task_lists/conversion/voluntary/redact_and_send.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/redact_and_send.en.yml
@@ -15,10 +15,10 @@ en:
               html:
                 <p>You need to create a redacted version of each applicable document after they've been signed by the Secretary of State:</p>
                 <ul>
-                  <li>supplemental Funding Agreement</li>
-                  <li>master Funding Agreement</li>
-                  <li>church Supplemental Agreement (if applicable)</li>
-                  <li>deed of Variation</li>
+                  <li>supplemental funding agreement</li>
+                  <li>master funding agreement</li>
+                  <li>church supplemental agreement (if applicable)</li>
+                  <li>deed of variation</li>
                 </ul>
                 <p>You must remove or hide:</p>
                 <ul>
@@ -37,7 +37,6 @@ en:
             guidance:
               html:
                 <p>Email the documents to <a href="mailto:fundingagreements.converters@education.gov.uk" target="_blank">fundingagreements.converters@education.gov.uk</a>.</p>
-                <p>Send the redacted funding agreement documents to the funding team at <a href="mailto:FundingAgreements.CONVERTERS@education.gov.uk" class="govuk-link" target="_blank">FundingAgreements.CONVERTERS@education.gov.uk</a>.</p>
 
           send_solicitors:
             title: Send the redacted and unredacted versions of documents to the solicitors


### PR DESCRIPTION
## Changes

Capitalised document names correctly to make consistent in the application and with other products in the division. Also removed some duplicate content from the redact and send documents task.

![localhost_3000_conversions_voluntary_projects_0081EDBB-7B59-4EAC-BBA6-A2DA41637DD7_task-list_redact_and_send](https://user-images.githubusercontent.com/104517016/230436231-1c8592b1-115f-46a4-86c6-ae85d735f109.png)

![localhost_3000_conversions_voluntary_projects_0081EDBB-7B59-4EAC-BBA6-A2DA41637DD7_task-list_receive_grant_payment_certificate](https://user-images.githubusercontent.com/104517016/230436196-45c92410-bde7-47bd-b147-7827c1f971fa.png)


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
