### PR TITLE
Users can provide the new Academy URN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - a new view that shows regional delivery officers the projects they have
   created
+- User can provide the new academy urn once it has be created in Get information
+  about schools
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   created
 - User can provide the new academy urn once it has be created in Get information
   about schools
+- Added a new list of all projects with Academy URNs
 
 ### Changed
 

--- a/app/controllers/all/projects_controller.rb
+++ b/app/controllers/all/projects_controller.rb
@@ -10,6 +10,14 @@ class All::ProjectsController < ApplicationController
     pre_fetch_incoming_trusts(@projects)
   end
 
+  def with_academy_urn
+    authorize Project, :index?
+    @pager, @projects = pagy(Project.with_academy_urn.by_conversion_date)
+
+    pre_fetch_establishments(@projects)
+    pre_fetch_incoming_trusts(@projects)
+  end
+
   private def pre_fetch_establishments(projects)
     EstablishmentsFetcher.new.call(projects)
   end

--- a/app/controllers/conversions/academy_urn_controller.rb
+++ b/app/controllers/conversions/academy_urn_controller.rb
@@ -1,0 +1,58 @@
+class Conversions::AcademyUrnController < ApplicationController
+  rescue_from Api::AcademiesApi::Client::NotFoundError, with: :not_found_error
+
+  def edit
+    @project = Project.find(params[:project_id])
+    authorize @project
+  end
+
+  def check
+    @project = Project.find(params[:project_id])
+    authorize @project
+
+    if academy_urn.blank?
+      @project.errors.add(:academy_urn, :blank)
+      return render :edit
+    end
+
+    @project.assign_attributes(academy_urn: academy_urn)
+    unless @project.valid?
+      @project.errors.add(:academy_urn, :invalid_urn)
+      return render :edit
+    end
+
+    result = fetch_academy_details(academy_urn)
+    @academy_urn = academy_urn
+    @establishment = result
+
+    render "confirm"
+  end
+
+  def update_academy_urn
+    @project = Project.find(params[:project_id])
+    authorize @project
+
+    @project.update(academy_urn: academy_urn)
+    redirect_to new_all_projects_path, notice: t("project.academy_urn.confirm.success", academy_urn: academy_urn, urn: @project.urn, school_name: @project.establishment.name)
+  end
+
+  def not_found_error
+    @academy_urn = academy_urn
+    render "not_found"
+  end
+
+  private def project_params
+    params.require(:conversion_project).permit(:academy_urn)
+  end
+
+  private def fetch_academy_details(academy_urn)
+    client = Api::AcademiesApi::Client.new
+    result = client.get_establishment(academy_urn.to_i)
+    raise result.error if result.error
+    result.object
+  end
+
+  private def academy_urn
+    project_params[:academy_urn]
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -36,6 +36,7 @@ class Project < ApplicationRecord
   scope :voluntary, -> { where(directive_academy_order: false) }
 
   scope :no_academy_urn, -> { where(academy_urn: nil) }
+  scope :with_academy_urn, -> { where.not(academy_urn: nil) }
   scope :provisional, -> { where(conversion_date_provisional: true) }
   scope :confirmed, -> { where(conversion_date_provisional: false) }
 

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -18,6 +18,24 @@ class ProjectPolicy
     user.regional_delivery_officer?
   end
 
+  def edit?
+    return false if @record.completed?
+
+    true
+  end
+
+  def check?
+    return false if @record.completed?
+
+    true
+  end
+
+  def update_academy_urn?
+    return false if @record.completed?
+
+    true
+  end
+
   def new?
     create?
   end

--- a/app/views/all/projects/with_academy_urn.html.erb
+++ b/app/views/all/projects/with_academy_urn.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
-      <%= t("project.all.new.title") %>
+      <%= t("project.all.with_academy_urn.title") %>
     </h1>
 
     <nav class="moj-sub-navigation" aria-label="Project list sub-navigation">
@@ -13,6 +13,6 @@
       </ul>
     </nav>
 
-    <%= render partial: "/projects/shared/new_table", locals: {projects: @projects, pager: @pager} %>
+    <%= render partial: "/projects/shared/with_academy_urn_table", locals: {projects: @projects, pager: @pager} %>
   </div>
 </div>

