### PR TITLE
Add the region to the unassigned projects view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add `outgoing_trust_ukprn` to Transfer::Project model
+- The unassigned project table now includes the region a project is in.
 
 ### Changed
 

--- a/app/views/projects/shared/_unassigned_table.html.erb
+++ b/app/views/projects/shared/_unassigned_table.html.erb
@@ -9,6 +9,7 @@
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.added_by") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.region") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assign") %></th>
       </tr>
@@ -20,6 +21,7 @@
         <td class="govuk-table__cell"><%= project.urn %></td>
         <td class="govuk-table__cell"><%= project.regional_delivery_officer.full_name %></td>
         <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
+        <td class="govuk-table__cell"><%= project.establishment.region_name %></td>
         <td class="govuk-table__cell">
           <%= link_to t("project.table.body.view_html", school_name: project.establishment.name), project_path(project) %>
         </td>

--- a/spec/features/projects/view_unassigend_team_projects_spec.rb
+++ b/spec/features/projects/view_unassigend_team_projects_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.feature "Viewing unassigned team projects" do
+  before do
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  context "as a regional casework services lead" do
+    let(:user) { create(:user, :team_leader) }
+
+    scenario "they can view all unassigned projects in the team" do
+      matching_project = create(:conversion_project, assigned_to: nil, assigned_to_regional_caseworker_team: true)
+
+      visit unassigned_team_projects_path
+
+      expect(page).to have_content(matching_project.urn)
+      expect(page).to have_content(matching_project.establishment.region_name)
+    end
+  end
+end


### PR DESCRIPTION
Regional casework services need to know which region a project is in
when making a decision about assignment.

Here we add the column to the table that is render in that view.

https://trello.com/c/FW4ISAHa
