### PR TITLE
Add project completion validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Do not allow a project to be completed until all conditions have been met, the
+  grant certificate is returned and the academy has opened
+
 ### Changed
 
 ### Fixed

--- a/app/controllers/projects_complete_controller.rb
+++ b/app/controllers/projects_complete_controller.rb
@@ -8,6 +8,11 @@ class ProjectsCompleteController < ApplicationController
     render :completed
   end
 
+  private def project_completable?
+    return true if @project.all_conditions_met? && @project.conversion_date_confirmed_and_passed? && @project.grant_payment_certificate_received?
+    false
+  end
+
   private def set_project_completed_at
     return if @project.completed?
 

--- a/app/controllers/projects_complete_controller.rb
+++ b/app/controllers/projects_complete_controller.rb
@@ -3,9 +3,14 @@ class ProjectsCompleteController < ApplicationController
     @project = Project.find(project_id)
     authorize @project, :update?
 
-    set_project_completed_at
+    if project_completable?
+      set_project_completed_at
 
-    render :completed
+      render :completed
+    else
+      flash[:alert] = I18n.t("project.complete.unable_to_complete_html")
+      redirect_to project_conversion_tasks_path(@project)
+    end
   end
 
   private def project_completable?

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -19,4 +19,8 @@ class Conversion::Project < Project
   def all_conditions_met?
     tasks_data.conditions_met_confirm_all_conditions_met?
   end
+
+  def conversion_date_confirmed_and_passed?
+    !conversion_date_provisional? && conversion_date.past?
+  end
 end

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -23,4 +23,11 @@ class Conversion::Project < Project
   def conversion_date_confirmed_and_passed?
     !conversion_date_provisional? && conversion_date.past?
   end
+
+  def grant_payment_certificate_received?
+    user = assigned_to
+    tasks = Conversion::Task::ReceiveGrantPaymentCertificateTaskForm.new(tasks_data, user)
+    return true if tasks.status.eql?(:completed)
+    false
+  end
 end

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -15,4 +15,8 @@ class Conversion::Project < Project
 
     conversion_dates.order(:created_at).first.previous_date
   end
+
+  def all_conditions_met?
+    tasks_data.conditions_met_confirm_all_conditions_met?
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -114,10 +114,6 @@ class Project < ApplicationRecord
     assigned_to.nil?
   end
 
-  def all_conditions_met?
-    tasks_data.conditions_met_confirm_all_conditions_met?
-  end
-
   def director_of_child_services
     local_authority = establishment.local_authority
     local_authority&.director_of_child_services

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -106,6 +106,13 @@ en:
           <p>You will not be able to change this project once it is completed.</p>
       submit_button: Complete project
       back_link: Return to project list
+      unable_to_complete_html:
+        <p>This project cannot be completed until:</p>
+        <ul>
+        <li>The conversion date has been confirmed and is in the past</li>
+        <li>The confirm all conditions have been met task is completed</li>
+        <li>The receive grant payment certificate task is completed</li>
+        </ul>
     summary:
       incoming_trust:
         title: Incoming trust

--- a/spec/accessibility/projects_spec.rb
+++ b/spec/accessibility/projects_spec.rb
@@ -38,7 +38,17 @@ RSpec.feature "Test projects accessibility", driver: :headless_firefox, accessib
   end
 
   scenario "project completed page" do
-    project = create(:conversion_project, regional_delivery_officer: user, assigned_to: user)
+    tasks_data = create(:conversion_tasks_data,
+      receive_grant_payment_certificate_check_and_save: true,
+      receive_grant_payment_certificate_update_kim: true,
+      receive_grant_payment_certificate_update_sheet: true,
+      conditions_met_confirm_all_conditions_met: true)
+    project = create(:conversion_project,
+      regional_delivery_officer: user,
+      assigned_to: user,
+      tasks_data: tasks_data,
+      conversion_date: 1.month.ago.at_beginning_of_month,
+      conversion_date_provisional: false)
     visit project_path(project)
 
     click_on I18n.t("project.complete.submit_button")

