### PR TITLE
Release 27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [Release 27][release-27]
+
+### Added
+
 - Display generated DfE number in project information view for the establishment
 - Service support users now see their own sub-navigation in the application
 
@@ -17,7 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   "confirmed" and "unconfirmed"
 - Update the column values on the Openers page, and add new tags for the
   Direction to transfer and Trust modification order column values
-- Move route of the Openers page to `/projects/all/openers/month/year`
+- Move route of the Openers page to `/projects/all/opening/month/year`
 - Move route of the Projects with changed conversion dates to
   `/projects/all/revised-conversion-date/month/year`
 - Tie the Openers and Revised conversion date pages together with tabs
@@ -33,7 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Changed the content on the conversion date change confirmation page to provide
   clearer, more direct guidance about how and when a date can be changed by
   phrasing the heading as a statement and not a question
-- Adding a new project where the school is not considred 'religious'
+- Adding a new project where the school is not considered 'religious'
   automatically marks the 'Church supplemental agreement' as not applicable,
   users can make the task applicable if desired
 - Adding a new project that has not been issued with a directive academy order
@@ -926,7 +934,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-26...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-27...HEAD
+[release-27]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-26...release-27
 [release-26]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-25...release-26
 [release-25]:


### PR DESCRIPTION
### Added

- Display generated DfE number in project information view for the establishment
- Service support users now see their own sub-navigation in the application

### Changed

- Change the values of the "All conditions met" tag in the openers list, to
  "confirmed" and "unconfirmed"
- Update the column values on the Openers page, and add new tags for the
  Direction to transfer and Trust modification order column values
- Move route of the Openers page to `/projects/all/opening/month/year`
- Move route of the Projects with changed conversion dates to
  `/projects/all/revised-conversion-date/month/year`
- Tie the Openers and Revised conversion date pages together with tabs
- Update content in project creation confirmation page to make clear delivery
  officers must add contacts
- Change primary action button on project creation confirmation page to point to
  external contacts page
- Pull full stop out of mailto link on single worksheet task and into text
- Change primary action button to point to external contacts page
- Add missing full stop to guidance in grant payment certificate task
- Updated the way we present academy name and URN in the conversion date change
  confirmation page so it is consistent with other confirmation pages
- Changed the content on the conversion date change confirmation page to provide
  clearer, more direct guidance about how and when a date can be changed by
  phrasing the heading as a statement and not a question
- Adding a new project where the school is not considered 'religious'
  automatically marks the 'Church supplemental agreement' as not applicable,
  users can make the task applicable if desired
- Adding a new project that has not been issued with a directive academy order
  automatically marks the 'Process the sponsored support grant' task as not
  applicable, users can make the task applicable if desired

### Fixed