### PR TITLE
Update academy urn view scopes

### DIFF
--- a/app/controllers/all/projects_controller.rb
+++ b/app/controllers/all/projects_controller.rb
@@ -4,7 +4,7 @@ class All::ProjectsController < ApplicationController
 
   def new
     authorize Project, :index?
-    @pager, @projects = pagy(Project.no_academy_urn.by_conversion_date)
+    @pager, @projects = pagy(Project.not_completed.no_academy_urn.by_conversion_date)
 
     pre_fetch_establishments(@projects)
     pre_fetch_incoming_trusts(@projects)
@@ -12,7 +12,7 @@ class All::ProjectsController < ApplicationController
 
   def with_academy_urn
     authorize Project, :index?
-    @pager, @projects = pagy(Project.with_academy_urn.by_conversion_date)
+    @pager, @projects = pagy(Project.not_completed.with_academy_urn.by_conversion_date)
 
     pre_fetch_establishments(@projects)
     pre_fetch_incoming_trusts(@projects)

--- a/spec/requests/all/projects_controller_spec.rb
+++ b/spec/requests/all/projects_controller_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe All::ProjectsController, type: :request do
+  before do
+    sign_in_with(user)
+    mock_all_academies_api_responses
+  end
+
+  let!(:completed_project) { create(:conversion_project, completed_at: Date.today, urn: 165432) }
+  let!(:project_without_urn) { create(:conversion_project, academy_urn: nil, urn: 132342) }
+  let!(:project_with_urn) { create(:conversion_project, academy_urn: 123456, urn: 154232) }
+  let(:user) { create(:user) }
+
+  describe "new" do
+    it "does not include completed projects" do
+      get new_all_projects_path
+
+      expect(response.body).to include project_without_urn.urn.to_s
+
+      expect(response.body).not_to include completed_project.urn.to_s
+      expect(response.body).not_to include project_with_urn.urn.to_s
+    end
+  end
+
+  describe "with_academy_urn" do
+    it "does not include completed projects" do
+      get with_academy_urn_all_projects_path
+
+      expect(response.body).to include project_with_urn.urn.to_s
+
+      expect(response.body).not_to include completed_project.urn.to_s
+      expect(response.body).not_to include project_without_urn.urn.to_s
+    end
+  end
+end

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -9,6 +9,22 @@ module AcademiesApiHelpers
     allow(Api::AcademiesApi::Client).to receive(:new).and_return(fake_client)
   end
 
+  def mock_all_academies_api_responses
+    establishment = build(:academies_api_establishment)
+    trust = build(:academies_api_trust)
+
+    establishments = build_list(:academies_api_establishment, 3)
+    trusts = build_list(:academies_api_trust, 3)
+
+    fake_client = double(Api::AcademiesApi::Client,
+      get_establishments: Api::AcademiesApi::Client::Result.new(establishments, nil),
+      get_establishment: Api::AcademiesApi::Client::Result.new(establishment, nil),
+      get_trusts: Api::AcademiesApi::Client::Result.new(trusts, nil),
+      get_trust: Api::AcademiesApi::Client::Result.new(trust, nil))
+
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(fake_client)
+  end
+
   def mock_successful_api_response_to_create_any_project
     mock_successful_api_establishment_response(urn: any_args)
     mock_successful_api_trust_response(ukprn: any_args)


### PR DESCRIPTION
We noticed during a product review that the two 'academy urn' views
include completed projects when they should not.

https://trello.com/c/KZmV71Rx
