### PR TITLE
(Bug) User can add duplicate projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Address subtle bug in Project creation, which meant two projects with the same
+  URN were created in error
+
 ## [Release 22][release-22]
 
 ### Added

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -114,6 +114,6 @@ class Conversion::CreateProjectForm
   end
 
   private def urn_unique_for_in_progress_conversions
-    errors.add(:urn, :duplicate) if Project.in_progress.where(urn: urn).any?
+    errors.add(:urn, :duplicate) if Project.not_completed.where(urn: urn).any?
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -42,6 +42,7 @@ class Project < ApplicationRecord
   scope :by_conversion_date, -> { order(conversion_date: :asc) }
 
   scope :completed, -> { where.not(completed_at: nil).order(completed_at: :desc) }
+  scope :not_completed, -> { where(completed_at: nil) }
   scope :in_progress, -> { where(completed_at: nil).assigned.by_conversion_date }
 
   scope :assigned, -> { where.not(assigned_to: nil) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -417,6 +417,21 @@ RSpec.describe Project, type: :model do
       end
     end
 
+    describe "not_completed scope" do
+      before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+      it "only returns projects where completed_at is nil" do
+        completed_project = create(:conversion_project, completed_at: Date.today - 1.year)
+        in_progress_project_1 = create(:conversion_project, completed_at: nil)
+        in_progress_project_2 = create(:conversion_project, completed_at: nil)
+
+        projects = Project.not_completed
+
+        expect(projects).to include(in_progress_project_1, in_progress_project_2)
+        expect(projects).to_not include(completed_project)
+      end
+    end
+
     describe "#assigned" do
       it "only includes projects assigned to a user" do
         mock_successful_api_response_to_create_any_project

--- a/spec/support/shared_examples/create_conversion_project_form.rb
+++ b/spec/support/shared_examples/create_conversion_project_form.rb
@@ -204,6 +204,17 @@ RSpec.shared_examples "a conversion project FormObject" do
         expect(form.errors.messages[:urn]).to include I18n.t("errors.attributes.urn.duplicate")
       end
     end
+
+    context "when there is another project with the same urn which is not completed" do
+      it "is invalid" do
+        _project_with_urn = create(:conversion_project, urn: 121813, assigned_to: nil)
+        form = build(form_factory.to_sym)
+
+        form.urn = 121813
+        expect(form).to be_invalid
+        expect(form.errors.messages[:urn]).to include I18n.t("errors.attributes.urn.duplicate")
+      end
+    end
   end
 
   describe "incoming_trust_ukprn" do


### PR DESCRIPTION
## Changes

A very subtle bug occurred with the CreateProject form, allowing two projects
with the same URN & UKPRN combination to be created.

This happened because the duplicate project had a nil `assigned_to` value, which
meant it did not appear in the `Project.in_progress` scope.

Adding a new `Project.not_completed` scope to use instead for this validation
has fixed the issue. A project which has no `assigned_to` value is not considered
`in_progress` because no-one will actively be working on it.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
