### PR TITLE
Refactor task list part two: funding agreement contact task

### DIFF
--- a/app/forms/conversion/task/funding_agreement_contact_task_form.rb
+++ b/app/forms/conversion/task/funding_agreement_contact_task_form.rb
@@ -1,0 +1,33 @@
+class Conversion::Task::FundingAgreementContactTaskForm < ::BaseTaskForm
+  attribute :name, :string
+  attribute :email, :string
+  attribute :title, :string
+
+  validates :name, :email, :title, presence: true
+  validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}
+
+  def initialize(tasks_data)
+    @tasks_data = tasks_data
+    @project = tasks_data.project
+    @contact = Contact.find_or_create_by(project: @project, funding_agreement_contact: true)
+
+    super(@tasks_data)
+
+    assign_attributes(
+      name: @contact.name,
+      title: @contact.title,
+      email: @contact.email
+    )
+  end
+
+  def save
+    @contact.assign_attributes(
+      project: @project,
+      name: name,
+      title: title,
+      email: email,
+      funding_agreement_contact: true
+    )
+    @contact.save!
+  end
+end

--- a/app/views/conversions/tasks/funding_agreement_contact/edit.html.erb
+++ b/app/views/conversions/tasks/funding_agreement_contact/edit.html.erb
@@ -1,0 +1,23 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversions_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: update_task_path(@project, @task.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_text_field :name, width: 20 %>
+      <%= form.govuk_text_field :title, width: 20 %>
+      <%= form.govuk_text_field :email, width: 20 %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversions/shared/task_notes" %>
+  </div>
+</div>

--- a/config/locales/conversion/tasks/funding_agreement_contact.en.yml
+++ b/config/locales/conversion/tasks/funding_agreement_contact.en.yml
@@ -1,0 +1,26 @@
+en:
+  conversion:
+    task:
+      funding_agreement_contact:
+        title: Confirm who will get the funding agreement letters
+        hint:
+          html:
+            <p>For voluntary conversions, this person will most likely be from
+            the school. They will most likely be from the trust if this is a
+            sponsored conversion. It is not necessarily the person you contact
+            most.<p>
+  helpers:
+    label:
+      conversion_task_funding_agreement_contact_task_form:
+        name: Name
+        title: Role
+        email: Email
+  errors:
+    attributes:
+      name:
+        blank: Enter a full name
+      title:
+        blank: Enter a role
+      email:
+        blank: Enter an email address
+        invalid: Enter a valid email address

--- a/db/migrate/20230426111303_add_funding_agreement_contact_to_contacts.rb
+++ b/db/migrate/20230426111303_add_funding_agreement_contact_to_contacts.rb
@@ -1,0 +1,5 @@
+class AddFundingAgreementContactToContacts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :contacts, :funding_agreement_contact, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_25_114922) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_26_111303) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_25_114922) do
     t.datetime "updated_at", null: false
     t.integer "category", default: 0, null: false
     t.string "organisation_name"
+    t.boolean "funding_agreement_contact", default: false
     t.index ["category"], name: "index_contacts_on_category"
     t.index ["project_id"], name: "index_contacts_on_project_id"
   end

--- a/spec/forms/conversion/tasks/funding_agreement_contact_task_form_spec.rb
+++ b/spec/forms/conversion/tasks/funding_agreement_contact_task_form_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe Conversion::Task::FundingAgreementContactTaskForm do
+  describe "validations" do
+    let(:form) { valid_form }
+
+    it "requires name" do
+      form.name = nil
+      expect(form).to be_invalid
+    end
+
+    it "requires title" do
+      form.title = nil
+      expect(form).to be_invalid
+    end
+
+    it "requires email" do
+      form.email = nil
+      expect(form).to be_invalid
+    end
+
+    it "validates the format of email" do
+      form.email = "not.a.valid.email.com"
+      expect(form).to be_invalid
+
+      form.email = "a.valid@email.com"
+      expect(form).to be_valid
+    end
+  end
+
+  describe "#save" do
+    before { mock_successful_api_response_to_create_any_project }
+
+    let(:project) { create(:conversion_project) }
+
+    it "sets funding_agreement_contact to true" do
+      form = described_class.new(project.task_list)
+      form.assign_attributes(valid_form.attributes)
+
+      expect { form.save }.to change { Contact.count }.by(1)
+
+      funding_agreement_contact = Contact.first
+
+      expect(funding_agreement_contact.funding_agreement_contact?).to be true
+    end
+  end
+
+  describe "the contact" do
+    before { mock_successful_api_response_to_create_any_project }
+    context "when there is no main contact for the project" do
+      it "creates a new empty Contact" do
+        project = create(:conversion_project)
+        form = described_class.new(project.task_list)
+
+        expect(form.name).to be_nil
+        expect(form.email).to be_nil
+      end
+    end
+
+    context "when there is main contact for the project" do
+      it "loads the existing Contact" do
+        project = create(:conversion_project)
+        main_contact = create(:contact, funding_agreement_contact: true, project: project)
+        form = described_class.new(project.task_list)
+
+        expect(form.name).to eql main_contact.name
+        expect(form.email).to eql main_contact.email
+      end
+    end
+  end
+
+  def valid_form
+    tasks_data = Conversion::Voluntary::TaskList.new
+    form = described_class.new(tasks_data)
+
+    form.assign_attributes(
+      name: "Jane Doe",
+      title: "School manager",
+      email: "jane.doe@school.sch.uk"
+    )
+
+    form
+  end
+end


### PR DESCRIPTION
This is our second scenario that motivates the refactor to the task list.

Here we prove that we can have a task with no attributes stored in the task list table. This task creates a `Contact` object instead - this would not have been a simple thing to do with the old models.

The thing about this one is that the designs are not finalised so I have had to guess at what this task might look like, again - this work is not shown to users so I am not concerned and we can come back and refine this task when designs are completed - what I do want to do is demonstarte how the refactor can handle a task like this one.

To support this we override the `initialize` and `save` methods on the `TaskForm` which lets us load the correct `Contact` and save it again.

We added a `funding_agreement_contact` attribute to `Contact` so we can identify the correct one, we considered a new association but felt like this was acceptatble - this way we can call `find_or_create_by` and keep things tidy and approachable (I think!) - if we ever end up with multiple matching contacts we will just fectch the first one.

![image](https://user-images.githubusercontent.com/480578/234564938-4a332fca-50b9-489a-94f1-bfa756c16961.png)