--- a/spec/features/users_can_complete_a_project_spec.rb
+++ b/spec/features/users_can_complete_a_project_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.feature "Users can complete a project" do
   let(:user) { create(:user, :caseworker) }
-  let(:project) { create(:conversion_project, assigned_to: user) }
 
   before do
     mock_successful_api_responses(urn: 123456, ukprn: 10061021)
@@ -10,25 +9,56 @@ RSpec.feature "Users can complete a project" do
     mock_pre_fetched_api_responses_for_any_establishment_and_trust
   end
 
-  scenario "successfully" do
-    visit project_path(project)
+  context "when all conditions have been met and the academy has opened" do
+    let(:tasks_data) {
+      create(:conversion_tasks_data,
+        receive_grant_payment_certificate_check_and_save: true,
+        receive_grant_payment_certificate_update_kim: true,
+        receive_grant_payment_certificate_update_sheet: true,
+        conditions_met_confirm_all_conditions_met: true)
+    }
+    let(:project) {
+      create(:conversion_project,
+        assigned_to: user,
+        conversion_date: 2.months.ago.at_beginning_of_month,
+        conversion_date_provisional: false,
+        tasks_data: tasks_data)
+    }
 
-    click_on I18n.t("project.complete.submit_button")
+    scenario "the project is completed successfully" do
+      visit project_path(project)
 
-    expect(page).to have_content("Project completed")
-    expect(page).to have_content("You have completed the project for #{project.establishment.name} #{project.urn}.")
-    expect(project.reload.completed_at).not_to be_nil
+      click_on I18n.t("project.complete.submit_button")
 
-    expect(page).to have_link "short survey", href: "https://forms.office.com/e/xf0k4LcWVN"
+      expect(page).to have_content("Project completed")
+      expect(page).to have_content("You have completed the project for #{project.establishment.name} #{project.urn}.")
+      expect(project.reload.completed_at).not_to be_nil
 
-    click_on I18n.t("project.complete.back_link")
-    # The project listing is no longer on the index page (open projects only)
-    expect(page).to_not have_content(project.establishment.name)
+      expect(page).to have_link "short survey", href: "https://forms.office.com/e/xf0k4LcWVN"
 
-    # The project has moved to the Completed tab
-    click_on I18n.t("subnavigation.completed_projects")
-    click_on project.establishment.name
+      click_on I18n.t("project.complete.back_link")
+      # The project listing is no longer on the index page (open projects only)
+      expect(page).to_not have_content(project.establishment.name)
 
-    expect(page).to have_content(DateTime.now.to_formatted_s(:govuk_date_time_date_only))
+      # The project has moved to the Completed tab
+      click_on I18n.t("subnavigation.completed_projects")
+      click_on project.establishment.name
+
+      expect(page).to have_content(DateTime.now.to_formatted_s(:govuk_date_time_date_only))
+    end
+  end
+
+  context "when the project does not have all conditions met and the academy has not opened" do
+    let(:project) { create(:conversion_project, assigned_to: user) }
+
+    scenario "the project cannot be completed" do
+      visit project_path(project)
+
+      click_on I18n.t("project.complete.submit_button")
+
+      expect(page).to_not have_content("Project completed")
+      expect(page).to have_content("This project cannot be completed")
+      expect(project.reload.completed_at).to be_nil
+    end
   end
 end

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -118,4 +118,35 @@ RSpec.describe Conversion::Project do
       end
     end
   end
