### PR TITLE
Display trust's group identifier within the project information view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Display trust's Group Identifier within the project information view
+
 - added a new view that can list projects by user
 
 ### Changed

--- a/app/models/api/academies_api/trust.rb
+++ b/app/models/api/academies_api/trust.rb
@@ -1,6 +1,7 @@
 class Api::AcademiesApi::Trust < Api::BaseApiModel
   attr_accessor(
     :ukprn,
+    :group_identifier,
     :original_name,
     :companies_house_number,
     :address_street,
@@ -18,6 +19,7 @@ class Api::AcademiesApi::Trust < Api::BaseApiModel
   def self.attribute_map
     {
       ukprn: "giasData.ukprn",
+      group_identifier: "giasData.groupId",
       original_name: "giasData.groupName",
       companies_house_number: "giasData.companiesHouseNumber",
       address_street: "giasData.groupContactAddress.street",

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -74,6 +74,10 @@
       row.value { @project.incoming_trust_ukprn.to_s }
     end
     summary_list.row do |row|
+      row.key { t('project_information.show.trust_details.rows.group_identifier') }
+      row.value { @project.incoming_trust.group_identifier.to_s }
+    end
+    summary_list.row do |row|
       row.key { t('project_information.show.trust_details.rows.companies_house_number') }
       row.value {
         (@project.incoming_trust.companies_house_number +

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -248,6 +248,7 @@ en:
           view_in_gias: View the trust information in GIAS (opens in new tab)
           address: Address
           ukprn: UK Provider Reference Number
+          group_identifier: Group identifier (ID)
           companies_house_number: Companies House number
           view_companies_house: View the Companies House information (opens in new tab)
       local_authority_details:


### PR DESCRIPTION
## Changes

Although the Acadmies API only lets us search for trusts by UKPRN, we have learnt that users prefer other identifiers in their searches. We have identified that Group Identifier (ID) is one of their preferences and one that we are able to access via the Academies API. So to help users gain more confidence that they have the correct trust, we are displaying this group identifier within the project information view.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
