### PR TITLE
Fix wrong notification banner when user not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Address subtle bug in Project creation, which meant two projects with the same
   URN were created in error
+- Notification banner when users email not recognised is no longer a success
+  banner.
 
 ### Added
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,7 +11,7 @@ class SessionsController < ApplicationController
 
       redirect_to root_path
     else
-      redirect_to sign_in_path, notice: I18n.t("unknown_user.message", email_address: authenticated_user_email_address)
+      redirect_to sign_in_path, alert: I18n.t("unknown_user.message", email_address: authenticated_user_email_address)
     end
   end
 

--- a/spec/features/users_can_sign_in_spec.rb
+++ b/spec/features/users_can_sign_in_spec.rb
@@ -37,6 +37,7 @@ RSpec.feature "Users can sign in to the application" do
       expect(page).to have_button(I18n.t("sign_in.button"))
       within(".flash") do
         expect(page).to have_content(I18n.t("sign_in.message.failure"))
+        expect(page).not_to have_css(".notice")
       end
     end
   end


### PR DESCRIPTION
A helpful user pointed out that when their email is not registered in
the applcation and they attempt to sign it, the notification banner
title is 'success' even though the action clearly fails.

Here we switch this notificaiton to the 'important' notification.