### PR TITLE
Use Parliamentary Members API to get MP details

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,5 @@ REDIS_URL=REDIS_URL
 
 # GOV.UK Notify
 GOV_NOTIFY_API_KEY=GOV_NOTIFY_API_KEY
+
+MEMBERS_API_HOST=https://members-api.parliament.uk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- new MembersApi Client to call the Parliamentary Members API and retrieve MP
+  details
+
 ## [Release 21][release-21]
 
 ### Fixed

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
-  rescue_from AcademiesApi::Client::Error, with: :client_error
+  rescue_from Api::AcademiesApi::Client::Error, with: :client_error
 
   def not_found_error
     render "pages/page_not_found", status: :not_found

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -77,7 +77,7 @@ class Conversion::CreateProjectForm
   end
 
   private def fetch_establishment(urn)
-    result = AcademiesApi::Client.new.get_establishment(urn)
+    result = Api::AcademiesApi::Client.new.get_establishment(urn)
     raise result.error if result.error.present?
 
     result.object
@@ -102,14 +102,14 @@ class Conversion::CreateProjectForm
 
   private def establishment_exists
     establishment
-  rescue AcademiesApi::Client::NotFoundError
+  rescue Api::AcademiesApi::Client::NotFoundError
     errors.add(:urn, :no_establishment_found)
   end
 
   private def trust_exists
-    result = AcademiesApi::Client.new.get_trust(incoming_trust_ukprn)
+    result = Api::AcademiesApi::Client.new.get_trust(incoming_trust_ukprn)
     raise result.error if result.error.present?
-  rescue AcademiesApi::Client::NotFoundError
+  rescue Api::AcademiesApi::Client::NotFoundError
     errors.add(:incoming_trust_ukprn, :no_trust_found)
   end
 

--- a/app/models/api/academies_api/client.rb
+++ b/app/models/api/academies_api/client.rb
@@ -1,4 +1,4 @@
-class AcademiesApi::Client
+class Api::AcademiesApi::Client
   ACADEMIES_API_TIMEOUT = ENV.fetch("ACADEMIES_API_TIMEOUT", 0.6).to_f
 
   class Error < StandardError; end
@@ -18,7 +18,7 @@ class AcademiesApi::Client
 
     case response.status
     when 200
-      Result.new(AcademiesApi::Establishment.new.from_hash(single_establishment_from_bulk(response)), nil)
+      Result.new(Api::AcademiesApi::Establishment.new.from_hash(single_establishment_from_bulk(response)), nil)
     when 404
       Result.new(nil, NotFoundError.new(I18n.t("academies_api.get_establishment.errors.not_found", urn: urn)))
     else
@@ -32,7 +32,7 @@ class AcademiesApi::Client
     case response.status
     when 200
       establishments = JSON.parse(response.body).map do |establishment|
-        AcademiesApi::Establishment.new.from_hash(establishment)
+        Api::AcademiesApi::Establishment.new.from_hash(establishment)
       end
       Result.new(establishments, nil)
     when 404
@@ -47,7 +47,7 @@ class AcademiesApi::Client
 
     case response.status
     when 200
-      Result.new(AcademiesApi::Trust.new.from_hash(single_trust_from_bulk(response)), nil)
+      Result.new(Api::AcademiesApi::Trust.new.from_hash(single_trust_from_bulk(response)), nil)
     when 404
       Result.new(nil, NotFoundError.new(I18n.t("academies_api.get_trust.errors.not_found", ukprn: ukprn)))
     else
@@ -61,7 +61,7 @@ class AcademiesApi::Client
     case response.status
     when 200
       trusts = JSON.parse(response.body)["data"].map do |trust|
-        AcademiesApi::Trust.new.from_hash(trust)
+        Api::AcademiesApi::Trust.new.from_hash(trust)
       end
       Result.new(trusts, nil)
     when 404

--- a/app/models/api/academies_api/establishment.rb
+++ b/app/models/api/academies_api/establishment.rb
@@ -1,4 +1,4 @@
-class AcademiesApi::Establishment < AcademiesApi::BaseApiModel
+class Api::AcademiesApi::Establishment < Api::BaseApiModel
   attr_accessor(
     :urn,
     :name,

--- a/app/models/api/academies_api/trust.rb
+++ b/app/models/api/academies_api/trust.rb
@@ -1,4 +1,4 @@
-class AcademiesApi::Trust < AcademiesApi::BaseApiModel
+class Api::AcademiesApi::Trust < Api::BaseApiModel
   attr_accessor(
     :ukprn,
     :original_name,

--- a/app/models/api/base_api_model.rb
+++ b/app/models/api/base_api_model.rb
@@ -1,4 +1,4 @@
-class AcademiesApi::BaseApiModel
+class Api::BaseApiModel
   include ActiveModel::Serializers::JSON
 
   class AttributeMapMissingError < RuntimeError; end

--- a/app/models/api/members_api/member_contact_details.rb
+++ b/app/models/api/members_api/member_contact_details.rb
@@ -1,0 +1,31 @@
+class Api::MembersApi::MemberContactDetails < Api::BaseApiModel
+  attr_accessor(
+    :type,
+    :type_description,
+    :type_id,
+    :is_preferred,
+    :is_web_address,
+    :notes,
+    :line1,
+    :line2,
+    :postcode,
+    :phone,
+    :email
+  )
+
+  def self.attribute_map
+    {
+      type: "type",
+      type_description: "typeDescription",
+      type_id: "typeId",
+      is_preferred: "isPreferred",
+      is_web_address: "isWebAddress",
+      notes: "notes",
+      line1: "line1",
+      line2: "line2",
+      postcode: "postcode",
+      phone: "phone",
+      email: "email"
+    }
+  end
+end

--- a/app/models/api/members_api/member_name.rb
+++ b/app/models/api/members_api/member_name.rb
@@ -1,0 +1,19 @@
+class Api::MembersApi::MemberName < Api::BaseApiModel
+  attr_accessor(
+    :id,
+    :name_list_as,
+    :name_display_as,
+    :name_full_title,
+    :name_address_as
+  )
+
+  def self.attribute_map
+    {
+      id: "id",
+      name_list_as: "nameListAs",
+      name_display_as: "nameDisplayAs",
+      name_full_title: "nameFullTitle",
+      name_address_as: "nameAddressAs"
+    }
+  end
+end

--- a/app/models/members_api/client.rb
+++ b/app/models/members_api/client.rb
@@ -1,8 +1,44 @@
 class MembersApi::Client
+  class Error < StandardError; end
+
+  class MultipleResultsError < StandardError; end
+
   attr_reader :connection
 
   def initialize(connection: nil)
     @connection = connection || default_connection
+  end
+
+  def constituency(search_term)
+    response = constituency_search(search_term)
+
+    case response.status
+    when 200
+      body = JSON.parse(response.body)
+      Result.new(body, nil)
+    else
+      Result.new(nil, Error.new(I18n.t("members_api.errors.other")))
+    end
+  end
+
+  def member_id(search_term)
+    constituency_data = constituency(search_term)
+    if constituency_data.object["items"].count > 1
+      Result.new(nil, MultipleResultsError.new(I18n.t("members_api.errors.multiple", search_term: search_term)))
+    else
+      member_id_from_constituency(constituency_data)
+    end
+  end
+
+  private def constituency_search(search_term)
+    @connection.get("/api/Location/Constituency/Search", {searchText: search_term})
+  rescue Faraday::Error => error
+    raise Error.new(error)
+  end
+
+  private def member_id_from_constituency(constituency_data)
+    constituency = constituency_data.object["items"][0]["value"]
+    constituency.dig("currentRepresentation", "member", "value", "id")
   end
 
   private def default_connection
@@ -15,5 +51,14 @@ class MembersApi::Client
         "Content-Type": "application/json"
       }
     )
