### PR TITLE
Refactor task list part one: tasks as first class models

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,0 +1,64 @@
+class TasksController < ApplicationController
+  before_action :find_project, :find_tasks_data, :find_task, :find_task_notes
+
+  def edit
+    render task_view
+  end
+
+  def update
+    authorize @tasks_data
+    @task.assign_attributes task_params
+
+    if @task.valid?
+      @task.save
+      flash.now[:notice] = "Task saved successfully"
+    else
+      flash.now[:alert] = "Task could not be saved"
+    end
+    render task_view
+  end
+
+  private def find_project
+    @project = Project.find(params[:project_id])
+  end
+
+  private def find_tasks_data
+    @tasks_data = @project.task_list
+  end
+
+  private def find_task
+    @task = klass_from_path.new(@tasks_data)
+  end
+
+  private def task_params
+    params.fetch(task_param_key, {}).permit @task.attributes.keys
+  end
+
+  private def task_param_key
+    @task.class.model_name.param_key
+  end
+
+  private def find_task_notes
+    @notes = Note.includes([:user, :project]).where(project: @project, task_identifier: @task.identifier)
+  end
+
+  private def klass_from_path
+    "#{project_type}::Task::#{task_klass_identifier}TaskForm".constantize
+  end
+
+  private def task_view
+    "#{project_type.pluralize}/tasks/#{task_identifier}/edit".downcase
+  end
+
+  private def project_type
+    @project.class.name.split("::").first
+  end
+
+  private def task_identifier
+    params.fetch(:task_identifier).underscore
+  end
+
+  private def task_klass_identifier
+    task_identifier.underscore.classify
+  end
+end

--- a/app/forms/base_task_form.rb
+++ b/app/forms/base_task_form.rb
@@ -1,0 +1,55 @@
+class BaseTaskForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  def self.identifier
+    name.split("::").last.underscore.delete_suffix("_task_form")
+  end
+
+  def initialize(tasks_data)
+    @tasks_data = tasks_data
+    super(attributes_from_tasks_data)
+  end
+
+  def save
+    @tasks_data.assign_attributes prefixed_attributes
+    @tasks_data.save!
+  end
+
+  def identifier
+    self.class.identifier.to_sym
+  end
+
+  def status
+    return :completed if completed?
+    return :in_progress if in_progress?
+
+    :not_started
+  end
+
+  def locales_path
+    self.class.name.underscore.delete_suffix("_task_form").tr("/", ".")
+  end
+
+  private def attributes_from_tasks_data
+    @tasks_data.attributes
+      .select { |key| key.start_with?(attribute_prefix.to_s) }
+      .transform_keys { |key| key.delete_prefix(attribute_prefix.to_s + "_") }
+  end
+
+  private def prefixed_attributes
+    attributes.transform_keys { |key| "#{attribute_prefix}_#{key}" }
+  end
+
+  private def attribute_prefix
+    identifier
+  end
+
+  private def in_progress?
+    attributes.values.any?(&:present?)
+  end
+
+  private def completed?
+    attributes.values.all?(&:present?)
+  end
+end

--- a/app/forms/conversion/task/redact_and_send_task_form.rb
+++ b/app/forms/conversion/task/redact_and_send_task_form.rb
@@ -1,0 +1,6 @@
+class Conversion::Task::RedactAndSendTaskForm < ::BaseTaskForm
+  attribute :redact, :boolean
+  attribute :send_redaction, :boolean
+  attribute :save_redaction, :boolean
+  attribute :send_solicitors, :boolean
+end

--- a/app/models/conversion/voluntary/tasks/one_hundred_and_twenty_five_year_lease.rb
+++ b/app/models/conversion/voluntary/tasks/one_hundred_and_twenty_five_year_lease.rb
@@ -1,5 +1,5 @@
 class Conversion::Voluntary::Tasks::OneHundredAndTwentyFiveYearLease < TaskList::OptionalTask
   attribute :email
   attribute :receive
-  attribute :save
+  attribute :save_lease
 end

--- a/app/models/conversion/voluntary/tasks/redact_and_send.rb
+++ b/app/models/conversion/voluntary/tasks/redact_and_send.rb
@@ -1,6 +1,6 @@
 class Conversion::Voluntary::Tasks::RedactAndSend < TaskList::Task
   attribute :redact
-  attribute :save
-  attribute :send
+  attribute :save_redaction
+  attribute :send_redaction
   attribute :send_solicitors
 end

