### PR TITLE
By local authority view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - A view, by trust, that shows the trusts that have in-progress projects in the
   application and lists the projects.
 - Add Route and Academy name to the CSV export
+- A view, by local authority, that shows the local authorities that have
+  in-progress projects in the applicaiton and list those projects.
 
 ### Changed
 

--- a/app/controllers/all/local_authorities/projects_controller.rb
+++ b/app/controllers/all/local_authorities/projects_controller.rb
@@ -4,7 +4,7 @@ class All::LocalAuthorities::ProjectsController < ApplicationController
 
   def index
     authorize Project, :index?
-    @local_authorities = ByLocalAuthorityProjectFetcherService.new.call
+    @pager, @local_authorities = pagy_array(ByLocalAuthorityProjectFetcherService.new.call)
   end
 
   def show

--- a/app/controllers/all/local_authorities/projects_controller.rb
+++ b/app/controllers/all/local_authorities/projects_controller.rb
@@ -6,4 +6,20 @@ class All::LocalAuthorities::ProjectsController < ApplicationController
     authorize Project, :index?
     @local_authorities = ByLocalAuthorityProjectFetcherService.new.call
   end
+
+  def show
+    authorize Project, :index?
+    @local_authority = LocalAuthority.find_by!(code: local_authority_code)
+    @projects = Project.not_completed.to_a.select { |p| p.establishment.local_authority_code == local_authority_code }
+
+    pre_fetch_establishments(@projects)
+  end
+
+  private def local_authority_code
+    params[:local_authority_id]
+  end
+
+  private def pre_fetch_establishments(projects)
+    EstablishmentsFetcher.new.call(projects)
+  end
 end

--- a/app/controllers/all/local_authorities/projects_controller.rb
+++ b/app/controllers/all/local_authorities/projects_controller.rb
@@ -1,0 +1,9 @@
+class All::LocalAuthorities::ProjectsController < ApplicationController
+  after_action :verify_authorized
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
+
+  def index
+    authorize Project, :index?
+    @local_authorities = ByLocalAuthorityProjectFetcherService.new.call
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,6 +4,7 @@ class Project < ApplicationRecord
   attr_writer :establishment, :incoming_trust
 
   delegated_type :tasks_data, types: %w[Conversion::TasksData, Transfer::TasksData], dependent: :destroy
+  delegate :local_authority_code, to: :establishment
 
   has_many :notes, dependent: :destroy
   has_many :contacts, dependent: :destroy, class_name: "Contact::Project"

--- a/app/services/by_local_authority_project_fetcher_service.rb
+++ b/app/services/by_local_authority_project_fetcher_service.rb
@@ -1,0 +1,31 @@
+class ByLocalAuthorityProjectFetcherService
+  def call
+    conversion_counts = conversions_count_by_local_authority
+
+    if conversion_counts
+      local_authorities = LocalAuthority.where(code: conversion_counts.keys)
+
+      sort_local_authorities_by_name(build_local_authorities_objects(local_authorities, conversion_counts))
+    end
+  end
+
+  private def conversions_count_by_local_authority
+    Project.not_completed.select(:id, :urn).group_by { |p| p.establishment.local_authority_code }
+  end
+
+  private def build_local_authorities_objects(local_authorities, conversion_counts)
+    return [] unless local_authorities.any? && conversion_counts.any?
+
+    local_authorities.map do |local_authority|
+      OpenStruct.new(
+        name: local_authority.name,
+        code: local_authority.code,
+        conversion_count: conversion_counts.fetch(local_authority.code).count
+      )
+    end
+  end
+
+  private def sort_local_authorities_by_name(local_authority_objects)
+    local_authority_objects.sort_by { |local_authority_object| local_authority_object.name }
+  end
+end

--- a/app/views/all/local_authorities/projects/_local_authority_table.html.erb
+++ b/app/views/all/local_authorities/projects/_local_authority_table.html.erb
@@ -2,6 +2,7 @@
   <%= govuk_inset_text(text: t("project.table.by_local_authority.empty")) %>
 <% else %>
   <table class="govuk-table" name="projects_table" aria-label="Projects table">
+    <caption class="govuk-table__caption govuk-!-display-none"><%= t("project.table.by_local_authority.caption") %></caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.local_authority_name") %></th>

