### PR TITLE
Add mandatory `outgoing_trust_ukprn` to Transfer::Project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add `outgoing_trust_ukprn` to Transfer::Project model
+
 ### Changed
 
 - All `regional-casework-services` URLs are now `team`, e.g.

--- a/app/models/transfer/project.rb
+++ b/app/models/transfer/project.rb
@@ -2,4 +2,18 @@ class Transfer::Project < Project
   def self.policy_class
     ProjectPolicy
   end
+
+  validates :outgoing_trust_ukprn, presence: true
+  validates :outgoing_trust_ukprn, ukprn: true
+  validate :outgoing_trust_exists, if: -> { outgoing_trust_ukprn.present? }
+
+  def outgoing_trust
+    @outgoing_trust ||= fetch_trust(outgoing_trust_ukprn)
+  end
+
+  private def outgoing_trust_exists
+    outgoing_trust
+  rescue Api::AcademiesApi::Client::NotFoundError
+    errors.add(:outgoing_trust_ukprn, :no_trust_found)
+  end
 end

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -347,6 +347,11 @@ en:
         no_trust_found: There's no trust with that UKPRN. Check the number you entered is correct.
         not_a_number: UKPRN can only contain numbers. No letters or special characters.
         must_be_correct_format: UKPRN must be 8 digits long and start with a 1. For example, 12345678.
+      outgoing_trust_ukprn:
+        blank: Enter a UKPRN
+        no_trust_found: There's no trust with that UKPRN. Check the number you entered is correct.
+        not_a_number: UKPRN can only contain numbers. No letters or special characters.
+        must_be_correct_format: UKPRN must be 8 digits long and start with a 1. For example, 12345678.
       regional_delivery_officer_id:
         blank: Choose a regional delivery officer
       advisory_board_date:

--- a/db/migrate/20230613093255_add_outgoing_trust_ukprn_to_projects.rb
+++ b/db/migrate/20230613093255_add_outgoing_trust_ukprn_to_projects.rb
@@ -1,0 +1,5 @@
+class AddOutgoingTrustUkprnToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :outgoing_trust_ukprn, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_09_151244) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_13_093255) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -195,6 +195,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_09_151244) do
     t.uuid "tasks_data_id"
     t.string "tasks_data_type"
     t.uuid "funding_agreement_contact_id"
+    t.integer "outgoing_trust_ukprn"
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Project, type: :model do
   describe "Columns" do
     it { is_expected.to have_db_column(:urn).of_type :integer }
     it { is_expected.to have_db_column(:incoming_trust_ukprn).of_type :integer }
+    it { is_expected.to have_db_column(:outgoing_trust_ukprn).of_type :integer }
     it { is_expected.to have_db_column(:conversion_date).of_type :date }
     it { is_expected.to have_db_column(:caseworker_id).of_type :uuid }
     it { is_expected.to have_db_column(:team_leader_id).of_type :uuid }
@@ -54,6 +55,7 @@ RSpec.describe Project, type: :model do
 
     it { is_expected.to validate_presence_of(:advisory_board_date) }
     it { is_expected.not_to validate_presence_of(:conversion_date) }
+    it { is_expected.not_to validate_presence_of(:outgoing_trust_ukprn) }
 
     describe "#urn" do
       it { is_expected.to validate_presence_of(:urn) }

--- a/spec/models/transfer/project_spec.rb
+++ b/spec/models/transfer/project_spec.rb
@@ -6,4 +6,37 @@ RSpec.describe Transfer::Project do
       expect(described_class.policy_class).to eql(ProjectPolicy)
     end
   end
+
+  describe "#outgoing_trust_ukprn" do
+    before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+    it { is_expected.to validate_presence_of(:outgoing_trust_ukprn) }
+
+    context "when the outgoing_trust_ukprn is not a number" do
+      subject { described_class.new(outgoing_trust_ukprn: "Super Schools Trust") }
+
+      it "is invalid" do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:outgoing_trust_ukprn]).to include(I18n.t("errors.attributes.outgoing_trust_ukprn.must_be_correct_format"))
+      end
+    end
+
+    context "when no trust with that UKPRN exists in the API and the UKPRN is present" do
+      let(:no_trust_found_result) do
+        Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::NotFoundError.new("No trust found with that UKPRN. Enter a valid UKPRN."))
+      end
+
+      subject { described_class.new(outgoing_trust_ukprn: 12345678) }
+
+      before do
+        allow_any_instance_of(Api::AcademiesApi::Client).to \
+          receive(:get_trust) { no_trust_found_result }
+      end
+
+      it "is invalid" do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:outgoing_trust_ukprn]).to include(I18n.t("errors.attributes.outgoing_trust_ukprn.no_trust_found"))
+      end
+    end
+  end
 end


### PR DESCRIPTION


## Changes

The `outgoing_trust_ukprn` attribute is mandatory for Transfer::Project but not other kinds of Project. Add the standard validations, to ensure it is not blank, is a valid UKPRN and that the trust exists, to Transfer::Project only.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
