### PR TITLE
Show the academy name to service support users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - notes associated with a change to the conversion date can no longer be
   deleted, only edited by the user that added them.
+- The 'new academy URN' and 'with academy URN' views now include the confirmed
+  academy name, this helps servcice support ensure the correct details have been
+  added to Get information about schools.
 
 ### Fixed
 

--- a/app/helpers/project_helper.rb
+++ b/app/helpers/project_helper.rb
@@ -64,4 +64,10 @@ module ProjectHelper
         .new(message: t("project.notifications.not_assigned_html"))
     end
   end
+
+  def academy_name(project)
+    return govuk_tag(text: "Unconfirmed", colour: "grey") if project.tasks_data.academy_details_name.nil?
+
+    project.tasks_data.academy_details_name
+  end
 end

--- a/app/views/projects/shared/_new_table.html.erb
+++ b/app/views/projects/shared/_new_table.html.erb
@@ -10,6 +10,7 @@
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_phase") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.route") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.academy_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.academy_urn") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
       </tr>
@@ -23,6 +24,7 @@
         <td class="govuk-table__cell"><%= project.establishment.phase %></td>
         <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
         <td class="govuk-table__cell"><%= t("project.table.body.#{project.route}") %></td>
+        <td class="govuk-table__cell"><%= academy_name(project) %></td>
         <td class="govuk-table__cell">
           <a href="<%= project_academy_urn_path(project) %>">
             <%= t("project.table.body.edit_html", school_name: project.establishment.name) %>

--- a/app/views/projects/shared/_with_academy_urn_table.html.erb
+++ b/app/views/projects/shared/_with_academy_urn_table.html.erb
@@ -10,6 +10,7 @@
       <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_phase") %></th>
       <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
       <th class="govuk-table__header" scope="col"><%= t("project.table.headers.route") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.academy_name") %></th>
       <th class="govuk-table__header" scope="col"><%= t("project.table.headers.academy_urn") %></th>
       <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
     </tr>
@@ -23,6 +24,7 @@
         <td class="govuk-table__cell"><%= project.establishment.phase %></td>
         <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
         <td class="govuk-table__cell"><%= t("project.table.body.#{project.route}") %></td>
+        <td class="govuk-table__cell"><%= project.academy.name %></td>
         <td class="govuk-table__cell"><%= project.academy_urn %></td>
         <td class="govuk-table__cell">
           <a href="<%= project_path(project) %>">

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -146,6 +146,7 @@ en:
         route: Route
         school_phase: School phase
         school_type: School type
+        academy_name: Academy name
         academy_urn: Academy URN
       body:
         view_html: View <span class="govuk-visually-hidden">%{school_name}</span> project

--- a/spec/features/projects/new/users_can_view_a_list_of_new_projects_spec.rb
+++ b/spec/features/projects/new/users_can_view_a_list_of_new_projects_spec.rb
@@ -61,6 +61,7 @@ RSpec.feature "Viewing all new projects" do
         expect(page).to have_content("School phase")
         expect(page).to have_content("Conversion date")
         expect(page).to have_content("Route")
+        expect(page).to have_content("Academy name")
         expect(page).to have_content("View project")
       end
     end

--- a/spec/features/projects/with_academy_urn/users_can_view_a_list_of_projects_with_academy_urn_spec.rb
+++ b/spec/features/projects/with_academy_urn/users_can_view_a_list_of_projects_with_academy_urn_spec.rb
@@ -62,6 +62,7 @@ RSpec.feature "Viewing all projects with an academy URN" do
         expect(page).to have_content("Conversion date")
         expect(page).to have_content("Route")
         expect(page).to have_content("Academy URN")
+        expect(page).to have_content("Academy URN")
         expect(page).to have_content("View project")
       end
     end

--- a/spec/helpers/project_helper_spec.rb
+++ b/spec/helpers/project_helper_spec.rb
@@ -250,4 +250,19 @@ RSpec.describe ProjectHelper, type: :helper do
       end
     end
   end
+
+  describe "#academy_name" do
+    it "returns the academy name when available" do
+      tasks_data = Conversion::TasksData.new(academy_details_name: "New Academy")
+      project = build(:conversion_project, tasks_data: tasks_data)
+
+      expect(helper.academy_name(project)).to eql "New Academy"
+    end
+
+    it "returns a unconfirmed tag when there is no academy name" do
+      project = build(:conversion_project)
+
+      expect(helper.academy_name(project)).to include("grey", "Unconfirmed")
+    end
+  end
 end


### PR DESCRIPTION
Once the academy name is confirmed, a service support users adds the new
record to Get infromation about schools, we then read that information
back in and show it.

So the service support users knows the academy name and can provide it
we show it on our views that support this process.

Once the new academy record is created the service support user adds the
URN and can verify the correct name is being returns - for this reason,
the 'with academy URN' view shows the fetched name NOT the local
'confirmed' name.

https://trello.com/c/2SjUUyCI

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/17b2fd09-6af3-4e09-bc63-2cccb1e4fe19)

