### PR TITLE
List of projects added by a user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- a new view that shows regional delivery officers the projects they have
+  created
+
 ### Changed
 
 - when creating a new conversion project, users are asked 'what kind of academy

--- a/app/controllers/user/projects_controller.rb
+++ b/app/controllers/user/projects_controller.rb
@@ -10,6 +10,14 @@ class User::ProjectsController < ApplicationController
     pre_fetch_incoming_trusts(@projects)
   end
 
+  def added_by
+    authorize Project, :index?
+    @pager, @projects = pagy(Project.added_by(current_user).not_completed.by_conversion_date.includes(:assigned_to))
+
+    pre_fetch_establishments(@projects)
+    pre_fetch_incoming_trusts(@projects)
+  end
+
   def completed
     authorize Project, :index?
     @pager, @projects = pagy(Project.assigned_to(current_user).completed)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -56,6 +56,7 @@ class Project < ApplicationRecord
   scope :opening_by_month_year, ->(month, year) { includes(:task_list).where(conversion_date_provisional: false).and(where("YEAR(conversion_date) = ?", year)).and(where("MONTH(conversion_date) = ?", month)) }
 
   scope :assigned_to, ->(user) { where(assigned_to_id: user.id) }
+  scope :added_by, ->(user) { where(regional_delivery_officer: user) }
 
   scope :by_region, ->(region) { where(region: region) }
 

--- a/app/views/conversions/voluntary/projects/created.html.erb
+++ b/app/views/conversions/voluntary/projects/created.html.erb
@@ -9,6 +9,6 @@
           school_name: @project.establishment.name,
           urn: @project.urn,
           contacts_link: path_to_project_contacts(@project)) %>
-    <%= govuk_button_link_to t("conversion_project.voluntary.create.assigned_to_regional_caseworker_team.button"), in_progress_user_projects_path %>
+    <%= govuk_button_link_to t("conversion_project.voluntary.create.assigned_to_regional_caseworker_team.button"), added_by_user_projects_path %>
   </div>
 </div>

--- a/app/views/internal_contacts/show.html.erb
+++ b/app/views/internal_contacts/show.html.erb
@@ -12,7 +12,7 @@
   <h2 class="govuk-heading-l"><%= t("contact.index.internal_contacts") %></h2>
   <%= govuk_summary_list do |summary_list|
         summary_list.row do |row|
-          row.key { t("project_information.show.project_details.rows.assigned_to") }
+          row.key { t("contact.internal_contacts.assigned_to") }
           row.value { display_name(@project.assigned_to) }
           if @project.assigned_to.present?
             row.action(text: "Email", href: mail_to_path(@project.assigned_to.email), visually_hidden_text: "assigned to")
@@ -22,7 +22,7 @@
           end
         end
         summary_list.row do |row|
-          row.key { t("project_information.show.project_details.rows.regional_delivery_officer") }
+          row.key { t("contact.internal_contacts.added_by") }
           row.value { display_name(@project.regional_delivery_officer) }
           if @project.regional_delivery_officer.present?
             row.action(text: "Email", href: mail_to_path(@project.regional_delivery_officer.email), visually_hidden_text: "regional delivery officer")

--- a/app/views/projects/shared/_project_index_sub_navigation.html.erb
+++ b/app/views/projects/shared/_project_index_sub_navigation.html.erb
@@ -7,6 +7,12 @@
                      path: in_progress_user_projects_path}
         end %>
 