+  end
+
+  class Result
+    attr_reader :object, :error
+
+    def initialize(object, error)
+      @object = object
+      @error = error
+    end
   end
 end

--- a/app/models/members_api/client.rb
+++ b/app/models/members_api/client.rb
@@ -1,0 +1,19 @@
+class MembersApi::Client
+  attr_reader :connection
+
+  def initialize(connection: nil)
+    @connection = connection || default_connection
+  end
+
+  private def default_connection
+    Faraday.new(
+      url: ENV["MEMBERS_API_HOST"],
+      request: {
+        params_encoder: Faraday::FlatParamsEncoder
+      },
+      headers: {
+        "Content-Type": "application/json"
+      }
+    )
+  end
+end

--- a/app/models/members_api/client.rb
+++ b/app/models/members_api/client.rb
@@ -32,6 +32,20 @@ class MembersApi::Client
     end
   end
 
+  def member_name(member_id)
+    response = member(member_id)
+
+    case response.status
+    when 200
+      body = JSON.parse(response.body)
+      Result.new(body, nil)
+    when 404
+      Result.new(nil, NotFoundError.new(I18n.t("members_api.errors.member_not_found", member_id: member_id)))
+    else
+      Result.new(nil, Error.new(I18n.t("members_api.errors.other")))
+    end
+  end
+
   def member_contact_details(member_id)
     response = member_contact(member_id)
 
@@ -55,6 +69,12 @@ class MembersApi::Client
   private def member_id_from_constituency(constituency_data)
     constituency = constituency_data.object["items"][0]["value"]
     constituency.dig("currentRepresentation", "member", "value", "id")
+  end
+
+  private def member(member_id)
+    @connection.get("/api/Members/#{member_id}")
+  rescue Faraday::Error => error
+    raise Error.new(error)
   end
 
   private def member_contact(member_id)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -116,18 +116,18 @@ class Project < ApplicationRecord
   end
 
   private def fetch_academy(urn)
-    AcademiesApi::Client.new.get_establishment(urn)
+    Api::AcademiesApi::Client.new.get_establishment(urn)
   end
 
   private def fetch_establishment(urn)
-    result = AcademiesApi::Client.new.get_establishment(urn)
+    result = Api::AcademiesApi::Client.new.get_establishment(urn)
     raise result.error if result.error.present?
 
     result.object
   end
 
   private def fetch_trust(ukprn)
-    result = AcademiesApi::Client.new.get_trust(ukprn)
+    result = Api::AcademiesApi::Client.new.get_trust(ukprn)
     raise result.error if result.error.present?
 
     result.object
@@ -135,13 +135,13 @@ class Project < ApplicationRecord
 
   private def establishment_exists
     establishment
-  rescue AcademiesApi::Client::NotFoundError
+  rescue Api::AcademiesApi::Client::NotFoundError
     errors.add(:urn, :no_establishment_found)
   end
 
   private def trust_exists
     incoming_trust
-  rescue AcademiesApi::Client::NotFoundError
+  rescue Api::AcademiesApi::Client::NotFoundError
     errors.add(:incoming_trust_ukprn, :no_trust_found)
   end
 end

--- a/app/services/establishments_fetcher.rb
+++ b/app/services/establishments_fetcher.rb
@@ -3,7 +3,7 @@ class EstablishmentsFetcher
     return unless projects&.any?
 
     urns = projects.map(&:urn)
-    establishments = AcademiesApi::Client.new.get_establishments(urns).object
+    establishments = Api::AcademiesApi::Client.new.get_establishments(urns).object
 
     projects.each do |project|
       project.establishment = establishments.find { |establishment| establishment.urn == project.urn.to_s }

--- a/app/services/incoming_trusts_fetcher.rb
+++ b/app/services/incoming_trusts_fetcher.rb
@@ -3,7 +3,7 @@ class IncomingTrustsFetcher
     return unless projects&.any?
 
     ukprns = projects.map(&:incoming_trust_ukprn)
-    trusts = AcademiesApi::Client.new.get_trusts(ukprns).object
+    trusts = Api::AcademiesApi::Client.new.get_trusts(ukprns).object
 
     projects.each do |project|
       project.incoming_trust = trusts.find { |trust| trust.ukprn == project.incoming_trust_ukprn.to_s }

