### PR TITLE
Dynamically set the Redirect Uri passed through to the IdP

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,7 +3,10 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     {
       client_id: ENV["AZURE_APPLICATION_CLIENT_ID"],
       client_secret: ENV["AZURE_APPLICATION_CLIENT_SECRET"],
-      tenant_id: ENV["AZURE_TENANT_ID"]
+      tenant_id: ENV["AZURE_TENANT_ID"],
+      authorize_params: {
+        redirect_uri: ENV["AZURE_REDIRECT_URI"]
+      }
     }
 end
 


### PR DESCRIPTION
If the app is put behind a proxy, the redirect URI query parameter that is sent to the Microsoft Identity Provider (IdP) contains the proxy url/hostname instead of the app's FQDN. 

According to the [Omniauth readme](https://github.com/RIPAGlobal/omniauth-azure-activedirectory-v2#explaining-authorize_params) it's possible to override the parameters in the initial request. I looked at the [Microsoft OAuth docs](https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code) and there does seem to be a `redirect_uri` option that can be defined.

I propose we use an environment variable for setting this value.