### PR TITLE
Release 28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release 28][release-28]
+
 ### Added
 
 - Do not allow a project to be completed until all conditions have been met, the
@@ -955,7 +957,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-27...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-28...HEAD
+[release-28]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-27...release-28
 [release-27]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-26...release-27
 [release-26]:


### PR DESCRIPTION
Added

- Do not allow a project to be completed until all conditions have been met, the grant certificate is returned and the academy has opened
- Header navigation to allow users to move between the main sections of the site. The navigation items show refelect the user's role.
- Navigation to the All projects section to allow users to move between in progress, completed and statistics views.
- The Opening section is now included in all projects, it shows conversion that are due to open in the next calendar month and those that were going to open but are no longer.
- Add bare bones Transfer::Project and Transfer::TasksData models
- Create an opening projects csv exporter
- The team projects section now has primary navigation.

Changed

- the urls that some service support views were found have changed.
- the layout of the statistics page has been updated.
- The service support section now uses primary navigation to allow for more logical groupings of views.
- The primary navigation is now shown on all local authority views.

Fixed

- Redirect the user if they accidentally visit `/projects`

## Checklist

- [x] Check that this pull request has the correct version number.
- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` to move Unreleased changes into a new version.
- [x] Update the release links at the bottom of `CHANGELOG.md` to reflect the
      new version.