--- a/app/views/conversions/tasks/redact_and_send/edit.html.erb
+++ b/app/views/conversions/tasks/redact_and_send/edit.html.erb
@@ -1,0 +1,26 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversions_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: update_task_path(@project, @task.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :redact)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :save_redaction)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :send_redaction)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :send_solicitors)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversions/shared/task_notes" %>
+  </div>
+</div>

--- a/app/views/conversions/tasks/shared/_task_notes.html.erb
+++ b/app/views/conversions/tasks/shared/_task_notes.html.erb
@@ -1,0 +1,24 @@
+<aside>
+  <h2 class="govuk-heading-m"><%= t("note.show.task_notes.title") %></h2>
+
+  <%= govuk_button_link_to t("note.show.task_notes.add"),
+        new_project_note_path(task_identifier: @task.identifier),
+        secondary: true,
+        class: "govuk-!-margin-bottom-3" %>
+
+  <ul class="list-style-none">
+    <% @notes.each do |note| %>
+      <li>
+        <p class="govuk-body govuk-!-margin-bottom-0"><%= note.created_at.to_date.to_formatted_s(:govuk) %></p>
+        <h3 class="govuk-heading-s govuk-!-padding-top-0"><%= note.user.full_name %></h3>
+        <p class="govuk-body"><%= render_markdown(note.body) %></p>
+
+        <% if policy(note).edit? %>
+          <%= govuk_link_to t("note.show.task_notes.edit"), edit_project_note_path(@project, note) %>
+        <% end %>
+
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+      </li>
+    <% end %>
+  </ul>
+</aside>

--- a/app/views/conversions/voluntary/task_lists/tasks/one_hundred_and_twenty_five_year_lease.html.erb
+++ b/app/views/conversions/voluntary/task_lists/tasks/one_hundred_and_twenty_five_year_lease.html.erb
@@ -18,7 +18,7 @@
 
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :email)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :receive)) %>
-        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :save)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :save_lease)) %>
       </div>
 
       <%= form.govuk_submit t("task_list.continue_button.text") if policy(@task_list).update? %>

--- a/app/views/conversions/voluntary/task_lists/tasks/redact_and_send.html.erb
+++ b/app/views/conversions/voluntary/task_lists/tasks/redact_and_send.html.erb
@@ -11,8 +11,8 @@
 
       <div class="govuk-form-group">
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :redact)) %>
-        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :save)) %>
-        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :send)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :save_redaction)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :send_redaction)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :send_solicitors)) %>
       </div>
 

--- a/config/locales/conversion/tasks/redact_and_send.en.yml
+++ b/config/locales/conversion/tasks/redact_and_send.en.yml
@@ -1,0 +1,43 @@
+en:
+  conversion:
+      task:
+        redact_and_send:
+          title: Redact and send documents
+          hint:
+            html:
+              <p>All relevant documents will be added to GOV.UK and the school or trust websites. These documents must be redacted to remove sensitive information.</p>
+
+          redact:
+            title: Redact all relevant documents
+            guidance_link: Help redacting the documents
+            guidance:
+              html:
+                <p>You need to create a redacted version of each applicable document after they've been signed by the Secretary of State:</p>
+                <ul>
+                  <li>supplemental funding agreement</li>
+                  <li>master funding agreement</li>
+                  <li>church supplemental agreement (if applicable)</li>
+                  <li>deed of variation</li>
+                </ul>
+                <p>You must remove or hide:</p>
+                <ul>
+                  <li>names</li>
+                  <li>signatures</li>
+                  <li>home addresses</li>
+                  <li>any other personal information</li>
+                </ul>
+
+          save_redaction:
+            title: Save relevant documents in the school's SharePoint folder
+
+          send_redaction:
+            title: Send the redacted documents to the funding team to be published on GOV.UK
+            guidance_link: Help sending documents
+            guidance:
+              html:
+                <p>Email the documents to <a href="mailto:fundingagreements.converters@education.gov.uk" target="_blank">fundingagreements.converters@education.gov.uk</a>.</p>
+
+          send_solicitors:
+            title: Send the redacted and unredacted versions of documents to the solicitors
+            hint:
+              html: <p>You can copy the school and trust into this email too. They will publish relevant documents on their websites.</p>

--- a/config/locales/task_lists/conversion/voluntary/one_hundred_and_twenty_five_year_lease.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/one_hundred_and_twenty_five_year_lease.en.yml
@@ -14,7 +14,7 @@ en:
             title: Email the solicitors to ask if all relevant parties have agreed and signed the 125 year lease
           receive:
             title: Receive email from the solicitors confirming all relevant parties have agreed and signed the 125 year lease
