### PR TITLE
Add unassigned counts to stats page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - stop search engines from crawling the application
+- the statistics page includes the counts of unassigend projects, which makes
+  the numbers add up
 
 ## [Release 21][release-21]
 

--- a/app/models/project_statistics.rb
+++ b/app/models/project_statistics.rb
@@ -19,6 +19,10 @@ class ProjectStatistics
     @projects.in_progress.count
   end
 
+  def total_number_of_unassigned_projects
+    @projects.unassigned_to_user.count
+  end
+
   def total_number_of_completed_projects
     @projects.completed.count
   end
@@ -43,6 +47,10 @@ class ProjectStatistics
     @projects.assigned_to_regional_caseworker_team.completed.count
   end
 
+  def unassigned_projects_with_regional_casework_services
+    @projects.assigned_to_regional_caseworker_team.unassigned_to_user.count
+  end
+
   def total_projects_not_with_regional_casework_services
     @projects.not_assigned_to_regional_caseworker_team.count
   end
@@ -61,6 +69,10 @@ class ProjectStatistics
 
   def completed_projects_not_with_regional_casework_services
     @projects.not_assigned_to_regional_caseworker_team.completed.count
+  end
+
+  def unassigned_projects_not_with_regional_casework_services
+    @projects.not_assigned_to_regional_caseworker_team.unassigned_to_user.count
   end
 
   def total_projects_within_london_region
@@ -241,6 +253,10 @@ class ProjectStatistics
 
   def completed_projects_within_east_midlands_region
     @projects.by_region("east_midlands").completed.count
+  end
+
+  def unassigned_projects_in_region(region)
+    @projects.by_region(region).unassigned_to_user.count
   end
 
   def opener_date_and_project_total

--- a/app/views/all/statistics/projects/index.html.erb
+++ b/app/views/all/statistics/projects/index.html.erb
@@ -26,6 +26,10 @@
           <td class="govuk-table__cell">Completed projects</td>
           <td class="govuk-table__cell"><%= @project_statistics.total_number_of_completed_projects %></td>
         </tr>
+        <tr class="govuk-table__row" id="unassigned">
+          <td class="govuk-table__cell">Unassigned projects</td>
+          <td class="govuk-table__cell"><%= @project_statistics.total_number_of_unassigned_projects %></td>
+        </tr>
         <tr class="govuk-table__row" id="all_projects">
           <td class="govuk-table__cell">All projects</td>
           <td class="govuk-table__cell"><%= @project_statistics.total_number_of_projects %></td>
@@ -58,6 +62,10 @@
         <tr class="govuk-table__row" id="completed">
           <td class="govuk-table__cell">Completed projects</td>
           <td class="govuk-table__cell"><%= @project_statistics.completed_projects_with_regional_casework_services %></td>
+        </tr>
+        <tr class="govuk-table__row" id="unassigned">
+          <td class="govuk-table__cell">Unassigned projects</td>
+          <td class="govuk-table__cell"><%= @project_statistics.unassigned_projects_with_regional_casework_services %></td>
         </tr>
         <tr class="govuk-table__row" id="all_projects">
           <td class="govuk-table__cell">All projects with Regional casework services</td>
@@ -92,6 +100,10 @@
           <td class="govuk-table__cell">Completed projects</td>
           <td class="govuk-table__cell"><%= @project_statistics.completed_projects_not_with_regional_casework_services %></td>
         </tr>
+        <tr class="govuk-table__row" id="unassigned">
+          <td class="govuk-table__cell">Unassigned projects</td>
+          <td class="govuk-table__cell"><%= @project_statistics.unassigned_projects_not_with_regional_casework_services %></td>
+        </tr>
         <tr class="govuk-table__row" id="all_projects">
           <td class="govuk-table__cell">All projects not with Regional casework services</td>
           <td class="govuk-table__cell"><%= @project_statistics.total_projects_not_with_regional_casework_services %></td>
@@ -99,7 +111,7 @@
       </tbody>
     </table>
   </div>
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <h2 class="govuk-heading-l">Projects per region</h2>
     <table class="govuk-table" name="not_with_regional_casework_services_statistics_table" aria-label="Not with Regional casework services statistics">
       <thead class="govuk-table__head">
@@ -109,6 +121,7 @@
           <th class="govuk-table__header" scope="col">Sponsored projects</th>
           <th class="govuk-table__header" scope="col">In-progress projects</th>
           <th class="govuk-table__header" scope="col">Completed projects</th>
+          <th class="govuk-table__header" scope="col">Unassigned</th>
           <th class="govuk-table__header" scope="col">All projects</th>
         </tr>
       </thead>
@@ -119,6 +132,8 @@
           <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_london_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_london_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_london_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.unassigned_projects_in_region(:london) %></td>
