### PR TITLE
Add correct pluralisations for DirectorOfChildServices

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,8 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym "RESTful"
 # end
+
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.irregular "director_of_child_services", "directors_of_child_services"
+  inflect.irregular "Director of Child Services", "Directors of Child Services"
+end


### PR DESCRIPTION

## Changes

One Director of Child Services; two Directors of Child Services

By default, Rails would make the plural of "Director of Child Services", "Director of Child Services"

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
