### PR TITLE
Service support user views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Display generated DfE number in project information view for the establishment
+- Service support users now see their own sub-navigation in the application
 
 ### Changed
 

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -2,6 +2,8 @@ class RootController < ApplicationController
   def home
     return redirect_to unassigned_regional_casework_services_projects_path if current_user.team_leader?
 
+    return redirect_to new_all_projects_path if current_user.service_support?
+
     redirect_to in_progress_user_projects_path
   end
 end

--- a/app/views/all/projects/new.html.erb
+++ b/app/views/all/projects/new.html.erb
@@ -1,16 +1,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
-      <%= t("project.all.new.title") %>
+      <%= t("service_support.title") %>
     </h1>
 
-    <nav class="moj-sub-navigation" aria-label="Project list sub-navigation">
-      <ul class="moj-sub-navigation__list">
-        <%= render partial: "shared/sub_navigation_item", locals: {name: t("project.subnavigation.new"), path: new_all_projects_path} %>
-        <%= render partial: "shared/sub_navigation_item", locals: {name: t("project.subnavigation.with_academy_urn"), path: with_academy_urn_all_projects_path} %>
-      </ul>
-    </nav>
+    <%= render partial: "shared/service_support_sub_navigation" %>
+
+    <h2 class="govuk-heading-m"><%= t("service_support.section.without_urn.title") %></h2>
 
     <%= render partial: "/projects/shared/new_table", locals: {projects: @projects, pager: @pager} %>
+
   </div>
 </div>

--- a/app/views/all/projects/with_academy_urn.html.erb
+++ b/app/views/all/projects/with_academy_urn.html.erb
@@ -1,15 +1,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
-      <%= t("project.all.with_academy_urn.title") %>
+      <%= t("service_support.title") %>
     </h1>
 
-    <nav class="moj-sub-navigation" aria-label="Project list sub-navigation">
-      <ul class="moj-sub-navigation__list">
-        <%= render partial: "shared/sub_navigation_item", locals: {name: t("project.subnavigation.new"), path: new_all_projects_path} %>
-        <%= render partial: "shared/sub_navigation_item", locals: {name: t("project.subnavigation.with_academy_urn"), path: with_academy_urn_all_projects_path} %>
-      </ul>
-    </nav>
+    <%= render partial: "shared/service_support_sub_navigation" %>
+
+    <h2 class="govuk-heading-m"><%= t("service_support.section.with_urn.title") %></h2>
 
     <%= render partial: "/projects/shared/with_academy_urn_table", locals: {projects: @projects, pager: @pager} %>
   </div>

--- a/app/views/local_authorities/index.html.erb
+++ b/app/views/local_authorities/index.html.erb
@@ -1,8 +1,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
-      <%= t("local_authority.index.title") %>
+      <%= t("service_support.title") %>
     </h1>
+
+    <%= render partial: "shared/service_support_sub_navigation" %>
+
+    <h2 class="govuk-heading-m"><%= t("service_support.section.local_authorities.title") %></h2>
 
     <%= govuk_button_link_to t("local_authority.new.title"), new_local_authority_path if policy(LocalAuthority).new? %>
 

--- a/app/views/shared/_service_support_sub_navigation.html.erb
+++ b/app/views/shared/_service_support_sub_navigation.html.erb
@@ -1,0 +1,7 @@
+<nav class="moj-sub-navigation" aria-label="Sub-navigation">
+  <ul class="moj-sub-navigation__list">
+    <%= render partial: "shared/sub_navigation_item", locals: {name: t("service_support.sub_navigation.without_urn"), path: new_all_projects_path} %>
+    <%= render partial: "shared/sub_navigation_item", locals: {name: t("service_support.sub_navigation.with_urn"), path: with_academy_urn_all_projects_path} %>
+    <%= render partial: "shared/sub_navigation_item", locals: {name: t("service_support.sub_navigation.local_authorities"), path: local_authorities_path} %>
+  </ul>
+</nav>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -31,10 +31,6 @@ en:
           title: All sponsored completed projects
         voluntary:
           title: All voluntary completed projects
-      new:
-        title: All conversions without an academy URN
-      with_academy_urn:
-        title: All conversions with an academy URN
       trust_ukprn:
           title: Projects for %{trust}
     regional_casework_services:

--- a/config/locales/service_support.en.yml
+++ b/config/locales/service_support.en.yml
@@ -1,0 +1,14 @@
+en:
+  service_support:
+    title: Service support
+    sub_navigation:
+      without_urn: URNs to create
+      with_urn: URNs added
+      local_authorities: Manage local authorities
+    section:
+      without_urn:
+        title: URNs to create
+      with_urn:
+        title: URNs added
+      local_authorities:
+        title: Manage local authorities

--- a/spec/features/conversions/users_can_edit_the_academy_urn_spec.rb
+++ b/spec/features/conversions/users_can_edit_the_academy_urn_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature "Users can edit the Academy URN" do
         click_on "Save and return"
         expect(page).to have_content("Are these details correct?")
         click_on "Cancel"
-        expect(page).to have_content("All conversions without an academy URN")
+        expect(page).to have_content("URNs to create")
         expect(page).to have_content(project.establishment.name)
       end
     end

--- a/spec/features/local_authorities/users_can_view_local_authorities_spec.rb
+++ b/spec/features/local_authorities/users_can_view_local_authorities_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Users can view local authorities" do
   scenario "they can view all local authorities" do
     visit local_authorities_path
 
-    expect(page).to have_content("Local Authorities")
+    expect(page).to have_content("Manage local authorities")
     expect(page).to have_content(local_authority_1.name)
     expect(page).to have_content(local_authority_2.name)
   end

--- a/spec/features/projects/new/users_can_view_a_list_of_new_projects_spec.rb
+++ b/spec/features/projects/new/users_can_view_a_list_of_new_projects_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature "Viewing all new projects" do
     def view_all_new_projects
       visit new_all_projects_path
 
-      expect(page).to have_content(I18n.t("project.all.new.title"))
+      expect(page).to have_content(I18n.t("service_support.section.without_urn.title"))
 
       within("tbody") do
         expect(page).to have_content(project_without_academy_urn.establishment.name)

--- a/spec/features/projects/with_academy_urn/users_can_view_a_list_of_projects_with_academy_urn_spec.rb
+++ b/spec/features/projects/with_academy_urn/users_can_view_a_list_of_projects_with_academy_urn_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature "Viewing all projects with an academy URN" do
     def view_all_projects_with_academy_urn
       visit with_academy_urn_all_projects_path
 
-      expect(page).to have_content(I18n.t("project.all.with_academy_urn.title"))
+      expect(page).to have_content(I18n.t("service_support.section.with_urn.title"))
 
       within("tbody") do
         expect(page).to have_content(project_with_academy_urn.urn)

--- a/spec/features/service_support/users_can_navigate_the_application_spec.rb
+++ b/spec/features/service_support/users_can_navigate_the_application_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.feature "Service support users can navigate the application" do
+  let(:user) { create(:user, :service_support) }
+
+  before do
+    mock_all_academies_api_responses
+    sign_in_with_user(user)
+  end
+
+  scenario "when the sign in they are redirected to the appropriate view and can see the sub navigation" do
+    expect(page).to have_content("Service support")
+    expect(page).to have_link("URNs to create")
+    expect(page).to have_link("URNs added")
+    expect(page).to have_link("Manage local authorities")
+  end
+
+  scenario "they can view the projects that need records added to GIAS i.e. those that require academy URNs" do
+    project = create(:conversion_project, academy_urn: nil)
+
+    click_link("URNs to create")
+
+    expect(page).to have_content("URNs to create")
+    expect(page).to have_content(project.urn)
+  end
+
+  scenario "they can view the projects that have a record on GIAS" do
+    project = create(:conversion_project, academy_urn: 149061)
+
+    click_link("URNs added")
+
+    expect(page).to have_content("URNs added")
+    expect(page).to have_content(project.academy_urn)
+  end
+
+  scenario "they can view all local authorities" do
+    local_authority = create(:local_authority)
+
+    click_link("Manage local authorities")
+
+    expect(page).to have_content("Manage local authorities")
+    expect(page).to have_content(local_authority.name)
+  end
+end


### PR DESCRIPTION
This work brings the three service support user views togther and redirects them to it upon login or visiting the root page.

We haven't consolidate the paths just yet, that may come later, for now we want to have the option of sharing the behaviour of the new app/service with users.

https://trello.com/c/692dTdzf

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/c0ceb614-f6c4-49c8-804b-83b0f470d483)
