### PR TITLE
Import Director of Child Services data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Add importer to import Director of Child Services data
+
 ## [Release 25][release-25]
 
 ### Added

--- a/app/services/director_of_child_services_importer.rb
+++ b/app/services/director_of_child_services_importer.rb
@@ -1,0 +1,42 @@
+require "csv"
+
+class InvalidEntryError < StandardError
+end
+
+class MissingLocalAuthorityError < StandardError
+end
+
+class DirectorOfChildServicesImporter
+  def call(csv_path)
+    sanitized_csv(csv_path).each do |row|
+      Contact::DirectorOfChildServices.transaction do
+        local_authority = LocalAuthority.find_by(code: row[:la])
+        if local_authority
+          dcs = Contact::DirectorOfChildServices.find_or_create_by(local_authority_id: local_authority.id)
+          dcs.name = row[:name]
+          dcs.title = row[:title]
+          dcs.email = row[:email]
+          dcs.phone = row[:phone]
+          unless dcs.save
+            puts "Unable to save Contact::DirectorOfChildServices for LocalAuthority code #{row[:la]}"
+            raise InvalidEntryError.new(dcs.errors)
+          end
+        else
+          raise MissingLocalAuthorityError.new("Local Authority code #{row[:la]} does not exist")
+        end
+      end
+    end
+  end
+
+  def sanitized_csv(csv_path)
+    sanitized_rows = []
+    CSV.foreach(csv_path, headers: true, header_converters: :symbol) do |row|
+      sanitized_row = row.map do |key, value|
+        value = (value.blank? || value == "0") ? nil : value
+        [key, value]
+      end.to_h
+      sanitized_rows << sanitized_row
+    end
+    sanitized_rows
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,9 @@ en:
     local_authority_importer:
       import:
         error: You must provide a path
+    director_of_child_services_importer:
+      import:
+        error: You must provide a path, e.g. director_of_child_services:import[path/to/data.csv]
   assignment:
     assign_regional_delivery_officer:
       title: Change regional delivery officer for %{school_name}

--- a/lib/tasks/director_of_child_services/import.rake
+++ b/lib/tasks/director_of_child_services/import.rake
@@ -1,0 +1,10 @@
+namespace :director_of_child_services do
+  desc ">> Call the Contact::DirectorOfChildServices importer service with a CSV of directors"
+  task :import, [:csv_path] => :environment do |_task, args|
+    abort I18n.t("tasks.director_of_child_services_importer.import.error") if args[:csv_path].nil?
+
+    csv_path = Rails.root.join(args[:csv_path])
+
+    DirectorOfChildServicesImporter.new.call(csv_path)
+  end
+end

--- a/spec/lib/tasks/director_of_child_services/import_spec.rb
+++ b/spec/lib/tasks/director_of_child_services/import_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "rake director_of_child_services:import", type: :task do
+  subject { Rake::Task["director_of_child_services:import"] }
+
+  let(:csv_path) { "/csv/dcs.csv" }
+
+  before do
+    allow_any_instance_of(DirectorOfChildServicesImporter).to receive(:call)
+  end
+
+  it "calls DirectorOfChildServices service with the supplied path" do
+    expect_any_instance_of(DirectorOfChildServicesImporter).to receive(:call).with(Pathname.new(csv_path)).once
+
+    subject.invoke(csv_path)
+  end
+
+  it "errors if no path is supplied" do
+    expect { subject.execute }
+      .to raise_error(SystemExit, I18n.t("tasks.director_of_child_services_importer.import.error"))
+  end
+end

--- a/spec/services/director_of_child_services_importer_spec.rb
+++ b/spec/services/director_of_child_services_importer_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe DirectorOfChildServicesImporter do
+  subject { DirectorOfChildServicesImporter.new }
+
+  let(:csv_path) { "/csv/dcs.csv" }
+  let(:csv) do
+    <<~CSV
+      LA,Name,Title,Email,Phone
+      200,John Doe,Executive Director Supporting People,john.doe@camden.gov.uk,0
+      201,Sarah White,Director of Children's Services,sarah.white@royalgreenwich.gov.uk,0
+      202,Claire Doe,Director of Children's Services,claire.doe@hackney.gov.uk,020 8000 0000
+    CSV
+  end
+
+  before { allow(File).to receive(:open).with(csv_path, any_args).and_return(csv) }
+
+  describe "#call" do
+    context "when all the local authorities exist" do
+      before do
+        create(:local_authority, code: 200)
+        create(:local_authority, code: 201)
+        create(:local_authority, code: 202)
+      end
+
+      it "upserts directors of child services from the provided CSV" do
+        subject.call(csv_path)
+
+        expect(Contact::DirectorOfChildServices.count).to be 3
+      end
+    end
+
+    context "when a local authority does not exist" do
+      it "does not import the directors of child services" do
+        expect { subject.call(csv_path) }.to raise_error(MissingLocalAuthorityError)
+        expect(Contact::DirectorOfChildServices.count).to eq 0
+      end
+    end
+
+    context "when a row is malformed" do
+      let(:csv) do
+        <<~CSV
+          LA,Name,Title,Email,Phone
+          200,John Doe,,john.doe@camden.gov.uk,0
+        CSV
+      end
+
+      before { create(:local_authority, code: 200) }
+
+      it "raises an InvalidEntryError" do
+        expect { subject.call(csv_path) }.to raise_error(InvalidEntryError)
+      end
+    end
+  end
+end


### PR DESCRIPTION


## Changes

Note that this commit does not contain the seed data, as it includes sensitive information.

The importer is run with
`rake director_of_child_services:import[path/to/data.csv]`

The CSV headers must be
`LA,Name,Title,Email,Phone`
where `LA` is the local authority code

This importer borrows heavily from the LocalAuthorityImporter by @beeLorna 

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