--- a/config/locales/members_api.en.yml
+++ b/config/locales/members_api.en.yml
@@ -1,0 +1,5 @@
+en:
+  members_api:
+    errors:
+      other: There was an error connecting to the Members API
+      multiple: "Multiple results found for search term: %{search_term}"

--- a/config/locales/members_api.en.yml
+++ b/config/locales/members_api.en.yml
@@ -3,3 +3,4 @@ en:
     errors:
       other: There was an error connecting to the Members API
       multiple: "Multiple results found for search term: %{search_term}"
+      member_not_found: "Member not found: %{member_id}"

--- a/spec/factories/academies_api/establishment.rb
+++ b/spec/factories/academies_api/establishment.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :academies_api_establishment, class: "AcademiesApi::Establishment" do
+  factory :academies_api_establishment, class: "Api::AcademiesApi::Establishment" do
     urn { "123456" }
     name { "Caludon Castle School" }
     local_authority { "West Placefield Council" }

--- a/spec/factories/academies_api/trust.rb
+++ b/spec/factories/academies_api/trust.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :academies_api_trust, class: "AcademiesApi::Trust" do
+  factory :academies_api_trust, class: "Api::AcademiesApi::Trust" do
     ukprn { "10061021" }
     original_name { "THE ROMERO CATHOLIC ACADEMY" }
     companies_house_number { "09702162" }

