### PR TITLE
Move three conversion-specific attributes from Project to Conversion::Project

### DIFF
--- a/app/controllers/all/opening/projects_controller.rb
+++ b/app/controllers/all/opening/projects_controller.rb
@@ -2,7 +2,7 @@ class All::Opening::ProjectsController < ApplicationController
   def confirmed
     authorize Project, :index?
 
-    @projects = ProjectsFetcher.new.sorted_openers(month, year)
+    @projects = ConversionProjectsFetcher.new.sorted_openers(month, year)
     @date = "#{Date::MONTHNAMES[month.to_i]} #{year}"
   end
 
@@ -16,7 +16,7 @@ class All::Opening::ProjectsController < ApplicationController
   def download_csv
     authorize Project, :index?
 
-    @projects = ProjectsFetcher.new.sorted_openers(month, year)
+    @projects = ConversionProjectsFetcher.new.sorted_openers(month, year)
     @date = "#{Date::MONTHNAMES[month.to_i]} #{year}"
     @month = month
     @year = year

--- a/app/controllers/all/opening/projects_controller.rb
+++ b/app/controllers/all/opening/projects_controller.rb
@@ -9,7 +9,7 @@ class All::Opening::ProjectsController < ApplicationController
   def revised
     authorize Project, :index?
 
-    @projects = Project.conversion_date_revised_from(month, year)
+    @projects = Conversion::Project.conversion_date_revised_from(month, year)
     @date = "#{Date::MONTHNAMES[month.to_i]} #{year}"
   end
 

--- a/app/controllers/all/trust/projects_controller.rb
+++ b/app/controllers/all/trust/projects_controller.rb
@@ -5,7 +5,7 @@ class All::Trust::ProjectsController < ApplicationController
   def by_trust
     authorize Project, :index?
     ukprn = params[:trust_ukprn]
-    @pager, @projects = pagy(Project.by_trust_ukprn(ukprn).by_conversion_date)
+    @pager, @projects = pagy(Conversion::Project.by_trust_ukprn(ukprn).by_conversion_date)
 
     pre_fetch_establishments(@projects)
     @trust = Api::AcademiesApi::Client.new.get_trust(ukprn).object

--- a/app/controllers/service_support/projects_controller.rb
+++ b/app/controllers/service_support/projects_controller.rb
@@ -4,7 +4,7 @@ class ServiceSupport::ProjectsController < ApplicationController
 
   def without_academy_urn
     authorize Project, :index?
-    @pager, @projects = pagy(Project.not_completed.no_academy_urn.by_conversion_date)
+    @pager, @projects = pagy(Conversion::Project.not_completed.no_academy_urn.by_conversion_date)
 
     pre_fetch_establishments(@projects)
     pre_fetch_incoming_trusts(@projects)
@@ -12,7 +12,7 @@ class ServiceSupport::ProjectsController < ApplicationController
 
   def with_academy_urn
     authorize Project, :index?
-    @pager, @projects = pagy(Project.not_completed.with_academy_urn.by_conversion_date)
+    @pager, @projects = pagy(Conversion::Project.not_completed.with_academy_urn.by_conversion_date)
 
     pre_fetch_establishments(@projects)
     pre_fetch_incoming_trusts(@projects)

--- a/app/controllers/user/projects_controller.rb
+++ b/app/controllers/user/projects_controller.rb
@@ -12,7 +12,7 @@ class User::ProjectsController < ApplicationController
 
   def added_by
     authorize Project, :index?
-    @pager, @projects = pagy(Project.added_by(current_user).not_completed.by_conversion_date.includes(:assigned_to))
+    @pager, @projects = pagy(Conversion::Project.added_by(current_user).not_completed.by_conversion_date.includes(:assigned_to))
 
     pre_fetch_establishments(@projects)
     pre_fetch_incoming_trusts(@projects)

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -4,6 +4,8 @@ class Conversion::Project < Project
   end
 
   validates :academy_urn, urn: true, if: -> { academy_urn.present? }
