### PR TITLE
Move full stop from link to text in single worksheet task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Tie the Openers and Revised conversion date pages together with tabs
 - Update content in project creation confirmation page to make clear delivery
   officers must add contacts
-- Change primary action button to point to external contacts page
+- Change primary action button on project creation confirmation page to point to
+  external contacts page
+- Pull full stop out of mailto link on single worksheet task and into text
 
 ### Fixed
 

--- a/config/locales/conversion/tasks/single_worksheet.en.yml
+++ b/config/locales/conversion/tasks/single_worksheet.en.yml
@@ -18,7 +18,7 @@ en:
         send:
           title: Send the approved single worksheet to Academies Operational Practice Unit
           hint:
-            html: <p>Send the single worksheet and, if needed, the direction to transfer and trust modification order to <a href="mailto:academiesdelivery.operations@education.gov.uk" target="_blank">academiesdelivery.operations@education.gov.uk.</a></p>
+            html: <p>Send the single worksheet and, if needed, the direction to transfer and trust modification order to <a href="mailto:academiesdelivery.operations@education.gov.uk" target="_blank">academiesdelivery.operations@education.gov.uk</a>.</p>
           guidance_link: When you must complete this
           guidance:
             html:


### PR DESCRIPTION
## Changes

This takes the full stop in a sentence of guidance about the single worksheet out of the mailto hyperlink and into the <p> text outside the link.

## Before

<img width="701" alt="Screenshot 2023-05-30 at 2 53 04 pm" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/6d7fc17c-5c83-48cd-9c17-4cde2574883b">

## After

<img width="663" alt="Screenshot 2023-05-30 at 3 01 41 pm" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/930befe5-b849-49aa-8fcb-18f3f9c08ff4">

It also adds more specifics to the changelog about a change to where the primary action button points on the confirmation page after a delivery officer creates a project.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
