### PR TITLE
Opening export includes MP details

### DIFF
--- a/app/models/api/members_api/client.rb
+++ b/app/models/api/members_api/client.rb
@@ -27,16 +27,8 @@ class Api::MembersApi::Client
     member_id = member_id(constituency).object
     member_name = member_name(member_id).object
     contact_details = member_contact_details(member_id).object.find { |details| details.type_id == 1 }
-    {
-      name: member_name.name_display_as,
-      email: contact_details.email,
-      address_line1: contact_details.line1,
-      address_line2: contact_details.line2,
-      address_line3: contact_details.line3,
-      address_line4: contact_details.line4,
-      address_line5: contact_details.line5,
-      address_postcode: contact_details.postcode
-    }
+
+    Api::MembersApi::MemberDetails.new(member_name, contact_details)
   end
 
   def member_id(search_term)

--- a/app/models/api/members_api/member_details.rb
+++ b/app/models/api/members_api/member_details.rb
@@ -1,0 +1,39 @@
+class Api::MembersApi::MemberDetails
+  def initialize(member_name, member_contact_details)
+    @member_name = member_name
+    @member_contact_details = member_contact_details
+  end
+
+  def name
+    @member_name.name_display_as
+  end
+
+  def email
+    @member_contact_details.email
+  end
+
+  def address
+    OpenStruct.new(
+      line1: address_lines[0],
+      line2: address_lines[1],
+      line3: address_lines[2],
+      postcode: address_postcode
+    )
+  end
+
+  private def address_lines
+    all_address_lines = [
+      @member_contact_details.line1,
+      @member_contact_details.line2,
+      @member_contact_details.line3,
+      @member_contact_details.line4,
+      @member_contact_details.line5
+    ]
+
+    all_address_lines.compact_blank
+  end
+
+  private def address_postcode
+    @member_contact_details.postcode
+  end
+end

--- a/app/services/opening_projects_csv_exporter.rb
+++ b/app/services/opening_projects_csv_exporter.rb
@@ -24,10 +24,21 @@ class OpeningProjectsCsvExporter
   end
 
   private def row(project)
+    mp_details = fetch_mp_details(project)
     {
       school_urn: project.urn,
       dfe_number: project.establishment.dfe_number,
-      school_name: project.establishment.name
+      school_name: project.establishment.name,
+      mp_name: mp_details.name,
+      mp_email: mp_details.email,
+      mp_address_line_1: mp_details.address.line1,
+      mp_address_line_2: mp_details.address.line2,
+      mp_address_line_3: mp_details.address.line3,
+      mp_address_postcode: mp_details.address.postcode
     }
+  end
+
+  private def fetch_mp_details(project)
+    Api::MembersApi::Client.new.member_for_constituency(project.establishment.parliamentary_constituency)
   end
 end

--- a/app/services/opening_projects_csv_exporter.rb
+++ b/app/services/opening_projects_csv_exporter.rb
@@ -1,24 +1,33 @@
-require "csv"
-
 class OpeningProjectsCsvExporter
+  require "csv"
+
   def initialize(projects)
     @projects = projects
+
+    raise ArgumentError.new("You must provide at least one project") if @projects.count.zero?
   end
 
   def call
     @csv = CSV.generate(headers: true) do |csv|
       csv << headers
       @projects.each do |project|
-        csv << row(project)
+        csv << row(project).values
       end
     end
   end
 
   private def headers
-    ["School URN", "DfE number", "School name"]
+    example_row = row(@projects.first)
+    example_row.keys.map do |column|
+      I18n.t("opening_projects_csv_export.headers.#{column}")
+    end
   end
 
   private def row(project)
-    [project.urn, project.establishment.dfe_number, project.establishment.name]
+    {
+      school_urn: project.urn,
+      dfe_number: project.establishment.dfe_number,
+      school_name: project.establishment.name
+    }
   end
 end

--- a/config/locales/opening_projects_csv_exporter.yml
+++ b/config/locales/opening_projects_csv_exporter.yml
@@ -1,0 +1,6 @@
+en:
+  opening_projects_csv_export:
+    headers:
+      school_urn: School URN
+      dfe_number: DfE number
+      school_name: School name

--- a/config/locales/opening_projects_csv_exporter.yml
+++ b/config/locales/opening_projects_csv_exporter.yml
@@ -4,3 +4,9 @@ en:
       school_urn: School URN
       dfe_number: DfE number
       school_name: School name
+      mp_name: MP name
+      mp_email: MP email
+      mp_address_line_1: "MP address 1"
+      mp_address_line_2: "MP address 2"
+      mp_address_line_3: "MP address 3"
+      mp_address_postcode: MP postcode

--- a/spec/models/api/members_api/client_spec.rb
+++ b/spec/models/api/members_api/client_spec.rb
@@ -56,10 +56,10 @@ RSpec.describe Api::MembersApi::Client do
 
       response = fake_client.member_for_constituency("St Albans")
 
-      expect(response[:name]).to eq("Joe Bloggs")
-      expect(response[:email]).to eq("joe.bloggs@email.com")
-      expect(response[:address_line1]).to eq("Houses of Parliment")
-      expect(response[:address_postcode]).to eq("SW1A 0AA")
+      expect(response.name).to eq("Joe Bloggs")
+      expect(response.email).to eq("joe.bloggs@email.com")
+      expect(response.address.line1).to eq("Houses of Parliment")
+      expect(response.address.postcode).to eq("SW1A 0AA")
     end
   end
 

