### PR TITLE
Store active directory group ids on user

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,6 @@ class SessionsController < ApplicationController
   def create
     if registered_user
       create_session
-      assign_active_directory_user_id
 
       redirect_to root_path
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  serialize :active_directory_user_group_ids, Array
+
   has_many :projects, foreign_key: "caseworker"
   has_many :notes
 

--- a/db/migrate/20230609151244_add_active_directory_ids_to_user.rb
+++ b/db/migrate/20230609151244_add_active_directory_ids_to_user.rb
@@ -1,0 +1,5 @@
+class AddActiveDirectoryIdsToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :active_directory_user_group_ids, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_09_110127) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_09_151244) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -218,6 +218,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_09_110127) do
     t.string "active_directory_user_id"
     t.boolean "caseworker", default: false
     t.boolean "service_support", default: false
+    t.string "active_directory_user_group_ids"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/features/users_can_sign_in_spec.rb
+++ b/spec/features/users_can_sign_in_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Users can sign in to the application" do
       click_button(I18n.t("sign_in.button"))
 
       expect(page).not_to have_button(I18n.t("sign_in.button"))
-      expect(user.reload.active_directory_user_id).to eq "b5095c3e-0141-4478-81ad-99d0fbd087ed"
+      expect(user.reload.active_directory_user_id).to eq "test-user-id"
     end
 
     scenario "from any page, they are redirected to the sign in page" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe User do
     it { is_expected.to have_db_column(:regional_delivery_officer).of_type :boolean }
     it { is_expected.to have_db_column(:caseworker).of_type :boolean }
     it { is_expected.to have_db_column(:service_support).of_type :boolean }
+    it { is_expected.to have_db_column(:active_directory_user_group_ids).of_type :string }
   end
 
   describe "scopes" do

--- a/spec/requests/sign_in_spec.rb
+++ b/spec/requests/sign_in_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Sign in" do
   let(:user) { create(:user, :caseworker) }
 
-  context "when the user is signed out" do
+  context "when the user is unauthenticated" do
     it "redirects them to the sign in page and shows a helpful message" do
       get root_path
 
@@ -12,7 +12,7 @@ RSpec.describe "Sign in" do
     end
   end
 
-  context "when the user is signed in" do
+  context "when the user is authenticated" do
     before do
       mock_successful_authentication(user.email)
       allow_any_instance_of(RootController).to receive(:user_id).and_return(user.id)

--- a/spec/support/sign_in_helpers.rb
+++ b/spec/support/sign_in_helpers.rb
@@ -4,12 +4,19 @@ module SignInHelpers
     allow_any_instance_of(ApplicationController).to receive(:user_id).and_return(user.id)
   end
 
-  def mock_successful_authentication(email_address)
+  def mock_successful_authentication(email_address, groups = nil)
+    test_groups = groups || ["test-group-id-one", "test-group-id-two"]
+
     OmniAuth.config.mock_auth[:azure_activedirectory_v2] = OmniAuth::AuthHash.new({
       info: {
         email: email_address
       },
-      uid: "b5095c3e-0141-4478-81ad-99d0fbd087ed"
+      uid: "test-user-id",
+      extra: {
+        raw_info: {
+          groups: test_groups
+        }
+      }
     })
     OmniAuth.config.test_mode = true
   end


### PR DESCRIPTION
We don't want to have to manage user authrorisation ourselves.

When a user is authenticated against the DfE Active Directory, it returns an array of the Group IDs the user is part of. We can leverage this authorise users.

The first step is to store the IDs with the User, we do so here.

We store all the Group IDs in the same column and serialize the result, later we can check which groups we care about.

https://trello.com/c/W1w259AY/1641-store-the-active-directory-group-ids-with-the-user