--- a/app/views/conversions/academy_urn/confirm.html.erb
+++ b/app/views/conversions/academy_urn/confirm.html.erb
@@ -1,0 +1,39 @@
+<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      <%= t("project.academy_urn.confirm.title") %>
+    </h1>
+
+    <%= t("project.academy_urn.confirm.body_html", urn: @academy_urn) %>
+
+    <%= govuk_summary_list do |summary_list|
+          summary_list.row do |row|
+            row.key { t("project.academy_urn.confirm.academy_name") }
+            row.value { @establishment.name }
+          end
+          summary_list.row do |row|
+            row.key { t("project.academy_urn.confirm.academy_address") }
+            row.value { address_markup(@establishment.address) }
+          end
+          summary_list.row do |row|
+            row.key { t("project.academy_urn.confirm.local_authority") }
+            row.value { @establishment.local_authority_name }
+          end
+          summary_list.row do |row|
+            row.key { t("project.academy_urn.confirm.school_phase") }
+            row.value { @establishment.phase }
+          end
+        end %>
+
+    <%= form_for @project, url: conversions_voluntary_project_academy_urn_path, method: :patch do |form| %>
+      <%= form.hidden_field :academy_urn, value: @academy_urn %>
+      <%= form.govuk_submit t("project.academy_urn.confirm.save_and_return") do %>
+        <%= govuk_link_to t("cancel"), new_all_projects_path %>
+      <% end %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/conversions/academy_urn/edit.html.erb
+++ b/app/views/conversions/academy_urn/edit.html.erb
@@ -1,0 +1,24 @@
+<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      <%= t("project.academy_urn.title", school_name: @project.establishment.name) %>
+    </h1>
+
+    <%= t("project.academy_urn.body_html") %>
+
+    <%= form_for @project, url: conversions_voluntary_project_academy_urn_path, method: :post do |form| %>
+        <%= form.govuk_error_summary %>
+
+        <div class="govuk-form-group">
+          <%= form.govuk_text_field :academy_urn, width: 20, label: {size: "m", text: t("project.academy_urn.edit.label")}, hint: {text: t("project.academy_urn.edit.hint")} %>
+        </div>
+
+        <%= form.govuk_submit t("task_list.continue_button.text") do %>
+          <%= govuk_link_to t("cancel"), new_all_projects_path %>
+        <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/conversions/academy_urn/not_found.html.erb
+++ b/app/views/conversions/academy_urn/not_found.html.erb
@@ -1,0 +1,17 @@
+<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      <%= t("project.academy_urn.not_found.title", academy_urn: @academy_urn) %>
+    </h1>
+
+    <%= t("project.academy_urn.not_found.body_html") %>
+
+    <div class="govuk-button-group">
+      <%= govuk_button_link_to t("project.academy_urn.not_found.enter_urn_again"), conversions_voluntary_project_academy_urn_path(@project) %>
+      <%= govuk_link_to t("cancel"), new_all_projects_path %>
+    </div>
+  </div>
+</div>

--- a/app/views/projects/shared/_new_table.html.erb
+++ b/app/views/projects/shared/_new_table.html.erb
@@ -10,6 +10,7 @@
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_phase") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.route") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.academy_urn") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
       </tr>
     </thead>
@@ -22,6 +23,11 @@
         <td class="govuk-table__cell"><%= project.establishment.phase %></td>
         <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
         <td class="govuk-table__cell"><%= t("project.table.body.#{project.route}") %></td>
+        <td class="govuk-table__cell">
+          <a href="<%= conversions_voluntary_project_academy_urn_path(project) %>">
+            <%= t("project.table.body.edit_html", school_name: project.establishment.name) %>
+          </a>
+        </td>
         <td class="govuk-table__cell">
           <a href="<%= path_to_project(project) %>">
             <%= t("project.table.body.view_html", school_name: project.establishment.name) %>

--- a/app/views/projects/shared/_with_academy_urn_table.html.erb
+++ b/app/views/projects/shared/_with_academy_urn_table.html.erb
@@ -1,0 +1,38 @@
+<% if projects.empty? %>
+  <%= govuk_inset_text(text: t("project.table.with_academy_urn.empty")) %>
+<% else %>
+  <table class="govuk-table" name="projects_table" aria-label="Projects table">
+    <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_type") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_phase") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.route") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.academy_urn") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
+    </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% projects.each do |project| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+        <td class="govuk-table__cell"><%= project.urn %></td>
+        <td class="govuk-table__cell"><%= project.establishment.type %></td>
+        <td class="govuk-table__cell"><%= project.establishment.phase %></td>
+        <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
+        <td class="govuk-table__cell"><%= t("project.table.body.#{project.route}") %></td>
+        <td class="govuk-table__cell"><%= project.academy_urn %></td>
+        <td class="govuk-table__cell">
+          <a href="<%= path_to_project(project) %>">
+            <%= t("project.table.body.view_html", school_name: project.establishment.name) %>
+          </a>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<%= govuk_pagination(pagy: pager) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
   support_email_subject: "Complete conversions, transfers and changes: support query"
   "yes": "Yes"
   "no": "No"
