### PR TITLE
First pass at data export for funding agreement letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   are due to open in the next calendar month and those that were going to open
   but are no longer.
 - Add bare bones Transfer::Project and Transfer::TasksData models
+- Create an opening projects csv exporter
 
 ### Changed
 
@@ -37,8 +38,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Display generated DfE number in project information view for the establishment
 - Service support users now see their own sub-navigation in the application
-- Add the Funding Agreement letters task
-- Indicate the Funding Agreement Letters contact on external contacts page
 
 ### Changed
 

--- a/app/controllers/all/opening/projects_controller.rb
+++ b/app/controllers/all/opening/projects_controller.rb
@@ -13,6 +13,19 @@ class All::Opening::ProjectsController < ApplicationController
     @date = "#{Date::MONTHNAMES[month.to_i]} #{year}"
   end
 
+  def download_csv
+    authorize Project, :index?
+
+    @projects = ProjectsFetcher.new.sorted_openers(month, year)
+    @date = "#{Date::MONTHNAMES[month.to_i]} #{year}"
+    @month = month
+    @year = year
+
+    @csv = OpeningProjectsCsvExporter.new(@projects).call
+
+    send_data @csv, filename: "opener.csv", type: :csv, disposition: "attachment"
+  end
+
   private def month
     params[:month]
   end

--- a/app/controllers/all/opening/projects_controller.rb
+++ b/app/controllers/all/opening/projects_controller.rb
@@ -23,7 +23,7 @@ class All::Opening::ProjectsController < ApplicationController
 
     @csv = OpeningProjectsCsvExporter.new(@projects).call
 
-    send_data @csv, filename: "opener.csv", type: :csv, disposition: "attachment"
+    send_data @csv, filename: "opening_#{month}_#{year}.csv", type: :csv, disposition: "attachment"
   end
 
   private def month

--- a/app/models/api/members_api/client.rb
+++ b/app/models/api/members_api/client.rb
@@ -23,6 +23,13 @@ class Api::MembersApi::Client
     end
   end
 
+  def member_for_constituency(constituency)
+    member_id = member_id(constituency).object
+    member_name = member_name(member_id).object
+    contact_details = member_contact_details(member_id).object.find { |details| details.type_id == 1 }
+    {name: member_name.name_display_as, email: contact_details.email, address_line1: contact_details.line1, address_line2: contact_details.line2, address_line3: contact_details.line3, address_postcode: contact_details.postcode}
+  end
+
   def member_id(search_term)
     constituency_data = constituency(search_term)
     raise constituency_data.error if constituency_data.error.present?

--- a/app/models/api/members_api/client.rb
+++ b/app/models/api/members_api/client.rb
@@ -27,7 +27,16 @@ class Api::MembersApi::Client
     member_id = member_id(constituency).object
     member_name = member_name(member_id).object
     contact_details = member_contact_details(member_id).object.find { |details| details.type_id == 1 }
-    {name: member_name.name_display_as, email: contact_details.email, address_line1: contact_details.line1, address_line2: contact_details.line2, address_line3: contact_details.line3, address_postcode: contact_details.postcode}
+    {
+      name: member_name.name_display_as,
+      email: contact_details.email,
+      address_line1: contact_details.line1,
+      address_line2: contact_details.line2,
+      address_line3: contact_details.line3,
+      address_line4: contact_details.line4,
+      address_line5: contact_details.line5,
+      address_postcode: contact_details.postcode
+    }
   end
 
   def member_id(search_term)

--- a/app/services/opening_projects_csv_exporter.rb
+++ b/app/services/opening_projects_csv_exporter.rb
@@ -1,0 +1,24 @@
+require "csv"
+
+class OpeningProjectsCsvExporter
+  def initialize(projects)
+    @projects = projects
+  end
+
+  def call
+    @csv = CSV.generate(headers: true) do |csv|
+      csv << headers
+      @projects.each do |project|
+        csv << row(project)
+      end
+    end
+  end
+
+  private def headers
+    ["School URN", "DfE number", "School name"]
+  end
+
+  private def row(project)
+    [project.urn, project.establishment.dfe_number, project.establishment.name]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
           namespace :opening do
             get "confirmed/:month/:year", to: "projects#confirmed", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :confirmed, defaults: {month: Date.today.next_month.month, year: Date.today.next_month.year}
             get "revised/:month/:year", to: "projects#revised", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :revised, defaults: {month: Date.today.next_month.month, year: Date.today.next_month.year}
+            get "confirmed/:month/:year/csv", to: "projects#download_csv", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :csv
           end
           namespace :statistics do
             get "/", to: "projects#index"

--- a/spec/models/api/members_api/client_spec.rb
+++ b/spec/models/api/members_api/client_spec.rb
@@ -45,6 +45,24 @@ RSpec.describe Api::MembersApi::Client do
     end
   end
 
