### PR TITLE
Refactor task list part five: optional tasks

### DIFF
--- a/app/forms/base_optional_task_form.rb
+++ b/app/forms/base_optional_task_form.rb
@@ -1,0 +1,15 @@
+class BaseOptionalTaskForm < BaseTaskForm
+  attribute :not_applicable, :boolean
+
+  private def not_applicable?
+    not_applicable
+  end
+
+  private def completed?
+    actions_when_applicable.values.all?(&:present?)
+  end
+
+  private def actions_when_applicable
+    attributes.except("not_applicable")
+  end
+end

--- a/app/forms/base_task_form.rb
+++ b/app/forms/base_task_form.rb
@@ -22,6 +22,7 @@ class BaseTaskForm
   end
 
   def status
+    return :not_applicable if not_applicable?
     return :completed if completed?
     return :in_progress if in_progress?
 
@@ -52,5 +53,9 @@ class BaseTaskForm
 
   private def completed?
     attributes.values.all?(&:present?)
+  end
+
+  private def not_applicable?
+    false
   end
 end

--- a/app/forms/conversion/task/articles_of_association_task_form.rb
+++ b/app/forms/conversion/task/articles_of_association_task_form.rb
@@ -1,0 +1,6 @@
+class Conversion::Task::ArticlesOfAssociationTaskForm < ::BaseOptionalTaskForm
+  attribute :received, :boolean
+  attribute :cleared, :boolean
+  attribute :signed, :boolean
+  attribute :saved, :boolean
+end

--- a/app/models/conversion/task_list.rb
+++ b/app/models/conversion/task_list.rb
@@ -1,12 +1,29 @@
 class Conversion::TaskList < ::BaseTaskList
   def self.layout
     [
-      identifier: :project_kick_off,
-      tasks: [
-        Conversion::Task::StakeholderKickOffTaskForm,
-        Conversion::Task::FundingAgreementContactTaskForm,
-        Conversion::Task::RedactAndSendTaskForm
-      ]
+      {
+        identifier: :project_kick_off,
+        tasks: [
+          Conversion::Task::StakeholderKickOffTaskForm,
+          Conversion::Task::FundingAgreementContactTaskForm
+        ]
+      },
+      {
+        identifier: :legal_documents,
+        tasks: [
+          Conversion::Task::ArticlesOfAssociationTaskForm
+        ]
+      },
+      {
+        identifier: :get_ready_for_opening,
+        tasks: []
+      },
+      {
+        identifier: :after_opening,
+        tasks: [
+          Conversion::Task::RedactAndSendTaskForm
+        ]
+      }
     ]
   end
 end

--- a/app/views/conversions/tasks/articles_of_association/edit.html.erb
+++ b/app/views/conversions/tasks/articles_of_association/edit.html.erb
@@ -1,0 +1,40 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: conversions_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
+      <div class="govuk-form-group">
+        <h2 class="govuk-heading-l"><%= t("conversion.voluntary.tasks.articles_of_association.clear_section.title") %></h2>
+        <div class="app-task-section__hint">
+          <%= t("conversion.voluntary.tasks.articles_of_association.clear_section.hint.html") %>
+        </div>
+
+        <%= govuk_details(
+              summary_text: t("conversion.voluntary.tasks.articles_of_association.clear_section.guidance_link"),
+              text: t("conversion.voluntary.tasks.articles_of_association.clear_section.guidance.html")
+            ) %>
+
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :received)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :cleared)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "conversions/shared/task_notes" %>
+  </div>
+</div>

--- a/config/locales/conversion/task_list.en.yml
+++ b/config/locales/conversion/task_list.en.yml
@@ -3,3 +3,9 @@ en:
     task_list:
       project_kick_off:
         title: Project kick off
+      legal_documents:
+        title: Clear and sign legal documents
+      get_ready_for_opening:
+        title: Get ready for opening
+      after_opening:
+        title: After opening

--- a/config/locales/conversion/tasks/articles_of_association.en.yml
+++ b/config/locales/conversion/tasks/articles_of_association.en.yml
@@ -1,0 +1,27 @@
+en:
+  conversion:
+    task:
+      articles_of_association:
+        title: Articles of association
+        hint:
+          html: <p>The articles of association must be updated if the trust currently uses a version from February 2016 or earlier.</p>
+        clear_section:
+          title: Check and clear the articles of association
+          hint:
+            html: <p>You can use the <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Academy-Governance-(includes-clearing-Articles-of-Association).aspx" target="_blank">academy governance guidance (opens in new tab)</a> to help you check and clear the articles of association.</p>
+          guidance_link: Help checking for changes
+          guidance:
+            html:
+              <p>Changes that personalise the model documents to a school or trust, and remove or add optional clauses, are expected. The wording of clauses should not change.</p>
+              <p>You'll need to <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Commissioning%20Form.aspx" target="_blank">contact the policy team (opens in new tab)</a> about changes to clause text.</p>
+
+        received:
+          title: Received
+        cleared:
+          title: Cleared
+        signed:
+          title: Signed by school or trust
+        saved:
+          title: Saved in the school's SharePoint folder
+        not_applicable:
+          title: Not applicable

