### PR TITLE
Make Legal Advisors Office, Legal Adviser's Office

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - update to hint text in external stakeholder kick-off task so content works for
   both sponsored and voluntary conversions
-- Corrected Legal Adviser's Office to Legal Advisors Office in trust
+- Corrected Legal Advisor's Office to Legal Adviser's Office in trust
   modification order task checkboxes
 - Added new guidance to project creation page so users know to find information
   in the advisory board template

--- a/config/locales/task_lists/conversion/voluntary/trust_modification_order.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/trust_modification_order.en.yml
@@ -29,9 +29,9 @@ en:
           received:
             title: Received
           sent_legal:
-            title: Sent to Legal Advisors Office
+            title: Sent to Legal Adviser's Office
           cleared:
-            title: Cleared by Legal Advisors Office
+            title: Cleared by Legal Adviser's Office
           saved:
             title: Saved in the school's SharePoint folder
           not_applicable:


### PR DESCRIPTION
## Changes

This corrects the use of Legal Advisors Office to Legal Adviser's Office in the trust modification order task.

<img width="684" alt="Screenshot 2023-04-27 at 09 27 10" src="https://user-images.githubusercontent.com/104517016/234804702-0844e2f6-d3bf-40bd-9cda-f0f76ae4859e.png">

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
