### PR TITLE
(Fix) Remove nil warning in tests

### DIFF
--- a/spec/features/projects/new/users_can_view_a_list_of_new_projects_spec.rb
+++ b/spec/features/projects/new/users_can_view_a_list_of_new_projects_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature "Viewing all new projects" do
       expect(page).to have_content(I18n.t("project.all.new.title"))
 
       within("tbody") do
-        expect(page).to have_content(project_without_academy_urn.academy_urn)
+        expect(page).to have_content(project_without_academy_urn.establishment.name)
 
         expect(page).not_to have_content(project_with_academy_urn.academy_urn)
       end


### PR DESCRIPTION
This test was testing for the presence of nil, which generated a warning each time the tests were run. Swap the expectation for something better.

```
Checking for expected text of nil is confusing and/or pointless since it will
always match. Please specify a string or regexp instead.
```

