### PR TITLE
Add ARM Linux to bundler platforms for macOS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,6 +212,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.14.3-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.14.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.3-x86_64-darwin)
@@ -416,6 +418,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-20


### PR DESCRIPTION
To allow for the ruby application to build if it is being run from within docker on an ARM based Mac.

## Changes

- Add `aarch64-linux` to `Gemfile.lock` with the command `bundle lock --add-platform aarch64-linux`

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