+
           <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_london_region %></td>
         </tr>
         <tr class="govuk-table__row" id="south_east">
@@ -127,6 +142,7 @@
           <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_south_east_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_south_east_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_south_east_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.unassigned_projects_in_region(:south_east) %></td>
           <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_south_east_region %></td>
         </tr>
         <tr class="govuk-table__row" id="yorkshire_and_the_humber">
@@ -135,6 +151,7 @@
           <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_yorkshire_and_the_humber_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_yorkshire_and_the_humber_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_yorkshire_and_the_humber_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.unassigned_projects_in_region(:yorkshire_and_the_humber) %></td>
           <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_yorkshire_and_the_humber_region %></td>
         </tr>
         <tr class="govuk-table__row" id="north_west">
@@ -143,6 +160,7 @@
           <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_north_west_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_north_west_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_north_west_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.unassigned_projects_in_region(:north_west) %></td>
           <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_north_west_region %></td>
         </tr>
         <tr class="govuk-table__row" id="east_of_england">
@@ -151,6 +169,7 @@
           <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_east_of_england_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_east_of_england_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_east_of_england_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.unassigned_projects_in_region(:east_of_england) %></td>
           <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_east_of_england_region %></td>
         </tr>
         <tr class="govuk-table__row" id="west_midlands">
@@ -159,6 +178,7 @@
           <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_west_midlands_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_west_midlands_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_west_midlands_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.unassigned_projects_in_region(:west_midlands) %></td>
           <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_west_midlands_region %></td>
         </tr>
         <tr class="govuk-table__row" id="north_east">
@@ -167,6 +187,7 @@
           <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_north_east_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_north_east_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_north_east_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.unassigned_projects_in_region(:north_west) %></td>
           <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_north_east_region %></td>
         </tr>
         <tr class="govuk-table__row" id="south_west">
@@ -175,6 +196,7 @@
           <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_south_west_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_south_west_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_south_west_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.unassigned_projects_in_region(:south_west) %></td>
           <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_south_west_region %></td>
         </tr>
         <tr class="govuk-table__row" id="east_midlands">
@@ -183,6 +205,7 @@
           <td class="govuk-table__cell"><%= @project_statistics.sponsored_projects_within_east_midlands_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.in_progress_projects_within_east_midlands_region %></td>
           <td class="govuk-table__cell"><%= @project_statistics.completed_projects_within_east_midlands_region %></td>
+          <td class="govuk-table__cell"><%= @project_statistics.unassigned_projects_in_region(:east_midlands) %></td>
           <td class="govuk-table__cell"><%= @project_statistics.total_projects_within_east_midlands_region %></td>
         </tr>
       </tbody>

--- a/spec/models/project_statistics_spec.rb
+++ b/spec/models/project_statistics_spec.rb
@@ -9,16 +9,17 @@ RSpec.describe ProjectStatistics, type: :model do
     let!(:sponsored_in_progress_project_2) { create(:involuntary_conversion_project, completed_at: nil) }
     let!(:voluntary_completed_project_1) { create(:conversion_project, completed_at: Date.today + 2.years) }
     let!(:sponsored_completed_project_2) { create(:involuntary_conversion_project, completed_at: Date.today + 2.years) }
+    let!(:unassigned_projects_with) { create(:conversion_project, assigned_to: nil) }
 
     describe "#total_number_of_projects" do
       it "returns the total number of all projects" do
-        expect(subject.total_number_of_projects).to eql(4)
+        expect(subject.total_number_of_projects).to eql(5)
       end
     end
 
     describe "#total_number_of_voluntary_projects" do
       it "returns the total number of all voluntary projects" do
-        expect(subject.total_number_of_voluntary_projects).to eql(2)
+        expect(subject.total_number_of_voluntary_projects).to eql(3)
       end
     end
 
@@ -34,6 +35,12 @@ RSpec.describe ProjectStatistics, type: :model do
       end
     end
 
+    describe "#total_number_of_unassigned_projects" do
+      it "returns the total number of all unassigned projects" do
+        expect(subject.total_number_of_unassigned_projects).to eql(1)
+      end
+    end
+
     describe "#total_number_of_completed_projects" do
       it "returns the total number of all completed projects" do
         expect(subject.total_number_of_completed_projects).to eql(2)
@@ -46,16 +53,17 @@ RSpec.describe ProjectStatistics, type: :model do
     let!(:voluntary_completed_project_with_regional_casework_services_2) { create(:conversion_project, assigned_to_regional_caseworker_team: true, completed_at: Date.today + 2.years) }
     let!(:sponsored_in_progress_project_with_regional_casework_services_1) { create(:involuntary_conversion_project, assigned_to_regional_caseworker_team: true, completed_at: nil) }
     let!(:sponsored_completed_project_with_regional_casework_services_2) { create(:involuntary_conversion_project, assigned_to_regional_caseworker_team: true, completed_at: Date.today + 2.years) }
