### PR TITLE
Remove task_list_id and task_list_type from project

### DIFF
--- a/db/migrate/20230609110127_remove_task_list_id_and_task_list_type_from_projects.rb
+++ b/db/migrate/20230609110127_remove_task_list_id_and_task_list_type_from_projects.rb
@@ -1,0 +1,6 @@
+class RemoveTaskListIdAndTaskListTypeFromProjects < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :projects, :task_list_type, :string
+    remove_column :projects, :task_list_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_08_114403) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_09_110127) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -185,8 +185,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_08_114403) do
     t.datetime "completed_at"
     t.text "trust_sharepoint_link"
     t.string "type"
-    t.uuid "task_list_id"
-    t.string "task_list_type"
     t.uuid "assigned_to_id"
     t.boolean "assigned_to_regional_caseworker_team", default: false
     t.date "conversion_date"

--- a/doc/task-lists-and-tasks.md
+++ b/doc/task-lists-and-tasks.md
@@ -88,7 +88,7 @@ type (the scope). Do so by loading only notes form the projects of the task list
 type:
 
 ```
-projects = Project.where(task_list_type: "Conversion::Voluntary::TaskList").map { |project| project.id }
+projects = Project.where(tasks_data_type: "Conversion::TasksData").map { |project| project.id }
 Note.where(task_identifier: "<old task identifier>", project_id: projects).destroy_all
 ```
 
@@ -97,7 +97,7 @@ Note.where(task_identifier: "<old task identifier>", project_id: projects).destr
 When renaming a task, the task notes should be migrated to the new identifier:
 
 ```
-projects = Project.where(task_list_type: "Conversion::Voluntary::TaskList").map { |project| project.id }
+projects = Project.where(tasks_data_type: "Conversion::TasksData").map { |project| project.id }
 Note.where(task_identifier: "<old task identifier>", project_id: projects).update(task_identifier: "<new task identifier>")
 ```
 
@@ -108,6 +108,6 @@ not be followed:
 
 ```
 task_identifiers = Conversion::Voluntary::TaskList.new.tasks.map { |task| task.class.identifier }
-projects = Project.where(task_list_type: "Conversion::Voluntary::TaskList").map { |project| project.id }
+projects = Project.where(tasks_data_type: "Conversion::TasksData").map { |project| project.id }
 Note.where(project_id: projects).where.not(task_identifier: [task_identifiers, nil])
 ```


### PR DESCRIPTION
## Changes

These two Project attributes are now redundant:

`task_list_id`
`task_list_type`

Remove the two columns from projects. Update the documentation to reflect that we've now moved to the TasksData model.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
