### PR TITLE
Release 22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release 22][release-22]
+
 ### Added
 
 - new MembersApi Client to call the Parliamentary Members API and retrieve MP
@@ -15,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - stop search engines from crawling the application
-- the statistics page includes the counts of unassigend projects, which makes
+- the statistics page includes the counts of unassigned projects, which makes
   the numbers add up
 
 ## [Release 21][release-21]
@@ -773,7 +775,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-21...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-22...HEAD
+[release-22]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-21...release-22
 [release-21]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-20...release-21
 [release-20]:


### PR DESCRIPTION
### Added

- new MembersApi Client to call the Parliamentary Members API and retrieve MP
  details
- show the Member of Parliament details for a school on a new page

### Changed

- stop search engines from crawling the application
- the statistics page includes the counts of unassigned projects, which makes
  the numbers add up

## Checklist

- [x] Check that this pull request has the correct version number.
- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` to move Unreleased changes into a new version.
- [x] Update the release links at the bottom of `CHANGELOG.md` to reflect the
      new version.