### PR TITLE
Add the Funding agreement letters contact task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Display generated DfE number in project information view for the establishment
 - Service support users now see their own sub-navigation in the application
+- Add the Funding Agreement letters task
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Display generated DfE number in project information view for the establishment
 - Service support users now see their own sub-navigation in the application
 - Add the Funding Agreement letters task
+- Indicate the Funding Agreement Letters contact on external contacts page
 
 ### Changed
 

--- a/app/forms/conversion/task/funding_agreement_contact_task_form.rb
+++ b/app/forms/conversion/task/funding_agreement_contact_task_form.rb
@@ -1,34 +1,20 @@
 class Conversion::Task::FundingAgreementContactTaskForm < ::BaseTaskForm
-  attribute :name, :string
-  attribute :email, :string
-  attribute :title, :string
-
-  validates :name, :email, :title, presence: true
-  validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}
+  attribute :funding_agreement_contact_id, :string
 
   def initialize(tasks_data, user)
     @tasks_data = tasks_data
     @user = user
-    @project = tasks_data.project
-    @contact = Contact::Project.find_or_create_by(project: @project, funding_agreement_contact: true)
+    @project = @tasks_data.project
 
     super(@tasks_data, @user)
-
-    assign_attributes(
-      name: @contact.name,
-      title: @contact.title,
-      email: @contact.email
-    )
+    self.funding_agreement_contact_id = @project.funding_agreement_contact_id
   end
 
   def save
-    @contact.assign_attributes(
-      project: @project,
-      name: name,
-      title: title,
-      email: email,
-      funding_agreement_contact: true
-    )
-    @contact.save!
+    @project.update!(funding_agreement_contact_id: funding_agreement_contact_id)
+  end
+
+  private def completed?
+    @project.funding_agreement_contact_id.present?
   end
 end

--- a/app/models/conversion/task_list.rb
+++ b/app/models/conversion/task_list.rb
@@ -8,7 +8,8 @@ class Conversion::TaskList < ::BaseTaskList
           Conversion::Task::StakeholderKickOffTaskForm,
           Conversion::Task::ConversionGrantTaskForm,
           Conversion::Task::SponsoredSupportGrantTaskForm,
