### PR TITLE
Correctly enforce project ID constraints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,23 +72,25 @@ Rails.application.routes.draw do
     post "conversion-date", to: "/conversions/date_histories#create"
   end
 
-  namespace :conversions do
-    get "/", to: "/conversions/projects#index"
-    namespace :voluntary do
-      get "/", to: "/conversions/voluntary/projects#index"
-      get "projects/:id", to: "/conversions/voluntary/projects#show", constraints: {id: VALID_UUID_REGEX}, as: :project
+  constraints(id: VALID_UUID_REGEX) do
+    namespace :conversions do
+      get "/", to: "/conversions/projects#index"
+      namespace :voluntary do
+        get "/", to: "/conversions/voluntary/projects#index"
+        get "projects/:id", to: "/conversions/voluntary/projects#show", as: :project
 
-      resources :projects,
-        only: %i[new create],
-        concerns: %i[task_listable contactable notable assignable informationable completable internal_contactable conversion_date_historyable memberable]
-    end
-    namespace :involuntary do
-      get "/", to: "/conversions/involuntary/projects#index"
-      get "projects/:id", to: "/conversions/involuntary/projects#show", constraints: {id: VALID_UUID_REGEX}, as: :project
+        resources :projects,
+          only: %i[new create],
+          concerns: %i[task_listable contactable notable assignable informationable completable internal_contactable conversion_date_historyable memberable]
+      end
+      namespace :involuntary do
+        get "/", to: "/conversions/involuntary/projects#index"
+        get "projects/:id", to: "/conversions/involuntary/projects#show", as: :project
 
-      resources :projects,
-        only: %i[new create],
-        concerns: %i[task_listable contactable notable assignable informationable completable internal_contactable conversion_date_historyable]
+        resources :projects,
+          only: %i[new create],
+          concerns: %i[task_listable contactable notable assignable informationable completable internal_contactable conversion_date_historyable]
+      end
     end
   end
 


### PR DESCRIPTION

## Changes

Previously, visiting `/projects/:id` with an incorrect project ID was correctly rendering a 404, while visiting `/conversions/voluntary/projects/:id/task-list` was incorrectly rendering a 500 error.

This was because we were only applying the route constraint on the "outermost" `projects` resource group. And within the voluntary & involuntary namespaces we were only applying the constraint to the `#show` route. 

So visiting any of the concern routes with an incorrect project ID made the application pass the ID to the database and throw an `ActiveRecord::StatementInvalid` error (rendered as a 500).

Encapsulate all the namespaced routes with the routing constraint. This means the `#show` page *and* all the concernable pages will be subject to the route constraint.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
