### PR TITLE
Release 21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release 21][release-21]
+
 ### Fixed
 
 - the link to a project on the openers table now reads 'View Project' not 'html'
@@ -759,7 +761,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-20...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-21...HEAD
+[release-21]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-20...release-21
 [release-20]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-19...release-20
 [release-19]:


### PR DESCRIPTION
### Fixed

- the link to a project on the openers table now reads 'View Project' not 'html'
### Changed
- standardised capitalisation in redact and send documents task
- removed duplicate content from send redacted docs to funding team to publish
  on gov.uk action in redact and send documents task
- standardised capitalisation in the receive grant payment certificate task
### Added
- a section to project that shows the academy details, currently this will not
  show details until the academy URN is provided
- the academy details will be shown in full once the academy URN is supplied,
  when the academy details cannot be found, a helpful message is shown