### PR TITLE
Create a bare bones Transfer::Project and Transfer::TasksData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The Opening section is now included in all projects, it shows conversion that
   are due to open in the next calendar month and those that were going to open
   but are no longer.
+- Add bare bones Transfer::Project and Transfer::TasksData models
 
 ### Changed
 

--- a/app/models/transfer/project.rb
+++ b/app/models/transfer/project.rb
@@ -1,0 +1,5 @@
+class Transfer::Project < Project
+  def self.policy_class
+    ProjectPolicy
+  end
+end

--- a/app/models/transfer/tasks_data.rb
+++ b/app/models/transfer/tasks_data.rb
@@ -1,0 +1,7 @@
+class Transfer::TasksData < ActiveRecord::Base
+  include TasksDatable
+
+  def self.policy_class
+    TaskListPolicy
+  end
+end

--- a/db/migrate/20230607103526_create_transfer_tasks_data.rb
+++ b/db/migrate/20230607103526_create_transfer_tasks_data.rb
@@ -1,0 +1,7 @@
+class CreateTransferTasksData < ActiveRecord::Migration[7.0]
+  def change
+    create_table :transfer_tasks_data, id: :uuid do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_05_095316) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_07_103526) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -202,6 +202,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_05_095316) do
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"
     t.index ["team_leader_id"], name: "index_projects_on_team_leader_id"
     t.index ["urn"], name: "index_projects_on_urn"
+  end
+
+  create_table "transfer_tasks_data", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/factories/transfer/project_factory.rb
+++ b/spec/factories/transfer/project_factory.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :transfer_project, class: "Transfer::Project" do
+    type { "Transfer::Project" }
+    urn { 123456 }
+    incoming_trust_ukprn { 10061021 }
+    conversion_date { (Date.today + 2.years).at_beginning_of_month }
+    advisory_board_date { (Date.today - 2.weeks) }
+    establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/establishment-folder" }
+    trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }
+    assigned_to { association :user, :caseworker, email: "user.#{SecureRandom.uuid}@education.gov.uk" }
+    directive_academy_order { false }
+    region { Project.regions["london"] }
+    regional_delivery_officer { association :user, :regional_delivery_officer }
+    tasks_data { association :transfer_tasks_data }
+  end
+end

--- a/spec/factories/transfer/tasks_data_factory.rb
+++ b/spec/factories/transfer/tasks_data_factory.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :transfer_tasks_data, class: "Transfer::TasksData" do
+  end
+end

--- a/spec/models/transfer/project_spec.rb
+++ b/spec/models/transfer/project_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Transfer::Project do
+  describe ".policy_class" do
+    it "returns the correct policy" do
+      expect(described_class.policy_class).to eql(ProjectPolicy)
+    end
+  end
+end

--- a/spec/models/transfer/tasks_data_spec.rb
+++ b/spec/models/transfer/tasks_data_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Transfer::TasksData, type: :model do
+  describe ".policy_class" do
+    it "returns the correct policy" do
+      expect(described_class.policy_class).to eql(TaskListPolicy)
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Add a new Project type, Transfer::Project. It uses the ProjectPolicy.

Add a new Transfer::TasksData model, which uses a new table `transfer_tasks_data` and the TaskListPolicy.

Add factories for the project and tasks data, and prove that new models can be created using them.

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