--- a/spec/models/api/academies_api/client_spec.rb
+++ b/spec/models/api/academies_api/client_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe AcademiesApi::Client do
+RSpec.describe Api::AcademiesApi::Client do
   it "uses the environment variables to build the connection" do
     ClimateControl.modify(
       ACADEMIES_API_HOST: "https://test.academies.api",
@@ -11,7 +11,7 @@ RSpec.describe AcademiesApi::Client do
       expect(client_connection.scheme).to eql "https"
       expect(client_connection.host).to eql "test.academies.api"
       expect(client_connection.headers["ApiKey"]).to eql "api-key"
-      expect(client_connection.options[:timeout]).to eql AcademiesApi::Client::ACADEMIES_API_TIMEOUT
+      expect(client_connection.options[:timeout]).to eql Api::AcademiesApi::Client::ACADEMIES_API_TIMEOUT
     end
   end
 
@@ -35,7 +35,7 @@ RSpec.describe AcademiesApi::Client do
 
       it "returns a Result with a NotFoundError and no establishment" do
         expect(subject.object).to be_nil
-        expect(subject.error).to be_a(AcademiesApi::Client::NotFoundError)
+        expect(subject.error).to be_a(Api::AcademiesApi::Client::NotFoundError)
         expect(subject.error.message).to eq(I18n.t("academies_api.get_establishment.errors.not_found", urn:))
       end
     end
@@ -45,7 +45,7 @@ RSpec.describe AcademiesApi::Client do
 
       it "returns a Result with an Error and no establishment" do
         expect(subject.object).to be_nil
-        expect(subject.error).to be_a(AcademiesApi::Client::Error)
+        expect(subject.error).to be_a(Api::AcademiesApi::Client::Error)
         expect(subject.error.message).to eq(I18n.t("academies_api.get_establishment.errors.other", urn:))
       end
     end
@@ -54,7 +54,7 @@ RSpec.describe AcademiesApi::Client do
       let(:client) { described_class.new(connection: fake_failed_establishment_connection) }
 
       it "raises an Error" do
-        expect { subject }.to raise_error(AcademiesApi::Client::Error)
+        expect { subject }.to raise_error(Api::AcademiesApi::Client::Error)
       end
     end
   end
@@ -80,7 +80,7 @@ RSpec.describe AcademiesApi::Client do
 
       it "returns a Result with a NotFoundError and no establishment" do
         expect(subject.object).to be_nil
-        expect(subject.error).to be_a(AcademiesApi::Client::NotFoundError)
+        expect(subject.error).to be_a(Api::AcademiesApi::Client::NotFoundError)
         expect(subject.error.message).to eq(I18n.t("academies_api.get_establishments.errors.not_found", urns:))
       end
     end
@@ -90,7 +90,7 @@ RSpec.describe AcademiesApi::Client do
 
       it "returns a Result with an Error and no establishment" do
         expect(subject.object).to be_nil
-        expect(subject.error).to be_a(AcademiesApi::Client::Error)
+        expect(subject.error).to be_a(Api::AcademiesApi::Client::Error)
         expect(subject.error.message).to eq(I18n.t("academies_api.get_establishments.errors.other", urns:))
       end
     end
@@ -99,7 +99,7 @@ RSpec.describe AcademiesApi::Client do
       let(:client) { described_class.new(connection: fake_failed_establishment_connection) }
 
       it "raises an Error" do
-        expect { subject }.to raise_error(AcademiesApi::Client::Error)
+        expect { subject }.to raise_error(Api::AcademiesApi::Client::Error)
       end
     end
   end
@@ -148,7 +148,7 @@ RSpec.describe AcademiesApi::Client do
 
       it "returns a Result with a NotFoundError and no establishment" do
         expect(subject.object).to be_nil
-        expect(subject.error).to be_a(AcademiesApi::Client::NotFoundError)
+        expect(subject.error).to be_a(Api::AcademiesApi::Client::NotFoundError)
         expect(subject.error.message).to eq(I18n.t("academies_api.get_trust.errors.not_found", ukprn:))
       end
     end
@@ -158,7 +158,7 @@ RSpec.describe AcademiesApi::Client do
 
       it "returns a Result with an Error and no trust" do
         expect(subject.object).to be_nil
-        expect(subject.error).to be_a(AcademiesApi::Client::Error)
+        expect(subject.error).to be_a(Api::AcademiesApi::Client::Error)
         expect(subject.error.message).to eq(I18n.t("academies_api.get_trust.errors.other", ukprn:))
       end
     end
@@ -167,7 +167,7 @@ RSpec.describe AcademiesApi::Client do
       let(:client) { described_class.new(connection: fake_failed_trust_connection) }
 
       it "raises an Error" do
-        expect { subject }.to raise_error(AcademiesApi::Client::Error)
+        expect { subject }.to raise_error(Api::AcademiesApi::Client::Error)
       end
     end
   end
@@ -197,7 +197,7 @@ RSpec.describe AcademiesApi::Client do
 
       it "returns a Result with a NotFoundError and no establishment" do
         expect(subject.object).to be_nil
-        expect(subject.error).to be_a(AcademiesApi::Client::NotFoundError)
+        expect(subject.error).to be_a(Api::AcademiesApi::Client::NotFoundError)
         expect(subject.error.message).to eq(I18n.t("academies_api.get_trusts.errors.not_found", ukprns:))
       end
     end
@@ -207,7 +207,7 @@ RSpec.describe AcademiesApi::Client do
 
       it "returns a Result with an Error and no trust" do
         expect(subject.object).to be_nil
-        expect(subject.error).to be_a(AcademiesApi::Client::Error)
+        expect(subject.error).to be_a(Api::AcademiesApi::Client::Error)
         expect(subject.error.message).to eq(I18n.t("academies_api.get_trusts.errors.other", ukprns:))
       end
     end
@@ -216,7 +216,7 @@ RSpec.describe AcademiesApi::Client do
       let(:client) { described_class.new(connection: fake_failed_trust_connection) }
 
       it "raises an Error" do
-        expect { subject }.to raise_error(AcademiesApi::Client::Error)
+        expect { subject }.to raise_error(Api::AcademiesApi::Client::Error)
       end
     end
   end

--- a/spec/models/api/base_api_model_spec.rb
+++ b/spec/models/api/base_api_model_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe AcademiesApi::BaseApiModel do
+RSpec.describe Api::BaseApiModel do
   shared_examples "a method which maps a response to model attributes" do
     let(:establishment_name) { "Caludon castle school" }
     let(:establishment_type) { "Academy converter" }
@@ -14,7 +14,7 @@ RSpec.describe AcademiesApi::BaseApiModel do
     end
     let(:json_response) { JSON.generate(response) }
     let(:testing_model) do
-      Class.new(AcademiesApi::BaseApiModel) do
+      Class.new(Api::BaseApiModel) do
         attr_accessor :name, :type
 
         def self.attribute_map
@@ -47,10 +47,10 @@ RSpec.describe AcademiesApi::BaseApiModel do
   describe ".attribute_map" do
     context "when .attribute_map is not overridden" do
       let(:error_message) { ".attribute_map hasn't been overridden" }
-      let(:testing_model) { Class.new(AcademiesApi::BaseApiModel) }
+      let(:testing_model) { Class.new(Api::BaseApiModel) }
 
-      it "raises a #{AcademiesApi::BaseApiModel::AttributeMapMissingError}" do
-        expect { testing_model.attribute_map }.to raise_error(AcademiesApi::BaseApiModel::AttributeMapMissingError, error_message)
+      it "raises a #{Api::BaseApiModel::AttributeMapMissingError}" do
+        expect { testing_model.attribute_map }.to raise_error(Api::BaseApiModel::AttributeMapMissingError, error_message)
       end
     end
   end

--- a/spec/models/api/members_api/client_spec.rb
+++ b/spec/models/api/members_api/client_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe MembersApi::Client do
+RSpec.describe Api::MembersApi::Client do
   it "uses the environment variables to build the connection" do
     ClimateControl.modify(
       MEMBERS_API_HOST: "https://members-api.test"
@@ -31,7 +31,7 @@ RSpec.describe MembersApi::Client do
 
       it "returns a Result with an Error" do
         expect(subject.object).to be_nil
-        expect(subject.error).to be_a(MembersApi::Client::Error)
+        expect(subject.error).to be_a(Api::MembersApi::Client::Error)
         expect(subject.error.message).to eq(I18n.t("members_api.errors.other"))
       end
     end
@@ -40,7 +40,7 @@ RSpec.describe MembersApi::Client do
       let(:client) { described_class.new(connection: fake_failed_constituency_search_connection) }
 
       it "raises an Error" do
-        expect { subject }.to raise_error(MembersApi::Client::Error)
+        expect { subject }.to raise_error(Api::MembersApi::Client::Error)
       end
     end
   end
@@ -83,7 +83,7 @@ RSpec.describe MembersApi::Client do
 
       it "returns a MultipleResultsError" do
         expect(subject.object).to be_nil
-        expect(subject.error).to be_a(MembersApi::Client::MultipleResultsError)
+        expect(subject.error).to be_a(Api::MembersApi::Client::MultipleResultsError)
         expect(subject.error.message).to eq(I18n.t("members_api.errors.multiple", search_term: "St A"))
       end
     end
@@ -99,7 +99,7 @@ RSpec.describe MembersApi::Client do
 
       it "returns a Result with a NotFoundError" do
         expect(subject.object).to be_nil
-        expect(subject.error).to be_a(MembersApi::Client::NotFoundError)
+        expect(subject.error).to be_a(Api::MembersApi::Client::NotFoundError)
         expect(subject.error.message).to eq(I18n.t("members_api.errors.member_not_found", member_id: 1234))
       end
     end
@@ -112,12 +112,8 @@ RSpec.describe MembersApi::Client do
       end
 
       it "returns a Result with the JSON response body and no error" do
-        expect(subject.object).to eql({
-          "value" => {
-            "id" => 4679,
-            "nameAddressAs" => "Neil O'Brien"
-          }
-        })
+        expect(subject.object).to be_a(Api::MembersApi::MemberName)
+        expect(subject.object.name_address_as).to eq("Neil O'Brien")
         expect(subject.error).to be_nil
       end
     end
@@ -126,7 +122,7 @@ RSpec.describe MembersApi::Client do
       let(:client) { described_class.new(connection: fake_failed_member_connection) }
 
       it "raises an Error" do
-        expect { subject }.to raise_error(MembersApi::Client::Error)
+        expect { subject }.to raise_error(Api::MembersApi::Client::Error)
       end
     end
 
@@ -135,7 +131,7 @@ RSpec.describe MembersApi::Client do
 
       it "returns a Result with an Error" do
         expect(subject.object).to be_nil
-        expect(subject.error).to be_a(MembersApi::Client::Error)
+        expect(subject.error).to be_a(Api::MembersApi::Client::Error)
         expect(subject.error.message).to eq(I18n.t("members_api.errors.other"))
       end
     end
@@ -151,7 +147,7 @@ RSpec.describe MembersApi::Client do
 
       it "returns a Result with a NotFoundError" do
         expect(subject.object).to be_nil
-        expect(subject.error).to be_a(MembersApi::Client::NotFoundError)
+        expect(subject.error).to be_a(Api::MembersApi::Client::NotFoundError)
         expect(subject.error.message).to eq(I18n.t("members_api.errors.member_not_found", member_id: 1234))
       end
     end
@@ -180,21 +176,10 @@ RSpec.describe MembersApi::Client do
       end
 
       it "returns a Result with the JSON response body and no error" do
-        expect(subject.object).to eql("value" => [{
-          "email" => "daisy.cooper.mp@parliament.uk",
-          "isPreferred" => false,
-          "line1" => "House of Commons",
-          "line2" => "London",
-          "phone" => "020 7219 8568",
-          "postcode" => "SW1A 0AA",
-          "type" => "Parliamentary office",
-          "typeId" => 1
-        },
-          {"isPreferred" => false,
-           "line1" => "Constituency office",
-           "phone" => "01727 519900",
-           "type" => "Constituency office",
-           "typeId" => 4}])
+        expect(subject.object).to be_a(Array)
+        expect(subject.object[0]).to be_a(Api::MembersApi::MemberContactDetails)
+        expect(subject.object[0].line1).to eq("House of Commons")
+        expect(subject.object[0].postcode).to eq("SW1A 0AA")
         expect(subject.error).to be_nil
       end
     end
@@ -203,7 +188,7 @@ RSpec.describe MembersApi::Client do
       let(:client) { described_class.new(connection: fake_failed_member_contact_connection) }
 
       it "raises an Error" do
-        expect { subject }.to raise_error(MembersApi::Client::Error)
+        expect { subject }.to raise_error(Api::MembersApi::Client::Error)
       end
     end
 
@@ -212,7 +197,7 @@ RSpec.describe MembersApi::Client do
 
       it "returns a Result with an Error" do
         expect(subject.object).to be_nil
-        expect(subject.error).to be_a(MembersApi::Client::Error)
+        expect(subject.error).to be_a(Api::MembersApi::Client::Error)
         expect(subject.error.message).to eq(I18n.t("members_api.errors.other"))
       end
     end

--- a/spec/models/members_api/client_spec.rb
+++ b/spec/models/members_api/client_spec.rb
@@ -89,6 +89,83 @@ RSpec.describe MembersApi::Client do
     end
   end
 
+  describe "#member_contact_details" do
+    let(:client) { described_class.new(connection: fake_successful_member_contact_connection(1234, fake_response)) }
+
+    subject { client.member_contact_details(1234) }
+
+    context "when the member id is not found" do
+      let(:fake_response) { [404, nil, nil] }
+
+      it "returns a Result with a NotFoundError" do
+        expect(subject.object).to be_nil
+        expect(subject.error).to be_a(MembersApi::Client::NotFoundError)
+        expect(subject.error.message).to eq(I18n.t("members_api.errors.member_not_found", member_id: 1234))
+      end
+    end
+
+    context "when the member id is found" do
+      let(:fake_response) do
+        [200, nil, {
+          "value" => [{
+            "type" => "Parliamentary office",
+            "typeId" => 1,
+            "isPreferred" => false,
+            "line1" => "House of Commons",
+            "line2" => "London",
+            "postcode" => "SW1A 0AA",
+            "phone" => "020 7219 8568",
+            "email" => "daisy.cooper.mp@parliament.uk"
+          },
+            {
+              "type" => "Constituency office",
+              "typeId" => 4,
+              "isPreferred" => false,
+              "line1" => "Constituency office",
+              "phone" => "01727 519900"
+            }]
+        }.to_json]
+      end
+
+      it "returns a Result with the JSON response body and no error" do
+        expect(subject.object).to eql("value" => [{
+          "email" => "daisy.cooper.mp@parliament.uk",
+          "isPreferred" => false,
+          "line1" => "House of Commons",
+          "line2" => "London",
+          "phone" => "020 7219 8568",
+          "postcode" => "SW1A 0AA",
+          "type" => "Parliamentary office",
+          "typeId" => 1
+        },
+          {"isPreferred" => false,
+           "line1" => "Constituency office",
+           "phone" => "01727 519900",
+           "type" => "Constituency office",
+           "typeId" => 4}])
+        expect(subject.error).to be_nil
+      end
+    end
+
+    context "when the connection fails" do
+      let(:client) { described_class.new(connection: fake_failed_member_contact_connection) }
+
+      it "raises an Error" do
+        expect { subject }.to raise_error(MembersApi::Client::Error)
+      end
+    end
+
+    context "when where is any other error" do
+      let(:fake_response) { [500, nil, nil] }
+
+      it "returns a Result with an Error" do
+        expect(subject.object).to be_nil
+        expect(subject.error).to be_a(MembersApi::Client::Error)
+        expect(subject.error.message).to eq(I18n.t("members_api.errors.other"))
+      end
+    end
+  end
+
   def fake_successful_constituency_search_connection(response)
     Faraday.new do |builder|
       builder.adapter :test do |stub|
@@ -103,6 +180,26 @@ RSpec.describe MembersApi::Client do
     Faraday.new do |builder|
       builder.adapter :test do |stub|
         stub.get("/api/Location/Constituency/Search") do |_env|
+          raise Faraday::Error
+        end
+      end
+    end
+  end
+
+  def fake_successful_member_contact_connection(id, response)
+    Faraday.new do |builder|
+      builder.adapter :test do |stub|
+        stub.get("/api/Members/#{id}/Contact") do |_env|
+          response
+        end
+      end
+    end
+  end
+
+  def fake_failed_member_contact_connection
+    Faraday.new do |builder|
+      builder.adapter :test do |stub|
+        stub.get("/api/Members/1234/Contact") do |_env|
           raise Faraday::Error
         end
       end

--- a/spec/models/members_api/client_spec.rb
+++ b/spec/models/members_api/client_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe MembersApi::Client do
+  it "uses the environment variables to build the connection" do
+    ClimateControl.modify(
+      MEMBERS_API_HOST: "https://members-api.test"
+    ) do
+      client_connection = described_class.new.connection
+
+      expect(client_connection.scheme).to eql "https"
+      expect(client_connection.host).to eql "members-api.test"
+    end
+  end
+end

--- a/spec/models/members_api/client_spec.rb
+++ b/spec/models/members_api/client_spec.rb
@@ -11,4 +11,101 @@ RSpec.describe MembersApi::Client do
       expect(client_connection.host).to eql "members-api.test"
     end
   end
+
+  describe "#constituency_search" do
+    let(:client) { described_class.new(connection: fake_successful_constituency_search_connection(fake_response)) }
+
+    subject { client.constituency("St Albans") }
+
+    context "when there is a result" do
+      let(:fake_response) { [200, nil, {items: [{value: {name: "St Albans", id: 12345}}]}.to_json] }
+
+      it "returns a Result with the JSON response body and no error" do
+        expect(subject.object).to eql("items" => [{"value" => {"name" => "St Albans", "id" => 12345}}])
+        expect(subject.error).to be_nil
+      end
+    end
+
+    context "when there is any other error" do
+      let(:fake_response) { [500, nil, nil] }
+
+      it "returns a Result with an Error" do
+        expect(subject.object).to be_nil
+        expect(subject.error).to be_a(MembersApi::Client::Error)
+        expect(subject.error.message).to eq(I18n.t("members_api.errors.other"))
+      end
+    end
+
+    context "when the connection fails" do
+      let(:client) { described_class.new(connection: fake_failed_constituency_search_connection) }
+
+      it "raises an Error" do
+        expect { subject }.to raise_error(MembersApi::Client::Error)
+      end
+    end
+  end
+
+  describe "#member_id" do
+    let(:client) { described_class.new(connection: fake_successful_constituency_search_connection(fake_response)) }
+
+    context "when there is one result" do
+      subject { client.member_id("St Albans") }
+
+      let(:fake_response) do
+        [
+          200,
+          nil,
+          {
+            items: [{
+              value: {
+                name: "St Albans", currentRepresentation: {
+                  member: {
+                    value: {
+                      id: 12345
+                    }
+                  }
+                }
+              }
+            }]
+          }.to_json
+        ]
+      end
+
+      it "returns a the ID" do
+        expect(subject).to eql(12345)
+      end
+    end
+
+    context "when there is more than one result" do
+      subject { client.member_id("St A") }
+
+      let(:fake_response) { [200, nil, {items: [{value: {name: "St Albans"}}, {value: {name: "Lewisham West and Penge"}}]}.to_json] }
+
+      it "returns a MultipleResultsError" do
+        expect(subject.object).to be_nil
+        expect(subject.error).to be_a(MembersApi::Client::MultipleResultsError)
+        expect(subject.error.message).to eq(I18n.t("members_api.errors.multiple", search_term: "St A"))
+      end
+    end
+  end
+
+  def fake_successful_constituency_search_connection(response)
+    Faraday.new do |builder|
+      builder.adapter :test do |stub|
+        stub.get("/api/Location/Constituency/Search") do |_env|
+          response
+        end
+      end
+    end
+  end
+
+  def fake_failed_constituency_search_connection
+    Faraday.new do |builder|
+      builder.adapter :test do |stub|
+        stub.get("/api/Location/Constituency/Search") do |_env|
+          raise Faraday::Error
+        end
+      end
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -61,11 +61,11 @@ RSpec.describe Project, type: :model do
 
       context "when no establishment with that URN exists in the API and the URN is present" do
         let(:no_establishment_found_result) do
-          AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError.new("Could not find establishment with URN: 12345"))
+          Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::NotFoundError.new("Could not find establishment with URN: 12345"))
         end
 
         before do