+  cancel: Cancel
   phase_banner:
     phase: Beta
     phase_notice:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -120,6 +120,9 @@ en:
         added_by: Added by
         conversion_date: Conversion date
         revised_conversion_date: Revised conversion date
+        route: Route
+        school_phase: School phase
+        school_type: School type
       body:
         view_html: View <span class="govuk-visually-hidden">%{school_name}</span> project
         assign_html: Assign <span class="govuk-visually-hidden">%{school_name}</span> project

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -75,8 +75,32 @@ en:
               </ul>
           </div>
         </details>
-    edit:
-      title: Edit a project
+    academy_urn:
+      title: Create academy URN for %{school_name} conversion
+      body_html:
+        <p>This is the URN for the academy that the school is converting to.</p>
+        <p>To add the academy URN you must have already created a new establishment in GIAS.</p>
+        <p>It can take up to 24 hours for changes to the academy URN to appear on the project information page.</p>
+      edit:
+        label: Enter academy URN
+        hint: A URN is a 6 digit number.
+      not_found:
+        title: No information found for URN %{academy_urn}
+        body_html:
+          <p>GIAS (Get Information about Schools) may not be up-to-date. It can take up to 24 hours for changes to appear in GIAS.</p>
+          <p>Try again in 24 hours if the URN you entered is correct.</p>
+          <p>Check the URN you entered is correct. Enter it again if it was incorrect.</p>
+        enter_urn_again: Enter URN again
+      confirm:
+        title: Are these details correct?
+        body_html:
+          <p>GIAS (Get Information about Schools) has the following information for URN %{urn}:</p>
+        academy_name: Academy name
+        academy_address: Academy address
+        local_authority: Local authority
+        school_phase: School phase
+        save_and_return: Yes, save and return
+        success: Academy URN %{academy_urn} added to %{school_name}, %{urn}
     update:
       success: Project has been updated successfully
     complete:
@@ -123,8 +147,10 @@ en:
         route: Route
         school_phase: School phase
         school_type: School type
+        academy_urn: Academy URN
       body:
         view_html: View <span class="govuk-visually-hidden">%{school_name}</span> project
+        edit_html: Create academy URN <span class="govuk-visually-hidden">for %{school_name}</span>
         assign_html: Assign <span class="govuk-visually-hidden">%{school_name}</span> project
       in_progress:
         empty: There are no projects in progress.
@@ -295,3 +321,6 @@ en:
         host_not_allowed: Enter a trust sharepoint link in the correct format. SharePoint links start with 'https://educationgovuk.sharepoint.com' or 'https://educationgovuk-my.sharepoint.com/'
       directive_academy_order:
         inclusion: Select yes if this project has had a directive academy order issued
+      academy_urn:
+        blank: Please enter an Academy URN
+        invalid_urn: Please enter a valid URN. The URN must be 6 digits long. For example, 123456.

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -33,6 +33,8 @@ en:
           title: All voluntary completed projects
       new:
         title: All conversions without an academy URN
+      with_academy_urn:
+        title: All conversions with an academy URN
     regional_casework_services:
       in_progress:
         title: Regional Casework Services projects in progress
@@ -160,6 +162,8 @@ en:
         empty: There are no unassigned projects.
       new:
         empty: There are no conversions without an academy URN
+      with_academy_urn:
+        empty: There are no conversions with an academy URN
     openers:
       title: Academies opening in %{date}
       subtitle: Schools that are expected to become academies.
@@ -195,6 +199,9 @@ en:
       north_east: North East
       south_west: South West
       east_midlands: East Midlands
+    subnavigation:
+      new: URNs to create
+      with_academy_urn: URNs added
   project_information:
     show:
       side_navigation:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,12 @@ Rails.application.routes.draw do
     post "conversion-date", to: "/conversions/date_histories#create"
   end
 
