### PR TITLE
Try to capture exceptions in Applcation Insights

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,6 +104,9 @@ Rails.application.configure do
 
   # Use Application Insights if a key is available
   if (key = ENV.fetch("APPLICATION_INSIGHTS_KEY", nil))
+    # send task intrumentation
     config.middleware.use ApplicationInsights::Rack::TrackRequest, key, 500, 60
+    # send unhandled exceptions
+    ApplicationInsights::UnhandledException.collect(key)
   end
 end


### PR DESCRIPTION
We have been asked to use MS Application Insights if possible.

We are already sending Rack telemetry, here we are seeing what exception
handling might look like.

We are using the archived gem to achieve this right now, it may support
all that we need we do not really know.

According to the docs, this is all that is required:

https://github.com/microsoft/ApplicationInsights-Ruby#collecting-unhandled-exceptions

I've tested this locally and it sent the exception I raised manually so
this appears to be a good first step.

The plan is to deploy this and see if any exceptions are raised in our
existing service (Sentry) and from here, also in Application Insights.

![Screenshot 2023-04-28 at 15-26-18 Microsoft Azure](https://user-images.githubusercontent.com/480578/235175720-ed293df0-b430-45d0-9a1c-13c7fcbabf5e.png)