-          allow_any_instance_of(AcademiesApi::Client).to \
+          allow_any_instance_of(Api::AcademiesApi::Client).to \
             receive(:get_establishment) { no_establishment_found_result }
 
           subject.assign_attributes(urn: 123456)
@@ -81,11 +81,11 @@ RSpec.describe Project, type: :model do
     describe "#incoming_trust_ukprn" do
       context "when no trust with that UKPRN exists in the API and the UKPRN is present" do
         let(:no_trust_found_result) do
-          AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError.new("No trust found with that UKPRN. Enter a valid UKPRN."))
+          Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::NotFoundError.new("No trust found with that UKPRN. Enter a valid UKPRN."))
         end
 
         before do
-          allow_any_instance_of(AcademiesApi::Client).to \
+          allow_any_instance_of(Api::AcademiesApi::Client).to \
             receive(:get_trust) { no_trust_found_result }
 
           subject.assign_attributes(incoming_trust_ukprn: 12345678)
@@ -162,7 +162,7 @@ RSpec.describe Project, type: :model do
 
       project = build(:conversion_project, academy_urn: 123456)
 
-      expect(project.academy).to be_a(AcademiesApi::Establishment)
+      expect(project.academy).to be_a(Api::AcademiesApi::Establishment)
     end
 
     it "returns nil when the urn cannot be found" do