+  validates :conversion_date, presence: true
+  validates :conversion_date, first_day_of_month: true
 
   scope :no_academy_urn, -> { where(academy_urn: nil) }
   scope :with_academy_urn, -> { where.not(academy_urn: nil) }
@@ -11,6 +13,8 @@ class Conversion::Project < Project
   scope :provisional, -> { where(conversion_date_provisional: true) }
   scope :confirmed, -> { where(conversion_date_provisional: false) }
   scope :opening_by_month_year, ->(month, year) { includes(:tasks_data).where(conversion_date_provisional: false).and(where("YEAR(conversion_date) = ?", year)).and(where("MONTH(conversion_date) = ?", month)) }
+  scope :by_conversion_date, -> { order(conversion_date: :asc) }
+  scope :in_progress, -> { where(completed_at: nil).assigned.by_conversion_date }
 
   has_many :conversion_dates, dependent: :destroy, class_name: "Conversion::DateHistory"
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -13,8 +13,6 @@ class Project < ApplicationRecord
   validates :urn, urn: true
   validates :incoming_trust_ukprn, presence: true
   validates :incoming_trust_ukprn, ukprn: true
-  validates :conversion_date, presence: true
-  validates :conversion_date, first_day_of_month: true
   validates :advisory_board_date, presence: true
   validates :advisory_board_date, date_in_the_past: true
   validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
@@ -33,11 +31,9 @@ class Project < ApplicationRecord
   scope :sponsored, -> { where(directive_academy_order: true) }
   scope :voluntary, -> { where(directive_academy_order: false) }
 
-  scope :by_conversion_date, -> { order(conversion_date: :asc) }
-
   scope :completed, -> { where.not(completed_at: nil).order(completed_at: :desc) }
   scope :not_completed, -> { where(completed_at: nil) }
-  scope :in_progress, -> { where(completed_at: nil).assigned.by_conversion_date }
+  scope :in_progress, -> { where(completed_at: nil).assigned }
 
   scope :assigned, -> { where.not(assigned_to: nil) }
   scope :assigned_to_caseworker, ->(user) { where(assigned_to: user).or(where(caseworker: user)) }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -11,7 +11,6 @@ class Project < ApplicationRecord
 
   validates :urn, presence: true
   validates :urn, urn: true
-  validates :academy_urn, urn: true, if: -> { academy_urn.present? }
   validates :incoming_trust_ukprn, presence: true
   validates :incoming_trust_ukprn, ukprn: true
   validates :conversion_date, presence: true
@@ -34,8 +33,6 @@ class Project < ApplicationRecord
   scope :sponsored, -> { where(directive_academy_order: true) }
   scope :voluntary, -> { where(directive_academy_order: false) }
 
-  scope :no_academy_urn, -> { where(academy_urn: nil) }
-  scope :with_academy_urn, -> { where.not(academy_urn: nil) }
   scope :provisional, -> { where(conversion_date_provisional: true) }
   scope :confirmed, -> { where(conversion_date_provisional: false) }
 
@@ -99,14 +96,6 @@ class Project < ApplicationRecord
     @incoming_trust ||= fetch_trust(incoming_trust_ukprn)
   end
 
-  def academy
-    @academy ||= fetch_academy(academy_urn).object
-  end
-
-  def academy_found?
-    academy.present?
-  end
-
   def completed?
     completed_at.present?
   end
@@ -118,10 +107,6 @@ class Project < ApplicationRecord
   def director_of_child_services
     local_authority = establishment.local_authority
     local_authority&.director_of_child_services
-  end
-
-  private def fetch_academy(urn)
-    Api::AcademiesApi::Client.new.get_establishment(urn)
   end
 
   private def fetch_establishment(urn)

--- a/app/models/project_statistics.rb
+++ b/app/models/project_statistics.rb
@@ -1,6 +1,6 @@
 class ProjectStatistics
   def initialize
