### PR TITLE
Users can view a list of projects for a given trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - a new 'Confirm the academy name' task that collects the confirmed new academy
   name so that the Get information about schools record can be added.
 - Add hint text to External contacts tab
+- Users can view a list of projects for a given trust
 
 ### Changed
 

--- a/app/controllers/all/trust/projects_controller.rb
+++ b/app/controllers/all/trust/projects_controller.rb
@@ -1,0 +1,17 @@
+class All::Trust::ProjectsController < ApplicationController
+  after_action :verify_authorized
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
+
+  def by_trust
+    authorize Project, :index?
+    ukprn = params[:trust_ukprn]
+    @pager, @projects = pagy(Project.by_trust_ukprn(ukprn).by_conversion_date)
+
+    pre_fetch_establishments(@projects)
+    @trust = Api::AcademiesApi::Client.new.get_trust(ukprn).object
+  end
+
+  private def pre_fetch_establishments(projects)
+    EstablishmentsFetcher.new.call(projects)
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -59,6 +59,8 @@ class Project < ApplicationRecord
 
   scope :by_region, ->(region) { where(region: region) }
 
+  scope :by_trust_ukprn, ->(ukprn) { where(incoming_trust_ukprn: ukprn) }
+
   enum :region, {
     london: "H",
     south_east: "J",

--- a/app/views/all/trust/projects/by_trust.html.erb
+++ b/app/views/all/trust/projects/by_trust.html.erb
@@ -1,0 +1,35 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t("project.all.trust_ukprn.title", trust: @trust.name) %>
+    </h1>
+      <% if @projects.empty? %>
+        <%= govuk_inset_text(text: t("project.table.trust_ukprn.empty", trust: @trust.name)) %>
+      <% else %>
+        <table class="govuk-table" name="projects_table" aria-label="Projects table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school") %></th>
+              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
+              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
+              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+          <% @projects.each do |project| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+              <td class="govuk-table__cell"><%= project.urn %></td>
+              <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
+              <td class="govuk-table__cell">
+                <a href="<%= project_path(project) %>">
+                  <%= t("project.table.body.view_html", school_name: project.establishment.name) %>
+                </a>
+              </td>
+              </tr>
+          <% end %>
+          </tbody>
+        </table>
+      <% end %>
+  </div>
+</div>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -35,6 +35,8 @@ en:
         title: All conversions without an academy URN
       with_academy_urn:
         title: All conversions with an academy URN
+      trust_ukprn:
+          title: Projects for %{trust}
     regional_casework_services:
       in_progress:
         title: Regional Casework Services projects in progress
@@ -164,6 +166,8 @@ en:
         empty: There are no conversions with an academy URN
       by_user:
         empty: There are no projects assigned to %{user}
+      trust_ukprn:
+        empty: There are no projects for %{trust}
     openers:
       title: Academies opening in %{date}
       subtitle: Schools that are expected to become academies.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,9 @@ Rails.application.routes.draw do
           namespace :statistics do
             get "/", to: "projects#index"
           end
+          namespace :trust do
+            get ":trust_ukprn", to: "projects#by_trust", as: :by_trust
+          end
 
           get "new", to: "projects#new", as: :new
           get "with_academy_urn", to: "projects#with_academy_urn", as: :with_academy_urn

--- a/spec/features/projects/trust/users_can_view_a_list_of_projects_for_a_given_trust_spec.rb
+++ b/spec/features/projects/trust/users_can_view_a_list_of_projects_for_a_given_trust_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.feature "Users can view a list of projects for a given trust" do
+  before do
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  let(:user) { create(:user, email: "user@education.gov.uk") }
+
+  context "when a trust has no projects" do
+    scenario "they see an empty message" do
+      trust = build(:academies_api_trust)
+
+      visit by_trust_all_trust_projects_path(trust.ukprn)
+
+      expect(page).to have_content("Projects for #{trust.name}")
+      expect(page).to have_content("There are no projects for #{trust.name}")
+    end
+  end
+
+  context "when a trust has a project" do
+    scenario "they see the project listed" do
+      project = create(:conversion_project, incoming_trust_ukprn: 10060639)
+      trust = build(:academies_api_trust, ukprn: project.incoming_trust_ukprn)
+
+      visit by_trust_all_trust_projects_path(10060639)
+
+      expect(page).to have_content("Projects for #{trust.name}")
+      expect(page).to have_content(project.urn)
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -674,6 +674,19 @@ RSpec.describe Project, type: :model do
         expect(Project.added_by(user)).to_not include(other_project)
       end
     end
+
+    describe "by_trust_ukprn scope" do
+      it "returns only the projects for a given trust" do
+        mock_successful_api_response_to_create_any_project
+        trust_ukprn = 10061021
+        project_one = create(:conversion_project, incoming_trust_ukprn: trust_ukprn)
+        project_two = create(:conversion_project, incoming_trust_ukprn: trust_ukprn)
+        project_three = create(:conversion_project, incoming_trust_ukprn: 10134567)
+
+        expect(Project.by_trust_ukprn(trust_ukprn)).to include(project_one, project_two)
+        expect(Project.by_trust_ukprn(trust_ukprn)).to_not include(project_three)
+      end
+    end
   end
 
   describe "region" do


### PR DESCRIPTION
## Changes

Users can view a list of projects for a given trust

Some regional delivery officers are also `Trust relationship managers` and want to see all projects for the trust whose relationship they manage.

Currently this view is only accessible via url: `/projects/all/trust/<trust_ukprn>`

Projects are ordered by conversion date, in ascending order

<img width="1294" alt="Screenshot 2023-05-22 at 15 36 59" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/59832893/f78f7076-d92f-421b-8b89-c5d2057c1b2d">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
