### PR TITLE
Move `directive_academy_order` to Conversion::Project

### DIFF
--- a/app/controllers/all/completed/projects_controller.rb
+++ b/app/controllers/all/completed/projects_controller.rb
@@ -12,7 +12,7 @@ class All::Completed::ProjectsController < ApplicationController
 
   def voluntary
     authorize Project, :index?
-    @pager, @projects = pagy(Project.completed.voluntary)
+    @pager, @projects = pagy(Conversion::Project.completed.voluntary)
 
     pre_fetch_establishments(@projects)
     pre_fetch_incoming_trusts(@projects)
@@ -20,7 +20,7 @@ class All::Completed::ProjectsController < ApplicationController
 
   def sponsored
     authorize Project, :index?
-    @pager, @projects = pagy(Project.completed.sponsored)
+    @pager, @projects = pagy(Conversion::Project.completed.sponsored)
 
     pre_fetch_establishments(@projects)
     pre_fetch_incoming_trusts(@projects)

--- a/app/controllers/all/in_progress/projects_controller.rb
+++ b/app/controllers/all/in_progress/projects_controller.rb
@@ -9,7 +9,7 @@ class All::InProgress::ProjectsController < ApplicationController
 
   def voluntary
     authorize Project, :index?
-    @pager, @projects = pagy(Project.in_progress.voluntary.includes(:assigned_to))
+    @pager, @projects = pagy(Conversion::Project.in_progress.voluntary.includes(:assigned_to))
 
     pre_fetch_establishments(@projects)
     pre_fetch_incoming_trusts(@projects)
@@ -17,7 +17,7 @@ class All::InProgress::ProjectsController < ApplicationController
 
   def sponsored
     authorize Project, :index?
-    @pager, @projects = pagy(Project.in_progress.sponsored.includes(:assigned_to))
+    @pager, @projects = pagy(Conversion::Project.in_progress.sponsored.includes(:assigned_to))
 
     pre_fetch_establishments(@projects)
     pre_fetch_incoming_trusts(@projects)

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -6,6 +6,7 @@ class Conversion::Project < Project
   validates :academy_urn, urn: true, if: -> { academy_urn.present? }
   validates :conversion_date, presence: true
   validates :conversion_date, first_day_of_month: true
+  validates :directive_academy_order, inclusion: {in: [true, false]}
 
   scope :no_academy_urn, -> { where(academy_urn: nil) }
   scope :with_academy_urn, -> { where.not(academy_urn: nil) }
@@ -15,6 +16,9 @@ class Conversion::Project < Project
   scope :opening_by_month_year, ->(month, year) { includes(:tasks_data).where(conversion_date_provisional: false).and(where("YEAR(conversion_date) = ?", year)).and(where("MONTH(conversion_date) = ?", month)) }
   scope :by_conversion_date, -> { order(conversion_date: :asc) }
   scope :in_progress, -> { where(completed_at: nil).assigned.by_conversion_date }
+
+  scope :sponsored, -> { where(directive_academy_order: true) }
+  scope :voluntary, -> { where(directive_academy_order: false) }
 
   has_many :conversion_dates, dependent: :destroy, class_name: "Conversion::DateHistory"
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -17,7 +17,6 @@ class Project < ApplicationRecord
   validates :advisory_board_date, date_in_the_past: true
   validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
   validates :trust_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
-  validates :directive_academy_order, inclusion: {in: [true, false]}
 
   validate :establishment_exists, if: -> { urn.present? }
   validate :trust_exists, if: -> { incoming_trust_ukprn.present? }
@@ -28,8 +27,6 @@ class Project < ApplicationRecord
   belongs_to :assigned_to, class_name: "User", optional: true
 
   scope :conversions, -> { where(type: "Conversion::Project") }
-  scope :sponsored, -> { where(directive_academy_order: true) }
-  scope :voluntary, -> { where(directive_academy_order: false) }
 
   scope :completed, -> { where.not(completed_at: nil).order(completed_at: :desc) }
   scope :not_completed, -> { where(completed_at: nil) }

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe Conversion::Project do
         end
       end
     end
