### PR TITLE
Change "Role" to "DCS Position" for Director of Child Services

### DIFF
--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -107,6 +107,10 @@
     <h2 class="govuk-heading-l"><%= t('project_information.show.director_of_child_services.title') %></h2>
     <%= govuk_summary_list(actions: false) do |summary_list|
       summary_list.row do |row|
+        row.key { t('project_information.show.director_of_child_services.rows.title') }
+        row.value { @project.director_of_child_services.title }
+      end
+      summary_list.row do |row|
         row.key { t('project_information.show.director_of_child_services.rows.name') }
         row.value { @project.director_of_child_services.name }
       end

--- a/config/locales/local_authorities.en.yml
+++ b/config/locales/local_authorities.en.yml
@@ -16,7 +16,7 @@ en:
       county: County
       postcode: Postcode
       director_of_child_services:
-        form_title: Director of Child Services
+        form_title: Director of child services
         email: Email
         name: Name
         title: DCS Position
@@ -28,7 +28,7 @@ en:
       code: Code
       address: Address
       director_of_child_services:
-        heading: Director of Child Services
+        heading: Director of child services
         title: DCS Position
         name: Name
         email: Email
@@ -49,7 +49,7 @@ en:
       county: County
       postcode: Postcode
       director_of_child_services:
-        form_title: Director of Child Services
+        form_title: Director of child services
         email: Email
         name: Name
         title: DCS Position

--- a/config/locales/local_authorities.en.yml
+++ b/config/locales/local_authorities.en.yml
@@ -19,7 +19,7 @@ en:
         form_title: Director of Child Services
         email: Email
         name: Name
-        title: Role
+        title: DCS Position
         phone: Phone
       save_and_return: Save and return
     update:
@@ -29,7 +29,7 @@ en:
       address: Address
       director_of_child_services:
         heading: Director of Child Services
-        title: Role
+        title: DCS Position
         name: Name
         email: Email
         phone: Phone
@@ -52,7 +52,7 @@ en:
         form_title: Director of Child Services
         email: Email
         name: Name
-        title: Role
+        title: DCS Position
         phone: Phone
       save_and_return: Save and return
     destroy:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -259,6 +259,7 @@ en:
       director_of_child_services:
         title: Director of Child Services
         rows:
+          title: DCS Position
           name: Name
           email: Email
           phone: Phone

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -257,7 +257,7 @@ en:
           local_authority: Local authority
           address: Address
       director_of_child_services:
-        title: Director of Child Services
+        title: Director of child services
         rows:
           title: DCS Position
           name: Name


### PR DESCRIPTION

## Changes

Change "Role" to "DCS Position" for Director of Child Services and show the DCS Position on the project information page.

Correct capitalisation for director of child services.

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
