### PR TITLE
Release 29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [Release 29][release-29]
+
+### Added
+
 - Add `outgoing_trust_ukprn` to Transfer::Project model
 - The unassigned project table now includes the region a project is in.
 - Add a link to the service guidance in the application footer.
@@ -979,7 +987,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-28...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-29...HEAD
+[release-29]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-28...release-29
 [release-28]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-27...release-28
 [release-27]:


### PR DESCRIPTION
### Added

- Add `outgoing_trust_ukprn` to Transfer::Project model
- The unassigned project table now includes the region a project is in.
- Add a link to the service guidance in the application footer.

### Changed

- All `regional-casework-services` URLs are now `team`, e.g.
  `/projects/team/in-progress`
- Content updated in trust modification order task. Checkbox descriptions now
  accurate. Additional clarifications added to guidance.

### Fixed

- A user who has no role is now redirected to the all projects section of the
  application.
- The list of projects with a revised conversion date for the month and year no
  longer includes projects with provisional and confirmed conversion dates that
  do not match.