--- a/app/views/all/local_authorities/projects/_local_authority_table.html.erb
+++ b/app/views/all/local_authorities/projects/_local_authority_table.html.erb
@@ -24,3 +24,5 @@
     </tbody>
   </table>
 <% end %>
+
+<%= govuk_pagination(pagy: pager) %>

--- a/app/views/all/local_authorities/projects/_local_authority_table.html.erb
+++ b/app/views/all/local_authorities/projects/_local_authority_table.html.erb
@@ -1,0 +1,22 @@
+<% if local_authorities.empty? %>
+  <%= govuk_inset_text(text: t("project.table.by_local_authority.empty")) %>
+<% else %>
+  <table class="govuk-table" name="projects_table" aria-label="Projects table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.local_authority_name") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.local_authority_code") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_count") %></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% local_authorities.each do |local_authority| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__header govuk-table__cell"><%= local_authority.name %></td>
+        <td class="govuk-table__cell"><%= local_authority.code %></td>
+        <td class="govuk-table__cell"><%= local_authority.conversion_count %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/all/local_authorities/projects/_local_authority_table.html.erb
+++ b/app/views/all/local_authorities/projects/_local_authority_table.html.erb
@@ -7,6 +7,7 @@
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.local_authority_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.local_authority_code") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_count") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view_projects") %></th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -15,6 +16,9 @@
         <td class="govuk-table__header govuk-table__cell"><%= local_authority.name %></td>
         <td class="govuk-table__cell"><%= local_authority.code %></td>
         <td class="govuk-table__cell"><%= local_authority.conversion_count %></td>
+        <td class="govuk-table__cell">
+          <%= link_to t("project.table.body.view_projects_for_local_authority_html", local_authority_name: local_authority.name), by_local_authority_all_local_authorities_projects_path(local_authority.code) %>
+        </td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/all/local_authorities/projects/index.html.erb
+++ b/app/views/all/local_authorities/projects/index.html.erb
@@ -8,6 +8,6 @@
       <%= t("project.all.by_local_authority.title") %>
     </h1>
 
-    <%= render partial: "local_authority_table", locals: {local_authorities: @local_authorities} %>
+    <%= render partial: "local_authority_table", locals: {local_authorities: @local_authorities, pager: @pager} %>
   </div>
 </div>

--- a/app/views/all/local_authorities/projects/index.html.erb
+++ b/app/views/all/local_authorities/projects/index.html.erb
@@ -1,0 +1,13 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t("project.all.by_local_authority.title") %>
+    </h1>
+
+    <%= render partial: "local_authority_table", locals: {local_authorities: @local_authorities} %>
+  </div>
+</div>

--- a/app/views/all/local_authorities/projects/show.html.erb
+++ b/app/views/all/local_authorities/projects/show.html.erb
@@ -1,0 +1,41 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t("project.all.trust_ukprn.title", trust: @local_authority.name) %>
+    </h1>
+      <% if @projects.empty? %>
+        <%= govuk_inset_text(text: t("project.table.trust_ukprn.empty", trust: @local_authority.name)) %>
+      <% else %>
+        <table class="govuk-table" name="projects_table" aria-label="Projects table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
+              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
+              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
+              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
+              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+          <% @projects.each do |project| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+              <td class="govuk-table__cell"><%= project.urn %></td>
+              <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
+              <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
+              <td class="govuk-table__cell">
+                <a href="<%= project_path(project) %>">
+                  <%= t("project.table.body.view_html", school_name: project.establishment.name) %>
+                </a>
+              </td>
+              </tr>
+          <% end %>
+          </tbody>
+        </table>
+      <% end %>
+  </div>
+</div>

--- a/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
@@ -14,6 +14,8 @@
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_trust"), path: all_trusts_projects_path, namespace: "/projects/all/trusts"} %>
 
+          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_local_authority"), path: all_local_authorities_projects_path, namespace: "/projects/all/local-authorities"} %>
+
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.completed"), path: all_completed_projects_path, namespace: "/projects/all/completed"} %>
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.statistics"), path: all_statistics_projects_path, namespace: "/projects/all/statistics"} %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,6 +131,7 @@ en:
         in_progress: In progress
         opening: Opening
         by_trust: By trust
