### PR TITLE
Add `team` to User

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add a rake task to update the `team` attribute on all existing users
+
 ### Changed
 
 ### Fixed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,22 @@ class User < ApplicationRecord
 
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}
 
+  enum :team, {
+    london: "london",
+    south_east: "south_east",
+    yorkshire_and_the_humber: "yorkshire_and_the_humber",
+    north_west: "north_west",
+    east_of_england: "east_of_england",
+    west_midlands: "west_midlands",
+    north_east: "north_east",
+    south_west: "south_west",
+    east_midlands: "east_midlands",
+    regional_casework_services: "regional_casework_services",
+    service_support: "service_support",
+    academies_operational_practice_unit: "academies_operational_practice_unit",
+    education_and_skills_funding_agency: "education_and_skills_funding_agency"
+  }, suffix: true
+
   def full_name
     "#{first_name} #{last_name}"
   end

--- a/app/services/user_team_updater.rb
+++ b/app/services/user_team_updater.rb
@@ -1,0 +1,14 @@
+class UserTeamUpdater
+  class UserTeamError < StandardError; end
+
+  def initialize(user:)
+    @user = user
+  end
+
+  def update!
+    @user.update!(team: "service_support") if @user.service_support?
+    @user.update!(team: "regional_casework_services") if @user.caseworker? || @user.team_leader?
+  rescue ActiveRecord::RecordInvalid
+    raise UserTeamError.new("Unable to update team for user #{@user.id}")
+  end
+end

--- a/db/migrate/20230626112559_add_team_to_user.rb
+++ b/db/migrate/20230626112559_add_team_to_user.rb
@@ -1,0 +1,5 @@
+class AddTeamToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :team, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_26_084707) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_26_112559) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -221,6 +221,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_26_084707) do
     t.boolean "caseworker", default: false
     t.boolean "service_support", default: false
     t.string "active_directory_user_group_ids"
+    t.string "team"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/lib/tasks/teams/update_users.rake
+++ b/lib/tasks/teams/update_users.rake
@@ -1,0 +1,8 @@
+namespace :update_teams do
+  desc ">> Update teams information"
+  task users: :environment do
+    User.all.each do |user|
+      UserTeamUpdater.new(user: user).update!
+    end
+  end
+end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     team_leader { false }
     regional_delivery_officer { false }
     caseworker { false }
+    team { User.teams["london"] }
 
     trait :caseworker do
       email { "caseworker-#{SecureRandom.uuid}@education.gov.uk" }

--- a/spec/lib/tasks/teams/update_users_spec.rb
+++ b/spec/lib/tasks/teams/update_users_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "rake update_teams:users", type: :task do
+  subject { Rake::Task["update_teams:users"] }
+
+  let(:mock_user_team_updater) { double(UserTeamUpdater, update!: true) }
+
+  before do
+    allow(UserTeamUpdater).to receive(:new).and_return(mock_user_team_updater)
+  end
+
+  let!(:user) { create(:user, team: nil, caseworker: true) }
+
+  it "calls UserTeamUpdater service on all users" do
+    subject.invoke
+    expect(mock_user_team_updater).to have_received(:update!)
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe User do
     it { is_expected.to have_db_column(:caseworker).of_type :boolean }
     it { is_expected.to have_db_column(:service_support).of_type :boolean }
     it { is_expected.to have_db_column(:active_directory_user_group_ids).of_type :string }
+    it { is_expected.to have_db_column(:team).of_type :string }
   end
 
   describe "scopes" do
@@ -96,6 +97,14 @@ RSpec.describe User do
       user = create(:user)
 
       expect(user.has_role?).to be false
+    end
+  end
+
+  describe "#team" do
+    it "uses the enum suffix as expected" do
+      user = create(:user, team: "london")
+
+      expect(user.london_team?).to be true
     end
   end
 end

--- a/spec/services/user_team_updater_spec.rb
+++ b/spec/services/user_team_updater_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe UserTeamUpdater do
+  let(:updater) { described_class.new(user: user) }
+  let(:user) { create(:user, :caseworker) }
+
+  describe "#update!" do
+    context "when the user is service_support" do
+      let(:user) { create(:user, team: nil, service_support: true) }
+
+      it "sets the team to be service_support" do
+        updater.update!
+        expect(user.team).to eq("service_support")
+      end
+    end
+
+    context "when the user is a caseworker" do
+      let(:user) { create(:user, team: nil, caseworker: true) }
+
+      it "sets the team to be regional_casework_services" do
+        updater.update!
+        expect(user.team).to eq("regional_casework_services")
+      end
+    end
+
+    context "when the user is team_leader" do
+      let(:user) { create(:user, team: nil, team_leader: true) }
+
+      it "sets the team to be regional_casework_services" do
+        updater.update!
+        expect(user.team).to eq("regional_casework_services")
+      end
+    end
+
+    context "when the user is a regional_delivery_officer" do
+      let(:user) { create(:user, team: nil, regional_delivery_officer: true) }
+
+      it "does not set the team" do
+        updater.update!
+        expect(user.team).to be_nil
+      end
+    end
+
+    context "when the user has no role" do
+      let(:user) { create(:user, team: nil, caseworker: false, regional_delivery_officer: false, team_leader: false) }
+
+      it "does not set the team" do
+        updater.update!
+        expect(user.team).to be_nil
+      end
+    end
+
+    it "raises an error when the transaction fails for any reason" do
+      allow(user).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+
+      expect { updater.update! }.to raise_error(UserTeamUpdater::UserTeamError)
+        .with_message("Unable to update team for user #{user.id}")
+    end
+  end
+end


### PR DESCRIPTION


## Changes

Add a team attribute to User. Possible values are taken from an enum of regions + three other non-region teams.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
