### PR TITLE
Add a BOM to the CSV file and enforce UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Enforce UTF-8 encoding in the CSV download via a BOM (byte order mark) and by
+  generating the CSV file in UTF-8
+
 ## [Release 29][release-29]
 
 ### Added

--- a/app/services/opening_projects_csv_exporter.rb
+++ b/app/services/opening_projects_csv_exporter.rb
@@ -8,7 +8,7 @@ class OpeningProjectsCsvExporter
   end
 
   def call
-    @csv = CSV.generate(headers: true) do |csv|
+    @csv = CSV.generate("\uFEFF", headers: true, encoding: "UTF-8") do |csv|
       csv << headers
       @projects.each do |project|
         csv << row(project).values

--- a/spec/services/opening_projects_csv_exporter_spec.rb
+++ b/spec/services/opening_projects_csv_exporter_spec.rb
@@ -244,5 +244,19 @@ RSpec.describe OpeningProjectsCsvExporter do
       expect(csv_export).to include("Project lead")
       expect(csv_export).to include("Joe Bloggs")
     end
+
+    it "prepends a BOM to the file" do
+      project = build(:conversion_project, urn: 654321)
+
+      csv_export = OpeningProjectsCsvExporter.new([project]).call
+      expect(csv_export.chr).to eq("\uFEFF")
+    end
+
+    it "sends the file in UTF-8 encoding" do
+      project = build(:conversion_project, urn: 654321)
+
+      csv_export = OpeningProjectsCsvExporter.new([project]).call
+      expect(csv_export.encoding.name).to eq("UTF-8")
+    end
   end
 end


### PR DESCRIPTION
## Changes

The CSV was not displaying correctly in MS Excel, due to UTF-8 encoding not being enforced. Enforce UTF-8 via a BOM prepended to the CSV data (byte order mark) and encoding the CSV file as it is generated.

Screenshot below to show the apostrophe in "Children's services" is being rendered correctly in Excel.

<img width="594" alt="Screenshot 2023-06-22 at 11 33 08" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/e17287f1-4ed4-453b-9818-2a6400480df6">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