+  concern :academy_urn_updateable do
+    get "academy-urn", to: "/conversions/academy_urn#edit"
+    post "academy-urn", to: "/conversions/academy_urn#check"
+    patch "academy-urn", to: "/conversions/academy_urn#update_academy_urn"
+  end
+
   constraints(id: VALID_UUID_REGEX) do
     namespace :conversions do
       get "/", to: "/conversions/projects#index"
@@ -81,7 +87,7 @@ Rails.application.routes.draw do
 
         resources :projects,
           only: %i[new create],
-          concerns: %i[task_listable contactable notable assignable informationable completable internal_contactable conversion_date_historyable memberable]
+          concerns: %i[task_listable contactable notable assignable informationable completable internal_contactable conversion_date_historyable memberable academy_urn_updateable]
       end
       namespace :involuntary do
         get "/", to: "/conversions/involuntary/projects#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,7 @@ Rails.application.routes.draw do
           end
 
           get "new", to: "projects#new", as: :new
+          get "with_academy_urn", to: "projects#with_academy_urn", as: :with_academy_urn
         end
         namespace :regional_casework_services, path: "regional-casework-services" do
           get "in-progress", to: "projects#in_progress"

--- a/spec/features/conversions/users_can_edit_the_academy_urn_spec.rb
+++ b/spec/features/conversions/users_can_edit_the_academy_urn_spec.rb
@@ -1,0 +1,121 @@
+require "rails_helper"
+
+RSpec.feature "Users can edit the Academy URN" do
+  let(:user) { create(:user, :caseworker) }
+
+  before do
+    mock_pre_fetched_api_responses_for_any_establishment_and_trust
+    sign_in_with_user(user)
+  end
+
+  context "when the user does not enter a URN in the Academy URN field" do
+    before do
+      mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    end
+
+    scenario "the user sees an error message" do
+      _project = create(:conversion_project, assigned_to: user, academy_urn: nil)
+      visit new_all_projects_path
+
+      click_on "Create academy URN"
+      click_on "Save and return"
+
+      expect(page).to have_content("Please enter an Academy URN")
+    end
+  end
+
+  context "when the Academy URN is invalid" do
+    before do
+      mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    end
+
+    scenario "the user sees an error message" do
+      _project = create(:conversion_project, assigned_to: user, academy_urn: nil)
+      visit new_all_projects_path
+
+      click_on "Create academy URN"
+      fill_in "conversion_project[academy_urn]", with: "FFFFFF"
+      click_on "Save and return"
+
+      expect(page).to have_content("Please enter a valid URN. The URN must be 6 digits long. For example, 123456.")
+    end
+  end
+
+  context "when the Academy URN is found" do
+    before do
+      mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    end
+
+    context "when the Academy URN is correct" do
+      scenario "the user can save the Academy URN on the project" do
+        project = create(:conversion_project, assigned_to: user, academy_urn: nil, urn: 111111)
+        visit new_all_projects_path
+
+        click_on "Create academy URN"
+        fill_in "conversion_project[academy_urn]", with: 123456
+
+        click_on "Save and return"
+        expect(page).to have_content("Are these details correct?")
+        click_on "Yes, save and return"
+        expect(page).to have_content("Academy URN 123456 added to #{project.establishment.name}, 111111")
+      end
+    end
+
+    context "when the Academy URN is incorrect" do
+      scenario "the user can go back to the list by clicking Cancel" do
+        project = create(:conversion_project, assigned_to: user, academy_urn: nil)
+        visit new_all_projects_path
+
+        click_on "Create academy URN"
+        fill_in "conversion_project[academy_urn]", with: 123456
+
+        click_on "Save and return"
+        expect(page).to have_content("Are these details correct?")
+        click_on "Cancel"
+        expect(page).to have_content("All conversions without an academy URN")
+        expect(page).to have_content(project.establishment.name)
+      end
+    end
+  end
+
+  context "when the Academy URN is not found" do
+    before do
+      mock_successful_api_trust_response(ukprn: any_args)
+      mock_successful_api_establishment_response(urn: 111111)
+      mock_establishment_not_found(urn: 123456)
+    end
+
+    scenario "the user sees a helpful message and can go back and search again" do
+      project = create(:conversion_project, assigned_to: user, academy_urn: nil, urn: 111111)
+      visit new_all_projects_path
+
+      click_on "Create academy URN"
+      fill_in "conversion_project[academy_urn]", with: 123456
+
+      click_on "Save and return"
+      expect(page).to have_content("No information found for URN 123456")
+
+      click_on "Enter URN again"
+      expect(page).to have_content("Create academy URN for #{project.establishment.name} conversion")
+    end
+  end
+
+  context "when the Academies API returns an error" do
+    before do
+      mock_successful_api_trust_response(ukprn: any_args)
+      mock_successful_api_establishment_response(urn: 111111)
+      mock_timeout_api_establishment_response(urn: 123456)
+    end
+
+    scenario "the user sees a helpful message" do
+      _project = create(:conversion_project, assigned_to: user, academy_urn: nil, urn: 111111)
+      visit new_all_projects_path
+
+      click_on "Create academy URN"
+      fill_in "conversion_project[academy_urn]", with: 123456
+
+      click_on "Save and return"
+      expect(page).to have_content("The service timed out when getting the details of the school or trust.")
+    end
+  end
+end