-          Conversion::Task::AcademyDetailsTaskForm
+          Conversion::Task::AcademyDetailsTaskForm,
+          Conversion::Task::FundingAgreementContactTaskForm
         ]
       },
       {

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,6 +7,7 @@ class Project < ApplicationRecord
 
   has_many :notes, dependent: :destroy
   has_many :contacts, dependent: :destroy, class_name: "Contact::Project"
+  has_one :funding_agreement_contact, dependent: :destroy, class_name: "Contact::Project", required: false
 
   validates :urn, presence: true
   validates :urn, urn: true

--- a/app/views/conversions/tasks/funding_agreement_contact/edit.html.erb
+++ b/app/views/conversions/tasks/funding_agreement_contact/edit.html.erb
@@ -6,14 +6,24 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @task, url: project_edit_task_path(@project, @task.identifier), method: :put do |form| %>
-      <%= form.govuk_error_summary %>
+    <% if @project.contacts.count > 0 %>
+      <%= form_for @task, url: project_edit_task_path(@project, @task.identifier), method: :put do |form| %>
+        <%= form.govuk_error_summary %>
 
-      <%= form.govuk_text_field :name, width: 20 %>
-      <%= form.govuk_text_field :title, width: 20 %>
-      <%= form.govuk_text_field :email, width: 20 %>
+        <%= form.govuk_collection_radio_buttons :funding_agreement_contact_id,
+              @project.contacts,
+              :id,
+              :name,
+              :title,
+              legend: {text: t("conversion.task.funding_agreement_contact.choose_a_contact.title"), size: "l"},
+              form_group: {id: "funding-agreement-contact-choose-a-contact"} %>
 
-      <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+        <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+      <% end %>
+    <% else %>
+      <h2 class="govuk-heading-l"><%= t("conversion.task.funding_agreement_contact.no_contacts.title") %></h2>
+      <%= t("conversion.task.funding_agreement_contact.no_contacts.add_contacts_guidance_html", add_contact_link: project_contacts_path(@project)) %>
+      <%= govuk_button_link_to t("task_list.continue_button.text"), project_conversion_tasks_path(@project) %>
     <% end %>
   </div>
 

--- a/app/views/external_contacts/_contact_group.html.erb
+++ b/app/views/external_contacts/_contact_group.html.erb
@@ -33,5 +33,7 @@
           end
         end
       end %>
-
+    <% if @project.funding_agreement_contact_id == contact.id %>
+      <p><%= t("contact.details.funding_agreement_letters") %></p>
+    <% end %>
   <% end %>

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -16,6 +16,7 @@ en:
       email: Email
       phone: Phone
       edit_link: Change
+      funding_agreement_letters: This person will receive the funding agreement letters.
     new:
       title: Add contact
       save_contact_button: Add contact

--- a/config/locales/conversion/tasks/funding_agreement_contact.en.yml
+++ b/config/locales/conversion/tasks/funding_agreement_contact.en.yml
@@ -5,22 +5,18 @@ en:
         title: Confirm who will get the funding agreement letters
         hint:
           html:
-            <p>For voluntary conversions, this person will most likely be from
-            the school. They will most likely be from the trust if this is a
-            sponsored conversion. It is not necessarily the person you contact
-            most.<p>
-  helpers:
-    label:
-      conversion_task_funding_agreement_contact_task_form:
-        name: Name
-        title: Role
-        email: Email
-  errors:
-    attributes:
-      name:
-        blank: Enter a full name
-      title:
-        blank: Enter a role
-      email:
-        blank: Enter an email address
-        invalid: Enter a valid email address
+            <p>This person will most likely be from the school in a voluntary conversion. They will most likely be from the trust in a sponsored conversion.</p>
+            <p>They are not necessarily the person you contact most.</p>
+            <p>You must add a new contact first if this person is not already in the contacts list.</p>
+        guidance_link: What funding agreement letters are for
+        guidance:
+          html:
+            <p>After you have confirmed all conditions have been met, ADOP (Academy delivery operational practice) will send funding agreement letters the school or trust. These confirm the DfE will to enter into a funding agreement with the academy and trust.</p>
+        no_contacts:
+          title: Add contacts
+          add_contacts_guidance_html:
+            <p>You must <a href="%{add_contact_link}">add a contact</a> before you can choose which person will get the funding agreement letters.</p>
+            <p>Then you can come back to this task and confirm who will get the letters.</p>
+        choose_a_contact:
+          title: Choose a contact
+          legend:

--- a/db/migrate/20230531110401_remove_funding_agreement_contact_column_from_contacts.rb
+++ b/db/migrate/20230531110401_remove_funding_agreement_contact_column_from_contacts.rb
@@ -1,0 +1,5 @@
+class RemoveFundingAgreementContactColumnFromContacts < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :contacts, :funding_agreement_contact, :boolean, default: false
+  end
+end

--- a/db/migrate/20230605095316_add_funding_agreement_letters_contact_id_to_project.rb
+++ b/db/migrate/20230605095316_add_funding_agreement_letters_contact_id_to_project.rb
@@ -1,0 +1,5 @@
+class AddFundingAgreementLettersContactIdToProject < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :funding_agreement_contact_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_17_131621) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_31_110401) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -21,7 +21,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_17_131621) do
     t.datetime "updated_at", null: false
     t.integer "category", default: 0, null: false
     t.string "organisation_name"
-    t.boolean "funding_agreement_contact", default: false
     t.string "type"
     t.uuid "local_authority_id"
     t.index ["category"], name: "index_contacts_on_category"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_31_110401) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_05_095316) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -196,6 +196,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_31_110401) do
     t.integer "academy_urn"
     t.uuid "tasks_data_id"
     t.string "tasks_data_type"
+    t.uuid "funding_agreement_contact_id"
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -25,6 +25,7 @@ RSpec.feature "Users can complete conversion tasks" do
   tasks_with_collected_data = %w[
     stakeholder_kick_off
     academy_details
+    funding_agreement_contact
   ]
 
   it "confirms we are checking all tasks" do
@@ -106,6 +107,34 @@ RSpec.feature "Users can complete conversion tasks" do
     scenario "the Conditions met task shows the provisional conversion date in the hint text" do
       click_on "Confirm all conditions have been met"
       expect(page).to have_content("All conditions must be met before the deadline or the school will not be able to convert on 1 December 2023")
+    end
+  end
+
+  context "the funding agreement letters task" do
+    let(:project) { create(:conversion_project, assigned_to: user) }
+
+    context "when the project has contacts already" do
+      let!(:contact) { create(:project_contact, project: project) }
+
+      it "lets the user select an existing contact" do
+        visit project_conversion_tasks_path(project)
+        click_on "Confirm who will get the funding agreement letters"
+        choose contact.name
+        click_on I18n.t("task_list.continue_button.text")
+
+        expect(project.reload.funding_agreement_contact_id).to eq contact.id
+      end
+    end
+
+    context "when the project has no contacts" do
+      it "directs the user to add contacts" do
+        visit project_conversion_tasks_path(project)
+        click_on "Confirm who will get the funding agreement letters"
+
+        expect(page).to have_content("Add contacts")
+        click_link "add a contact"
+        expect(page.current_path).to include("external-contacts")
+      end
     end
   end
 

