### PR TITLE
Conversion date history notes cannot be deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- notes associated with a change to the conversion date can no longer be
+  deleted, only edited by the user that added them.
+
 ### Fixed
 
 ## [Release 25][release-25]

--- a/app/policies/note_policy.rb
+++ b/app/policies/note_policy.rb
@@ -18,6 +18,8 @@ class NotePolicy
   end
 
   def destroy?
+    return false if @note.conversion_date_history_id.present?
+
     edit?
   end
 

--- a/spec/factories/conversion/date_history_factory.rb
+++ b/spec/factories/conversion/date_history_factory.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :date_history, class: Conversion::DateHistory do
-    project { association :project }
+    project { association :conversion_project }
     previous_date { Date.today.at_beginning_of_month - 1.month }
     revised_date { previous_date + 2.months }
-    note { association :note, project: project }
+    note { association :note }
   end
 end

--- a/spec/factories/note_factory.rb
+++ b/spec/factories/note_factory.rb
@@ -9,5 +9,10 @@ FactoryBot.define do
       task_identifier { "handover" }
       body { "I really enjoyed performing this task" }
     end
+
+    trait :conversion_date_history do
+      conversion_date_history_id { association :date_history }
+      body { "This is the reason the conversion date has changed" }
+    end
   end
 end

--- a/spec/policies/note_policy_spec.rb
+++ b/spec/policies/note_policy_spec.rb
@@ -31,4 +31,24 @@ RSpec.describe NotePolicy do
       end
     end
   end
+
+  context "when the note is from a conversion date history" do
+    permissions :edit?, :update? do
+      it "allows if the note is from a date history" do
+        note = build(:note, :conversion_date_history, user: application_user)
+        allow(note).to receive(:conversion_date_history_id).and_return("uuid")
+
+        expect(subject).to permit(application_user, note)
+      end
+    end
+
+    permissions :destroy? do
+      it "denies all actions if the note is from a date history" do
+        note = build(:note, :conversion_date_history, user: application_user)
+        allow(note).to receive(:conversion_date_history_id).and_return("uuid")
+
+        expect(subject).not_to permit(application_user, note)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Changing the conversion date is a signigicant event and we do not want
to loose the note associsated with the change.

We use the Note model to store it, which by design, allows the user who
created the note to delete it.

This change prevents that for notes associated with a conversion date
history change.

https://trello.com/c/OBQzALPu