### PR TITLE
Add more columns to the funding agreement letters export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - A view, by trust, that shows the trusts that have in-progress projects in the
   application and lists the projects.
+- Add Route and Academy name to the CSV export
 
 ### Changed
 

--- a/app/models/api/members_api/client.rb
+++ b/app/models/api/members_api/client.rb
@@ -29,6 +29,8 @@ class Api::MembersApi::Client
     contact_details = member_contact_details(member_id).object.find { |details| details.type_id == 1 }
 
     Api::MembersApi::MemberDetails.new(member_name, contact_details)
+  rescue NoMethodError
+    Result.new(nil, Error.new(I18n.t("members_api.errors.contact_details_not_found", member_id: member_id)))
   end
 
   def member_id(search_term)

--- a/app/services/opening_projects_csv_exporter.rb
+++ b/app/services/opening_projects_csv_exporter.rb
@@ -29,6 +29,7 @@ class OpeningProjectsCsvExporter
       school_urn: project.urn,
       dfe_number: project.establishment.dfe_number,
       project_type: "Conversion",
+      route: I18n.t("project.openers.route.#{project.route}"),
       conversion_date: project.conversion_date.strftime("%Y/%m/%d"),
       director_of_child_services_name: project.director_of_child_services&.name,
       director_of_child_services_role: project.director_of_child_services&.title,
@@ -63,7 +64,8 @@ class OpeningProjectsCsvExporter
       mp_address_line_3: mp_details.address.line3,
       mp_address_postcode: mp_details.address.postcode,
       approval_date: project.advisory_board_date.strftime("%Y/%m/%d"),
-      project_lead: project.assigned_to.full_name
+      project_lead: project.assigned_to.full_name,
+      academy_name: project.academy.name
     }
   end
 

--- a/app/services/opening_projects_csv_exporter.rb
+++ b/app/services/opening_projects_csv_exporter.rb
@@ -30,7 +30,7 @@ class OpeningProjectsCsvExporter
       dfe_number: project.establishment.dfe_number,
       project_type: "Conversion",
       route: I18n.t("project.openers.route.#{project.route}"),
-      conversion_date: project.conversion_date.strftime("%Y/%m/%d"),
+      conversion_date: project.conversion_date.to_formatted_s(:csv),
       director_of_child_services_name: project.director_of_child_services&.name,
       director_of_child_services_role: project.director_of_child_services&.title,
       director_of_child_services_email: project.director_of_child_services&.email,
@@ -63,7 +63,7 @@ class OpeningProjectsCsvExporter
       mp_address_line_2: mp_details.address.line2,
       mp_address_line_3: mp_details.address.line3,
       mp_address_postcode: mp_details.address.postcode,
-      approval_date: project.advisory_board_date.strftime("%Y/%m/%d"),
+      approval_date: project.advisory_board_date.to_formatted_s(:csv),
       project_lead: project.assigned_to.full_name,
       academy_name: project.academy.name
     }

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Date::DATE_FORMATS[:csv] = "%Y/%m/%d"

--- a/config/locales/members_api.en.yml
+++ b/config/locales/members_api.en.yml
@@ -4,3 +4,4 @@ en:
       other: There was an error connecting to the Members API
       multiple: "Multiple results found for search term: %{search_term}"
       member_not_found: "Member not found: %{member_id}"
+      contact_details_not_found: "Contact details not found for member %{member_id}"

--- a/config/locales/opening_projects_csv_exporter.yml
+++ b/config/locales/opening_projects_csv_exporter.yml
@@ -39,3 +39,5 @@ en:
       mp_address_postcode: MP postcode
       approval_date: Approval date
       project_lead: Project lead
+      route: Route
+      academy_name: Academy name

--- a/spec/models/api/members_api/client_spec.rb
+++ b/spec/models/api/members_api/client_spec.rb
@@ -61,6 +61,20 @@ RSpec.describe Api::MembersApi::Client do
       expect(response.address.line1).to eq("Houses of Parliment")
       expect(response.address.postcode).to eq("SW1A 0AA")
     end
+
+    it "raises an error if the member_contact_details is nil" do
+      fake_client = Api::MembersApi::Client.new
+      allow(fake_client).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(4744, nil))
+      fake_name = double(Api::MembersApi::MemberName, name_display_as: "Joe Bloggs")
+      allow(fake_client).to receive(:member_name).and_return(Api::MembersApi::Client::Result.new(fake_name, nil))
+      allow(fake_client).to receive(:member_contact_details).and_return(Api::MembersApi::Client::Result.new(nil, nil))
+
+      response = fake_client.member_for_constituency("St Albans")
+
+      expect(response.object).to be_nil
+      expect(response.error).to be_a(Api::MembersApi::Client::Error)
+      expect(response.error.message).to eq(I18n.t("members_api.errors.contact_details_not_found", member_id: 4744))
+    end
   end
 
   describe "#member_id" do

--- a/spec/services/opening_projects_csv_exporter_spec.rb
+++ b/spec/services/opening_projects_csv_exporter_spec.rb
@@ -281,7 +281,6 @@ RSpec.describe OpeningProjectsCsvExporter do
       expect(csv_export.encoding.name).to eq("UTF-8")
     end
 
-
     it "returns a csv with the new academy name" do
       establishment = build(:academies_api_establishment)
       allow(establishment).to receive(:name).and_return("New Academy")

--- a/spec/services/opening_projects_csv_exporter_spec.rb
+++ b/spec/services/opening_projects_csv_exporter_spec.rb
@@ -40,6 +40,28 @@ RSpec.describe OpeningProjectsCsvExporter do
       expect(csv_export).to include("Conversion")
     end
 
+    context "a voluntary project" do
+      it "returns a csv with the project route" do
+        project = build(:conversion_project)
+
+        csv_export = OpeningProjectsCsvExporter.new([project]).call
+
+        expect(csv_export).to include("Route")
+        expect(csv_export).to include("Voluntary")
+      end
+    end
+
+    context "a sponsored project" do
+      it "returns a csv with the project route" do
+        project = build(:conversion_project, :sponsored)
+
+        csv_export = OpeningProjectsCsvExporter.new([project]).call
+
+        expect(csv_export).to include("Route")
+        expect(csv_export).to include("Sponsored")
+      end
+    end
+
     it "returns a csv with the project conversion date" do
       project = build(:conversion_project, conversion_date: Date.new(2025, 5, 1))
 
@@ -257,6 +279,19 @@ RSpec.describe OpeningProjectsCsvExporter do
 
       csv_export = OpeningProjectsCsvExporter.new([project]).call
       expect(csv_export.encoding.name).to eq("UTF-8")
+    end
+
+
+    it "returns a csv with the new academy name" do
+      establishment = build(:academies_api_establishment)
+      allow(establishment).to receive(:name).and_return("New Academy")
+      project = build(:conversion_project)
+      allow(project).to receive(:academy).and_return(establishment)
+
+      csv_export = OpeningProjectsCsvExporter.new([project]).call
+
+      expect(csv_export).to include("Academy name")
+      expect(csv_export).to include("New Academy")
     end
   end
 end


### PR DESCRIPTION
## Changes

- Rescue an error we saw on production when an MPs contact details were nil
- Add Route and Academy name to the CSV
- Do a little refactoring

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