@@ -210,8 +210,8 @@ RSpec.describe Project, type: :model do
       end
 
       it "caches the response" do
-        academies_api_client = double(AcademiesApi::Client, get_establishment: AcademiesApi::Client::Result.new(double, nil))
-        allow(AcademiesApi::Client).to receive(:new).and_return(academies_api_client)
+        academies_api_client = double(Api::AcademiesApi::Client, get_establishment: Api::AcademiesApi::Client::Result.new(double, nil))
+        allow(Api::AcademiesApi::Client).to receive(:new).and_return(academies_api_client)
         project = described_class.new(urn: urn)
 
         project.establishment
@@ -221,31 +221,31 @@ RSpec.describe Project, type: :model do
       end
     end
 
-    context "when the Academies API client returns a #{AcademiesApi::Client::NotFoundError}" do
+    context "when the Academies API client returns a #{Api::AcademiesApi::Client::NotFoundError}" do
       let(:error_message) { "Could not find establishment with URN: 123456" }
-      let(:error) { AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError.new(error_message)) }
+      let(:error) { Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::NotFoundError.new(error_message)) }
 
       before do
-        allow_any_instance_of(AcademiesApi::Client).to \
+        allow_any_instance_of(Api::AcademiesApi::Client).to \
           receive(:get_establishment).with(urn) { error }
       end
 
       it "raises the error" do