-    @projects = Project.all
+    @projects = Conversion::Project.all
   end
 
   def total_number_of_projects
@@ -263,7 +263,7 @@ class ProjectStatistics
     hash = {}
     (1..6).each do |i|
       date = Date.today + i.month
-      hash["#{Date::MONTHNAMES[date.month]} #{date.year}"] = Project.opening_by_month_year(date.month, date.year).count
+      hash["#{Date::MONTHNAMES[date.month]} #{date.year}"] = Conversion::Project.opening_by_month_year(date.month, date.year).count
     end
     hash
   end

--- a/app/services/conversion_projects_fetcher.rb
+++ b/app/services/conversion_projects_fetcher.rb
@@ -1,4 +1,4 @@
-class ProjectsFetcher
+class ConversionProjectsFetcher
   def sorted_openers(month, year)
     projects = Conversion::Project.opening_by_month_year(month, year)
     sort_by_conditions_met_and_name(projects)

--- a/app/services/projects_fetcher.rb
+++ b/app/services/projects_fetcher.rb
@@ -1,6 +1,6 @@
 class ProjectsFetcher
   def sorted_openers(month, year)
-    projects = Project.opening_by_month_year(month, year)
+    projects = Conversion::Project.opening_by_month_year(month, year)
     sort_by_conditions_met_and_name(projects)
   end
 

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Conversion::Project do
     end
   end
 
-  describe "#opened?" do
+  describe "#conversion_date_confirmed_and_passed?" do
     let(:project) {
       build(:conversion_project,
         conversion_date: conversion_date,

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -95,6 +95,49 @@ RSpec.describe Conversion::Project do
         expect(scoped_projects).not_to include provisional_project
       end
     end
+
+    describe ".in_progress" do
+      it "is ordered by conversion date ascending" do
+        mock_successful_api_response_to_create_any_project
+        create(:conversion_project, conversion_date: Date.today.at_beginning_of_month + 2.month)
+        project_converting_last = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month + 3.month)
+        project_converting_first = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month + 1.month)
+
+        projects = Conversion::Project.in_progress
+
+        expect(projects.first).to eql project_converting_first
+        expect(projects.last).to eql project_converting_last
+      end
+    end
+
+    describe ".by_conversion_date" do
+      before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+      it "shows the project that will convert earliest first" do
+        last_project = create(:conversion_project, conversion_date: Date.today.beginning_of_month + 3.years)
+        middle_project = create(:conversion_project, conversion_date: Date.today.beginning_of_month + 2.years)
+        first_project = create(:conversion_project, conversion_date: Date.today.beginning_of_month + 1.year)
+
+        scoped_projects = Conversion::Project.by_conversion_date
+
+        expect(scoped_projects[0].id).to eq first_project.id
+        expect(scoped_projects[1].id).to eq middle_project.id
+        expect(scoped_projects[2].id).to eq last_project.id
+      end
+    end
+  end
+
+  describe "#conversion_date" do
+    it { is_expected.to validate_presence_of(:conversion_date) }
+
+    context "when the date is not on the first of the month" do
+      subject { build(:conversion_project, conversion_date: Date.today.months_since(6).at_end_of_month) }
+
+      it "is invalid" do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:conversion_date]).to include(I18n.t("errors.attributes.conversion_date.must_be_first_of_the_month"))
+      end
+    end
   end
 
   describe "#route" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -446,50 +446,6 @@ RSpec.describe Project, type: :model do
       end
     end
 
