### PR TITLE
Adding guidance to project creation questions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Add new guidance to project creation page so users know to find information
+- Added new guidance to project creation page so users know to find information
   in the advisory board template
 
 ## [Release 22][release-22]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Raise a specific error page if our access to the Academies Api has been
   revoked
 
+### Changed
+
+- Add new guidance to project creation page so users know to find information
+  in the advisory board template
+
 ## [Release 22][release-22]
 
 ### Added

--- a/app/views/conversions/voluntary/projects/new.html.erb
+++ b/app/views/conversions/voluntary/projects/new.html.erb
@@ -12,7 +12,7 @@
 
       <%= form.govuk_text_field :urn, label: {size: "m", text: t("helpers.label.conversion_project.urn")}, hint: {text: t("helpers.hint.project.urn").html_safe}, width: 10 %>
       <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m", text: t("helpers.label.conversion_project.incoming_trust_ukprn")}, hint: {text: t("helpers.hint.project.incoming_trust_ukprn").html_safe}, width: 10 %>
-      <%= form.govuk_date_field :advisory_board_date, legend: {text: t("helpers.legend.project.advisory_board_date")}, form_group: {id: "advisory-board-date"} %>
+      <%= form.govuk_date_field :advisory_board_date, legend: {text: t("helpers.legend.project.advisory_board_date")}, form_group: {id: "advisory-board-date"}, hint: {text: t("helpers.hint.project.advisory_board_date").html_safe} %>
       <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m", text: t("helpers.label.conversion_project.advisory_board_conditions")} %>
       <%= form.govuk_date_field :provisional_conversion_date, legend: {text: t("helpers.legend.conversion_project.provisional_conversion_date")}, omit_day: true, form_group: {id: "provisional-conversion-date"}, hint: {text: t("helpers.hint.conversion_project.provisional_conversion_date")} %>
       <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m", text: t("helpers.label.conversion_project.establishment_sharepoint_link")} %>

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -15,8 +15,8 @@ en:
     voluntary:
       route: Voluntary
       new:
-        title: Add a new conversion project
-        hint_html: <p class="govuk-body">Enter the school and trust information.</p><p class="govuk-body">This will create a conversion project for a school that has been granted an Academy order.</p>
+        title: Add a conversion
+        hint_html: <p class="govuk-body">Enter information about the school, trust and the advisory board decision.</p><p class="govuk-body">This will create a new conversion project.</p>
       create:
         assigned_to_regional_delivery_officer:
           html:
@@ -44,8 +44,8 @@ en:
   helpers:
     label:
       conversion_project:
-        urn: School URN
-        incoming_trust_ukprn: Incoming trust UK Provider Reference Number (UKPRN)
+        urn: School URN (Unique Reference Number)
+        incoming_trust_ukprn: Incoming trust UKPRN (UK Provider Reference Number)
         caseworker_id: Caseworker
         regional_delivery_officer_id: Regional delivery officer
         advisory_board_conditions: Advisory board conditions
@@ -58,20 +58,18 @@ en:
     hint:
       conversion_project:
         urn: |
-          This is the URN of the existing school which is converting to an academy. A URN is a 6-digit number.
-          <br /><br />
-          <a href="https://www.get-information-schools.service.gov.uk/Search" class="govuk-link" rel="noreferrer noopener" target="_blank">Search Get Information About Schools (GIAS) to find the school's URN (opens in a new tab)</a>.
+          This is the URN of the existing school which is converting to an academy. A URN is a 6-digit number. You can find it in the advisory board template.
         incoming_trust_ukprn: |
           A UKPRN is an 8-digit number that always starts with a 1.
           <br /><br />
           <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in a new tab)</a>.
         caseworker_id: The caseworker responsible for this project
-        provisional_conversion_date: If you do not have a provisional date, enter a date that is at least six months after the advisory board. You can change this later.
+        provisional_conversion_date: You can find this in the advisory board template.
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
         assigned_to_regional_caseworker_team: Are you handing this project over to Regional Casework Services?
-        directive_academy_order: Has a Directive academy order been issued?
+        directive_academy_order: Has a directive academy order been issued?
   errors:
     attributes:
       conversion_date:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -249,7 +249,7 @@ en:
         urn: |
           This is the URN of the existing school which is converting to an academy. A URN is a 6-digit number.
           <br /><br />
-          <a href="https://www.get-information-schools.service.gov.uk/Search" class="govuk-link" rel="noreferrer noopener" target="_blank">Search Get Information About Schools (GIAS) to find the school's URN (opens in new tab)</a>.
+          You can find the school URN in the advisory board template.
         incoming_trust_ukprn: |
           A UKPRN is an 8-digit number that always starts with a 1.
           <br/ ><br />
@@ -258,6 +258,7 @@ en:
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
+        advisory_board_date: You can find this in the advisory board template.
   errors:
     attributes:
       urn:

--- a/spec/features/users_can_create_involuntary_conversion_projects_spec.rb
+++ b/spec/features/users_can_create_involuntary_conversion_projects_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Users can create new involuntary conversion projects" do
     scenario "a new project is created" do
       expect(page).to have_content(I18n.t("conversion_project.involuntary.new.title"))
       fill_in "School URN", with: urn
-      fill_in "Incoming trust UK Provider Reference Number (UKPRN)", with: ukprn
+      fill_in "Incoming trust UKPRN (UK Provider Reference Number)", with: ukprn
 
       within("#provisional-conversion-date") do
         completion_date = Date.today.at_beginning_of_month + 1.year

--- a/spec/features/users_can_create_voluntary_conversion_projects_spec.rb
+++ b/spec/features/users_can_create_voluntary_conversion_projects_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature "Users can create new voluntary conversion projects" do
 
   def fill_in_form
     fill_in "School URN", with: urn
-    fill_in "Incoming trust UK Provider Reference Number (UKPRN)", with: ukprn
+    fill_in "Incoming trust UKPRN (UK Provider Reference Number)", with: ukprn
 
     within("#provisional-conversion-date") do
       completion_date = Date.today + 1.year


### PR DESCRIPTION
## Changes

Adding guidance to add a conversion page so users know to find information in the advisory board template.

Also clarifying page title to make more succinct. 

And updated and corrected casing for directive academy order.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [X] Update the `CHANGELOG.md` if needed.
