### PR TITLE
Add index & edit pages for Directors of child services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add importer to import Director of Child Services data
+- Show the Directors of child services on their own index page. Allow the
+  director records to be edited from this page (but not added or deleted).
 
 ## [Release 25][release-25]
 

--- a/app/controllers/directors_of_child_services_controller.rb
+++ b/app/controllers/directors_of_child_services_controller.rb
@@ -1,0 +1,35 @@
+class DirectorsOfChildServicesController < ApplicationController
+  def index
+    @directors = Contact::DirectorOfChildServices
+      .all
+      .includes(:local_authority)
+      .sort_by { |dcs| dcs.local_authority.name }
+  end
+
+  def edit
+    authorize LocalAuthority
+
+    @director = Contact::DirectorOfChildServices.find(params[:id])
+    @local_authority = @director.local_authority
+  end
+
+  def update
+    authorize LocalAuthority
+
+    @director = Contact::DirectorOfChildServices.find(params[:id])
+    @local_authority = @director.local_authority
+    @director.assign_attributes(director_params)
+
+    if @director.valid?
+      @director.update(director_params)
+
+      redirect_to directors_of_child_services_path, notice: t("directors_of_child_services.update.success", local_authority: @director.local_authority.name)
+    else
+      render :edit
+    end
+  end
+
+  private def director_params
+    params.require(:contact_director_of_child_services).permit(:name, :title, :email, :phone)
+  end
+end

--- a/app/views/directors_of_child_services/edit.html.erb
+++ b/app/views/directors_of_child_services/edit.html.erb
@@ -1,0 +1,28 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= t("directors_of_child_services.edit.page_title", local_authority: @local_authority.name) %>
+    </h1>
+
+    <%= form_for @director, url: director_of_child_services_path(@director), method: :patch do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_text_field :title, label: {size: "m", text: t("directors_of_child_services.edit.title")}, width: 20 %>
+      <%= form.govuk_text_field :name, label: {size: "m", text: t("directors_of_child_services.edit.name")}, width: 20 %>
+      <%= form.govuk_email_field :email, label: {size: "m", text: t("directors_of_child_services.edit.email")}, width: 20 %>
+      <%= form.govuk_phone_field :phone, label: {size: "m", text: t("directors_of_child_services.edit.phone")}, width: 10 %>
+
+      <%= form.govuk_submit t("local_authority.edit.save_and_return") do %>
+        <%= govuk_link_to t("cancel"), directors_of_child_services_path %>
+      <% end %>
+    <% end %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <aside>
+      <h2 class="govuk-heading-s"><%= t("directors_of_child_services.edit.local_authority_address") %></h2>
+      <div class="govuk-body-m">
+        <%= address_markup(@local_authority.address) %>
+      </div>
+    </aside>
+  </div>
+</div>

--- a/app/views/directors_of_child_services/index.html.erb
+++ b/app/views/directors_of_child_services/index.html.erb
@@ -1,0 +1,36 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t("directors_of_child_services.index.title") %>
+    </h1>
+
+    <table class="govuk-table" name="directors_table" aria-label="Directors of Child Services table">
+      <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><%= t("directors_of_child_services.index.table.local_authority") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("directors_of_child_services.index.table.local_authority_address") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("directors_of_child_services.index.table.title") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("directors_of_child_services.index.table.name") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("directors_of_child_services.index.table.email") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("directors_of_child_services.index.table.edit") %></th>
+      </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      <% @directors.each do |director| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><%= director.local_authority&.name %></td>
+          <td class="govuk-table__cell"><%= address_markup(director.local_authority&.address) %></td>
+          <td class="govuk-table__cell"><%= director.title %></td>
+          <td class="govuk-table__cell"><%= director.name %></td>
+          <td class="govuk-table__cell"><%= director.email %></td>
+          <td class="govuk-table__cell">
+            <a href="<%= edit_director_of_child_services_path(director) %>">
+              <%= t("directors_of_child_services.index.table.edit_html", name: director.name) %>
+            </a>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -107,6 +107,10 @@
     <h2 class="govuk-heading-l"><%= t('project_information.show.director_of_child_services.title') %></h2>
     <%= govuk_summary_list(actions: false) do |summary_list|
       summary_list.row do |row|
+        row.key { t('project_information.show.director_of_child_services.rows.title') }
+        row.value { @project.director_of_child_services.title }
+      end
+      summary_list.row do |row|
         row.key { t('project_information.show.director_of_child_services.rows.name') }
         row.value { @project.director_of_child_services.name }
       end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,8 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym "RESTful"
 # end
+
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.irregular "director_of_child_services", "directors_of_child_services"
+  inflect.irregular "Director of Child Services", "Directors of Child Services"
+end

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -49,7 +49,7 @@ en:
         blank: Choose a category
   directors_of_child_services:
     index:
-      title: DCS (Director of Children's Services) contact details
+      title: DCS (Director of child services) contact details
       table:
         local_authority: Local authority
         local_authority_address: Local authority address

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -47,3 +47,24 @@ en:
     attributes:
       category:
         blank: Choose a category
+  directors_of_child_services:
+    index:
+      title: DCS (Director of Children's Services) contact details
+      table:
+        local_authority: Local authority
+        local_authority_address: Local authority address
+        title: DCS position
+        name: Name
+        email: Email
+        phone: Phone
+        edit: Edit
+        edit_html: Edit <span class="govuk-visually-hidden">%{name}</span>
+    edit:
+      page_title: Update contact details for %{local_authority}'s DCS
+      local_authority_address: Local authority address
+      name: Name
+      title: DCS position
+      email: Email
+      phone: Phone
+    update:
+      success: DCS for %{local_authority} has been updated

--- a/config/locales/local_authorities.en.yml
+++ b/config/locales/local_authorities.en.yml
@@ -16,7 +16,7 @@ en:
       county: County
       postcode: Postcode
       director_of_child_services:
-        form_title: Director of Child Services
+        form_title: Director of child services
         email: Email
         name: Name
         title: DCS Position
@@ -28,7 +28,7 @@ en:
       code: Code
       address: Address
       director_of_child_services:
-        heading: Director of Child Services
+        heading: Director of child services
         title: DCS Position
         name: Name
         email: Email
@@ -49,7 +49,7 @@ en:
       county: County
       postcode: Postcode
       director_of_child_services:
-        form_title: Director of Child Services
+        form_title: Director of child services
         email: Email
         name: Name
         title: DCS Position

--- a/config/locales/local_authorities.en.yml
+++ b/config/locales/local_authorities.en.yml
@@ -19,7 +19,7 @@ en:
         form_title: Director of Child Services
         email: Email
         name: Name
-        title: Role
+        title: DCS Position
         phone: Phone
       save_and_return: Save and return
     update:
@@ -29,7 +29,7 @@ en:
       address: Address
       director_of_child_services:
         heading: Director of Child Services
-        title: Role
+        title: DCS Position
         name: Name
         email: Email
         phone: Phone
@@ -52,7 +52,7 @@ en:
         form_title: Director of Child Services
         email: Email
         name: Name
-        title: Role
+        title: DCS Position
         phone: Phone
       save_and_return: Save and return
     destroy:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -259,6 +259,7 @@ en:
       director_of_child_services:
         title: Director of Child Services
         rows:
+          title: DCS Position
           name: Name
           email: Email
           phone: Phone

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -257,7 +257,7 @@ en:
           local_authority: Local authority
           address: Address
       director_of_child_services:
-        title: Director of Child Services
+        title: Director of child services
         rows:
           title: DCS Position
           name: Name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,8 @@ Rails.application.routes.draw do
 
   resources :local_authorities, path: "local-authorities", concerns: :has_destroy_confirmation
 
+  resources :directors_of_child_services, path: "directors-of-child-services", controller: "directors_of_child_services"
+
   # Projects - all projects are conversions right now
   constraints(id: VALID_UUID_REGEX) do
     resources :projects,

--- a/spec/features/users_can_view_directors_of_childrens_services_spec.rb
+++ b/spec/features/users_can_view_directors_of_childrens_services_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.feature "Users can view internal contacts for a project" do
+  let(:user) { create(:user, :service_support) }
+
+  before do
+    sign_in_with(user)
+  end
+
+  let(:a_council) { create(:local_authority, name: "A-town council") }
+  let(:z_council) { create(:local_authority, name: "Z-town council") }
+  let!(:dcs_a) { create(:director_of_child_services, local_authority: a_council) }
+  let!(:dcs_z) { create(:director_of_child_services, local_authority: z_council) }
+
+  scenario "The Directors of Children Services are ordered by their Local authority name" do
+    visit directors_of_child_services_path
+
+    expect(page.find(".govuk-table__body tr:first-of-type").text).to include("A-town council")
+    expect(page.find(".govuk-table__body tr:last-of-type").text).to include("Z-town council")
+  end
+end

--- a/spec/requests/directors_of_child_services_controller_spec.rb
+++ b/spec/requests/directors_of_child_services_controller_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe LocalAuthoritiesController, type: :request do
+  before do
+    sign_in_with(user)
+  end
+
+  let(:director) { create(:director_of_child_services) }
+
+  describe "#edit" do
+    context "when the user is NOT a service support user" do
+      let(:user) { create(:user, :caseworker) }
+
+      it "does not allow the user to edit" do
+        get edit_director_of_child_services_path(director)
+        follow_redirect!
+        expect(flash.alert).to eq I18n.t("unauthorised_action.message")
+      end
+    end
+
+    context "when the user is a service support user" do
+      let(:user) { create(:user, service_support: true) }
+
+      it "shows the edit form to the user" do
+        get edit_director_of_child_services_path(director)
+        expect(response.body).to include("Update contact details for #{director.local_authority.name}&#39;s DCS")
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:params) { {contact_director_of_child_services: {name: "John Director", email: "john@council.gov.uk"}} }
+
+    subject(:perform_request) do
+      put director_of_child_services_path(director), params: params
+      response
+    end
+
+    context "when the user is NOT a service support user" do
+      let(:user) { create(:user, :caseworker) }
+
+      it "does not allow the user to update" do
+        perform_request
+        expect(flash.alert).to eq I18n.t("unauthorised_action.message")
+      end
+    end
+
+    context "when the user is a service support user" do
+      let(:user) { create(:user, service_support: true) }
+
+      context "and the params are valid" do
+        it "allows the user to update the director of child services" do
+          perform_request
+          expect(subject).to redirect_to(directors_of_child_services_path)
+
+          director.reload
+          expect(director.name).to eq "John Director"
+        end
+      end
+
+      context "and the params are not valid" do
+        let(:params) { {contact_director_of_child_services: {name: "", email: ""}} }
+
+        it "re-renders the edit page with an error message" do
+          perform_request
+          expect(response.body).to include("There is a problem")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes

(I would add screenshots but they all contain sensitive information!)

Update the views for Directors of Child Services to match the designs in [this board](https://lucid.app/lucidspark/5f12e637-989c-4ee8-b5af-2225f0fdb417/edit?invitationId=inv_d3f413c4-ff92-4dd2-ac9f-6de2ac03cfcd&page=0_0#)

Add routes at `/directors-of-child-services` to expose a list of Directors, with their local authority information. The directors can then be edited. A director cannot be added or deleted from this page - to add or delete a director, you need to do it from the local authorities page `/local-authorities`, to keep the association between Directors and Local authorities.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
