### PR TITLE
Change Sharepoint to SharePoint on links in project summary

### DIFF
--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -117,10 +117,10 @@ en:
         title: Region
       establishment_sharepoint_link:
         title: School SharePoint folder
-        value: Open the school Sharepoint folder in a new tab
+        value: Open the school SharePoint folder in a new tab
       trust_sharepoint_link:
         title: Trust SharePoint folder
-        value: Open the trust Sharepoint folder in a new tab
+        value: Open the trust SharePoint folder in a new tab
       completed_at: Project completed
     assign:
       regional_delivery_officer:


### PR DESCRIPTION
## Changes

Throughout the project we have displayed `SharePoint` so. The changes to the 2 links are to reflect this and keep consistency

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
