### PR TITLE
Refactor task list part four: a task list

### DIFF
--- a/app/controllers/conversions/tasks_controller.rb
+++ b/app/controllers/conversions/tasks_controller.rb
@@ -1,0 +1,6 @@
+class Conversions::TasksController < ApplicationController
+  def index
+    @project = Project.find(params[:project_id])
+    @task_list = Conversion::TaskList.new(@project, current_user)
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -11,13 +11,10 @@ class TasksController < ApplicationController
 
     if @task.valid?
       @task.save
-      flash.now[:notice] = "Task saved successfully"
+      redirect_to conversions_tasks_path(@project), notice: t("task_list.save.success")
     else
-      flash.now[:alert] = "Task could not be saved"
+      render task_view
     end
-
-    @project.reload
-    render task_view
   end
 
   private def find_project

--- a/app/models/base_task_list.rb
+++ b/app/models/base_task_list.rb
@@ -1,0 +1,60 @@
+class BaseTaskList
+  attr_reader :sections, :tasks
+
+  def initialize(project, user)
+    @project = project
+    @user = user
+    @tasks_data = project.task_list
+    @sections = initialize_sections
+    @tasks = all_tasks
+  end
+
+  def all_tasks
+    @sections.map { |section| section.tasks }.flatten
+  end
+
+  private def initialize_sections
+    self.class.layout.map do |section|
+      tasks = initialize_tasks(section[:tasks])
+      Section.new(section[:identifier], tasks, locales_path)
+    end
+  end
+
+  def initialize_tasks(klasses)
+    klasses.map do |task_klass|
+      task_klass.new(@tasks_data, @user)
+    end
+  end
+
+  private def locales_path
+    self.class.name.underscore.tr("/", ".")
+  end
+
+  class << self
+    def identifiers
+      task_klasses.map { |klass| klass_to_identifier(klass) }
+    end
+
+    def layout
+      raise NotImplementedError, "You must implement the layout class method on your task list"
+    end
+
+    private def klass_to_identifier(klass)
+      klass.name.split("::").last.underscore.delete_suffix("_task_form").to_sym
+    end
+
+    private def task_klasses
+      layout.map { |section| section[:tasks] }.flatten
+    end
+  end
+
+  class Section
+    attr_reader :identifier, :tasks, :locales_path
+
+    def initialize(identifier, tasks, locales_path_prefix)
+      @identifier = identifier
+      @tasks = tasks
+      @locales_path = "#{locales_path_prefix}.#{identifier}"
+    end
+  end
+end

--- a/app/models/conversion/task_list.rb
+++ b/app/models/conversion/task_list.rb
@@ -1,0 +1,12 @@
+class Conversion::TaskList < ::BaseTaskList
+  def self.layout
+    [
+      identifier: :project_kick_off,
+      tasks: [
+        Conversion::Task::StakeholderKickOffTaskForm,
+        Conversion::Task::FundingAgreementContactTaskForm,
+        Conversion::Task::RedactAndSendTaskForm
+      ]
+    ]
+  end
+end

--- a/app/views/conversions/tasks/index.html.erb
+++ b/app/views/conversions/tasks/index.html.erb
@@ -1,0 +1,35 @@
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: root_path} %>
+<% end %>
+
+<%= render partial: "projects/shared/project_summary" %>
+<%= render partial: "projects/shared/project_actions" %>
+<%= render partial: "projects/shared/project_sub_navigation" %>
+
+<h2 class="govuk-heading-l"><%= t("project.show.title") %></h2>
+
+<ol class="app-task-list">
+  <% @task_list.sections.each do |section| %>
+    <li>
+      <h3 class="app-task-list__section">
+        <%= t("#{section.locales_path}.title") %>
+      </h3>
+      <ul class="app-task-list__items">
+        <% section.tasks.each do |task| %>
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <%= govuk_link_to(
+                    t("#{task.locales_path}.title"),
+                    edit_task_path(@project, task.identifier),
+                    aria: {describedby: task_id(task)}
+                  ) %>
+            </span>
+            <%= task_status_tag(task, task_id(task)) %>
+          </li>
+        <% end %>
+      </ul>
+    </li>
+  <% end %>
+</ol>
+
+<%= render "projects/show/complete" if policy(@project).update? %>

--- a/config/locales/conversion/task_list.en.yml
+++ b/config/locales/conversion/task_list.en.yml
@@ -1,0 +1,5 @@
+en:
+  conversion:
+    task_list:
+      project_kick_off:
+        title: Project kick off

--- a/config/locales/task_list.en.yml
+++ b/config/locales/task_list.en.yml
@@ -2,3 +2,5 @@ en:
   task_list:
     continue_button:
       text: Save and return
