### PR TITLE
Raise error if the Academies API returns 401 Unauthorised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Address subtle bug in Project creation, which meant two projects with the same
   URN were created in error
 
+### Added
+
+- Raise a specific error page if our access to the Academies Api has been
+  revoked
+
 ## [Release 22][release-22]
 
 ### Added

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
   rescue_from Api::AcademiesApi::Client::Error, with: :academies_api_client_error
+  rescue_from Api::AcademiesApi::Client::UnauthorisedError, with: :academies_api_unauthorised_error
 
   def not_found_error
     render "pages/page_not_found", status: :not_found
@@ -20,6 +21,10 @@ class ApplicationController < ActionController::Base
 
   private def academies_api_client_error
     render "pages/academies_api_client_timeout", status: 500
+  end
+
+  private def academies_api_unauthorised_error
+    render "pages/academies_api_client_unauthorised", status: 401
   end
 
   private def members_api_client_error

--- a/app/models/api/academies_api/client.rb
+++ b/app/models/api/academies_api/client.rb
@@ -7,6 +7,8 @@ class Api::AcademiesApi::Client
 
   class MultipleResultsError < StandardError; end
 
+  class UnauthorisedError < StandardError; end
+
   attr_reader :connection
 
   def initialize(connection: nil)
@@ -19,6 +21,8 @@ class Api::AcademiesApi::Client
     case response.status
     when 200
       Result.new(Api::AcademiesApi::Establishment.new.from_hash(single_establishment_from_bulk(response)), nil)
+    when 401
+      raise Api::AcademiesApi::Client::UnauthorisedError.new("Problems connecting to the Academies API")
     when 404
       Result.new(nil, NotFoundError.new(I18n.t("academies_api.get_establishment.errors.not_found", urn: urn)))
     else
@@ -35,6 +39,8 @@ class Api::AcademiesApi::Client
         Api::AcademiesApi::Establishment.new.from_hash(establishment)
       end
       Result.new(establishments, nil)
+    when 401
+      raise Api::AcademiesApi::Client::UnauthorisedError.new("Problems connecting to the Academies API")
     when 404
       Result.new(nil, NotFoundError.new(I18n.t("academies_api.get_establishments.errors.not_found", urns:)))
     else

--- a/app/views/pages/academies_api_client_unauthorised.html.erb
+++ b/app/views/pages/academies_api_client_unauthorised.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t("pages.academies_api_client_unauthorised.title") %></h1>
+    <p class="govuk-body">
+      <%= t("pages.academies_api_client_unauthorised.body_text") %>
+    </p>
+
+    <p class="govuk-body">
+      <%= t("pages.academies_api_client_unauthorised.email_help",
+            email: support_email).html_safe %>
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,10 @@ en:
       title: Sorry, there was a problem
       body_text: The service timed out when getting the details of the school or trust. Refresh the page to try again.
       email_help: Email the support team at %{email} if this error continues.
+    academies_api_client_unauthorised:
+      title: Sorry, there was a problem
+      body_text: The service is unable to retrieve school or trust details at this time. This may be a temporary error. Please try again soon.
+      email_help: Email the support team at %{email} if this error continues.
     members_api_client_error:
       title: Sorry, there was a problem
       body_text: The service encountered an error when getting the details of the Member of Parliament. Refresh the page to try again.

--- a/spec/features/users_can_view_static_pages_spec.rb
+++ b/spec/features/users_can_view_static_pages_spec.rb
@@ -37,4 +37,11 @@ RSpec.feature "Users can view static pages" do
     expect(page).to have_current_path("/academies_api_client_timeout")
     expect(page).to have_content("Sorry, there was a problem")
   end
+
+  scenario "can see the `API unauthorised` error page" do
+    visit page_path(id: "academies_api_client_unauthorised")
+
+    expect(page).to have_current_path("/academies_api_client_unauthorised")
+    expect(page).to have_content("Sorry, there was a problem")
+  end
 end

--- a/spec/models/api/academies_api/client_spec.rb
+++ b/spec/models/api/academies_api/client_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe Api::AcademiesApi::Client do
         expect { subject }.to raise_error(Api::AcademiesApi::Client::Error)
       end
     end
+
+    context "when the Academies Api returns 401 unauthorised" do
+      let(:fake_response) { [401, nil, "Unauthorized client."] }
+
+      it "raises an Error" do
+        expect { subject }.to raise_error(Api::AcademiesApi::Client::UnauthorisedError)
+      end
+    end
   end
 
   describe "#get_establishments" do
@@ -100,6 +108,14 @@ RSpec.describe Api::AcademiesApi::Client do
 
       it "raises an Error" do
         expect { subject }.to raise_error(Api::AcademiesApi::Client::Error)
+      end
+    end
+
+    context "when the Academies Api returns 401 unauthorised" do
+      let(:fake_response) { [401, nil, "Unauthorized client."] }
+
+      it "raises an Error" do
+        expect { subject }.to raise_error(Api::AcademiesApi::Client::UnauthorisedError)
       end
     end
   end

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -74,4 +74,12 @@ module AcademiesApiHelpers
     allow(test_client).to receive(:get_trust).with(ukprn).and_raise(Api::AcademiesApi::Client::Error)
     allow(Api::AcademiesApi::Client).to receive(:new).and_return(test_client)
   end
+
+  def mock_unauthorised_api_responses(urn:, ukprn:)
+    test_client = Api::AcademiesApi::Client.new
+
+    allow(test_client).to receive(:get_trust).with(ukprn).and_raise(Api::AcademiesApi::Client::UnauthorisedError)
+    allow(test_client).to receive(:get_establishment).with(ukprn).and_raise(Api::AcademiesApi::Client::UnauthorisedError)
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(test_client)
+  end
 end

--- a/spec/support/shared_examples/conversion_project.rb
+++ b/spec/support/shared_examples/conversion_project.rb
@@ -66,6 +66,16 @@ RSpec.shared_examples "a conversion project" do
       end
     end
 
+    context "when the Academies API returns an unauthorised error" do
+      before do
+        mock_unauthorised_api_responses(urn: 123456, ukprn: 10061021)
+      end
+
+      it "redirects to an informational client unauthorised page" do
+        expect(perform_request).to render_template("pages/academies_api_client_unauthorised")
+      end
+    end
+
     context "when the creating user is not a regional delivery officer" do
       let(:caseworker) { create(:user, :caseworker) }
 


### PR DESCRIPTION
## Changes

https://sdd-n7.sentry.io/issues/3912539267/?project=6684508&referrer=slack

We have had a few instances where our access to the Academies Api has been
revoked. This has resulted in the application returning a generic 500
error.

If our access has been revoked, raise a specific error with an informative page.
This will alert us to the situation more quickly, so we can
resolve it with the Academies Api maintainers.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
