### PR TITLE
Make clear delivery officers need to add contacts 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move route of the Projects with changed conversion dates to
   `/projects/all/revised-conversion-date/month/year`
 - Tie the Openers and Revised conversion date pages together with tabs
+- Update content in project creation confirmation page to make clear delivery
+  officers must add contacts
+- Change primary action button to point to external contacts page
 
 ### Fixed
 

--- a/app/views/conversions/projects/created.html.erb
+++ b/app/views/conversions/projects/created.html.erb
@@ -9,6 +9,6 @@
           school_name: @project.establishment.name,
           urn: @project.urn,
           contacts_link: project_contacts_path(@project)) %>
-    <%= govuk_button_link_to t("conversion_project.voluntary.create.assigned_to_regional_caseworker_team.button"), added_by_user_projects_path %>
+    <%= govuk_button_link_to t("conversion_project.voluntary.create.assigned_to_regional_caseworker_team.button"), project_contacts_path(@project) %>
   </div>
 </div>

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -24,16 +24,21 @@ en:
             <p class="govuk-body">You should add any contact details you have for the school, trust, solicitors, local authority and diocese (if applicable).</p>
         assigned_to_regional_caseworker_team:
           title: Project created
-          button: View projects you have added
+          button: Add contacts
           html:
             <p class="govuk-body">You have created a project for %{school_name}, URN %{urn}.</p>
+            <h2 class="govuk-heading-l">Add contact details</h2>
+            <p class="govuk-body">You must <a href="%{contacts_link}">add contact details</a> for the:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>school</li>
+              <li>trust</li>
+              <li>solicitors</li>
+              <li>local authority</li>
+            </ul> 
+            <p class="govuk-body">You must also add contact details for the diocese if this is a faith school.</p>
+            <p class="govuk-body">This will help the person continuing this project to organise the kick-off meeting.</p>
             <h2 class="govuk-heading-l">What happens next</h2>
             <p class="govuk-body">Another person will be assigned to this project.</p>
-            <h2 class="govuk-heading-l">Add contact details</h2>
-            <p class="govuk-body">You should <a href="%{contacts_link}">add any contact details</a> you have for the school, trust, solicitors, diocese and local authority.</p>
-            <p class="govuk-body">This will help the person continuing this project to organise kick-off meetings.</p>
-            <h2 class="govuk-heading-l">Help us improve the service</h2>
-            <p class="govuk-body">Complete this <a href="https://forms.office.com/e/xf0k4LcWVN" class="govuk-link" target="_blank">short survey (opens in new tab)</a>.</p>
     summary:
       route:
         title: Route


### PR DESCRIPTION
when a project has been created

## Changes

This work changes the content on the confirmation page that a delivery officer sees after creating a conversion. 

It prioritises and emphasises the importance of adding contact details to the project for caseworkers to pick up.

It also re-routes the primary action button to the external contacts page, so that the call to action on the page reflects the instruction in the content.

### Previous content

<img width="1049" alt="Screenshot 2023-05-25 at 11 50 29 am" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/d62f7f1b-bfd8-4474-8f74-37c5d3ad1442">

### New content

<img width="1043" alt="Screenshot 2023-05-25 at 11 50 54 am" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/90dca80a-fbdd-4d82-9520-0b13baade449">

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
