### PR TITLE
Add team projects primary navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   but are no longer.
 - Add bare bones Transfer::Project and Transfer::TasksData models
 - Create an opening projects csv exporter
+- The team projects section now has primary navigation.
 
 ### Changed
 

--- a/app/views/regional_casework_services/projects/completed.html.erb
+++ b/app/views/regional_casework_services/projects/completed.html.erb
@@ -1,11 +1,13 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/team_projects_primary_navigation" %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 
     <h1 class="govuk-heading-l">
       <%= t("project.regional_casework_services.completed.title") %>
     </h1>
-
-    <%= render partial: "projects/shared/project_index_sub_navigation" %>
 
     <%= render partial: "/projects/shared/completed_table", locals: {projects: @projects, pager: @pager} %>
 

--- a/app/views/regional_casework_services/projects/in_progress.html.erb
+++ b/app/views/regional_casework_services/projects/in_progress.html.erb
@@ -1,11 +1,13 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/team_projects_primary_navigation" %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 
     <h1 class="govuk-heading-l">
       <%= t("project.regional_casework_services.in_progress.title") %>
     </h1>
-
-    <%= render partial: "projects/shared/project_index_sub_navigation" %>
 
     <%= render partial: "/projects/shared/in_progress_table", locals: {projects: @projects, pager: @pager} %>
 

--- a/app/views/regional_casework_services/projects/unassigned.html.erb
+++ b/app/views/regional_casework_services/projects/unassigned.html.erb
@@ -1,13 +1,13 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/team_projects_primary_navigation" %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 
     <h1 class="govuk-heading-l">
       <%= t("project.regional_casework_services.unassigned.title") %>
     </h1>
-
-    <%= render partial: "/projects/shared/new_projects" if policy(:project).new? %>
-
-    <%= render partial: "/projects/shared/project_index_sub_navigation" %>
 
     <%= render partial: "/projects/shared/unassigned_table", locals: {projects: @projects, pager: @pager} %>
 

--- a/app/views/shared/navigation/_header_navigation.html.erb
+++ b/app/views/shared/navigation/_header_navigation.html.erb
@@ -10,7 +10,7 @@
 
       <%= if policy(:navigation).show_team_projects_header_navigation?
             render partial: "shared/navigation/header_navigation_item",
-              locals: {name: t("navigation.header.team_projects"), path: in_progress_regional_casework_services_projects_path, namespace: "/projects/regional-casework-services/"}
+              locals: {name: t("navigation.header.team_projects"), path: unassigned_regional_casework_services_projects_path, namespace: "/projects/regional-casework-services/"}
           end %>
 
       <%= if policy(:navigation).show_all_projects_header_navigation?

--- a/app/views/shared/navigation/_team_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_team_projects_primary_navigation.html.erb
@@ -1,0 +1,22 @@
+<div class="moj-primary-navigation">
+
+  <div class="moj-primary-navigation__container">
+
+    <div class="moj-primary-navigation__nav">
+
+      <nav class="moj-primary-navigation" aria-label="Primary navigation">
+        <ul class="moj-primary-navigation__list">
+
+          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.unassigned"), path: unassigned_regional_casework_services_projects_path, namespace: "/projects/regional-casework-services/unassigned"} %>
+
+          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.in_progress"), path: in_progress_regional_casework_services_projects_path, namespace: "/projects/regional-casework-services/in-progress"} %>
+
+          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.completed"), path: completed_regional_casework_services_projects_path, namespace: "/projects/regional-casework-services/completed"} %>
+
+        </ul>
+      </nav>
+
+    </div>
+  </div>
+
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,6 +132,10 @@ en:
         opening: Opening
         completed: Completed
         statistics: Statistics
+      team_projects:
+        in_progress: In progress
+        unassigend: Unassigned
+        completed: Completed
       service_support:
         conversion_urns: Conversion URNs
         local_authorities: Local authorities

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -33,11 +33,11 @@ en:
           title: Projects for %{trust}
     regional_casework_services:
       in_progress:
-        title: Regional Casework Services projects in progress
+        title: In progress
       completed:
-        title: Regional Casework Services completed projects
+        title: Completed
       unassigned:
-        title: Regional Casework Services unassigned projects
+        title: Unasssigned
     regional:
       in_progress:
         title: Regional projects in progress


### PR DESCRIPTION
We have a navigation pattern, here we follow it for the team projects
'section'.

Right now we only support the regional casework services team but other
teams will be supported soon.

https://trello.com/c/r0c5esjA

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/6e96230f-76da-404a-a616-99c2690116a0)