+    let!(:unassigned_projects_with_regional_casework_services) { create(:conversion_project, assigned_to_regional_caseworker_team: true, assigned_to: nil) }
 
     describe "#total_projects_with_regional_casework_services" do
       it "returns the total number of all projects within regional casework services" do
-        expect(subject.total_projects_with_regional_casework_services).to eql(4)
+        expect(subject.total_projects_with_regional_casework_services).to eql(5)
       end
     end
 
     describe "#voluntary_projects_with_regional_casework_services" do
       it "returns the total number of voluntary projects within regional casework services" do
-        expect(subject.voluntary_projects_with_regional_casework_services).to eql(2)
+        expect(subject.voluntary_projects_with_regional_casework_services).to eql(3)
       end
     end
 
@@ -76,6 +84,12 @@ RSpec.describe ProjectStatistics, type: :model do
         expect(subject.completed_projects_with_regional_casework_services).to eql(2)
       end
     end
+
+    describe "#unassigned_projects_with_regional_casework_services" do
+      it "returns the total number of unassigned projects within regional casework services" do
+        expect(subject.unassigned_projects_with_regional_casework_services).to eql(1)
+      end
+    end
   end
 
   describe "Regional projects that are not with regional casework services" do
@@ -83,16 +97,17 @@ RSpec.describe ProjectStatistics, type: :model do
     let!(:voluntary_completed_project_not_with_regional_casework_services_2) { create(:conversion_project, assigned_to_regional_caseworker_team: false, completed_at: Date.today + 2.years) }
     let!(:sponsored_in_progress_project_not_with_regional_casework_services_1) { create(:involuntary_conversion_project, assigned_to_regional_caseworker_team: false, completed_at: nil) }
     let!(:sponsored_completed_project_not_with_regional_casework_services_2) { create(:involuntary_conversion_project, assigned_to_regional_caseworker_team: false, completed_at: Date.today + 2.years) }
+    let!(:unassigned_project_not_with_regional_casework_services) { create(:conversion_project, assigned_to_regional_caseworker_team: false, assigned_to: nil) }
 
     describe "#total_projects_not_with_regional_casework_services" do
       it "returns the total number of projects not with regional casework services" do
-        expect(subject.total_projects_not_with_regional_casework_services).to eql(4)
+        expect(subject.total_projects_not_with_regional_casework_services).to eql(5)
       end
     end
 
     describe "#voluntary_projects_not_with_regional_casework_services" do
       it "returns the total number of voluntary projects not with regional casework services" do
-        expect(subject.voluntary_projects_not_with_regional_casework_services).to eql(2)
+        expect(subject.voluntary_projects_not_with_regional_casework_services).to eql(3)
       end
     end
 
@@ -111,6 +126,12 @@ RSpec.describe ProjectStatistics, type: :model do
     describe "#completed_projects_not_with_regional_casework_services" do
       it "returns the total number of completed projects not with regional casework services" do
         expect(subject.completed_projects_not_with_regional_casework_services).to eql(2)
+      end
+    end
+
+    describe "#unassigned_projects_not_with_regional_casework_services" do
+      it "returns the total number of unassigned  projects not within regional casework services" do
+        expect(subject.unassigned_projects_not_with_regional_casework_services).to eql(1)
       end
     end
   end
@@ -456,6 +477,16 @@ RSpec.describe ProjectStatistics, type: :model do
           expect(subject.completed_projects_within_east_midlands_region).to eql(2)
         end
       end
+    end
+  end
+
+  describe "#unassigned_projects_in_region" do
+    it "returns the total number of unassigned projects for a given region" do
+      _assigned_project_in_region = create(:conversion_project, region: :east_midlands)
+      _unassigned_project_in_region = create(:conversion_project, region: :east_midlands, assigned_to: nil)
+      _project_not_in_region = create(:conversion_project, region: :london)
+
+      expect(subject.unassigned_projects_in_region(:east_midlands)).to eql(1)
     end
   end
 


### PR DESCRIPTION
When we added the stats page, we should have include the projects that are unassigned to make the numbers add up.

This is because we currently do not consider an unassigned project to be 'in-progress'

We know that, right now, there will be no unassigned projects because the Regional delivery officer is always assigned when the project is created - we include the value for consistancy.

We've also increased the column width of the layout row that contains the big table of regions.

![image](https://user-images.githubusercontent.com/480578/232014072-7e4d99e8-48bd-4ce1-9b26-c947aaa1e48b.png)
