### PR TITLE
Update Receive grant payment certificate hint text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Removed the "Tell the Regional Delivery Officer the school has opened" task
 - Update content in Share the grant certificate and information about opening
   task to make it appropriate for both conversion types
+- Update hint text copy in Receive grant payment certificate to make it
+  applicable to both voluntary and sponsored conversions
 
 ## [Release 22][release-22]
 

--- a/config/locales/task_lists/conversion/involuntary/receive_grant_payment_certificate.en.yml
+++ b/config/locales/task_lists/conversion/involuntary/receive_grant_payment_certificate.en.yml
@@ -5,7 +5,7 @@ en:
         receive_grant_payment_certificate:
           title: Receive grant payment certificate
           hint:
-            html: <p>You should already have sent a copy of the <a href="https://www.gov.uk/government/publications/academy-support-grant" target="_blank">grant payment certificate (opens in new tab)</a> when confirming the opening date.</p>
+            html: <p>You should already have sent a copy of the <a href="https://www.gov.uk/government/publications/academy-support-grant" target="_blank">grant payment certificate (opens in new tab)</a> when confirming the academy's opening date.</p>
 
           check_and_save:
             title: Check and save the grant payment certificate in the school's SharePoint folder

--- a/config/locales/task_lists/conversion/voluntary/receive_grant_payment_certificate.en.yml
+++ b/config/locales/task_lists/conversion/voluntary/receive_grant_payment_certificate.en.yml
@@ -5,7 +5,7 @@ en:
         receive_grant_payment_certificate:
           title: Receive grant payment certificate
           hint:
-            html: <p>You should already have sent a copy of the <a href="https://www.gov.uk/government/publications/academy-support-grant" target="_blank">grant payment certificate (opens in new tab)</a> when confirming the school's opening date.</p>
+            html: <p>You should already have sent a copy of the <a href="https://www.gov.uk/government/publications/academy-support-grant" target="_blank">grant payment certificate (opens in new tab)</a> when confirming the academy's opening date.</p>
 
           check_and_save:
             title: Check and save the grant payment certificate in the school's SharePoint folder


### PR DESCRIPTION
Change Receive grant certificate task content hint text to make it applicable to both voluntary and sponsored conversions.