--- a/spec/features/conversions/users_can_select_a_funding_agreement_letter_contact_spec.rb
+++ b/spec/features/conversions/users_can_select_a_funding_agreement_letter_contact_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.feature "Users select a contact to receive the funding agreement letters" do
+  let(:user) { create(:user, :caseworker) }
+  let(:project) { create(:conversion_project, assigned_to: user) }
+
+  before do
+    mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    sign_in_with_user(user)
+  end
+
+  context "when the project already has some contacts" do
+    let!(:contact_1) { create(:project_contact, project: project, name: "John Smith") }
+    let!(:contact_2) { create(:project_contact, project: project, name: "Jane Jones") }
+
+    it "allows the user to select one of the existing contacts on the Funding Agreement Letters task page" do
+      visit project_conversion_tasks_path(project)
+      click_on "Confirm who will get the funding agreement letters"
+      expect(page).to have_content(contact_1.name)
+      expect(page).to have_content(contact_2.name)
+
+      choose contact_1.name
+      click_button "Save and return"
+
+      expect(project.reload.funding_agreement_contact_id).to eq(contact_1.id)
+      expect(page.find("#confirm-who-will-get-the-funding-agreement-letters-status").text).to eq("Completed")
+    end
+  end
+
+  context "when the project already has a funding agreement letters contact set" do
+    let!(:contact_1) { create(:project_contact, project: project, name: "John Smith") }
+    let!(:contact_2) { create(:project_contact, project: project, name: "Jane Jones") }
+
+    before do
+      project.update(funding_agreement_contact_id: contact_2.id)
+    end
+
+    it "shows the contact as preselected on the Funding Agreement Letters task page" do
+      visit project_conversion_tasks_path(project)
+      click_on "Confirm who will get the funding agreement letters"
+
+      expect(page).to have_checked_field(contact_2.name)
+    end
+
+    context "and the funding agreement letters contact is changed" do
+      it "switches the contact for the project" do
+        visit project_conversion_tasks_path(project)
+        click_on "Confirm who will get the funding agreement letters"
+
+        choose contact_1.name
+        click_on "Save and return"
+
+        expect(project.reload.funding_agreement_contact_id).to eq(contact_1.id)
+      end
+    end
+  end
+
+  context "when the project does not have any contacts" do
+    it "directs the user to the external contacts page" do
+      visit project_conversion_tasks_path(project)
+      click_on "Confirm who will get the funding agreement letters"
+
+      expect(page).to have_content("Add contacts")
+      click_link "add a contact"
+      expect(page.current_path).to include("external-contacts")
+    end
+
+    it "allows the user to go back to the task list without adding a user" do
+      visit project_conversion_tasks_path(project)
+      click_on "Confirm who will get the funding agreement letters"
+
+      expect(page).to have_content("Add contacts")
+      click_link "Save and return"
+      expect(page.find("#confirm-who-will-get-the-funding-agreement-letters-status").text).to eq("Not started")
+    end
+  end
+end

--- a/spec/features/users_can_manage_contacts_spec.rb
+++ b/spec/features/users_can_manage_contacts_spec.rb
@@ -99,6 +99,13 @@ RSpec.feature "Users can manage contacts" do
     expect(page).to have_content("There are not any contacts for this project yet.")
   end
 
+  scenario "if a contact is the funding agreement contact, it is indicated on the contact" do
+    project.update!(funding_agreement_contact_id: contact.id)
+
+    visit project_contacts_path(project)
+    expect(page).to have_content(I18n.t("contact.details.funding_agreement_letters"))
+  end
+
   private def expect_page_to_have_contact(name:, title:, organisation_name: nil, email: nil, phone: nil)
     expect(page).to have_content(name)
     expect(page).to have_content(organisation_name) if organisation_name

--- a/spec/forms/conversion/tasks/funding_agreement_contact_task_form_spec.rb
+++ b/spec/forms/conversion/tasks/funding_agreement_contact_task_form_spec.rb
@@ -3,84 +3,18 @@ require "rails_helper"
 RSpec.describe Conversion::Task::FundingAgreementContactTaskForm do
   let(:user) { create(:user) }
 
-  describe "validations" do
-    let(:form) { valid_form }
-
-    it "requires name" do
-      form.name = nil
-      expect(form).to be_invalid
-    end
-
-    it "requires title" do
-      form.title = nil
-      expect(form).to be_invalid
-    end
-
-    it "requires email" do
-      form.email = nil
-      expect(form).to be_invalid
-    end
-
-    it "validates the format of email" do
-      form.email = "not.a.valid.email.com"
-      expect(form).to be_invalid
-
-      form.email = "a.valid@email.com"
-      expect(form).to be_valid
-    end
-  end
-
   describe "#save" do
     before { mock_successful_api_response_to_create_any_project }
 
     let(:project) { create(:conversion_project) }
