### PR TITLE
Opening export handles no academy

### DIFF
--- a/app/services/opening_projects_csv_exporter.rb
+++ b/app/services/opening_projects_csv_exporter.rb
@@ -65,7 +65,7 @@ class OpeningProjectsCsvExporter
       mp_address_postcode: mp_details.address.postcode,
       approval_date: project.advisory_board_date.to_formatted_s(:csv),
       project_lead: project.assigned_to.full_name,
-      academy_name: project.academy.name
+      academy_name: project.academy&.name
     }
   end
 

--- a/spec/services/opening_projects_csv_exporter_spec.rb
+++ b/spec/services/opening_projects_csv_exporter_spec.rb
@@ -292,5 +292,14 @@ RSpec.describe OpeningProjectsCsvExporter do
       expect(csv_export).to include("Academy name")
       expect(csv_export).to include("New Academy")
     end
+
+    it "returns an empty string when there is no academy" do
+      project = build(:conversion_project)
+      allow(project).to receive(:academy).and_return(nil)
+
+      csv_export = OpeningProjectsCsvExporter.new([project]).call
+
+      expect(csv_export).to include("Academy name")
+    end
   end
 end


### PR DESCRIPTION
We are still ironing out how this export will work, but as lots of
projects have no academy we should guard against nil.

## Changes

_Add a summary of the changes in this pull request_

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