-          save:
+          save_lease:
             title: Save a copy of the confirmation email in the school's SharePoint folder
           not_applicable:
             title: Not applicable

--- a/config/locales/task_lists/conversion/voluntary/redact_and_send.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/redact_and_send.en.yml
@@ -28,10 +28,10 @@ en:
                   <li>any other personal information</li>
                 </ul>
 
-          save:
+          save_redaction:
             title: Save relevant documents in the school's SharePoint folder
 
-          send:
+          send_redaction:
             title: Send the redacted documents to the funding team to be published on GOV.UK
             guidance_link: Help sending documents
             guidance:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,6 +152,11 @@ Rails.application.routes.draw do
     end
   end
 
+  scope :new_tasks do
+    get ":project_id/tasks/:task_identifier", to: "tasks#edit", as: :edit_task
+    put ":project_id/tasks/:task_identifier", to: "tasks#update", as: :update_task
+  end
+
   get "cookies", to: "cookies#edit"
   post "cookies", to: "cookies#update"
 

--- a/db/migrate/20230420132458_do_not_use_save_as_an_attribute.rb
+++ b/db/migrate/20230420132458_do_not_use_save_as_an_attribute.rb
@@ -1,0 +1,8 @@
+class DoNotUseSaveAsAnAttribute < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :conversion_voluntary_task_lists, :redact_and_send_save, :redact_and_send_save_redaction
+    rename_column :conversion_voluntary_task_lists, :redact_and_send_send, :redact_and_send_send_redaction
+
+    rename_column :conversion_voluntary_task_lists, :one_hundred_and_twenty_five_year_lease_save, :one_hundred_and_twenty_five_year_lease_save_lease
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_04_144130) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_20_132458) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -203,15 +203,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_04_144130) do
     t.boolean "school_completed_saved"
     t.boolean "conditions_met_confirm_all_conditions_met"
     t.boolean "redact_and_send_redact"
-    t.boolean "redact_and_send_save"
-    t.boolean "redact_and_send_send"
+    t.boolean "redact_and_send_save_redaction"
+    t.boolean "redact_and_send_send_redaction"
     t.boolean "update_esfa_update"
     t.boolean "receive_grant_payment_certificate_check_and_save"
     t.boolean "receive_grant_payment_certificate_update_kim"
     t.boolean "receive_grant_payment_certificate_update_sheet"
     t.boolean "one_hundred_and_twenty_five_year_lease_email"
     t.boolean "one_hundred_and_twenty_five_year_lease_receive"
-    t.boolean "one_hundred_and_twenty_five_year_lease_save"
+    t.boolean "one_hundred_and_twenty_five_year_lease_save_lease"
     t.boolean "subleases_received"
     t.boolean "subleases_cleared"
     t.boolean "subleases_signed"