-        expect { subject.establishment }.to raise_error(AcademiesApi::Client::NotFoundError, error_message)
+        expect { subject.establishment }.to raise_error(Api::AcademiesApi::Client::NotFoundError, error_message)
       end
     end
 
-    context "when the Academies API client returns a #{AcademiesApi::Client::Error}" do
+    context "when the Academies API client returns a #{Api::AcademiesApi::Client::Error}" do
       let(:error_message) { "There was an error connecting to the Academies API, could not fetch establishment for URN: 123456" }
-      let(:error) { AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::Error.new(error_message)) }
+      let(:error) { Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::Error.new(error_message)) }
 
       before do
-        allow_any_instance_of(AcademiesApi::Client).to \
+        allow_any_instance_of(Api::AcademiesApi::Client).to \
           receive(:get_establishment).with(urn) { error }
       end
 
       it "raises the error" do
-        expect { subject.establishment }.to raise_error(AcademiesApi::Client::Error, error_message)
+        expect { subject.establishment }.to raise_error(Api::AcademiesApi::Client::Error, error_message)
       end
     end
   end
@@ -265,8 +265,8 @@ RSpec.describe Project, type: :model do
       end
 
       it "caches the response" do
-        academies_api_client = double(AcademiesApi::Client, get_trust: AcademiesApi::Client::Result.new(double, nil))
-        allow(AcademiesApi::Client).to receive(:new).and_return(academies_api_client)
+        academies_api_client = double(Api::AcademiesApi::Client, get_trust: Api::AcademiesApi::Client::Result.new(double, nil))
+        allow(Api::AcademiesApi::Client).to receive(:new).and_return(academies_api_client)
         project = described_class.new(urn: urn, incoming_trust_ukprn: ukprn)
 
         project.incoming_trust
@@ -276,31 +276,31 @@ RSpec.describe Project, type: :model do
       end
     end
 
-    context "when the Academies API client returns a #{AcademiesApi::Client::NotFoundError}" do
+    context "when the Academies API client returns a #{Api::AcademiesApi::Client::NotFoundError}" do
       let(:error_message) { "Could not find trust for UKPRN 10061021" }
-      let(:error) { AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError.new(error_message)) }
+      let(:error) { Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::NotFoundError.new(error_message)) }
 
       before do
-        allow_any_instance_of(AcademiesApi::Client).to \
+        allow_any_instance_of(Api::AcademiesApi::Client).to \
           receive(:get_trust).with(ukprn) { error }
       end
 
       it "raises the error" do
-        expect { subject.incoming_trust }.to raise_error(AcademiesApi::Client::NotFoundError, error_message)
+        expect { subject.incoming_trust }.to raise_error(Api::AcademiesApi::Client::NotFoundError, error_message)
       end
     end
 
-    context "when the Academies API client returns a #{AcademiesApi::Client::Error}" do
+    context "when the Academies API client returns a #{Api::AcademiesApi::Client::Error}" do
       let(:error_message) { "There was an error connecting to the Academies API, could not fetch trust with UKPRN 10061021" }
-      let(:error) { AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::Error.new(error_message)) }
+      let(:error) { Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::Error.new(error_message)) }
 
       before do
-        allow_any_instance_of(AcademiesApi::Client).to \
+        allow_any_instance_of(Api::AcademiesApi::Client).to \
           receive(:get_trust).with(ukprn) { error }
       end
 
       it "raises the error" do
-        expect { subject.incoming_trust }.to raise_error(AcademiesApi::Client::Error, error_message)
+        expect { subject.incoming_trust }.to raise_error(Api::AcademiesApi::Client::Error, error_message)
       end
     end
   end

--- a/spec/services/establishments_fetcher_spec.rb
+++ b/spec/services/establishments_fetcher_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe EstablishmentsFetcher do
         build(:conversion_project, urn: 234567)
       ]
     end
-    let(:mock_client) { AcademiesApi::Client.new }
+    let(:mock_client) { Api::AcademiesApi::Client.new }
     let(:establishment) { build(:academies_api_establishment, urn: "123456") }
     let(:establishment_2) { build(:academies_api_establishment, urn: "234567") }
-    let(:establishment_result) { AcademiesApi::Client::Result.new([establishment, establishment_2], nil) }
+    let(:establishment_result) { Api::AcademiesApi::Client::Result.new([establishment, establishment_2], nil) }
 
     before do
-      allow(AcademiesApi::Client).to receive(:new).and_return(mock_client)
+      allow(Api::AcademiesApi::Client).to receive(:new).and_return(mock_client)
       allow(mock_client).to receive(:get_establishment).and_return(true)
       allow(mock_client).to receive(:get_establishments).with([123456, 234567]).and_return(establishment_result)
     end

--- a/spec/services/incoming_trusts_fetcher_spec.rb
+++ b/spec/services/incoming_trusts_fetcher_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe IncomingTrustsFetcher do
         build(:conversion_project, incoming_trust_ukprn: 23456789)
       ]
     end
-    let(:mock_client) { AcademiesApi::Client.new }
+    let(:mock_client) { Api::AcademiesApi::Client.new }
     let(:trust) { build(:academies_api_trust, ukprn: "12345678") }
     let(:trust_2) { build(:academies_api_trust, ukprn: "23456789") }
-    let(:trusts_result) { AcademiesApi::Client::Result.new([trust, trust_2], nil) }
+    let(:trusts_result) { Api::AcademiesApi::Client::Result.new([trust, trust_2], nil) }
 
     before do
