### PR TITLE
Add irbrc to Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,7 @@ COPY --from=dependencies ${DEPS_HOME}/node_modules ${APP_HOME}/node_modules
 RUN mkdir -p ${APP_HOME}/log
 RUN mkdir -p ${APP_HOME}/tmp
 
+COPY .irbrc ${APP_HOME}/.irbrc
 COPY config.ru ${APP_HOME}/config.ru
 COPY Rakefile ${APP_HOME}/Rakefile
 COPY script ${APP_HOME}/script


### PR DESCRIPTION
In production environments in Azure the autocomplete in the Rails
console does not work well and actually makes things more risky.

We thought we had turned this off by including the setting in the irbrc
but this file was not included in the Docker build.