--- a/spec/forms/conversion/tasks/redact_and_send_task_form_spec.rb
+++ b/spec/forms/conversion/tasks/redact_and_send_task_form_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.describe Conversion::Task::RedactAndSendTaskForm do
+  describe ".identifier" do
+    it "returns the class name without 'TaskForm' as a string" do
+      expect(described_class.identifier).to eql "redact_and_send"
+    end
+  end
+
+  describe "#identifier" do
+    it "returns the class name without 'TaskForm' as a symbol" do
+      task_form = described_class.new(Conversion::Voluntary::TaskList.new)
+
+      expect(task_form.identifier).to eql :redact_and_send
+    end
+  end
+
+  describe "#save" do
+    context "when the form is valid" do
+      it "updates the task list data" do
+        task_data = Conversion::Voluntary::TaskList.new
+        task_form = described_class.new(task_data)
+        task_form.save_redaction = true
+
+        task_form.save
+
+        expect(task_data.redact_and_send_save_redaction).to eql true
+      end
+    end
+
+    context "when the form is invalid" do
+      it "raises error" do
+        task_data = Conversion::Voluntary::TaskList.new
+        task_form = described_class.new(task_data)
+        allow(task_data).to receive(:valid?).and_return(false)
+
+        expect { task_form.save }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+
+  describe "#status" do
+    context "when the task has no completed actions" do
+      it "returns :not_started" do
+        task_data = Conversion::Voluntary::TaskList.new
+        task_form = described_class.new(task_data)
+
+        expect(task_form.status).to eql :not_started
+      end
+    end
+
+    context "when the task has some completed actions" do
+      it "returns :in_progress" do
+        task_data = Conversion::Voluntary::TaskList.new
+        task_form = described_class.new(task_data)
+
+        task_form.redact = true
+
+        expect(task_form.status).to eql :in_progress
+      end
+    end
+
+    context "when the task has all completed actions" do
+      it "returns :completed" do
+        task_data = Conversion::Voluntary::TaskList.new
+        task_form = described_class.new(task_data)
+
+        task_form.redact = true
+        task_form.save_redaction = true
+        task_form.send_redaction = true
+        task_form.send_solicitors = true
+
+        expect(task_form.status).to eql :completed
+      end
+    end
+  end
+
+  describe "#locales_path" do
+    it "returns the task path without 'TaskForm' as a dot list" do
+      task_form = described_class.new(Conversion::Voluntary::TaskList.new)
+
+      expect(task_form.locales_path).to eql "conversion.task.redact_and_send"
+    end
+  end
+end

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe TasksController do
+  let!(:user) { create(:user) }
+
+  before do
+    sign_in_with(user)
+  end
+
+  describe "#edit" do
+    it "renders the correct edit view" do
+      mock_successful_api_response_to_create_any_project
+      project = create(:voluntary_conversion_project, assigned_to: user)
+
+      get edit_task_path(project, :redact_and_send)
+
+      expect(response).to render_template "conversions/tasks/redact_and_send/edit"
+    end
+  end
+
+  describe "#update" do
+    context "when the form is valid" do
+      it "updates the task attributes" do
+        mock_successful_api_response_to_create_any_project
+        project = create(:voluntary_conversion_project, assigned_to: user)
+        params = {
+          conversion_task_redact_and_send_task_form: {
+            redact: "1",
+            send_redaction: "1",
+            save_redaction: "1",
+            send_solicitors: "1"
+          }
+        }
+
+        put update_task_path(project, :redact_and_send), params: params
+
+        project.reload
+
+        expect(project.task_list.redact_and_send_redact).to eql true
+        expect(project.task_list.redact_and_send_send_redaction).to eql true
+        expect(project.task_list.redact_and_send_save_redaction).to eql true
+        expect(project.task_list.redact_and_send_send_solicitors).to eql true
+        expect(response.body).to include("Task saved successfully")
+      end
+    end
+
+    context "when the form is not valid" do
+      it "renders the edit view and does not save the task" do
+        mock_successful_api_response_to_create_any_project
+        project = create(:voluntary_conversion_project, assigned_to: user)
+        allow_any_instance_of(Conversion::Task::RedactAndSendTaskForm).to receive(:valid?).and_return(false)
+
+        put update_task_path(project, :redact_and_send)
+
+        expect(response).to render_template "conversions/tasks/redact_and_send/edit"
+        expect(response.body).to include("Task could not be saved")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Here is the first step in what we hope to be the last (?!) big refactoring of the task list.

The motivation for this is again to allow the tasks to handle more than simple checkboxes, the previous refactor went someone towards this but missed.

The main issue is that the TaskList is currently responsible for saving the tasks and does so through meta programming (it can save any task) - the result is that when we want to override the behaviour, we cannot.

This work, introduces a new `TaskForm` base class that can be used to create objects that save themselves, giving us the ability to override the behaviour as needed. Right now we have demonstated this by recreating the existing 'Redact and send' task with the new model.

You can load the new task at:

`/new_tasks/<project_id>/tasks/redact_and_send`

Interacting with this form and saving will result in the existing data being updated as well, this is beacuse the actual data is still persisted via the `conversions_voluntary_task_list` table and means when the time comes, we can simple switch the task lists and tasks to these new ones.

The main thing to look at here is the `BaseTaskForm` and the `TasksController` much of this is the same as the current implementation.

Some of this work will seem a bit odd, like redirect and flash messages - this is because it is intended to validate the task only - more behaviour will follow to round out the task list, but that will come in a later PR - this one focuses on the basics models.

I actually prefer this 'tasks as first class objects' approach because the tasks are where the complexity lies with the task list itself being a simple collection of tasks.

As a big refactor, please ask any questions either here or elsewhere.

We'll follow this work with:

- some other tasks that validate the new behaviour
- a new task list that is much simpler

Once we are happy with that, we will add all the other tasks and prepare to make the switch.

(https://trello.com/c/Xi1faJ3x)