--- a/spec/features/projects/new/users_can_view_a_list_of_new_projects_spec.rb
+++ b/spec/features/projects/new/users_can_view_a_list_of_new_projects_spec.rb
@@ -57,8 +57,8 @@ RSpec.feature "Viewing all new projects" do
       within("thead") do
         expect(page).to have_content("School")
         expect(page).to have_content("URN")
-        expect(page).to have_content("Type")
-        expect(page).to have_content("Phase")
+        expect(page).to have_content("School type")
+        expect(page).to have_content("School phase")
         expect(page).to have_content("Conversion date")
         expect(page).to have_content("Route")
         expect(page).to have_content("View project")

--- a/spec/features/projects/with_academy_urn/users_can_view_a_list_of_projects_with_academy_urn_spec.rb
+++ b/spec/features/projects/with_academy_urn/users_can_view_a_list_of_projects_with_academy_urn_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.feature "Viewing all projects with an academy URN" do
+  context "when there are no projects" do
+    before do
+      user = create(:user, :caseworker)
+      sign_in_with_user(user)
+    end
+
+    scenario "they can see a helpful message" do
+      visit with_academy_urn_all_projects_path
+
+      expect(page).to have_content(I18n.t("project.table.with_academy_urn.empty"))
+    end
+  end
+
+  context "when there are projects in progress" do
+    before do
+      sign_in_with_user(user)
+      mock_successful_api_response_to_create_any_project
+      mock_pre_fetched_api_responses_for_any_establishment_and_trust
+    end
+
+    let!(:project_without_academy_urn) { create(:conversion_project, urn: 121583, academy_urn: nil) }
+    let!(:project_with_academy_urn) { create(:conversion_project, urn: 115652, academy_urn: 115654) }
+
+    context "when signed in as a Regional caseworker" do
+      let(:user) { create(:user, :caseworker) }
+
+      scenario "they can view all in progress projects" do
+        view_all_projects_with_academy_urn
+        table_has_the_correct_headers
+      end
+    end
+
+    context "when signed in as a Regional caseworker team lead" do
+      let(:user) { create(:user, :team_leader) }
+
+      scenario "they can view all in progress projects" do
+        view_all_projects_with_academy_urn
+        table_has_the_correct_headers
+      end
+    end
+
+    context "when signed in as a Regional delivery officer" do
+      let(:user) { create(:user, :regional_delivery_officer) }
+
+      scenario "they can view all in progress projects" do
+        view_all_projects_with_academy_urn
+        table_has_the_correct_headers
+      end
+    end
+
+    def table_has_the_correct_headers
+      visit new_all_projects_path
+
+      within("thead") do
+        expect(page).to have_content("School")
+        expect(page).to have_content("URN")
+        expect(page).to have_content("School type")
+        expect(page).to have_content("School phase")
+        expect(page).to have_content("Conversion date")
+        expect(page).to have_content("Route")
+        expect(page).to have_content("Academy URN")
+        expect(page).to have_content("View project")
+      end
+    end
+
+    def view_all_projects_with_academy_urn
+      visit with_academy_urn_all_projects_path
+
+      expect(page).to have_content(I18n.t("project.all.with_academy_urn.title"))
+
+      within("tbody") do
+        expect(page).to have_content(project_with_academy_urn.urn)
+
+        expect(page).not_to have_content(project_without_academy_urn.urn)
+      end
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -669,6 +669,18 @@ RSpec.describe Project, type: :model do
       end
     end
 