--- a/spec/models/api/members_api/member_details_spec.rb
+++ b/spec/models/api/members_api/member_details_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe Api::MembersApi::MemberDetails do
+  describe "#name" do
+    it "returns the MP Name" do
+      mp_name = double(name_display_as: "Member Parliment")
+      mp_contact_details = double
+
+      member_details = described_class.new(mp_name, mp_contact_details)
+
+      expect(member_details.name).to eql "Member Parliment"
+    end
+  end
+
+  describe "#email" do
+    it "returns the MP email address" do
+      mp_name = double
+      mp_contact_details = double(email: "member.parliment@parliment.uk")
+
+      member_details = described_class.new(mp_name, mp_contact_details)
+
+      expect(member_details.email).to eql "member.parliment@parliment.uk"
+    end
+  end
+
+  describe "#address" do
+    context "when the address is across two lines" do
+      it "returns the MP address which is always the Houses of Parliment" do
+        mp_name = double
+        mp_contact_details = double(
+          line1: "Houses of Parliment",
+          line2: "London",
+          line3: "",
+          line4: "",
+          line5: "",
+          postcode: "SW1A 0AA"
+        )
+
+        member_details = described_class.new(mp_name, mp_contact_details)
+
+        expect(member_details.address.line1).to eql "Houses of Parliment"
+        expect(member_details.address.line2).to eql "London"
+        expect(member_details.address.line3).to be_nil
+        expect(member_details.address.postcode).to eql "SW1A 0AA"
+      end
+    end
+
+    context "when the address is across five lines" do
+      it "returns the MP address which is always the Houses of Parliment" do
+        mp_name = double
+        mp_contact_details = double(
+          line1: "Houses of Parliment",
+          line2: "",
+          line3: "",
+          line4: "",
+          line5: "London",
+          postcode: "SW1A 0AA"
+        )
+
+        member_details = described_class.new(mp_name, mp_contact_details)
+
+        expect(member_details.address.line1).to eql "Houses of Parliment"
+        expect(member_details.address.line2).to eql "London"
+        expect(member_details.address.line3).to be_nil
+        expect(member_details.address.postcode).to eql "SW1A 0AA"
+      end
+    end
+  end
+end

--- a/spec/requests/all/opening/projects_controller_spec.rb
+++ b/spec/requests/all/opening/projects_controller_spec.rb
@@ -86,6 +86,8 @@ RSpec.describe All::Opening::ProjectsController, type: :request do
   describe "#download_csv" do
     let!(:project) { create(:conversion_project, conversion_date: Date.new(2025, 5, 1), conversion_date_provisional: false) }
 
+    before { mock_successful_memeber_details }
+
     it "returns the csv with a successful response" do
       get csv_all_opening_projects_path(5, 2025)
       expect(response.body).to include(project.urn.to_s)

--- a/spec/services/opening_projects_csv_exporter_spec.rb
+++ b/spec/services/opening_projects_csv_exporter_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe OpeningProjectsCsvExporter do
   describe "#call" do
     before do
       mock_successful_api_response_to_create_any_project
+      mock_successful_memeber_details
     end
 
     it "raises when there are no projects" do
@@ -39,6 +40,25 @@ RSpec.describe OpeningProjectsCsvExporter do
 
       expect(csv_export).to include("School name")
       expect(csv_export).to include("Establishment name")
+    end
+
+    it "returns a csv with the MP details" do
+      project = build(:conversion_project)
+
+      csv_export = OpeningProjectsCsvExporter.new([project]).call
+
+      expect(csv_export).to include("MP name")
+      expect(csv_export).to include("MP email")
+      expect(csv_export).to include("MP address 1")
+      expect(csv_export).to include("MP address 2")
+      expect(csv_export).to include("MP address 3")
+      expect(csv_export).to include("MP postcode")
+
+      expect(csv_export).to include("Member Parliment")
+      expect(csv_export).to include("member.parliment@parliment.uk")
+      expect(csv_export).to include("House of Commons")
+      expect(csv_export).to include("London")
+      expect(csv_export).to include("SW1A 0AA")
     end
   end
 end

--- a/spec/services/opening_projects_csv_exporter_spec.rb
+++ b/spec/services/opening_projects_csv_exporter_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe OpeningProjectsCsvExporter do
       mock_successful_api_response_to_create_any_project
     end
 
+    it "raises when there are no projects" do
+      expect { OpeningProjectsCsvExporter.new([]) }.to raise_error(ArgumentError)
+    end
+
     it "returns a csv with the school urn" do
       project = build(:conversion_project, urn: 654321)
 

--- a/spec/support/members_api_helpers.rb
+++ b/spec/support/members_api_helpers.rb
@@ -43,6 +43,24 @@ module MembersApiHelpers
     allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
   end
 
+  def mock_successful_memeber_details
+    address = OpenStruct.new(
+      line1: "House of Commons",
+      line2: "London",
+      line3: "",
+      postcode: "SW1A 0AA"
+    )
+
+    member_details = double(
+      Api::MembersApi::MemberDetails,
+      name: "Member Parliment",
+      email: "member.parliment@parliment.uk",
+      address: address
+    )
+    members_client = double(Api::MembersApi::Client, member_for_constituency: member_details)
+    allow(Api::MembersApi::Client).to receive(:new).and_return(members_client)
+  end
+
   def mock_members_api_multiple_constituencies_response
     fake_body = {"items" => [
       {"value" => {"name" => "St Albans", "id" => 12345}},


### PR DESCRIPTION
We have to add a lot of columns to the export, so we are adding them in multiple PRs.

This one adds the MP details. Because we fetch this from the Members API, we want this in so we can test real world 
performance.

We took some time to improve the exporter so that the column names and order are defined in one place and come from the locales.

We also refactored the return from the members api client that we introduced.