### PR TITLE
Add full stop to guidance in grant certificate task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Change primary action button on project creation confirmation page to point to
   external contacts page
 - Pull full stop out of mailto link on single worksheet task and into text
+- Change primary action button to point to external contacts page
+- Add missing full stop to guidance in grant payment certificate task
 
 ### Fixed
 

--- a/config/locales/conversion/tasks/receive_grant_payment_certificate.en.yml
+++ b/config/locales/conversion/tasks/receive_grant_payment_certificate.en.yml
@@ -13,7 +13,7 @@ en:
           guidance_link: What to do if you have not received the grant payment certificate
           guidance:
             html:
-              <p>You should ask the school to send the certificate. You must record the date each time you contact them in <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&amp;file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&amp;action=default&amp;mobileredirect=true" target="_blank">the support grant assurance report (opens in new tab)</a></p>
+              <p>You should ask the school to send the certificate. You must record the date each time you contact them in <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&amp;file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&amp;action=default&amp;mobileredirect=true" target="_blank">the support grant assurance report (opens in new tab)</a>.</p>
 
         update_kim:
           title: Update KIM with date certificate is received


### PR DESCRIPTION
## Changes

Adding a missing full stop.

## Before

<img width="643" alt="Screenshot 2023-05-30 at 3 25 13 pm" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/34beb959-4383-4c09-87b5-cdd89e7b8638">


## After

<img width="639" alt="Screenshot 2023-05-30 at 3 25 28 pm" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/5d1df92d-ec4b-4b74-a03a-0762bfe4c952">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