+    let(:contact) { create(:project_contact, project: project) }
 
-    it "sets funding_agreement_contact to true" do
+    it "sets funding_agreement_contact_contact_id to the contact_id" do
       form = described_class.new(project.tasks_data, user)
-      form.assign_attributes(valid_form.attributes)
+      form.assign_attributes(funding_agreement_contact_id: contact.id)
+      form.save
 
-      expect { form.save }.to change { Contact.count }.by(1)
-
-      funding_agreement_contact = Contact.first
-
-      expect(funding_agreement_contact.funding_agreement_contact?).to be true
+      expect(project.funding_agreement_contact).to eq(contact)
     end
-  end
-
-  describe "the contact" do
-    before { mock_successful_api_response_to_create_any_project }
-    context "when there is no main contact for the project" do
-      it "creates a new empty Contact" do
-        project = create(:conversion_project)
-        form = described_class.new(project.tasks_data, user)
-
-        expect(form.name).to be_nil
-        expect(form.email).to be_nil
-      end
-    end
-
-    context "when there is main contact for the project" do
-      it "loads the existing Contact" do
-        project = create(:conversion_project)
-        main_contact = create(:project_contact, funding_agreement_contact: true, project: project)
-        form = described_class.new(project.tasks_data, user)
-
-        expect(form.name).to eql main_contact.name
-        expect(form.email).to eql main_contact.email
-      end
-    end
-  end
-
-  def valid_form
-    tasks_data = Conversion::TasksData.new
-    form = described_class.new(tasks_data, user)
-
-    form.assign_attributes(
-      name: "Jane Doe",
-      title: "School manager",
-      email: "jane.doe@school.sch.uk"
-    )
-
-    form
   end
 end

--- a/spec/models/conversion/task_list_spec.rb
+++ b/spec/models/conversion/task_list_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Conversion::TaskList do
         :conversion_grant,
         :sponsored_support_grant,
         :academy_details,
+        :funding_agreement_contact,
         :land_questionnaire,
         :land_registry,
         :supplemental_funding_agreement,
@@ -48,7 +49,8 @@ RSpec.describe Conversion::TaskList do
               Conversion::Task::StakeholderKickOffTaskForm,
               Conversion::Task::ConversionGrantTaskForm,
               Conversion::Task::SponsoredSupportGrantTaskForm,
-              Conversion::Task::AcademyDetailsTaskForm
+              Conversion::Task::AcademyDetailsTaskForm,
+              Conversion::Task::FundingAgreementContactTaskForm
             ]
           },
           {
@@ -108,7 +110,7 @@ RSpec.describe Conversion::TaskList do
       project = create(:conversion_project)
       task_list = described_class.new(project, user)
 
-      expect(task_list.tasks.count).to eql 25
+      expect(task_list.tasks.count).to eql 26
       expect(task_list.tasks.first).to be_a Conversion::Task::HandoverTaskForm
       expect(task_list.tasks.last).to be_a Conversion::Task::ReceiveGrantPaymentCertificateTaskForm
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to belong_to(:team_leader).required(false) }
     it { is_expected.to belong_to(:assigned_to).required(false) }
     it { is_expected.to belong_to(:tasks_data).required(true) }
+    it { is_expected.to have_one(:funding_agreement_contact).required(false) }
 
     describe "delete related entities" do
       context "when the project is deleted" do


### PR DESCRIPTION
## Changes

Add the "Confirm who will get the funding agreement letters" task.

This task was begun previously but this is a reworking & completion of it. 

If a project has external contacts already entered, then they will appear on the task page. The user will then be able to select a contact and assign them as the "funding agreement letters" contact. 

On the external contacts page, the "funding agreement letters" contact will be indicated as per the second screenshot.

<img width="1065" alt="Screenshot 2023-06-01 at 11 32 14" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/b4fa5630-c346-4343-acde-967addaa396d">

<img width="830" alt="Screenshot 2023-06-01 at 11 31 52" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/40fc4510-92c2-4715-968e-ccfc4fe1eb01">

If a project has no external contacts already, the user will be invited to add more contacts by some text on the task page, and a link leading to the external contacts page. They can then come back to the task later and assign contacts as above.

Previously, we had anticipated that the user would be adding a contact directly on the task page. This reworking means that only the contact ID is stored in the task data, and all contact details are stored in the contacts table.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