-    describe "opening_by_month_year scope" do
-      before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
-
-      it "only returns projects with a confirmed conversion date" do
-        conversion_project = create(:conversion_project)
-        expect(Project.opening_by_month_year(1, 2023)).to_not include(conversion_project)
-      end
-
-      it "only returns projects with a confirmed conversion date in that month & year" do
-        project_in_scope = create(:conversion_project, conversion_date: Date.new(2023, 1, 1), conversion_date_provisional: false)
-        project_not_in_scope = create(:conversion_project, conversion_date: Date.new(2023, 2, 1), conversion_date_provisional: true)
-        project_without_conversion_date = create(:conversion_project)
-
-        expect(Project.opening_by_month_year(1, 2023)).to_not include(project_not_in_scope, project_without_conversion_date)
-        expect(Project.opening_by_month_year(1, 2023)).to include(project_in_scope)
-      end
-    end
-
-    describe "provisional scope" do
-      it "only returns projects with a provisional conversion date" do
-        mock_successful_api_responses(urn: any_args, ukprn: any_args)
-        provisional_project = create(:conversion_project, conversion_date_provisional: true)
-        confirmed_project = create(:conversion_project, conversion_date_provisional: false)
-
-        scoped_projects = Project.provisional
-
-        expect(scoped_projects).to include provisional_project
-        expect(scoped_projects).not_to include confirmed_project
-      end
-    end
-
-    describe "confirmed scope" do
-      it "only returns projects with a confirmed conversion date" do
-        mock_successful_api_responses(urn: any_args, ukprn: any_args)
-        provisional_project = create(:conversion_project, conversion_date_provisional: true)
-        confirmed_project = create(:conversion_project, conversion_date_provisional: false)
-
-        scoped_projects = Project.confirmed
-
-        expect(scoped_projects).to include confirmed_project
-        expect(scoped_projects).not_to include provisional_project
-      end
-    end
-
     describe "by_conversion_date scope" do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 
@@ -593,42 +549,6 @@ RSpec.describe Project, type: :model do
     it "uses the enum value for regions" do
       project = create(:conversion_project, region: "E")
       expect(project.region).to eq("east_midlands")
-    end
-  end
-
-  describe "#revised_conversion_date" do
-    let(:first_of_this_month) { Date.today.at_beginning_of_month }
-    let(:first_of_future_month) { Date.today.at_beginning_of_month + 3.months }
-
-    it "does not include projects whose conversion date stayed the same" do
-      user = create(:user)
-      mock_successful_api_response_to_create_any_project
-      project = create(:conversion_project, assigned_to: user, conversion_date_provisional: false)
-      create(:date_history, project: project, previous_date: first_of_this_month, revised_date: first_of_this_month)
-
-      another_project = create(:conversion_project, assigned_to: user, conversion_date_provisional: false)
-      create(:date_history, project: another_project, previous_date: first_of_this_month, revised_date: first_of_future_month)
-
-      projects = Project.conversion_date_revised_from(first_of_this_month.month, first_of_this_month.year)
-
-      expect(projects).to include another_project
-      expect(projects).not_to include project
-    end
-
-    it "only includes projects whose latest date history previous date is in the supplied month and year" do
-      user = create(:user)
-      mock_successful_api_response_to_create_any_project
-
-      another_project = create(:conversion_project, assigned_to: user, conversion_date_provisional: false)
-      create(:date_history, project: another_project, previous_date: first_of_this_month, revised_date: first_of_future_month)
-
-      yet_another_project = create(:conversion_project, assigned_to: user, conversion_date_provisional: false)
-      create(:date_history, project: yet_another_project, previous_date: first_of_future_month, revised_date: first_of_future_month + 3.months)
-
-      projects = Project.conversion_date_revised_from(first_of_future_month.month, first_of_future_month.year)
-
-      expect(projects).to include yet_another_project
-      expect(projects).not_to include another_project
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -132,65 +132,6 @@ RSpec.describe Project, type: :model do
         end
       end
     end