+
+  describe "#grant_payment_certificate_received?" do
+    let(:user) { create(:user) }
+    let(:project) { build(:conversion_project, tasks_data: tasks_data) }
+
+    context "when the ReceiveGrantPaymentCertificateTaskForm is NOT completed" do
+      let(:tasks_data) {
+        create(:conversion_tasks_data,
+          receive_grant_payment_certificate_check_and_save: nil,
+          receive_grant_payment_certificate_update_kim: nil,
+          receive_grant_payment_certificate_update_sheet: nil)
+      }
+
+      it "returns false" do
+        expect(project.grant_payment_certificate_received?).to be false
+      end
+    end
+
+    context "when the ReceiveGrantPaymentCertificateTaskForm is completed" do
+      let(:tasks_data) {
+        create(:conversion_tasks_data,
+          receive_grant_payment_certificate_check_and_save: true,
+          receive_grant_payment_certificate_update_kim: true,
+          receive_grant_payment_certificate_update_sheet: true)
+      }
+
+      it "returns true" do
+        expect(project.grant_payment_certificate_received?).to be true
+      end
+    end
+  end
 end

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -54,4 +54,24 @@ RSpec.describe Conversion::Project do
       end
     end
   end
+
+  describe "#all_conditions_met?" do
+    context "when the all conditions met task is completed" do
+      let(:tasks_data) { create(:conversion_tasks_data, conditions_met_confirm_all_conditions_met: true) }
+      let(:project) { build(:conversion_project, tasks_data: tasks_data) }
+
+      it "returns true" do
+        expect(project.all_conditions_met?).to eq(true)
+      end
+    end
+
+    context "when the all conditions met task has not been completed" do
+      let(:tasks_data) { create(:conversion_tasks_data, conditions_met_confirm_all_conditions_met: nil) }
+      let(:project) { build(:conversion_project, tasks_data: tasks_data) }
+
+      it "returns false" do
+        expect(project.all_conditions_met?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -74,4 +74,48 @@ RSpec.describe Conversion::Project do
       end
     end
   end
+
+  describe "#opened?" do
+    let(:project) {
+      build(:conversion_project,
+        conversion_date: conversion_date,
+        conversion_date_provisional: conversion_date_provisional)
+    }
+
+    context "when the conversion date has not passed" do
+      let(:conversion_date) { Date.tomorrow }
+      let(:conversion_date_provisional) { false }
+
+      it "returns false" do
+        expect(project.conversion_date_confirmed_and_passed?).to be false
+      end
+    end
+
+    context "when the conversion date has passed but the conversion date is provisional" do
+      let(:conversion_date) { Date.yesterday }
+      let(:conversion_date_provisional) { true }
+
+      it "returns false" do
+        expect(project.conversion_date_confirmed_and_passed?).to be false
+      end
+    end
+
+    context "when the conversion date is provisional" do
+      let(:conversion_date) { Date.tomorrow }
+      let(:conversion_date_provisional) { true }
+
+      it "returns false" do
+        expect(project.conversion_date_confirmed_and_passed?).to be false
+      end
+    end
+
+    context "when the conversion date is confirmed and the conversion date has passed" do
+      let(:conversion_date) { Date.yesterday }
+      let(:conversion_date_provisional) { false }
+
+      it "returns true" do
+        expect(project.conversion_date_confirmed_and_passed?).to be true
+      end
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -336,26 +336,6 @@ RSpec.describe Project, type: :model do
     end
   end
 
-  describe "#all_conditions_met?" do
-    context "when the all conditions met task is completed" do
-      let(:tasks_data) { create(:conversion_tasks_data, conditions_met_confirm_all_conditions_met: true) }
-      let(:project) { build(:conversion_project, tasks_data: tasks_data) }
-
-      it "returns true" do
-        expect(project.all_conditions_met?).to eq(true)
-      end
-    end
-
-    context "when the all conditions met task has not been completed" do
-      let(:tasks_data) { create(:conversion_tasks_data, conditions_met_confirm_all_conditions_met: nil) }
-      let(:project) { build(:conversion_project, tasks_data: tasks_data) }
-
-      it "returns false" do
-        expect(project.all_conditions_met?).to eq(false)
-      end
-    end
-  end
-
   describe "Scopes" do
     describe "conversions" do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }


### PR DESCRIPTION
## Changes

A Project cannot be completed until All conditions have been met, the Grant payment certificate is received and the academy has opened. If the user tries to complete the project when these conditions are not met, they will see a message.

<img width="1152" alt="Screenshot 2023-06-01 at 15 45 14" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/291a0a9f-d46f-4fc2-8af5-8f993ddc106d">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