--- a/spec/forms/conversion/tasks/articles_of_association_task_form_spec.rb
+++ b/spec/forms/conversion/tasks/articles_of_association_task_form_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+RSpec.describe Conversion::Task::ArticlesOfAssociationTaskForm do
+  let(:user) { create(:user) }
+
+  describe ".identifier" do
+    it "returns the class name without 'TaskForm' as a string" do
+      expect(described_class.identifier).to eql "articles_of_association"
+    end
+  end
+
+  describe "#identifier" do
+    it "returns the class name without 'TaskForm' as a symbol" do
+      task_form = described_class.new(Conversion::Voluntary::TaskList.new, user)
+
+      expect(task_form.identifier).to eql :articles_of_association
+    end
+  end
+
+  describe "#save" do
+    context "when the form is valid" do
+      it "updates the task list data" do
+        mock_successful_api_response_to_create_any_project
+        project = create(:conversion_project)
+        task_data = project.task_list
+        task_data.user = user
+        task_form = described_class.new(task_data, user)
+        task_form.received = true
+
+        task_form.save
+
+        expect(task_data.articles_of_association_received).to eql true
+      end
+    end
+
+    context "when the form is invalid" do
+      it "raises error" do
+        mock_successful_api_response_to_create_any_project
+        project = create(:conversion_project)
+        task_data = project.task_list
+        task_data.user = user
+        task_form = described_class.new(task_data, user)
+        allow(task_data).to receive(:valid?).and_return(false)
+
+        expect { task_form.save }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+
+  describe "#status" do
+    context "when the task has no completed actions" do
+      it "returns :not_started" do
+        task_data = Conversion::Voluntary::TaskList.new
+        task_form = described_class.new(task_data, user)
+
+        expect(task_form.status).to eql :not_started
+      end
+    end
+
+    context "when the task has some completed actions" do
+      it "returns :in_progress" do
+        task_data = Conversion::Voluntary::TaskList.new
+        task_form = described_class.new(task_data, user)
+
+        task_form.received = true
+
+        expect(task_form.status).to eql :in_progress
+      end
+    end
+
+    context "when the task is not applicable" do
+      it "returns :not_applicable" do
+        task_data = Conversion::Voluntary::TaskList.new
+        task_form = described_class.new(task_data, user)
+
+        task_form.not_applicable = true
+
+        expect(task_form.status).to eql :not_applicable
+      end
+    end
+
+    context "when the task has all completed actions" do
+      it "returns :completed" do
+        task_data = Conversion::Voluntary::TaskList.new
+        task_form = described_class.new(task_data, user)
+
+        task_form.received = true
+        task_form.saved = true
+        task_form.cleared = true
+        task_form.signed = true
+
+        expect(task_form.status).to eql :completed
+      end
+    end
+  end
+
+  describe "#locales_path" do
+    it "returns the task path without 'TaskForm' as a dot list" do
+      task_form = described_class.new(Conversion::Voluntary::TaskList.new, user)
+
+      expect(task_form.locales_path).to eql "conversion.task.articles_of_association"
+    end
+  end
+end

--- a/spec/models/conversion/task_list_spec.rb
+++ b/spec/models/conversion/task_list_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Conversion::TaskList do
       converison_task_list_identifiers = [
         :stakeholder_kick_off,
         :funding_agreement_contact,
+        :articles_of_association,
         :redact_and_send
       ]
 
@@ -17,14 +18,32 @@ RSpec.describe Conversion::TaskList do
 
   describe ".layout" do
     it "returns the layout hash for the task list" do
-      conversion_task_list_layout = [
-        identifier: :project_kick_off,
-        tasks: [
-          Conversion::Task::StakeholderKickOffTaskForm,
-          Conversion::Task::FundingAgreementContactTaskForm,
-          Conversion::Task::RedactAndSendTaskForm
+      conversion_task_list_layout =
+        [
+          {
+            identifier: :project_kick_off,
+            tasks: [
+              Conversion::Task::StakeholderKickOffTaskForm,
+              Conversion::Task::FundingAgreementContactTaskForm
+            ]
+          },
+          {
+            identifier: :legal_documents,
+            tasks: [
+              Conversion::Task::ArticlesOfAssociationTaskForm
+            ]
+          },
+          {
+            identifier: :get_ready_for_opening,
+            tasks: []
+          },
+          {
+            identifier: :after_opening,
+            tasks: [
+              Conversion::Task::RedactAndSendTaskForm
+            ]
+          }
         ]
-      ]
       expect(described_class.layout).to eql conversion_task_list_layout
     end
   end
@@ -35,7 +54,7 @@ RSpec.describe Conversion::TaskList do
       project = create(:conversion_project)
       task_list = described_class.new(project, user)
 
-      expect(task_list.sections.count).to eql 1
+      expect(task_list.sections.count).to eql 4
     end
   end
 
@@ -45,7 +64,7 @@ RSpec.describe Conversion::TaskList do
       project = create(:conversion_project)
       task_list = described_class.new(project, user)
 
-      expect(task_list.tasks.count).to eql 3
+      expect(task_list.tasks.count).to eql 4
       expect(task_list.tasks.first).to be_a Conversion::Task::StakeholderKickOffTaskForm
       expect(task_list.tasks.last).to be_a Conversion::Task::RedactAndSendTaskForm
     end


### PR DESCRIPTION
Depends on #675 

Next on the new task list menu: Optional tasks, at this point there is nothing interesting here, this is a repeat of the existing approach against the new classes.

We have a `BaseOptionalTaskForm` that provides the additional behaviour, any subclass can inherit from this to become optional with little to no effort.

We start to flesh out the Converison task list here, adding more sections and moving the tasks into the right places.