### PR TITLE
Release 23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release 23][release-23]
+
 ### Fixed
 
 - Address subtle bug in Project creation, which meant two projects with the same
@@ -805,7 +807,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-22...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-23...HEAD
+[release-23]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-22...release-23
 [release-22]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-21...release-22
 [release-21]:


### PR DESCRIPTION
### Fixed

- Address subtle bug in Project creation, which meant two projects with the same
  URN were created in error
- Notification banner when users email not recognised is no longer a success
  banner.
- Fixed a bug where the project information page would not load if a Local
  Authority was not found

### Added

- Raise a specific error page if our access to the Academies Api has been
  revoked

### Changed

- update to hint text in external stakeholder kick-off task so content works for
  both sponsored and voluntary conversions
- Corrected Legal Advisor's Office to Legal Adviser's Office in trust
  modification order task checkboxes
- Added new guidance to project creation page so users know to find information
  in the advisory board template
- Updated content in Confirm the school has completed all actions task so that
  it applies to both types of conversion
- Removed the "Tell the Regional Delivery Officer the school has opened" task
- Update content in Share the grant certificate and information about opening
  task to make it appropriate for both conversion types

## Checklist

- [x] Check that this pull request has the correct version number.
- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` to move Unreleased changes into a new version.
- [x] Update the release links at the bottom of `CHANGELOG.md` to reflect the
      new version.