### PR TITLE
Handover note improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   added to Get information about schools.
 - the handover note added by regional delivery officers when creating a new
   project is now required
+- the handover note added by regional delivery officers when creating a new
+  project is now associated with the ' Handover with regional delivery officer'
+  task
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The 'new academy URN' and 'with academy URN' views now include the confirmed
   academy name, this helps servcice support ensure the correct details have been
   added to Get information about schools.
+- the handover note added by regional delivery officers when creating a new
+  project is now required
 
 ### Fixed
 

--- a/app/controllers/conversions/projects_controller.rb
+++ b/app/controllers/conversions/projects_controller.rb
@@ -41,7 +41,7 @@ class Conversions::ProjectsController < ProjectsController
       :advisory_board_conditions,
       :establishment_sharepoint_link,
       :trust_sharepoint_link,
-      :note_body,
+      :handover_note_body,
       :assigned_to_regional_caseworker_team,
       :directive_academy_order
     )

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -4,8 +4,6 @@ class Conversion::CreateProjectForm
   include ActiveRecord::AttributeAssignment
 
   SHAREPOINT_URLS = %w[educationgovuk-my.sharepoint.com educationgovuk.sharepoint.com].freeze
-  DIRECTIVE_ACADEMY_ORDER_RESPONSES = [OpenStruct.new(id: true, name: I18n.t("helpers.responses.conversion_project.directive_academy_order.yes")), OpenStruct.new(id: false, name: I18n.t("helpers.responses.conversion_project.directive_academy_order.no"))]
-  CASEWORKER_TEAM_RESPONSES = [OpenStruct.new(id: true, name: I18n.t("yes")), OpenStruct.new(id: false, name: I18n.t("no"))]
 
   class NegativeValueError < StandardError; end
 
@@ -48,10 +46,6 @@ class Conversion::CreateProjectForm
   def initialize(params = {})
     @attributes_with_invalid_values = []
     super(params)
-  end
-
-  def directive_academy_order_responses
-    DIRECTIVE_ACADEMY_ORDER_RESPONSES
   end
 
   def provisional_conversion_date=(hash)
@@ -120,7 +114,17 @@ class Conversion::CreateProjectForm
   end
 
   def assigned_to_regional_caseworker_team_responses
-    CASEWORKER_TEAM_RESPONSES
+    @assigned_to_regional_caseworker_team_responses ||= [
+      OpenStruct.new(id: true, name: I18n.t("yes")),
+      OpenStruct.new(id: false, name: I18n.t("no"))
+    ]
+  end
+
+  def directive_academy_order_responses
+    @directive_academy_order_responses ||= [
+      OpenStruct.new(id: true, name: I18n.t("helpers.responses.conversion_project.directive_academy_order.yes")),
+      OpenStruct.new(id: false, name: I18n.t("helpers.responses.conversion_project.directive_academy_order.no"))
+    ]
   end
 
   def save

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -23,6 +23,7 @@ class Conversion::CreateProjectForm
 
   validates :provisional_conversion_date,
     :advisory_board_date,
+    :handover_note_body,
     presence: true
 
   validates :provisional_conversion_date, date_in_the_future: true, first_day_of_month: true

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -14,7 +14,7 @@ class Conversion::CreateProjectForm
   attribute :advisory_board_conditions
   attribute :handover_note_body
   attribute :user
-  attribute :directive_academy_order
+  attribute :directive_academy_order, :boolean
   attribute :region
   attribute :assigned_to_regional_caseworker_team, :boolean
 
@@ -41,7 +41,7 @@ class Conversion::CreateProjectForm
 
   validate :urn_unique_for_in_progress_conversions, if: -> { urn.present? }
 
-  validates :directive_academy_order, inclusion: {in: %w[true false]}
+  validates :directive_academy_order, :assigned_to_regional_caseworker_team, inclusion: {in: [true, false]}
 
   def initialize(params = {})
     @attributes_with_invalid_values = []

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -153,7 +153,7 @@ class Conversion::CreateProjectForm
 
     ActiveRecord::Base.transaction do
       @project.save
-      @note = Note.create(body: handover_note_body, project: @project, user: user) if handover_note_body
+      @note = Note.create(body: handover_note_body, project: @project, user: user, task_identifier: :handover) if handover_note_body
       notify_team_leaders(@project) if assigned_to_regional_caseworker_team
     end
 

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -5,6 +5,7 @@ class Conversion::CreateProjectForm
 
   SHAREPOINT_URLS = %w[educationgovuk-my.sharepoint.com educationgovuk.sharepoint.com].freeze
   DIRECTIVE_ACADEMY_ORDER_RESPONSES = [OpenStruct.new(id: true, name: I18n.t("helpers.responses.conversion_project.directive_academy_order.yes")), OpenStruct.new(id: false, name: I18n.t("helpers.responses.conversion_project.directive_academy_order.no"))]
+  CASEWORKER_TEAM_RESPONSES = [OpenStruct.new(id: true, name: I18n.t("yes")), OpenStruct.new(id: false, name: I18n.t("no"))]
 
   class NegativeValueError < StandardError; end
 
@@ -17,6 +18,7 @@ class Conversion::CreateProjectForm
   attribute :user
   attribute :directive_academy_order
   attribute :region
+  attribute :assigned_to_regional_caseworker_team, :boolean
 
   attr_reader :provisional_conversion_date,
     :advisory_board_date
@@ -116,10 +118,6 @@ class Conversion::CreateProjectForm
   private def urn_unique_for_in_progress_conversions
     errors.add(:urn, :duplicate) if Project.not_completed.where(urn: urn).any?
   end
