### PR TITLE
Edit handover comments guidance and remove details component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- edit handover comments guidance and remove details component
 - when creating a new conversion project, users are asked 'what kind of academy
   order has been issued?' with directive academy order (DAO) or academy order
   (AO) being the responses

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -62,21 +62,13 @@ en:
     new:
       handover_comments_label: Handover comments
       handover_comments_hint:
-        <p class="govuk-body">Provide a brief overview of how the project has progressed so far, including any issues or concerns.</p>
-        <details class="govuk-details" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              What to make comments about
-            </span>
-          </summary>
-          <div class="govuk-details__text">
-            <p class="govuk-body">Useful things to comment on include whether the:</p>
+        <p class="govuk-body">You should give a brief overview of how the project has progressed so far, including any issues or concerns.</p>
+        <p class="govuk-body">Include information about whether the:</p>
               <ul class="govuk-list govuk-list--bullet">
-                <li>provisional conversion date has been agreed by the school, trust and local authority</li>
+                <li>provisional conversion date has been discussed with the local authority</li>
                 <li>local authority proforma has been received or requested</li>
+                <li>introduction and next steps email has been sent to external stakeholders</li>
               </ul>
-          </div>
-        </details>
     academy_urn:
       title: Create academy URN for %{school_name} conversion
       body_html:


### PR DESCRIPTION
## Changes

This work takes the guidance about what to include in handover comments out of the details component and into the standard text. Hopefully this helps delivery officers understand what to include and write better comments for caseworkers.

<img width="701" alt="Screenshot 2023-05-10 at 5 12 04 pm" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/bb09f93c-2d8a-4c6f-8b96-ebe3feccad1e">

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [X] Update the `CHANGELOG.md` if needed.