+        by_local_authority: By local authority
         completed: Completed
         statistics: Statistics
       team_projects:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -167,6 +167,7 @@ en:
         edit_html: Create academy URN <span class="govuk-visually-hidden">for %{school_name}</span>
         assign_html: Assign <span class="govuk-visually-hidden">%{school_name}</span> project
         view_projects_html: View projects <span class="govuk-visually-hidden">for %{trust_name}</span>
+        view_projects_for_local_authority_html: View projects<span class="govuk-visually-hidden"> for %{local_authority_name}</span>
       in_progress:
         empty: There are no projects in progress.
       completed:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -33,6 +33,8 @@ en:
           title: All voluntary completed projects
       trust_ukprn:
           title: Projects for %{trust}
+      by_local_authority:
+        title: All projects by local authority
     team:
       in_progress:
         title: In progress
@@ -157,6 +159,9 @@ en:
         group_identifier: Group identifier
         conversion_count: Conversions
         view_projects: View projects
+        local_authority_name: Local authority
+        local_authority_code: Code
+        conversion_count: Conversions
       body:
         view_html: View <span class="govuk-visually-hidden">%{school_name}</span> project
         edit_html: Create academy URN <span class="govuk-visually-hidden">for %{school_name}</span>
@@ -179,6 +184,8 @@ en:
       by_trust:
         empty: There are no trusts to view
         caption: Table of trusts that have in-progress projects
+      by_local_authority:
+        empty: There are no local authorities with projects
     openers:
       title: Academies opening in %{date}
       subtitle: Schools that are expected to become academies.

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -187,6 +187,7 @@ en:
         caption: Table of trusts that have in-progress projects
       by_local_authority:
         empty: There are no local authorities with projects
+        caption: Table of local authorities that have in-progress projects
     openers:
       title: Academies opening in %{date}
       subtitle: Schools that are expected to become academies.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,9 @@ Rails.application.routes.draw do
             get "/", to: "projects#index"
             get ":trust_ukprn", to: "projects#show", as: :by_trust
           end
+          namespace :local_authorities, path: "local-authorities" do
+            get "/", to: "projects#index"
+          end
         end
         namespace :team, path: "team" do
           get "in-progress", to: "projects#in_progress"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,7 @@ Rails.application.routes.draw do
           end
           namespace :local_authorities, path: "local-authorities" do
             get "/", to: "projects#index"
+            get ":local_authority_id", to: "projects#show", as: :by_local_authority
           end
         end
         namespace :team, path: "team" do

--- a/spec/features/projects/local_authorities/users_can_view_projects_by_local_authority_spec.rb
+++ b/spec/features/projects/local_authorities/users_can_view_projects_by_local_authority_spec.rb
@@ -29,6 +29,7 @@ RSpec.feature "Users can view a list of local authorities that have projectss" d
         expect(page).to have_content(local_authority.name)
         expect(page).to have_content(local_authority.code)
         expect(page).to have_content("1")
+        expect(page).to have_link("View projects", href: by_local_authority_all_local_authorities_projects_path(local_authority.code))
       end
     end
   end

--- a/spec/features/projects/local_authorities/users_can_view_projects_by_local_authority_spec.rb
+++ b/spec/features/projects/local_authorities/users_can_view_projects_by_local_authority_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.feature "Users can view a list of local authorities that have projectss" do
+  before do
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  let(:user) { create(:user, email: "user@education.gov.uk") }
+
+  context "when there are no projects to fetch local authorities for" do
+    scenario "they see an empty message" do
+      visit all_local_authorities_projects_path
+
+      expect(page).to have_content("There are no local authorities with project")
+    end
+  end
+
+  context "when there are projects to fetch trusts for" do
+    scenario "they see the trust listed and a link" do
+      establishment = build(:academies_api_establishment, urn: 123456, local_authority_code: "100")
+      local_authority = create(:local_authority, code: "100")
+      create(:conversion_project, urn: 123456)
+      allow_any_instance_of(Project).to receive(:establishment).and_return(establishment)
+
+      visit all_local_authorities_projects_path
+
+      within("tbody > tr:first-child") do
+        expect(page).to have_content(local_authority.name)
+        expect(page).to have_content(local_authority.code)
+        expect(page).to have_content("1")
+      end
+    end
+  end
+end