+    save:
+      success: Task updated sucessfully

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,6 +153,7 @@ Rails.application.routes.draw do
   end
 
   scope :new_tasks do
+    get ":project_id/tasks", to: "conversions/tasks#index", as: :conversions_tasks
     get ":project_id/tasks/:task_identifier", to: "tasks#edit", as: :edit_task
     put ":project_id/tasks/:task_identifier", to: "tasks#update", as: :update_task
   end

--- a/spec/models/base_task_list_spec.rb
+++ b/spec/models/base_task_list_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe BaseTaskList do
+  describe ".layout" do
+    it "must be implemented by all sub-classes" do
+      mock_successful_api_response_to_create_any_project
+      project = create(:conversion_project)
+      user = create(:user)
+
+      expect { TestClass.new(project, user) }.to raise_error(NotImplementedError)
+    end
+  end
+end
+
+class TestClass < BaseTaskList
+end

--- a/spec/models/conversion/task_list_spec.rb
+++ b/spec/models/conversion/task_list_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe Conversion::TaskList do
+  let(:user) { create(:user) }
+
+  describe ".identifiers" do
+    it "returns all the identifiers for the tasks in the list" do
+      converison_task_list_identifiers = [
+        :stakeholder_kick_off,
+        :funding_agreement_contact,
+        :redact_and_send
+      ]
+
+      expect(described_class.identifiers).to eql converison_task_list_identifiers
+    end
+  end
+
+  describe ".layout" do
+    it "returns the layout hash for the task list" do
+      conversion_task_list_layout = [
+        identifier: :project_kick_off,
+        tasks: [
+          Conversion::Task::StakeholderKickOffTaskForm,
+          Conversion::Task::FundingAgreementContactTaskForm,
+          Conversion::Task::RedactAndSendTaskForm
+        ]
+      ]
+      expect(described_class.layout).to eql conversion_task_list_layout
+    end
+  end
+
+  describe "#sections" do
+    it "returns an array of the sections in the task list" do
+      mock_successful_api_response_to_create_any_project
+      project = create(:conversion_project)
+      task_list = described_class.new(project, user)
+
+      expect(task_list.sections.count).to eql 1
+    end
+  end
+
+  describe "#tasks" do
+    it "returns an array of all the tasks in the task list" do
+      mock_successful_api_response_to_create_any_project
+      project = create(:conversion_project)
+      task_list = described_class.new(project, user)
+
+      expect(task_list.tasks.count).to eql 3
+      expect(task_list.tasks.first).to be_a Conversion::Task::StakeholderKickOffTaskForm
+      expect(task_list.tasks.last).to be_a Conversion::Task::RedactAndSendTaskForm
+    end
+  end
+end

--- a/spec/requests/conversions/tasks_controller_spec.rb
+++ b/spec/requests/conversions/tasks_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Conversions::TasksController do
+  describe "#index" do
+    it "render the task list" do
+      user = create(:user)
+      sign_in_with(user)
+      mock_successful_api_response_to_create_any_project
+      project = create(:conversion_project)
+
+      get conversions_tasks_path(project)
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template("conversions/tasks/index")
+    end
+  end
+end

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe TasksController do
 
   describe "#update" do
     context "when the form is valid" do
-      it "updates the task attributes" do
+      it "updates the task attributes and redirects to the tasks index" do
         mock_successful_api_response_to_create_any_project
         project = create(:voluntary_conversion_project, assigned_to: user)
         params = {
@@ -40,7 +40,8 @@ RSpec.describe TasksController do
         expect(project.task_list.redact_and_send_send_redaction).to eql true
         expect(project.task_list.redact_and_send_save_redaction).to eql true
         expect(project.task_list.redact_and_send_send_solicitors).to eql true
-        expect(response.body).to include("Task saved successfully")
+
+        expect(response).to redirect_to(conversions_tasks_path(project))
       end
     end
 
@@ -53,7 +54,7 @@ RSpec.describe TasksController do
         put update_task_path(project, :redact_and_send)
 
         expect(response).to render_template "conversions/tasks/redact_and_send/edit"
-        expect(response.body).to include("Task could not be saved")
+        expect(project.task_list.redact_and_send_redact).to be_nil
       end
     end
   end


### PR DESCRIPTION
depends on #674 

Here is the next proof in the task list refactor - the task list itself, not much is too different here, it's a base class that handles all the clever bits and simple definitions of the new task models in the actual classes.

As we have an index view from this work, we update the tasks to redirect back to the task list upon update - this is the current behaviour.

![image](https://user-images.githubusercontent.com/480578/234800071-ea56f2b0-6dee-441a-84fa-2fef36cfc112.png)
