### PR TITLE
Remove the signed in users email verification text from the view

### DIFF
--- a/app/views/all/completed/projects/index.html.erb
+++ b/app/views/all/completed/projects/index.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/all/completed/projects/sponsored.html.erb
+++ b/app/views/all/completed/projects/sponsored.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/all/completed/projects/voluntary.html.erb
+++ b/app/views/all/completed/projects/voluntary.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/all/conversion_date_changed/projects/index.html.erb
+++ b/app/views/all/conversion_date_changed/projects/index.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/all/in_progress/projects/index.html.erb
+++ b/app/views/all/in_progress/projects/index.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/all/in_progress/projects/sponsored.html.erb
+++ b/app/views/all/in_progress/projects/sponsored.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/all/in_progress/projects/voluntary.html.erb
+++ b/app/views/all/in_progress/projects/voluntary.html.erb
@@ -1,4 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/all/projects/new.html.erb
+++ b/app/views/all/projects/new.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/all/projects/with_academy_urn.html.erb
+++ b/app/views/all/projects/with_academy_urn.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/conversions/academy_urn/confirm.html.erb
+++ b/app/views/conversions/academy_urn/confirm.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/conversions/academy_urn/edit.html.erb
+++ b/app/views/conversions/academy_urn/edit.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/conversions/academy_urn/not_found.html.erb
+++ b/app/views/conversions/academy_urn/not_found.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/local_authorities/index.html.erb
+++ b/app/views/local_authorities/index.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/projects/unassigned.html.erb
+++ b/app/views/projects/unassigned.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/projects_openers/openers.html.erb
+++ b/app/views/projects_openers/openers.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/regional/projects/completed.html.erb
+++ b/app/views/regional/projects/completed.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/regional/projects/completed_by_region.html.erb
+++ b/app/views/regional/projects/completed_by_region.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/regional/projects/in_progress.html.erb
+++ b/app/views/regional/projects/in_progress.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/regional/projects/in_progress_by_region.html.erb
+++ b/app/views/regional/projects/in_progress_by_region.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/regional_casework_services/projects/completed.html.erb
+++ b/app/views/regional_casework_services/projects/completed.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/regional_casework_services/projects/in_progress.html.erb
+++ b/app/views/regional_casework_services/projects/in_progress.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/regional_casework_services/projects/unassigned.html.erb
+++ b/app/views/regional_casework_services/projects/unassigned.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/user/projects/added_by.html.erb
+++ b/app/views/user/projects/added_by.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
  <div class="govuk-grid-column-full">
 

--- a/app/views/user/projects/completed.html.erb
+++ b/app/views/user/projects/completed.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/user/projects/in_progress.html.erb
+++ b/app/views/user/projects/in_progress.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "projects/shared/signed_in_as", locals: {email_address: current_user.email} %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/spec/features/users_can_sign_in_spec.rb
+++ b/spec/features/users_can_sign_in_spec.rb
@@ -13,15 +13,14 @@ RSpec.feature "Users can sign in to the application" do
       click_button(I18n.t("sign_in.button"))
 
       expect(page).not_to have_button(I18n.t("sign_in.button"))
-      expect(page).to have_content(user.email)
       expect(user.reload.active_directory_user_id).to eq "b5095c3e-0141-4478-81ad-99d0fbd087ed"
     end
 
     scenario "from any page, they are redirected to the sign in page" do
       visit root_path
-      click_button(I18n.t("sign_in.button"))
 
-      expect(page).to have_content(user.email)
+      expect(page).to have_content("Sign in")
+      expect(page).to have_button(I18n.t("sign_in.button"))
     end
   end
 

--- a/spec/requests/sign_in_spec.rb
+++ b/spec/requests/sign_in_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe "Sign in" do
 
       follow_redirect!
 
-      expect(response.body).to include(user.email)
       expect(response).to have_http_status(:success)
     end
   end


### PR DESCRIPTION
## Changes

This PR removes the text `You are signed in with the email address user.name@education.gov.uk` from the top of the view pages

We now do not need to display to the user who is signed in from within the service. We had added this in the early stages of the product as a way to validate the sign in was working.

### Before 
<img width="1294" alt="Screenshot 2023-05-23 at 15 49 05" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/59832893/8e306f3f-3e7d-40c2-97f4-123a6661db88">

### After
<img width="1294" alt="Screenshot 2023-05-23 at 15 51 18" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/59832893/640fe672-f785-48ff-94d9-742b1fe40ba6">

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