+    <%= if @current_user.regional_delivery_officer?
+          render partial: "shared/sub_navigation_item",
+            locals: {name: t("subnavigation.added_by_projects"),
+                     path: added_by_user_projects_path}
+        end %>
+
     <%= unless @current_user.team_leader?
           render partial: "shared/sub_navigation_item",
             locals: {name: t("subnavigation.completed_projects"),

--- a/app/views/user/projects/added_by.html.erb
+++ b/app/views/user/projects/added_by.html.erb
@@ -1,0 +1,17 @@
+<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
+
+<div class="govuk-grid-row">
+ <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">
+      <%= t("project.user.added_by.title") %>
+    </h1>
+
+    <%= render partial: "projects/shared/new_projects" if policy(:project).new? %>
+
+    <%= render partial: "projects/shared/project_index_sub_navigation" %>
+
+    <%= render partial: "/projects/shared/in_progress_table", locals: {projects: @projects, pager: @pager} %>
+
+  </div>
+</div>

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -31,6 +31,9 @@ en:
       guidance: This will remove the contact for %{contact_title} called %{contact_name} from the contacts list.
     categories:
       choose: Choose category
+    internal_contacts:
+      assigned_to: Assigned to
+      added_by: Added by
   helpers:
     label:
       contact:

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -24,7 +24,7 @@ en:
             <p class="govuk-body">You should add any contact details you have for the school, trust, solicitors, local authority and diocese (if applicable).</p>
         assigned_to_regional_caseworker_team:
           title: Project created
-          button: Return to project list
+          button: View projects you have added
           html:
             <p class="govuk-body">You have created a project for %{school_name}, URN %{urn}.</p>
             <h2 class="govuk-heading-l">What happens next</h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,7 @@ en:
     external_contacts: External contacts
     internal_contacts: Internal contacts
     member_of_parliament: Member of Parliament
+    added_by_projects: Added by you
   pages:
     academies_api_client_timeout:
       title: Sorry, there was a problem

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -55,6 +55,8 @@ en:
         title: Assigned projects in progress
       completed:
         title: Assigned completed projects
+      added_by:
+        title: Added projects in progress
     new:
       handover_comments_label: Handover comments
       handover_comments_hint:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,6 +131,7 @@ Rails.application.routes.draw do
         namespace :user do
           get "in-progress", to: "projects#in_progress"
           get "completed", to: "projects#completed"
+          get "added-by", to: "projects#added_by"
         end
         get "unassigned"
 

--- a/spec/features/projects/added_by/user_can_view_the_projects_they_have_added_spec.rb
+++ b/spec/features/projects/added_by/user_can_view_the_projects_they_have_added_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.feature "Viewing all projects a user has added" do
+  context "when there are no projects" do
+    before do
+      user = create(:user, :regional_delivery_officer)
+      sign_in_with_user(user)
+    end
+
+    scenario "they can see a helpful message" do
+      visit added_by_user_projects_path
+
+      expect(page).to have_content(I18n.t("project.table.in_progress.empty"))
+    end
+  end
+
+  context "when there are projects added by the user" do
+    let(:user) { create(:user, :regional_delivery_officer) }
+
+    before do
+      sign_in_with_user(user)
+      mock_successful_api_response_to_create_any_project
+      mock_pre_fetched_api_responses_for_any_establishment_and_trust
+    end
+
+    let!(:completed_project) { create(:conversion_project, urn: 121583, completed_at: Date.yesterday, regional_delivery_officer: user) }
+    let!(:in_progress_project) { create(:conversion_project, urn: 115652, regional_delivery_officer: user) }
+    let!(:sponsored_in_progress_project) { create(:conversion_project, urn: 112209, directive_academy_order: true, regional_delivery_officer: user) }
+    let!(:voluntary_in_progress_project) { create(:conversion_project, urn: 103835, directive_academy_order: false, regional_delivery_officer: user) }
+    let!(:other_project) { create(:conversion_project) }
+
+    scenario "they can view all in progress projects that they added" do
+      view_all_added_projects
+    end
+
+    def view_all_added_projects
+      visit added_by_user_projects_path
+
+      expect(page).to have_content(I18n.t("project.user.added_by.title"))
+
+      within("tbody") do
+        expect(page).to have_content(in_progress_project.urn)
+        expect(page).to have_content(sponsored_in_progress_project.urn)
+        expect(page).to have_content(voluntary_in_progress_project.urn)
+
+        expect(page).not_to have_content(completed_project.urn)
+        expect(page).not_to have_content(other_project.urn)
+      end
+    end
+  end
+end

--- a/spec/features/team_leaders_can_assign_users_to_project_roles_spec.rb
+++ b/spec/features/team_leaders_can_assign_users_to_project_roles_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Team leaders can assign users to project roles" do
   scenario "Team leader assigns a user to the regional delivery officer role" do
     visit conversions_voluntary_project_internal_contacts_path(project_id)
 
-    regional_delivery_officer_summary_list_row = -> { page.find("dt", text: "Regional delivery officer").ancestor(".govuk-summary-list__row") }
+    regional_delivery_officer_summary_list_row = -> { page.find("dt", text: I18n.t("contact.internal_contacts.added_by")).ancestor(".govuk-summary-list__row") }
 
     within regional_delivery_officer_summary_list_row.call do
       expect(page).to have_content "Not yet assigned"

--- a/spec/features/users_can_create_voluntary_conversion_projects_spec.rb
+++ b/spec/features/users_can_create_voluntary_conversion_projects_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature "Users can create new voluntary conversion projects" do
 
         expect(page).to have_content("You have created a project for #{project.establishment.name}, URN #{project.urn}.")
         expect(page).to have_content("Another person will be assigned to this project.")
-        expect(page).to have_link("Return to project list", href: in_progress_user_projects_path)
+        expect(page).to have_link("View projects you have added", href: added_by_user_projects_path)
       end
 
       it "does not assign the user to the project" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -679,6 +679,18 @@ RSpec.describe Project, type: :model do
         expect(Project.by_region("london")).to_not include(west_mids_project)
       end
     end
+
+    describe "added_by scope" do
+      it "returns only the projects that were added by the given user" do
+        mock_successful_api_response_to_create_any_project
+        user = create(:user)
+        added_project = create(:conversion_project, regional_delivery_officer: user)
+        other_project = create(:conversion_project)
+
+        expect(Project.added_by(user)).to include(added_project)
+        expect(Project.added_by(user)).to_not include(other_project)
+      end
+    end
   end
 
   describe "region" do


### PR DESCRIPTION
When a regional delivery officer creates a new project and hands it over
to regional casework services, it dissappears from their view. This
means it is difficult for them to find it again and add notes or
contacts.

We already know the projects a user has 'created' so we can help by
showing a list of these projects.

![image](https://user-images.githubusercontent.com/480578/236248660-267dd745-28cf-4f51-88c3-3da3845572aa.png)