### PR TITLE
Apply govuk hint styling onto all hint text within the task list

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,7 +11,6 @@ $govuk-page-width: 1024px;
 
 @import "components/task-list";
 @import "components/task_list/check-box-action-component";
-@import "components/task_list/task-header-component";
 @import "components/notification-banner";
 
 // The accessible autocomplete component does not use

--- a/app/assets/stylesheets/components/task-list.scss
+++ b/app/assets/stylesheets/components/task-list.scss
@@ -79,3 +79,12 @@
     }
   }
 }
+
+.app-task-hint,
+.app-task-section__hint {
+  @extend .govuk-hint;
+
+  p {
+    @extend .govuk-hint;
+  }
+}

--- a/app/assets/stylesheets/components/task_list/task-header-component.scss
+++ b/app/assets/stylesheets/components/task_list/task-header-component.scss
@@ -1,4 +1,4 @@
-.app-task-hint {
+.app-task-hint, .app-task-section__hint {
   @extend .govuk-hint;
 
   p {

--- a/app/assets/stylesheets/components/task_list/task-header-component.scss
+++ b/app/assets/stylesheets/components/task_list/task-header-component.scss
@@ -1,7 +1,0 @@
-.app-task-hint, .app-task-section__hint {
-  @extend .govuk-hint;
-
-  p {
-    @extend .govuk-hint;
-  }
-}


### PR DESCRIPTION
## Changes

I have moved the scss code for this hint text into the general task-list scss file, as it felt more logical for it to sit within the general task-list styling. 

I am not aware of the original reasoning behind separating the hint text styling into it's own file, but it personally feels simpler to locate it within the `task-list.scss` file.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
