### PR TITLE
Handle cases where local authority information is missing

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -30,3 +30,4 @@
 /terraform
 /.idea/
 lib/generators/*/USAGE
+*.csv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   URN were created in error
 - Notification banner when users email not recognised is no longer a success
   banner.
+- Fixed a bug where the project information page would not load if a Local
+  Authority was not found
 
 ### Added
 

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -87,9 +87,11 @@
       row.key { t('project_information.show.local_authority_details.rows.local_authority') }
       row.value { @project.establishment.local_authority_name }
     end
-    summary_list.row do |row|
-      row.key { t('project_information.show.local_authority_details.rows.address') }
-      row.value { address_markup(@project.establishment.local_authority.address) }
+    if @project.establishment.local_authority
+      summary_list.row do |row|
+        row.key { t('project_information.show.local_authority_details.rows.address') }
+        row.value { address_markup(@project.establishment.local_authority.address) }
+      end
     end
   end %>
 </div>

--- a/spec/features/project_information/users_can_view_local_authority_details_spec.rb
+++ b/spec/features/project_information/users_can_view_local_authority_details_spec.rb
@@ -5,22 +5,49 @@ RSpec.feature "Users can view local authority details" do
   let(:project) { create(:conversion_project, :with_conditions, caseworker: user) }
   let(:local_authority) { create(:local_authority) }
 
-  before do
-    mock_successful_api_responses(urn: any_args, ukprn: any_args)
-    sign_in_with_user(user)
-    visit project_information_path(project)
-  end
+  context "when the local authority is found" do
+    before do
+      mock_successful_api_responses(urn: any_args, ukprn: any_args)
+      sign_in_with_user(user)
+      visit project_information_path(project)
+    end
 
-  scenario "they can view the name" do
-    within("#localAuthorityDetails") do
-      expect(page).to have_content(project.establishment.local_authority_name)
+    scenario "they can view the name" do
+      within("#localAuthorityDetails") do
+        expect(page).to have_content(project.establishment.local_authority_name)
+      end
+    end
+
+    scenario "they can view the address" do
+      within("#localAuthorityDetails") do
+        expect(page).to have_content(local_authority.address_1)
+        expect(page).to have_content(local_authority.address_postcode)
+      end
     end
   end
 
-  scenario "they can view the address" do
-    within("#localAuthorityDetails") do
-      expect(page).to have_content(local_authority.address_1)
-      expect(page).to have_content(local_authority.address_postcode)
+  context "when the local authority is not found" do
+    let(:local_authority) { nil }
+
+    before do
+      mock_successful_api_trust_response(ukprn: any_args)
+
+      establishment = build(:academies_api_establishment)
+      fake_result = Api::AcademiesApi::Client::Result.new(establishment, nil)
+      test_client = Api::AcademiesApi::Client.new
+
+      allow(establishment).to receive(:local_authority).and_return(nil)
+      allow(test_client).to receive(:get_establishment).with(any_args).and_return(fake_result)
+      allow(Api::AcademiesApi::Client).to receive(:new).and_return(test_client)
+
+      sign_in_with_user(user)
+      visit project_information_path(project)
+    end
+
+    scenario "they can view the name (from the establishment)" do
+      within("#localAuthorityDetails") do
+        expect(page).to have_content(project.establishment.local_authority_name)
+      end
     end
   end
 end


### PR DESCRIPTION
## Changes

If a local authority is not found, the project information page was not loading
correctly. Gracefully handle instances where the LA is not found. Show the
information we can, and do not attempt to render the LA address.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