-      allow(AcademiesApi::Client).to receive(:new).and_return(mock_client)
+      allow(Api::AcademiesApi::Client).to receive(:new).and_return(mock_client)
       allow(mock_client).to receive(:get_trust).and_return(true)
 
       allow(mock_client).to receive(:get_trusts).with([12345678, 23456789]).and_return(trusts_result)

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -1,12 +1,12 @@
 module AcademiesApiHelpers
   def mock_successful_api_calls(establishment:, trust:)
-    fake_client = double(AcademiesApi::Client,
-      get_establishments: AcademiesApi::Client::Result.new([establishment], nil),
-      get_establishment: AcademiesApi::Client::Result.new(establishment, nil),
-      get_trusts: AcademiesApi::Client::Result.new([trust], nil),
-      get_trust: AcademiesApi::Client::Result.new(trust, nil))
+    fake_client = double(Api::AcademiesApi::Client,
+      get_establishments: Api::AcademiesApi::Client::Result.new([establishment], nil),
+      get_establishment: Api::AcademiesApi::Client::Result.new(establishment, nil),
+      get_trusts: Api::AcademiesApi::Client::Result.new([trust], nil),
+      get_trust: Api::AcademiesApi::Client::Result.new(trust, nil))
 
-    allow(AcademiesApi::Client).to receive(:new).and_return(fake_client)
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(fake_client)
   end
 
   def mock_successful_api_response_to_create_any_project
@@ -22,21 +22,21 @@ module AcademiesApiHelpers
   def mock_successful_api_establishment_response(urn:, establishment: nil)
     establishment = build(:academies_api_establishment) if establishment.nil?
 
-    fake_result = AcademiesApi::Client::Result.new(establishment, nil)
-    test_client = AcademiesApi::Client.new
+    fake_result = Api::AcademiesApi::Client::Result.new(establishment, nil)
+    test_client = Api::AcademiesApi::Client.new
 
     allow(test_client).to receive(:get_establishment).with(urn).and_return(fake_result)
-    allow(AcademiesApi::Client).to receive(:new).and_return(test_client)
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(test_client)
   end
 
   def mock_successful_api_trust_response(ukprn:, trust: nil)
     trust = build(:academies_api_trust) if trust.nil?
 
-    fake_result = AcademiesApi::Client::Result.new(trust, nil)
-    test_client = AcademiesApi::Client.new
+    fake_result = Api::AcademiesApi::Client::Result.new(trust, nil)
+    test_client = Api::AcademiesApi::Client.new
 
     allow(test_client).to receive(:get_trust).with(ukprn).and_return(fake_result)
-    allow(AcademiesApi::Client).to receive(:new).and_return(test_client)
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(test_client)
   end
 
   def mock_pre_fetched_api_responses_for_any_establishment_and_trust
@@ -55,23 +55,23 @@ module AcademiesApiHelpers
   end
 
   def mock_establishment_not_found(urn:)
-    mock_client = AcademiesApi::Client.new
-    not_found_result = AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError)
+    mock_client = Api::AcademiesApi::Client.new
+    not_found_result = Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::NotFoundError)
     allow(mock_client).to receive(:get_establishment).with(urn).and_return(not_found_result)
-    allow(AcademiesApi::Client).to receive(:new).and_return(mock_client)
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(mock_client)
   end
 
   def mock_timeout_api_establishment_response(urn:)
-    test_client = AcademiesApi::Client.new
+    test_client = Api::AcademiesApi::Client.new
 
-    allow(test_client).to receive(:get_establishment).with(urn).and_raise(AcademiesApi::Client::Error)
-    allow(AcademiesApi::Client).to receive(:new).and_return(test_client)
+    allow(test_client).to receive(:get_establishment).with(urn).and_raise(Api::AcademiesApi::Client::Error)
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(test_client)
   end
 
   def mock_timeout_api_trust_response(ukprn:)
-    test_client = AcademiesApi::Client.new
+    test_client = Api::AcademiesApi::Client.new
 
-    allow(test_client).to receive(:get_trust).with(ukprn).and_raise(AcademiesApi::Client::Error)
-    allow(AcademiesApi::Client).to receive(:new).and_return(test_client)
+    allow(test_client).to receive(:get_trust).with(ukprn).and_raise(Api::AcademiesApi::Client::Error)
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(test_client)
   end
 end

--- a/spec/support/shared_examples/create_conversion_project_form.rb
+++ b/spec/support/shared_examples/create_conversion_project_form.rb
@@ -180,11 +180,11 @@ RSpec.shared_examples "a conversion project FormObject" do
 
     context "when no establishment with that URN exists in the API" do
       let(:no_establishment_found_result) do
-        AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError.new("Could not find establishment with URN: 12345"))
+        Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::NotFoundError.new("Could not find establishment with URN: 12345"))
       end
 
       before do
-        allow_any_instance_of(AcademiesApi::Client).to \
+        allow_any_instance_of(Api::AcademiesApi::Client).to \
           receive(:get_establishment) { no_establishment_found_result }
       end
 
@@ -213,11 +213,11 @@ RSpec.shared_examples "a conversion project FormObject" do
 
     context "when no trust with that UKPRN exists in the API" do
       let(:no_trust_found_result) do
-        AcademiesApi::Client::Result.new(nil, AcademiesApi::Client::NotFoundError.new("No trust found with that UKPRN. Enter a valid UKPRN."))
+        Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::NotFoundError.new("No trust found with that UKPRN. Enter a valid UKPRN."))
       end
 
       before do
-        allow_any_instance_of(AcademiesApi::Client).to \
+        allow_any_instance_of(Api::AcademiesApi::Client).to \
           receive(:get_trust) { no_trust_found_result }
       end
 


### PR DESCRIPTION
## Changes

We want to be able to show the name and contact details of a local authority's MP in the application, so that users can send a letter (or other correspondence) to the MP and notify them of a school's academisation.

The Parliamentary Members API is available to find details about members of parliament. 

Build a new MembersApi Client. Use it to find a constituency via a free text search (we will use the name of a school district as the search term). Then use that constituency data to find the member of parliament's name and contact details.

Render the MP's name and contact details as custom models we can later use in the UI.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
