### PR TITLE
(Fix) Route to project openers page should be `opening`

### DIFF
--- a/app/views/all/openers/projects/index.html.erb
+++ b/app/views/all/openers/projects/index.html.erb
@@ -10,7 +10,7 @@
       <ul class="moj-sub-navigation__list">
         <%= render partial: "shared/sub_navigation_item",
               locals: {name: t("subnavigation.openers"),
-                       path: "/projects/all/openers/#{@month}/#{@year}"} %>
+                       path: "/projects/all/opening/#{@month}/#{@year}"} %>
         <%= render partial: "shared/sub_navigation_item",
               locals: {name: t("subnavigation.revised"),
                        path: "/projects/all/revised-conversion-date/#{@month}/#{@year}"} %>

--- a/app/views/all/revised_conversion_date/projects/index.html.erb
+++ b/app/views/all/revised_conversion_date/projects/index.html.erb
@@ -9,7 +9,7 @@
       <ul class="moj-sub-navigation__list">
         <%= render partial: "shared/sub_navigation_item",
               locals: {name: t("subnavigation.openers"),
-                       path: "/projects/all/openers/#{@month}/#{@year}"} %>
+                       path: "/projects/all/opening/#{@month}/#{@year}"} %>
         <%= render partial: "shared/sub_navigation_item",
               locals: {name: t("subnavigation.revised"),
                        path: "/projects/all/revised-conversion-date/#{@month}/#{@year}"} %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,7 +78,7 @@ Rails.application.routes.draw do
           namespace :revised_conversion_date, path: "revised-conversion-date" do
             get "/:month/:year", to: "projects#index", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}
           end
-          namespace :openers do
+          namespace :openers, path: "opening" do
             get "/:month/:year", to: "projects#index", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}
           end
           namespace :statistics do

--- a/spec/features/users_can_view_a_table_of_project_openers_spec.rb
+++ b/spec/features/users_can_view_a_table_of_project_openers_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Users can view project openers in table form" do
         tasks_data = create(:conversion_tasks_data, conditions_met_confirm_all_conditions_met: true)
         _project = create(:conversion_project, tasks_data: tasks_data, conversion_date: Date.new(2023, 1, 1), conversion_date_provisional: false)
 
-        visit "/projects/all/openers/1/2023"
+        visit "/projects/all/opening/1/2023"
         expect(page).to have_css("strong.govuk-tag--turquoise", text: "confirmed")
       end
     end
@@ -27,7 +27,7 @@ RSpec.feature "Users can view project openers in table form" do
         tasks_data = create(:conversion_tasks_data, conditions_met_confirm_all_conditions_met: nil)
         _project = create(:conversion_project, tasks_data: tasks_data, conversion_date: Date.new(2023, 1, 1), conversion_date_provisional: false)
 
-        visit "/projects/all/openers/1/2023"
+        visit "/projects/all/opening/1/2023"
         expect(page).to have_css("strong.govuk-tag--blue", text: "unconfirmed")
       end
     end

--- a/spec/requests/all/openers/projects_controller_spec.rb
+++ b/spec/requests/all/openers/projects_controller_spec.rb
@@ -8,31 +8,31 @@ RSpec.describe All::Openers::ProjectsController, type: :request do
     sign_in_with(team_leader)
   end
 
-  describe "#openers" do
+  describe "#index" do
     context "when the month and year are missing" do
       it "returns a 404" do
-        get "/projects/all/openers"
+        get "/projects/all/opening"
         expect(response).to have_http_status(:not_found)
       end
     end
 
     context "when the year is missing" do
       it "returns a 404" do
-        get "/projects/all/openers/1"
+        get "/projects/all/opening/1"
         expect(response).to have_http_status(:not_found)
       end
     end
 
     context "when the month isn't in the scope 1..12" do
       it "returns a 404" do
-        get "/projects/all/openers/13/2022"
+        get "/projects/all/opening/13/2022"
         expect(response).to have_http_status(:not_found)
       end
     end
 
     context "when the year isn't in the scope 2000-2499" do
       it "returns a 404" do
-        get "/projects/all/openers/12/2555"
+        get "/projects/all/opening/12/2555"
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -51,13 +51,13 @@ RSpec.describe All::Openers::ProjectsController, type: :request do
       let(:mock_trusts_fetcher) { double(IncomingTrustsFetcher, call: true) }
 
       it "shows a page title with the month & year" do
-        get "/projects/all/openers/1/2022"
+        get "/projects/all/opening/1/2022"
         expect(response.body).to include("Academies opening in January 2022")
       end
 
       it "returns project details in table form" do
         conversion_project = create(:conversion_project, conversion_date: Date.new(2022, 1, 1), conversion_date_provisional: false)
-        get "/projects/all/openers/1/2022"
+        get "/projects/all/opening/1/2022"
         expect(response.body).to include(
           conversion_project.establishment.name,
           conversion_project.urn.to_s,
@@ -69,14 +69,14 @@ RSpec.describe All::Openers::ProjectsController, type: :request do
         project_in_scope = create(:conversion_project, urn: 100001, conversion_date: Date.new(2022, 1, 1), conversion_date_provisional: false)
         project_not_in_scope = create(:conversion_project, urn: 100002, conversion_date: Date.new(2022, 2, 1), conversion_date_provisional: false)
 
-        get "/projects/all/openers/1/2022"
+        get "/projects/all/opening/1/2022"
         expect(response.body).to include(project_in_scope.urn.to_s)
         expect(response.body).to_not include(project_not_in_scope.urn.to_s)
       end
 
       context "when there are no academies opening in that month & year" do
         it "shows a helpful message" do
-          get "/projects/all/openers/1/2022"
+          get "/projects/all/opening/1/2022"
           expect(response.body).to include("There are currently no schools expected to become academies in January 2022")
         end
       end


### PR DESCRIPTION
The route to the project openers page should be `/projects/opening`.

This was missed in an earlier commit.