-
-  attribute :assigned_to_regional_caseworker_team, :boolean
-
-  CASEWORKER_TEAM_RESPONSES = [OpenStruct.new(id: true, name: I18n.t("yes")), OpenStruct.new(id: false, name: I18n.t("no"))]
 
   def assigned_to_regional_caseworker_team_responses
     CASEWORKER_TEAM_RESPONSES

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -12,7 +12,7 @@ class Conversion::CreateProjectForm
   attribute :establishment_sharepoint_link
   attribute :trust_sharepoint_link
   attribute :advisory_board_conditions
-  attribute :note_body
+  attribute :handover_note_body
   attribute :user
   attribute :directive_academy_order
   attribute :region
@@ -152,7 +152,7 @@ class Conversion::CreateProjectForm
 
     ActiveRecord::Base.transaction do
       @project.save
-      @note = Note.create(body: note_body, project: @project, user: user) if note_body
+      @note = Note.create(body: handover_note_body, project: @project, user: user) if handover_note_body
       notify_team_leaders(@project) if assigned_to_regional_caseworker_team
     end
 

--- a/app/views/conversions/projects/new.html.erb
+++ b/app/views/conversions/projects/new.html.erb
@@ -17,7 +17,7 @@
       <%= form.govuk_date_field :provisional_conversion_date, legend: {text: t("helpers.legend.conversion_project.provisional_conversion_date")}, omit_day: true, form_group: {id: "provisional-conversion-date"}, hint: {text: t("helpers.hint.conversion_project.provisional_conversion_date")} %>
       <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m", text: t("helpers.label.conversion_project.establishment_sharepoint_link")} %>
       <%= form.govuk_text_field :trust_sharepoint_link, label: {size: "m", text: t("helpers.label.conversion_project.trust_sharepoint_link")} %>
-      <%= form.govuk_text_area :note_body,
+      <%= form.govuk_text_area :handover_note_body,
             label: {text: t("project.new.handover_comments_label"), size: "m"},
             hint: {text: t("project.new.handover_comments_hint").html_safe} %>
       <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, @project.assigned_to_regional_caseworker_team_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -342,3 +342,5 @@ en:
       academy_urn:
         blank: Please enter an Academy URN
         invalid_urn: Please enter a valid URN. The URN must be 6 digits long. For example, 123456.
+      handover_note_body:
+        blank: Enter handover notes

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -337,6 +337,8 @@ en:
         host_not_allowed: Enter a trust sharepoint link in the correct format. SharePoint links start with 'https://educationgovuk.sharepoint.com' or 'https://educationgovuk-my.sharepoint.com/'
       directive_academy_order:
         inclusion: Select directive academy order or academy order, whichever has been used for this conversion
+      assigned_to_regional_caseworker_team:
+        inclusion: Select yes or no
       academy_urn:
         blank: Please enter an Academy URN
         invalid_urn: Please enter a valid URN. The URN must be 6 digits long. For example, 123456.

--- a/spec/factories/conversion/create_project_form_factory.rb
+++ b/spec/factories/conversion/create_project_form_factory.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }
     user { association :user, :regional_delivery_officer }
     handover_note_body { "Handover notes" }
-    directive_academy_order { "false" }
+    directive_academy_order { false }
     assigned_to_regional_caseworker_team { false }
   end
 end

--- a/spec/factories/conversion/create_project_form_factory.rb
+++ b/spec/factories/conversion/create_project_form_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/establishment-folder" }
     trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }
     user { association :user, :regional_delivery_officer }
-    note_body { "A note" }
+    handover_note_body { "Handover notes" }
     directive_academy_order { "false" }
     assigned_to_regional_caseworker_team { false }
   end

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -329,7 +329,7 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
       it "creates a note if the note_body is not empty" do
         form = build(
           form_factory.to_sym,
-          note_body: "Some important words"
+          handover_note_body: "Some important words"
         )
         form.save
         expect(Note.count).to eq(1)

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -336,7 +336,7 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
         expect(project.tasks_data).to be_a(Conversion::TasksData)
       end
 
-      it "creates a note if the note_body is not empty" do
+      it "creates a note associated to the handover task" do
         form = build(
           form_factory.to_sym,
           handover_note_body: "Some important words"
@@ -344,6 +344,7 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
         form.save
         expect(Note.count).to eq(1)
         expect(Note.last.body).to eq("Some important words")
+        expect(Note.last.task_identifier).to eq("handover")
       end
 
       context "when the project does NOT have a directive academy order" do

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -228,6 +228,16 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
         expect(form.errors[:directive_academy_order]).to include("Select directive academy order or academy order, whichever has been used for this conversion")
       end
     end
+
+    describe "handover note body" do
+      it "is required" do
+        form = build(
+          form_factory.to_sym,
+          handover_note_body: ""
+        )
+        expect(form).to be_invalid
+      end
+    end
   end
 
   describe "urn" do

--- a/spec/requests/conversions/projects_controller_spec.rb
+++ b/spec/requests/conversions/projects_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Conversions::ProjectsController do
 
       context "when the note body is empty" do
         subject(:perform_request) do
-          post conversions_path, params: {conversion_create_project_form: {**project_form_params, note_body: ""}}
+          post conversions_path, params: {conversion_create_project_form: {**project_form_params, handover_note_body: ""}}
 
           response
         end


### PR DESCRIPTION
The goal of this work is twofold:

- make the handover note on the create project form required
- associate the handover note with the handover task

We are making the handover note required at all times as it is an important piece of information and is used more than it is not. The only time it would not be used is when the regional delivery officer creating the project is also working on the project. Whilst it is frustrating in this one instance, the rest of the time it is super valuable.

Associating the handover note to the handover task makes the note appear alongside the task, this is feedback we have recieved from users.