### PR TITLE
Fix: Different provisional/confirmed conversion dates is not a change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - A user who has no role is now redirected to the all projects section of the
   application.
+- The list of projects with a revised conversion date for the month and year no
+  longer includes projects with provisional and confirmed conversion dates that
+  do not match.
 
 ## [Release 28][release-28]
 

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -21,7 +21,7 @@ class Conversion::Project < Project
   def self.conversion_date_revised_from(month, year)
     projects = Conversion::Project.in_progress.confirmed
 
-    latest_date_histories = Conversion::DateHistory.group(:project_id).maximum(:created_at)
+    latest_date_histories = Conversion::DateHistory.group(:project_id).having("COUNT(created_at) > 1").maximum(:created_at)
 
     matching_date_histories = Conversion::DateHistory
       .where(project_id: latest_date_histories.keys)

--- a/spec/features/projects/revised_conversion_date/viewing_projects_with_a_revised_converison_date_spec.rb
+++ b/spec/features/projects/revised_conversion_date/viewing_projects_with_a_revised_converison_date_spec.rb
@@ -15,10 +15,11 @@ RSpec.feature "Viewing projects with a revised conversion date" do
 
     project_with_matching_date = create(:conversion_project, assigned_to: user, conversion_date_provisional: false, urn: 101133)
     create(:date_history, project: project_with_matching_date, previous_date: Date.today.at_beginning_of_month, revised_date: Date.today.at_beginning_of_month + 3.months)
+    create(:date_history, project: project_with_matching_date, previous_date: Date.today.at_beginning_of_month + 3.months, revised_date: Date.today.at_beginning_of_month + 4.months)
 
-    visit revised_all_opening_projects_path(Date.today.month, Date.today.year)
+    visit revised_all_opening_projects_path((Date.today + 3.months).month, Date.today.year)
 
-    expect(page).to have_content I18n.t("project.revised_conversion_date.title", date: Date.today.to_fs(:govuk_month))
+    expect(page).to have_content I18n.t("project.revised_conversion_date.title", date: (Date.today + 3.months).to_fs(:govuk_month))
     expect(page).to have_content project_with_matching_date.urn
     expect(page).not_to have_content project_with_confirmed_date.urn
     expect(page).not_to have_content project_with_other_date.urn


### PR DESCRIPTION
Previously we stored the provvisional covnersion date in a seperate
column. We then removed that and simply mark the project as 'with
provisional conversion date'.

However, we missed the impact this has on the
`self.conversion_date_revised_from` scope. Now the first Converison Date
History  is always the change from provisional to confirmed and, if the
dates are diffrent, the test is triggered and the project included when
it should not be.

The fix is to exclude any project that only has one
Conversion::DateHistory when grouping. A project in this state must only
have been confirmed and all projects must be confirmed.

(https://trello.com/c/UpLORrCE)