### PR TITLE
Display generated DfE number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Display generated DfE number in project information view for the establishment
+
 ### Changed
 
 - Change the values of the "All conditions met" tag in the openers list, to

--- a/app/models/api/academies_api/establishment.rb
+++ b/app/models/api/academies_api/establishment.rb
@@ -2,6 +2,7 @@ class Api::AcademiesApi::Establishment < Api::BaseApiModel
   attr_accessor(
     :urn,
     :name,
+    :establishment_number,
     :local_authority_name,
     :local_authority_code,
     :type,
@@ -24,6 +25,7 @@ class Api::AcademiesApi::Establishment < Api::BaseApiModel
     {
       urn: "urn",
       name: "establishmentName",
+      establishment_number: "establishmentNumber",
       local_authority_name: "localAuthorityName",
       local_authority_code: "localAuthorityCode",
       type: "establishmentType.name",
@@ -56,5 +58,9 @@ class Api::AcademiesApi::Establishment < Api::BaseApiModel
 
   def local_authority
     LocalAuthority.find_by(code: local_authority_code)
+  end
+
+  def dfe_number
+    "#{local_authority_code}/#{establishment_number}"
   end
 end

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -34,6 +34,10 @@
       row.value { address_markup(@project.establishment.address) }
     end
     summary_list.row do |row|
+      row.key { t('project_information.show.school_details.rows.dfe_number') }
+      row.value { @project.establishment.dfe_number }
+    end
+    summary_list.row do |row|
       row.key { t('project_information.show.school_details.rows.old_urn') }
       row.value { @project.urn.to_s }
     end

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -249,6 +249,7 @@ en:
           original_school_name: Original school name
           view_in_gias: View the school's information in GIAS (opens in new tab)
           address: Addresss
+          dfe_number: DfE number
           old_urn: Old Unique Reference Number
           school_type: School type
           age_range: Age range

--- a/spec/factories/academies_api/establishment.rb
+++ b/spec/factories/academies_api/establishment.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :academies_api_establishment, class: "Api::AcademiesApi::Establishment" do
     urn { "123456" }
     name { "Caludon Castle School" }
+    establishment_number { "1234" }
     local_authority_name { "West Placefield Council" }
     local_authority_code { "894" }
     type { "Academy converter" }

--- a/spec/features/project_information/users_can_view_school_details_spec.rb
+++ b/spec/features/project_information/users_can_view_school_details_spec.rb
@@ -14,6 +14,7 @@ RSpec.feature "Users can view school details" do
     within("#schoolDetails") do
       expect(page).to have_content(project.establishment.name)
       expect(page).to have_content(project.urn)
+      expect(page).to have_content(project.establishment.dfe_number)
       expect(page).to have_content(project.establishment.type)
       expect(page).to have_content(project.establishment.phase)
       expect(page).to have_content(project.establishment.region_name)

--- a/spec/models/api/academies_api/establishment_spec.rb
+++ b/spec/models/api/academies_api/establishment_spec.rb
@@ -1,12 +1,19 @@
 require "rails_helper"
 
 RSpec.describe Api::AcademiesApi::Establishment do
+  let(:establishment) { build(:academies_api_establishment, local_authority_code: "300", establishment_number: "4567") }
+
   describe "#local_authority" do
-    let(:establishment) { build(:academies_api_establishment, local_authority_code: "300") }
     let!(:local_authority) { create(:local_authority, code: "300") }
 
     it "returns the local authority" do
       expect(establishment.local_authority).to eql(local_authority)
+    end
+  end
+
+  describe "#dfe_number" do
+    it "returns the combination of the local authority code and establishment number as the dfe number" do
+      expect(establishment.dfe_number).to eql("300/4567")
     end
   end
 end


### PR DESCRIPTION
## Changes

The DfE number is another identifier for the establishment which may be useful for users to use as a form of validation.
It is also known as LAESTAB.

The DfE number is shown within the GIAS but isn't accessible via the AcademiesApi, so we have therefore needed to construct it from the local authority code and the establishment number.

<img width="825" alt="Screenshot 2023-05-24 at 15 13 18" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/59832893/4d710552-d77c-4528-8082-408a847aeaf6">


## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
