### PR TITLE
Fix: handle missing companies house number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- when a trust has no companies house number in the database, the project
+  information view can still render
+
 ## [Release 23][release-23]
 
 ### Fixed

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -75,7 +75,11 @@
     end
     summary_list.row do |row|
       row.key { t('project_information.show.trust_details.rows.companies_house_number') }
-      row.value { (@project.incoming_trust.companies_house_number + "<br/>" + link_to_companies_house(@project.incoming_trust.companies_house_number)).html_safe }
+      row.value {
+        (@project.incoming_trust.companies_house_number +
+         "<br/>" +
+         link_to_companies_house(@project.incoming_trust.companies_house_number)).html_safe if @project.incoming_trust.companies_house_number.present?
+      }
     end
   end %>
 </div>

--- a/spec/requests/project_information_controller_spec.rb
+++ b/spec/requests/project_information_controller_spec.rb
@@ -27,4 +27,14 @@ RSpec.describe ProjectInformationController, type: :request do
       expect(perform_request).to have_http_status :success
     end
   end
+
+  context "when the trust has no companies house number" do
+    it "renders nothing" do
+      trust = build(:academies_api_trust, companies_house_number: nil)
+      project = create(:conversion_project)
+      allow_any_instance_of(Project).to receive(:incoming_trust).and_return(trust)
+
+      expect { get project_information_path(project) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
We came across a trust record in the academies database without a
companies house number, this caused our view to explode.

Although the Get information about schools record for the trust has the
number, we should still handle this case and render nothing.

https://trello.com/c/mAAlHQ4r