-
-    describe "academy urn" do
-      context "when there is no academy urn" do
-        it "is valid" do
-          project = build(:conversion_project, academy_urn: nil)
-
-          expect(project).to be_valid
-        end
-      end
-
-      context "when there is an academy urn" do
-        it "the urn must be valid" do
-          project = build(:conversion_project, academy_urn: 12345678)
-
-          expect(project).to be_invalid
-
-          project = build(:conversion_project, academy_urn: 123456)
-
-          expect(project).to be_valid
-        end
-      end
-    end
-  end
-
-  describe "#academy" do
-    it "returns an establishment object when the urn can be found" do
-      mock_successful_api_response_to_create_any_project
-
-      project = build(:conversion_project, academy_urn: 123456)
-
-      expect(project.academy).to be_a(Api::AcademiesApi::Establishment)
-    end
-
-    it "returns nil when the urn cannot be found" do
-      mock_successful_api_response_to_create_any_project
-      mock_establishment_not_found(urn: 999999)
-
-      project = build(:conversion_project, academy_urn: 999999)
-
-      expect(project.academy).to be_nil
-    end
-  end
-
-  describe "#academy_found?" do
-    before { mock_successful_api_response_to_create_any_project }
-
-    it "returns true when the academy can be found" do
-      project = build(:conversion_project, academy_urn: 123456)
-
-      expect(project.academy_found?).to eql true
-    end
-
-    it "returns false when the academy cannot be found" do
-      project = build(:conversion_project, academy_urn: 123456)
-
-      allow_any_instance_of(Project).to receive(:academy).and_return(nil)
-
-      expect(project.academy_found?).to eql false
-    end
   end
 
   describe "#establishment" do
@@ -606,30 +547,6 @@ RSpec.describe Project, type: :model do
 
         expect(projects).to include(sponsored_project)
         expect(projects).not_to include(voluntary_project)
-      end
-    end
-
-    describe "#no_academy_urn" do
-      it "returns only projects where academy_urn is nil" do
-        mock_successful_api_response_to_create_any_project
-        new_project = create(:conversion_project, academy_urn: nil)
-        existing_project = create(:conversion_project, academy_urn: 126041)
-        projects = Project.no_academy_urn
-
-        expect(projects).to include(new_project)
-        expect(projects).not_to include(existing_project)
-      end
-    end
-
-    describe "#with_academy_urn" do
-      it "returns only projects where academy_urn is NOT nil" do
-        mock_successful_api_response_to_create_any_project
-        new_project = create(:conversion_project, academy_urn: nil)
-        existing_project = create(:conversion_project, academy_urn: 126041)
-        projects = Project.with_academy_urn
-
-        expect(projects).to include(existing_project)
-        expect(projects).not_to include(new_project)
       end
     end
 

--- a/spec/services/projects_fetcher_spec.rb
+++ b/spec/services/projects_fetcher_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ProjectsFetcher do
     let(:projects) { [project_d, project_b, project_a, project_c] }
 
     before do
-      allow(Project).to receive(:opening_by_month_year).and_return(projects)
+      allow(Conversion::Project).to receive(:opening_by_month_year).and_return(projects)
     end
 
     it "sorts the projects by conditions_met? true and then by school name" do

--- a/spec/services/projects_fetcher_spec.rb
+++ b/spec/services/projects_fetcher_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ProjectsFetcher do
+RSpec.describe ConversionProjectsFetcher do
   let(:projects_fetcher) { described_class.new }
 
   describe "#sorted_openers" do


### PR DESCRIPTION
## Changes

Now that Transfer::Project exists, we need to start moving the Conversion-specific attributes and scopes (etc) from Project to Conversion::Project.

The first three are:

- `academy_urn`
- `conversion_date_provisional`
- `conversion_date`

All three have been moved to Conversion::Project, and any scopes which rely on these attributes have also moved to Conversion::Project.

The scope `.in_progress` has stayed in Project, but its ordering by `conversion_date` has been removed. We imagine the concept of "in progress" will apply to all Project types, hence retaining this scope. 

A version of the `.in_progress` scope has been added to Conversion::Project, and retains the ordering by `conversion_date`. 

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