+    describe "#with_academy_urn" do
+      it "returns only projects where academy_urn is NOT nil" do
+        mock_successful_api_response_to_create_any_project
+        new_project = create(:conversion_project, academy_urn: nil)
+        existing_project = create(:conversion_project, academy_urn: 126041)
+        projects = Project.with_academy_urn
+
+        expect(projects).to include(existing_project)
+        expect(projects).not_to include(new_project)
+      end
+    end
+
     describe "by_region scope" do
       it "returns only projects for the given region" do
         mock_successful_api_response_to_create_any_project

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -25,6 +25,25 @@ RSpec.describe ProjectPolicy do
     end
   end
 
+  permissions :edit?, :check?, :update_academy_urn? do
+    it "grants access if project is assigned to the same user" do
+      expect(subject).to permit(application_user, build(:conversion_project, assigned_to: application_user, conversion_date_provisional: false))
+    end
+
+    it "grants access if the project is assigned to another user" do
+      expect(subject).to permit(application_user, build(:conversion_project, assigned_to: build(:user), conversion_date_provisional: false))
+    end
+
+    it "grants access if project is assigned to nil" do
+      expect(subject).to permit(application_user, build(:conversion_project, assigned_to: nil, conversion_date_provisional: false))
+    end
+
+    it "denies access if the project is completed" do
+      project = build(:conversion_project, assigned_to: application_user, conversion_date_provisional: false, completed_at: Date.yesterday)
+      expect(subject).not_to permit(application_user, project)
+    end
+  end
+
   permissions :change_conversion_date? do
     context "when the conversion date is not provisional" do
       it "grants access if project is assigned to the same user" do

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -81,7 +81,7 @@ module AcademiesApiHelpers
     test_client = Api::AcademiesApi::Client.new
 
     allow(test_client).to receive(:get_trust).with(ukprn).and_raise(Api::AcademiesApi::Client::UnauthorisedError)
-    allow(test_client).to receive(:get_establishment).with(ukprn).and_raise(Api::AcademiesApi::Client::UnauthorisedError)
+    allow(test_client).to receive(:get_establishment).with(urn).and_raise(Api::AcademiesApi::Client::UnauthorisedError)
     allow(Api::AcademiesApi::Client).to receive(:new).and_return(test_client)
   end
 end


### PR DESCRIPTION
## Changes

### Users can edit the Academy URN

Users can now edit a project to add an Academy URN. 

From the "All conversions without an academy URN" page (`/projects/all/new`) they can click on a link to add the Academy URN. This brings them to a form where they can enter the Academy URN.

<img width="1033" alt="Screenshot 2023-05-04 at 14 42 06" src="https://user-images.githubusercontent.com/1089521/236226492-740582b8-d326-4833-aac0-b5c9a5211f5a.png">

If they do not enter anything, they see an error message:

<img width="1142" alt="Screenshot 2023-05-04 at 14 43 35" src="https://user-images.githubusercontent.com/1089521/236226474-1001af4d-7875-4559-ad47-35ad9f9cb4fb.png">

If the Academy URN does not exist in GIAS, they see an error message:

<img width="1056" alt="Screenshot 2023-05-04 at 14 43 49" src="https://user-images.githubusercontent.com/1089521/236226471-0404f77c-53ba-47a3-a018-1a3e3678bf83.png">

If the Academy URN is found in GIAS, they see a confirmation message:

<img width="1106" alt="Screenshot 2023-05-04 at 14 43 15" src="https://user-images.githubusercontent.com/1089521/236226480-2f0a6860-948d-4eef-9311-a99695817ee9.png">

Upon confirmation, they are returned to the list page, with a success message:

<img width="1218" alt="Screenshot 2023-05-04 at 14 44 08" src="https://user-images.githubusercontent.com/1089521/236226464-16ccb203-f97f-431f-a52e-229e359bd7bd.png">

### New listing page

The "All conversions without an academy URN" now has a sister page featuring all projects with an academy URN. The two pages are linked by tabs.

<img width="1138" alt="Screenshot 2023-05-04 at 14 41 46" src="https://user-images.githubusercontent.com/1089521/236226460-9303a187-2bf7-4f03-bcc3-2598b2ca6421.png">

<img width="1124" alt="Screenshot 2023-05-04 at 14 41 55" src="https://user-images.githubusercontent.com/1089521/236226495-5450e286-95ef-42ec-99b3-9a153328c973.png">

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
