### PR TITLE
Fix by trust projects view

### DIFF
--- a/app/controllers/all/trusts/projects_controller.rb
+++ b/app/controllers/all/trusts/projects_controller.rb
@@ -10,7 +10,7 @@ class All::Trusts::ProjectsController < ApplicationController
   def show
     authorize Project, :index?
     ukprn = params[:trust_ukprn]
-    @pager, @projects = pagy(Conversion::Project.by_trust_ukprn(ukprn).by_conversion_date)
+    @pager, @projects = pagy(Conversion::Project.not_completed.by_trust_ukprn(ukprn).by_conversion_date)
 
     pre_fetch_establishments(@projects)
     @trust = Api::AcademiesApi::Client.new.get_trust(ukprn).object

--- a/app/views/all/trusts/projects/show.html.erb
+++ b/app/views/all/trusts/projects/show.html.erb
@@ -26,7 +26,7 @@
               <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
               <td class="govuk-table__cell"><%= project.urn %></td>
               <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
-              <td class="govuk-table__cell"><%= project.assigned_to.full_name %></td>
+              <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
               <td class="govuk-table__cell">
                 <a href="<%= project_path(project) %>">
                   <%= t("project.table.body.view_html", school_name: project.establishment.name) %>

--- a/spec/features/projects/trusts/users_can_view_a_list_of_projects_for_a_given_trust_spec.rb
+++ b/spec/features/projects/trusts/users_can_view_a_list_of_projects_for_a_given_trust_spec.rb
@@ -21,13 +21,28 @@ RSpec.feature "Users can view a list of projects for a given trust" do
 
   context "when a trust has a project" do
     scenario "they see the project listed" do
-      project = create(:conversion_project, incoming_trust_ukprn: 10060639)
+      project = create(:conversion_project, incoming_trust_ukprn: 10060639, urn: 103835)
+      trust = build(:academies_api_trust, ukprn: project.incoming_trust_ukprn)
+      completed_project = create(:conversion_project, completed_at: Date.today, incoming_trust_ukprn: 10060639, urn: 121813)
+
+      visit by_trust_all_trusts_projects_path(10060639)
+
+      expect(page).to have_content("Projects for #{trust.name}")
+      expect(page).to have_content(project.urn)
+      expect(page).not_to have_content(completed_project.urn)
+    end
+  end
+
+  context "when a project is unassigned" do
+    scenario "they see the project listed" do
+      project = create(:conversion_project, incoming_trust_ukprn: 10060639, urn: 103835, assigned_to: nil)
       trust = build(:academies_api_trust, ukprn: project.incoming_trust_ukprn)
 
       visit by_trust_all_trusts_projects_path(10060639)
 
       expect(page).to have_content("Projects for #{trust.name}")
       expect(page).to have_content(project.urn)
+      expect(page).to have_content("Not yet assigned")
     end
   end
 end


### PR DESCRIPTION
When we introduced the new master view for the existing projects for a
given trust view, we didn't realised it does not handle unassigned and
the scope includes completed projects.

This means the converison count on the trust view will not match that of
the view of projects.

