### PR TITLE
Making academy name and URN style consistent and clarifying content on conversion date confirmation page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Pull full stop out of mailto link on single worksheet task and into text
 - Change primary action button to point to external contacts page
 - Add missing full stop to guidance in grant payment certificate task
+- Updated the way we present academy name and URN in the conversion date change
+  confirmation page so it is consistent with other confirmation pages
+- Changed the content on the conversion date change confirmation page to provide
+  clearer, more direct guidance about how and when a date can be changed by
+  phrasing the heading as a statement and not a question
 
 ### Fixed
 

--- a/config/locales/conversion_history.en.yml
+++ b/config/locales/conversion_history.en.yml
@@ -8,15 +8,16 @@ en:
       panel:
         title: Conversion date changed
       body_html:
-        <p>You have changed the conversion date for %{school_name} %{urn}.</p>
+        <p>You have changed the conversion date for %{school_name}, URN %{urn}.</p>
         <h2 class="govuk-heading-m">New conversion date</h2>
         <p>The new conversion date is %{conversion_date}.</p>
         <h2 class="govuk-heading-m">What happens next</h2>
         <p>The conversion has moved to the new month in your project list.</p>
         <p>You can <a href="%{project_path}">continue working on this conversion</a>, or <a href="%{projects_path}">choose another project to work on</a> from your list.</p>
-        <h2 class="govuk-heading-m">Need to change the conversion date?</h2>
-        <p>You can change the conversion date as many times as you need.</p>
-        <p>If you made a mistake, go back and enter the correct date.</p>
+        <h2 class="govuk-heading-m">Changing the date again</h2>
+        <p>You can change the conversion date as many times as you need to.</p>
+        <p>Enter the conversion date again if this change was not right.</p> 
+        <p>You can alter the conversion date at any time if there are changes to the project in the future.</p>
   errors:
     attributes:
       revised_date:


### PR DESCRIPTION
## Changes

- Academy name and URN presented in way that is consistent with other confirmation pages in the build
- Content about when to change the date again is made more direct and clear by using statement rather than question in the heading. Also covers changing date because of further delays and not just because of human error

## Before

<img width="717" alt="Screenshot 2023-05-31 at 9 31 26 am" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/f39c06d9-0e78-4b20-8f72-e06fbf7aa771">

## After

<img width="724" alt="Screenshot 2023-05-31 at 9 30 48 am" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/ac22a6fb-0b76-402d-afd3-cf12180a3d47">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
