### PR TITLE
Change how we ask about directive academy order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+### Changed
+
+- when creating a new conversion project, users are asked 'what kind of academy
+  order has been issued?' with directive academy order (DAO) or academy order
+  (AO) being the responses
+
+### Fixed
+
 ## [Release 23][release-23]
 
 ### Fixed

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -4,7 +4,7 @@ class Conversion::CreateProjectForm
   include ActiveRecord::AttributeAssignment
 
   SHAREPOINT_URLS = %w[educationgovuk-my.sharepoint.com educationgovuk.sharepoint.com].freeze
-  DIRECTIVE_ACADEMY_ORDER_RESPONSES = [OpenStruct.new(id: true, name: I18n.t("yes")), OpenStruct.new(id: false, name: I18n.t("no"))]
+  DIRECTIVE_ACADEMY_ORDER_RESPONSES = [OpenStruct.new(id: true, name: I18n.t("helpers.responses.conversion_project.directive_academy_order.yes")), OpenStruct.new(id: false, name: I18n.t("helpers.responses.conversion_project.directive_academy_order.no"))]
 
   class NegativeValueError < StandardError; end
 

--- a/app/views/conversions/voluntary/projects/new.html.erb
+++ b/app/views/conversions/voluntary/projects/new.html.erb
@@ -21,7 +21,13 @@
             label: {text: t("project.new.handover_comments_label"), size: "m"},
             hint: {text: t("project.new.handover_comments_hint").html_safe} %>
       <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, @project.assigned_to_regional_caseworker_team_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>
-      <%= form.govuk_collection_radio_buttons :directive_academy_order, @project.directive_academy_order_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.directive_academy_order")}, form_group: {id: "directive-academy-order"} %>
+      <%= form.govuk_collection_radio_buttons :directive_academy_order,
+            @project.directive_academy_order_responses,
+            :id,
+            :name,
+            legend: {text: t("helpers.legend.conversion_project.directive_academy_order")},
+            hint: {text: t("helpers.hint.conversion_project.directive_academy_order")},
+            form_group: {id: "directive-academy-order"} %>
 
       <%= form.govuk_submit %>
     <% end %>

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -55,6 +55,7 @@ en:
       conversion_project:
         provisional_conversion_date: Provisional conversion date
         advisory_board_date: Date of advisory board
+        directive_academy_order: What kind of academy order has been used?
     hint:
       conversion_project:
         urn: |
@@ -69,7 +70,12 @@ en:
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
         assigned_to_regional_caseworker_team: Are you handing this project over to Regional Casework Services?
-        directive_academy_order: Has a directive academy order been issued?
+        directive_academy_order: A DAO (directive academy order) is always issued for sponsored conversions. Voluntary conversions are granted an AO (academy order).
+    responses:
+      conversion_project:
+        directive_academy_order:
+          "yes": Directive academy order
+          "no": Academy order
   errors:
     attributes:
       conversion_date:

--- a/spec/features/users_can_create_involuntary_conversion_projects_spec.rb
+++ b/spec/features/users_can_create_involuntary_conversion_projects_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature "Users can create new involuntary conversion projects" do
       fill_in "Handover comments", with: "A new handover comment"
 
       within("#directive-academy-order") do
-        choose "Yes"
+        choose "Directive academy order"
       end
 
       click_button("Continue")

--- a/spec/features/users_can_create_voluntary_conversion_projects_spec.rb
+++ b/spec/features/users_can_create_voluntary_conversion_projects_spec.rb
@@ -101,7 +101,7 @@ RSpec.feature "Users can create new voluntary conversion projects" do
       choose("No")
     end
     within("#directive-academy-order") do
-      choose "No"
+      choose "Academy order"
     end
   end
 end


### PR DESCRIPTION
We saw a number of instances of users getting the answer to the question
wrong, so we are rephrasing it.

We've also added hint text to align the response to the outcome, which
is a sponsored or voluntary project.

![image](https://user-images.githubusercontent.com/480578/235959811-50a68407-2179-491f-8071-d4b8c73f26a1.png)
