### PR TITLE
Disable console autocomplete

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,1 @@
+IRB.conf[:USE_AUTOCOMPLETE] = false


### PR DESCRIPTION
The Rails console is great, but on Azure the autocompelete is a pain,
disabling it will make working on Azure much nicer and less risky.

I have been unable to see any diffrence locally, but other developers
might have different results?

## Changes

_Add a summary of the changes in this pull request_

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
