### PR TITLE
Stop ignoring bundler config and configure it

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_BUILD__TINY_TDS: "--with-freetds-include=/opt/homebrew/include --with-freetds-lib=/opt/homebrew/lib"

--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,6 @@ tmp/
 
 # Dependencies
 /Brewfile.lock.json
-/.bundle/
 /node_modules/
 /vendor/bundle/
 


### PR DESCRIPTION
We have seen multiple instances of developers struggling to build tiny
tds because of the free-tds dependancy.

It takes us a while but we usually figure out that it is and define this
environment variable.

I cannot think of a reason to not have some local bundler config so
here we remove it from gitignore and commit the thing we keep
forgetting.

There is a small chance developers not using Brew will have to deal with
this - but those users are far less likely than those that will benefit
from this change.