### PR TITLE
Fix migration class name

### DIFF
--- a/db/migrate/20230517131621_add_conversion_academy_details_task_attributes.rb
+++ b/db/migrate/20230517131621_add_conversion_academy_details_task_attributes.rb
@@ -1,4 +1,4 @@
-class AddConversionAcademyNameTaskAttributes < ActiveRecord::Migration[7.0]
+class AddConversionAcademyDetailsTaskAttributes < ActiveRecord::Migration[7.0]
   def change
     add_column :conversion_voluntary_task_lists, :academy_details_name, :string
   end


### PR DESCRIPTION
A recent migration had a mis-matching class and file name. This is the
fix.
