### PR TITLE
New project logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Changed the content on the conversion date change confirmation page to provide
   clearer, more direct guidance about how and when a date can be changed by
   phrasing the heading as a statement and not a question
+- Adding a new project where the school is not considred 'religious'
+  automatically marks the 'Church supplemental agreement' as not applicable,
+  users can make the task applicable if desired
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Adding a new project where the school is not considred 'religious'
   automatically marks the 'Church supplemental agreement' as not applicable,
   users can make the task applicable if desired
+- Adding a new project that has not been issued with a directive academy order
+  automatically marks the 'Process the sponsored support grant' task as not
+  applicable, users can make the task applicable if desired
 
 ### Fixed
 

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -146,7 +146,7 @@ class Conversion::CreateProjectForm
       assigned_at: assigned_at,
       directive_academy_order: directive_academy_order,
       region: region,
-      tasks_data: Conversion::TasksData.new
+      tasks_data: new_tasks_data
     )
 
     return nil unless valid?
@@ -158,5 +158,16 @@ class Conversion::CreateProjectForm
     end
 
     @project
+  end
+
+  def new_tasks_data
+    Conversion::TasksData.new(
+      church_supplemental_agreement_not_applicable: church_supplemental_agreement_not_applicable?
+    )
+  end
+
+  private def church_supplemental_agreement_not_applicable?
+    return true unless establishment.has_diocese?
+    false
   end
 end

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -162,12 +162,18 @@ class Conversion::CreateProjectForm
 
   def new_tasks_data
     Conversion::TasksData.new(
-      church_supplemental_agreement_not_applicable: church_supplemental_agreement_not_applicable?
+      church_supplemental_agreement_not_applicable: church_supplemental_agreement_not_applicable?,
+      sponsored_support_grant_not_applicable: sponsored_support_grant_not_applicable?
     )
   end
 
   private def church_supplemental_agreement_not_applicable?
     return true unless establishment.has_diocese?
+    false
+  end
+
+  private def sponsored_support_grant_not_applicable?
+    return true if directive_academy_order == false
     false
   end
 end

--- a/app/models/api/academies_api/establishment.rb
+++ b/app/models/api/academies_api/establishment.rb
@@ -1,4 +1,6 @@
 class Api::AcademiesApi::Establishment < Api::BaseApiModel
+  DIOCESE_NOT_APPLICABLE_CODE = "0000"
+
   attr_accessor(
     :urn,
     :name,
@@ -10,6 +12,7 @@ class Api::AcademiesApi::Establishment < Api::BaseApiModel
     :age_range_upper,
     :phase,
     :diocese_name,
+    :diocese_code,
     :region_name,
     :region_code,
     :parliamentary_constituency,
@@ -33,6 +36,7 @@ class Api::AcademiesApi::Establishment < Api::BaseApiModel
       age_range_upper: "statutoryHighAge",
       phase: "phaseOfEducation.name",
       diocese_name: "diocese.name",
+      diocese_code: "diocese.code",
       region_name: "gor.name",
       region_code: "gor.code",
       parliamentary_constituency: "parliamentaryConstituency.name",
@@ -62,5 +66,9 @@ class Api::AcademiesApi::Establishment < Api::BaseApiModel
 
   def dfe_number
     "#{local_authority_code}/#{establishment_number}"
+  end
+
+  def has_diocese?
+    diocese_code != DIOCESE_NOT_APPLICABLE_CODE
   end
 end

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -58,6 +58,17 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
         expect(project.assigned_at).to eq DateTime.now
       end
     end
+
+    context "and the establishment has a diocese" do
+      it "sets the church supplemental agreement task to not applicable" do
+        establishment = build(:academies_api_establishment, diocese_code: "0000")
+        result = Api::AcademiesApi::Client::Result.new(establishment, nil)
+        allow_any_instance_of(Api::AcademiesApi::Client).to receive(:get_establishment).with(123456).and_return(result)
+        project = build(:create_project_form).save
+
+        expect(project.tasks_data.church_supplemental_agreement_not_applicable).to be true
+      end
+    end
   end
 
   describe "validations" do

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -69,6 +69,14 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
         expect(project.tasks_data.church_supplemental_agreement_not_applicable).to be true
       end
     end
+
+    context "and an academy order was issued, i.e. the project is voluntary" do
+      it "sets the Process the sponsored support grant task as not applicable" do
+        project = build(:create_project_form, directive_academy_order: false).save
+
+        expect(project.tasks_data.sponsored_support_grant_not_applicable).to be true
+      end
+    end
   end
 
   describe "validations" do

--- a/spec/models/api/academies_api/establishment_spec.rb
+++ b/spec/models/api/academies_api/establishment_spec.rb
@@ -16,4 +16,16 @@ RSpec.describe Api::AcademiesApi::Establishment do
       expect(establishment.dfe_number).to eql("300/4567")
     end
   end
+
+  describe "#has_diocese?" do
+    it "returns true when the diocese code is not 0000" do
+      establishment = build(:academies_api_establishment, diocese_code: "CE26")
+      expect(establishment.has_diocese?).to be true
+    end
+
+    it "returns false when the diocses code is 0000" do
+      establishment = build(:academies_api_establishment, diocese_code: "0000")
+      expect(establishment.has_diocese?).to be false
+    end
+  end
 end


### PR DESCRIPTION
When a new project is created we can help users by pre-marking some tasks as not applicable:

- when the school is not considered 'religious' the Church supplemental funding agreement task is likely to be not applicable
- when the project is considered 'voluntary' the Process the sponsored support grant task is likely to be not applicable

Here we add this logic into the create conversion project form object.

Along the way we looked for a reliable marker for a school being considered 'religious' - there wasn't a clear one so we have gone with if the school has a diocese - this may turn out to be not the best marker - but this feature is not critical so it is good enough for now.

https://trello.com/c/YvCZ2meO