+
+    describe "#directive_academy_order" do
+      it { is_expected.to allow_value(true).for(:directive_academy_order) }
+      it { is_expected.to allow_value(false).for(:directive_academy_order) }
+      it { is_expected.to_not allow_value(nil).for(:directive_academy_order) }
+
+      context "error messages" do
+        it "adds an appropriate error message if the value is nil" do
+          subject.assign_attributes(directive_academy_order: nil)
+          subject.valid?
+          expect(subject.errors[:directive_academy_order]).to include("Select directive academy order or academy order, whichever has been used for this conversion")
+        end
+      end
+    end
   end
 
   describe "scopes" do
@@ -123,6 +137,30 @@ RSpec.describe Conversion::Project do
         expect(scoped_projects[0].id).to eq first_project.id
         expect(scoped_projects[1].id).to eq middle_project.id
         expect(scoped_projects[2].id).to eq last_project.id
+      end
+    end
+
+    describe "#voluntary" do
+      it "returns only projects where directive_academy_order is false" do
+        mock_successful_api_response_to_create_any_project
+        voluntary_project = create(:conversion_project, directive_academy_order: false)
+        sponsored_project = create(:conversion_project, directive_academy_order: true)
+        projects = Conversion::Project.voluntary
+
+        expect(projects).to include(voluntary_project)
+        expect(projects).not_to include(sponsored_project)
+      end
+    end
+
+    describe "#sponsored" do
+      it "returns only projects where directive_academy_order is true" do
+        mock_successful_api_response_to_create_any_project
+        voluntary_project = create(:conversion_project, directive_academy_order: false)
+        sponsored_project = create(:conversion_project, directive_academy_order: true)
+        projects = Conversion::Project.sponsored
+
+        expect(projects).to include(sponsored_project)
+        expect(projects).not_to include(voluntary_project)
       end
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -108,20 +108,6 @@ RSpec.describe Project, type: :model do
     describe "#trust_sharepoint_link" do
       it { is_expected.to validate_presence_of :trust_sharepoint_link }
     end
-
-    describe "#directive_academy_order" do
-      it { is_expected.to allow_value(true).for(:directive_academy_order) }
-      it { is_expected.to allow_value(false).for(:directive_academy_order) }
-      it { is_expected.to_not allow_value(nil).for(:directive_academy_order) }
-
-      context "error messages" do
-        it "adds an appropriate error message if the value is nil" do
-          subject.assign_attributes(directive_academy_order: nil)
-          subject.valid?
-          expect(subject.errors[:directive_academy_order]).to include("Select directive academy order or academy order, whichever has been used for this conversion")
-        end
-      end
-    end
   end
 
   describe "#establishment" do
@@ -441,30 +427,6 @@ RSpec.describe Project, type: :model do
         second_users_projects = Project.assigned_to(second_user)
         expect(second_users_projects).to include(second_users_project)
         expect(second_users_projects).not_to include(first_users_project)
-      end
-    end
-
-    describe "#voluntary" do
-      it "returns only projects where directive_academy_order is false" do
-        mock_successful_api_response_to_create_any_project
-        voluntary_project = create(:conversion_project, directive_academy_order: false)
-        sponsored_project = create(:conversion_project, directive_academy_order: true)
-        projects = Project.voluntary
-
-        expect(projects).to include(voluntary_project)
-        expect(projects).not_to include(sponsored_project)
-      end
-    end
-
-    describe "#sponsored" do
-      it "returns only projects where directive_academy_order is true" do
-        mock_successful_api_response_to_create_any_project
-        voluntary_project = create(:conversion_project, directive_academy_order: false)
-        sponsored_project = create(:conversion_project, directive_academy_order: true)
-        projects = Project.sponsored
-
-        expect(projects).to include(sponsored_project)
-        expect(projects).not_to include(voluntary_project)
       end
     end
 


### PR DESCRIPTION


## Changes

Move the validation for `directive_academy_order` to the Conversion::Project model (from Project). This attribute is only required for conversions.

Also move two scopes - .voluntary and .sponsored - to the Conversion::Project model, as these rely on the directive_academy_order attribute.

Finally, amend two controllers to only look for Conversion::Projects. We may need to move these controllersi nto a conversion project namespace in future.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
