### PR TITLE
Update content in Share the grant certificate task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added new guidance to project creation page so users know to find information
   in the advisory board template
 - Removed the "Tell the Regional Delivery Officer the school has opened" task
+- Update content in Share the grant certificate and information about opening
+  task to make it appropriate for both conversion types
 
 ## [Release 22][release-22]
 

--- a/config/locales/task_lists/conversion/voluntary/share_information.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/share_information.en.yml
@@ -6,11 +6,11 @@ en:
           title: Share the grant certificate and information about opening
           hint:
             html:
-              <p>Once you have confirmed that all conditions have been met, contact the school and trust to tell them they can convert on the provisional conversion date.</p>
+              <p>Once you have confirmed that all conditions have been met, email your main contact at the school or trust to tell them the conversion will happen on the agreed date.</p>
 
           email:
             title: Email relevant information to your main contact
-            guidance_link: What to tell the school
+            guidance_link: What to tell the school or trust
             guidance:
               html:
                 <p>Email your main contact at the school or trust.</p>


### PR DESCRIPTION
## Changes

This PR makes the content in the Share the grant certificate and information about opening task appropriate for both voluntary and sponsored conversions.

<img width="927" alt="Screenshot 2023-04-26 at 11 29 47" src="https://user-images.githubusercontent.com/104517016/234548761-b217ee32-b313-42aa-b119-e7040c356f28.png">

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
