### PR TITLE
Update error messages for provisional conversion date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - when creating a new conversion project, users are asked 'what kind of academy
   order has been issued?' with directive academy order (DAO) or academy order
   (AO) being the responses
+- Correct the error messages for Provisional conversion date on the Create
+  conversion project form
 
 ### Fixed
 

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -79,6 +79,9 @@ en:
   errors:
     attributes:
       conversion_date:
-        blank: Enter a provisional conversion date
+        blank: Enter a month and year for the provisional conversion date, like 9 2023
         must_be_first_of_the_month: Provisional conversion date must be on the first day of the month
-        must_be_in_the_future: Provisional conversion date must be in the future.
+        must_be_in_the_future: Provisional conversion date must be in the future
+      provisional_conversion_date:
+        blank: Enter a month and year for the provisional conversion date, like 9 2023
+        must_be_in_the_future: Provisional conversion date must be in the future


### PR DESCRIPTION

## Changes

https://trello.com/c/G8f6a9Dt

The error messages shown on the Create conversion project form were not correct. We were missing an error message for the provisional conversion date `must_be_in_the_future` error, and we have updated the `blank` error message to be more helpful.


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