+  describe "#member_for_constituency" do
+    it "returns a hash when successful" do
+      fake_client = Api::MembersApi::Client.new
+      allow(fake_client).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(4744, nil))
+      fake_name = double(Api::MembersApi::MemberName, name_display_as: "Joe Bloggs")
+      allow(fake_client).to receive(:member_name).and_return(Api::MembersApi::Client::Result.new(fake_name, nil))
+      fake_contact_details = double(find: Api::MembersApi::MemberContactDetails.new.from_hash({email: "joe.bloggs@email.com", line1: "Houses of Parliment", postcode: "SW1A 0AA"}))
+      allow(fake_client).to receive(:member_contact_details).and_return(Api::MembersApi::Client::Result.new(fake_contact_details, nil))
+
+      response = fake_client.member_for_constituency("St Albans")
+
+      expect(response[:name]).to eq("Joe Bloggs")
+      expect(response[:email]).to eq("joe.bloggs@email.com")
+      expect(response[:address_line1]).to eq("Houses of Parliment")
+      expect(response[:address_postcode]).to eq("SW1A 0AA")
+    end
+  end
+
   describe "#member_id" do
     let(:client) { described_class.new(connection: fake_successful_constituency_search_connection(fake_response)) }
 

--- a/spec/requests/all/opening/projects_controller_spec.rb
+++ b/spec/requests/all/opening/projects_controller_spec.rb
@@ -82,4 +82,14 @@ RSpec.describe All::Opening::ProjectsController, type: :request do
       end
     end
   end
+
+  describe "#download_csv" do
+    it "returns the csv with a successful response" do
+      project = create(:conversion_project, conversion_date: Date.new(2025, 5, 1), conversion_date_provisional: false)
+
+      get csv_all_opening_projects_path(5, 2025)
+      expect(response.body).to include(project.urn.to_s)
+      expect(response).to have_http_status(:success)
+    end
+  end
 end

--- a/spec/requests/all/opening/projects_controller_spec.rb
+++ b/spec/requests/all/opening/projects_controller_spec.rb
@@ -84,12 +84,17 @@ RSpec.describe All::Opening::ProjectsController, type: :request do
   end
 
   describe "#download_csv" do
-    it "returns the csv with a successful response" do
-      project = create(:conversion_project, conversion_date: Date.new(2025, 5, 1), conversion_date_provisional: false)
+    let!(:project) { create(:conversion_project, conversion_date: Date.new(2025, 5, 1), conversion_date_provisional: false) }
 
+    it "returns the csv with a successful response" do
       get csv_all_opening_projects_path(5, 2025)
       expect(response.body).to include(project.urn.to_s)
       expect(response).to have_http_status(:success)
+    end
+
+    it "formats the csv filename with the month & year" do
+      get csv_all_opening_projects_path(5, 2025)
+      expect(response.header["Content-Disposition"]).to include("opening_5_2025.csv")
     end
   end
 end

--- a/spec/services/opening_projects_csv_exporter_spec.rb
+++ b/spec/services/opening_projects_csv_exporter_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe OpeningProjectsCsvExporter do
+  describe "#call" do
+    before do
+      mock_successful_api_response_to_create_any_project
+    end
+
+    it "returns a csv with the school urn" do
+      project = build(:conversion_project, urn: 654321)
+
+      csv_export = OpeningProjectsCsvExporter.new([project]).call
+
+      expect(csv_export).to include("School URN")
+      expect(csv_export).to include("654321")
+    end
+
+    it "returns a csv with the DfE number" do
+      establishment = build(:academies_api_establishment)
+      allow(establishment).to receive(:dfe_number).and_return("765/4321")
+      project = build(:conversion_project, establishment: establishment)
+
+      csv_export = OpeningProjectsCsvExporter.new([project]).call
+
+      expect(csv_export).to include("DfE number")
+      expect(csv_export).to include("765/4321")
+    end
+
+    it "returns a csv with the establishment name" do
+      establishment = build(:academies_api_establishment)
+      allow(establishment).to receive(:name).and_return("Establishment name")
+      project = build(:conversion_project, establishment: establishment)
+
+      csv_export = OpeningProjectsCsvExporter.new([project]).call
+
+      expect(csv_export).to include("School name")
+      expect(csv_export).to include("Establishment name")
+    end
+  end
+end


### PR DESCRIPTION
## Changes

This isn't the finished feature.

This work is to introduce the process of exporting projects from the openers list into a csv file.
This covers just a few basic attributes to allow us to test this against a larger number of projects within the `production environment`.

The are at least 44 attributes that will end up in the csv, so we want to make sure we have a solid foundation to work from.

### Next steps
To add in the remaining attributes once we know this is the sensible route.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
