### PR TITLE
Add footer link to the service guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add `outgoing_trust_ukprn` to Transfer::Project model
 - The unassigned project table now includes the region a project is in.
+- Add a link to the service guidance in the application footer.
 
 ### Changed
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,7 +55,16 @@
       </main>
     </div>
 
-    <%= govuk_footer(meta_items_title: "Helpful links", meta_items: {"Privacy notice" => page_path(id: "privacy"), "Accessibility Statement" => page_path(id: "accessibility"), "Cookies" => page_path(id: "cookies"), "Email support" => "mailto:#{Rails.application.config.support_email}?subject=#{I18n.t("support_email_subject")}"}) %>
+    <%= govuk_footer(
+          meta_items_title: "Helpful links",
+          meta_items: [
+            {text: "Privacy notice", href: page_path(id: "privacy")},
+            {text: "Accessibility Statement", href: page_path(id: "accessibility")},
+            {text: "Cookies", href: page_path(id: "cookies")},
+            {text: "How to use this service (opens in new tab)", href: "https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/Using-the-Complete-conversions,-transfers-and-changes-digital-product.aspx", attr: {target: "_blank"}},
+            {text: "Email support", href: "mailto:#{Rails.application.config.support_email}?subject=#{I18n.t("support_email_subject")}"}
+          ]
+        ) %>
 
   </body>
   <%= javascript_include_tag "application" %>

--- a/spec/features/navigation/footer_navigation_spec.rb
+++ b/spec/features/navigation/footer_navigation_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.feature "Footer navigation" do
+  scenario "users can see the footer links" do
+    visit root_path
+
+    expect(page).to have_link("Privacy notice")
+    expect(page).to have_link("Accessibility Statement")
+    expect(page).to have_link("Cookies")
+    expect(page).to have_link("How to use this service")
+    expect(page).to have_link("Email support")
+  end
+end


### PR DESCRIPTION
Adds a link to the new service guidance in the footer.

https://trello.com/c/rVD5vBhj

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/c7e71f37-69f4-4378-b555-6e3fb3a5e366)

