### PR TITLE
Update task list table name and fix a couple of Transfer issues

### DIFF
--- a/app/models/conversion/tasks_data.rb
+++ b/app/models/conversion/tasks_data.rb
@@ -1,7 +1,7 @@
 class Conversion::TasksData < ActiveRecord::Base
   include TasksDatable
 
-  self.table_name = "conversion_voluntary_task_lists"
+  self.table_name = "conversion_tasks_data"
 
   def self.policy_class
     TaskListPolicy

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,7 +3,7 @@ class Project < ApplicationRecord
 
   attr_writer :establishment, :incoming_trust
 
-  delegated_type :tasks_data, types: %w[Conversion::TaskList], dependent: :destroy
+  delegated_type :tasks_data, types: %w[Conversion::TasksData, Transfer::TasksData], dependent: :destroy
 
   has_many :notes, dependent: :destroy
   has_many :contacts, dependent: :destroy, class_name: "Contact::Project"

--- a/app/models/transfer/tasks_data.rb
+++ b/app/models/transfer/tasks_data.rb
@@ -1,6 +1,8 @@
 class Transfer::TasksData < ActiveRecord::Base
   include TasksDatable
 
+  self.table_name = "transfer_tasks_data"
+
   def self.policy_class
     TaskListPolicy
   end

--- a/db/migrate/20230608114403_rename_task_list_table.rb
+++ b/db/migrate/20230608114403_rename_task_list_table.rb
@@ -1,0 +1,5 @@
+class RenameTaskListTable < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :conversion_voluntary_task_lists, :conversion_tasks_data
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_07_103526) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_08_114403) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -35,7 +35,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_07_103526) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "conversion_voluntary_task_lists", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+  create_table "conversion_tasks_data", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.boolean "handover_review"
     t.boolean "handover_notes"
     t.boolean "handover_meeting"


### PR DESCRIPTION
To keep things consitent, keep the TasksData table names the same.

Also turned out we still have to set the table names on the models, I thought we didn't here #775 

Last thing I noticed is that we haven't update the delegated type name, doesn't seem to have stop it all from working, I checked the `tasks_data_type` in production and they are all set correctly?

Verified all this on the console by creating both types of Project and TasksData and verifying they can be loaded, see below.

https://trello.com/c/pqaaMSG4

<img width="1978" alt="Screenshot 2023-06-08 at 15 58 53" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/f9a81518-5874-4b44-9840-d549f6bfffc8">



