### PR TITLE
Add some missing locale strings

### DIFF
--- a/app/views/all/trust/projects/by_trust.html.erb
+++ b/app/views/all/trust/projects/by_trust.html.erb
@@ -9,7 +9,7 @@
         <table class="govuk-table" name="projects_table" aria-label="Projects table">
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">
-              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school") %></th>
+              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>

--- a/app/views/notes/_notes.html.erb
+++ b/app/views/notes/_notes.html.erb
@@ -9,6 +9,6 @@
   <%= render_markdown(note.body) %>
 
   <% if policy(note).edit? %>
-    <p class="govuk-body govuk-!-font-size-16"><%= govuk_link_to "Edit", edit_project_note_path(@project, note) %></p>
+    <p class="govuk-body govuk-!-font-size-16"><%= govuk_link_to t("edit"), edit_project_note_path(@project, note) %></p>
   <% end %>
 <% end %>

--- a/app/views/notes/confirm_destroy.html.erb
+++ b/app/views/notes/confirm_destroy.html.erb
@@ -4,8 +4,8 @@
       <h1 class="govuk-heading-l"><%= t("note.confirm_destroy.title") %></h1>
       <p><%= t("note.confirm_destroy.guidance") %></p>
 
-      <%= form.govuk_submit "Delete", warning: true do %>
-        <%= govuk_link_to "Cancel", edit_project_note_path(@project, @note) %>
+      <%= form.govuk_submit t("delete"), warning: true do %>
+        <%= govuk_link_to t("cancel"), edit_project_note_path(@project, @note) %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -12,7 +12,7 @@
       <%= form.govuk_text_area :body, label: {tag: "h1", size: "l"} %>
 
       <%= form.govuk_submit t("note.new.save_note_button") do %>
-        <%= govuk_link_to "Cancel", return_path %>
+        <%= govuk_link_to t("cancel"), return_path %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/user/projects/_table.html.erb
+++ b/app/views/user/projects/_table.html.erb
@@ -4,7 +4,7 @@
   <table class="govuk-table" name="projects_table" aria-label="Projects table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,8 @@ en:
   "yes": "Yes"
   "no": "No"
   cancel: Cancel
+  edit: Edit
+  delete: Delete
   phase_banner:
     phase: Beta
     phase_notice:
@@ -76,6 +78,8 @@ en:
       title: Change regional delivery officer for %{school_name}
     assign_assigned_to:
       title: Change assigned person for %{school_name}
+    assign_team_leader:
+      title: Change assigned team leader for %{school_name}
 
   subnavigation:
     project_task_list: Task list

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -262,6 +262,12 @@ en:
           it can take one day for the data to be syncronised
         rows:
           urn: Unique reference number (URN)
+          academy_name: Academy name
+          address: Address
+          school_type: School type
+          age_range: Age range
+          school_phase: School phase
+          region: Region
       trust_details:
         title: Trust details
         rows:


### PR DESCRIPTION
When looking into https://trello.com/c/6toiEBHZ we found some other missing locale strings, which were being overlooked by the i18n default behaviour (of presenting the local key in Sentence Case).