--- a/spec/features/projects/local_authorities/users_can_view_projects_for_a_local_authority_spec.rb
+++ b/spec/features/projects/local_authorities/users_can_view_projects_for_a_local_authority_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.feature "Users can view a list of projects for a local authority" do
+  before do
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  let(:user) { create(:user, email: "user@education.gov.uk") }
+
+  context "when the local authoritty cannot be found" do
+    scenario "they see a 404 error" do
+      visit by_local_authority_all_local_authorities_projects_path("000")
+
+      expect(page).to have_http_status(:not_found)
+    end
+  end
+
+  context "when there are projects for the local authority" do
+    scenario "they see the list of projects" do
+      establishment = build(:academies_api_establishment, urn: 123456, local_authority_code: "100")
+      create(:local_authority, code: "100")
+      project = create(:conversion_project, urn: 123456)
+      allow_any_instance_of(Project).to receive(:establishment).and_return(establishment)
+
+      visit by_local_authority_all_local_authorities_projects_path("100")
+
+      within("tbody > tr:first-child") do
+        expect(page).to have_content(project.establishment.name)
+        expect(page).to have_content(project.urn)
+      end
+    end
+  end
+end

--- a/spec/services/by_local_authority_project_fetcher_service_spec.rb
+++ b/spec/services/by_local_authority_project_fetcher_service_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe ByLocalAuthorityProjectFetcherService do
+  it "returns a sorted list of simple local authority objects with projects" do
+    establishment = build(:academies_api_establishment, local_authority_code: "909", urn: 121813)
+    another_establishment = build(:academies_api_establishment, local_authority_code: "213", urn: 121102)
+    yet_another_establishment = build(:academies_api_establishment, local_authority_code: "926", urn: 121583)
+
+    fake_client = double(Api::AcademiesApi::Client,
+      get_trust: Api::AcademiesApi::Client::Result.new(double, nil))
+
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(fake_client)
+    allow(fake_client).to receive(:get_establishment).with(establishment.urn).and_return(Api::AcademiesApi::Client::Result.new(establishment, nil))
+    allow(fake_client).to receive(:get_establishment).with(another_establishment.urn).and_return(Api::AcademiesApi::Client::Result.new(another_establishment, nil))
+    allow(fake_client).to receive(:get_establishment).with(yet_another_establishment.urn).and_return(Api::AcademiesApi::Client::Result.new(yet_another_establishment, nil))
+
+    create(:local_authority, code: "909", name: "Cumbria County Council")
+    create(:local_authority, code: "213", name: "Westminster City Council")
+    create(:local_authority, code: "926", name: "Norfolk County Council")
+
+    create(:conversion_project, urn: establishment.urn)
+    create(:conversion_project, urn: another_establishment.urn)
+    create(:conversion_project, urn: establishment.urn)
+    create(:conversion_project, urn: yet_another_establishment.urn)
+
+    result = described_class.new.call
+
+    expect(result.count).to eql 3
+
+    first_result = result.first
+
+    expect(first_result.name).to eql "Cumbria County Council"
+    expect(first_result.code).to eql "909"
+    expect(first_result.conversion_count).to eql 2
+
+    last_result = result.last
+
+    expect(last_result.name).to eql "Westminster City Council"
+    expect(last_result.code).to eql "213"
+    expect(last_result.conversion_count).to eql 1
+  end
+
+  it "returns an empty array when there are no projects to source trusts" do
+    expect(described_class.new.call).to eql []
+  end
+end


### PR DESCRIPTION
Hot on the heels of the by trust views, here is the by local authority! It is pretty much a repeat of #808, the main difference being a bit more effort is required to fetch the projects per local authority as they come via the establishment.

Another difference is tha there was no existing project for local authority view as there was for trusts - so that gets added.

Second time through, I wondered if the fetching of projects for the local authority might be better inside the service - my reasoning was to keep the scopes as close together as we can - not sure it is necessary, let me know your thoughts? 

I came to this the hard way (#810), once deployed to development it was obvious that the count of projects was for `not_completed` projects and the actual list of projects did not include this scope and so there were more projects!

https://trello.com/c/ShBg4EPS

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/5d786931-bb3d-46e2-9c17-756209c6e774)

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/f5089952-65db-46c9-bf60-9ea8b0222462)
