### PR TITLE
Add `team` to Project

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -60,6 +60,19 @@ class Project < ApplicationRecord
     east_midlands: "E"
   }, suffix: true
 
+  enum :team, {
+    london: "london",
+    south_east: "south_east",
+    yorkshire_and_the_humber: "yorkshire_and_the_humber",
+    north_west: "north_west",
+    east_of_england: "east_of_england",
+    west_midlands: "west_midlands",
+    north_east: "north_east",
+    south_west: "south_west",
+    east_midlands: "east_midlands",
+    regional_casework_services: "regional_casework_services"
+  }, suffix: true
+
   def establishment
     @establishment ||= fetch_establishment(urn)
   end

--- a/db/migrate/20230626152519_add_team_to_project.rb
+++ b/db/migrate/20230626152519_add_team_to_project.rb
@@ -1,0 +1,5 @@
+class AddTeamToProject < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :team, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_26_112559) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_26_152519) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -197,6 +197,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_26_112559) do
     t.string "tasks_data_type"
     t.uuid "funding_agreement_contact_id"
     t.integer "outgoing_trust_ukprn"
+    t.string "team"
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"

--- a/spec/factories/conversion/project_factory.rb
+++ b/spec/factories/conversion/project_factory.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
     region { Project.regions["london"] }
     regional_delivery_officer { association :user, :regional_delivery_officer }
     tasks_data { association :conversion_tasks_data }
+    team { Project.teams["london"] }
 
     trait :with_conditions do
       advisory_board_conditions { "The following must be met:\n 1. Must be red\n2. Must be blue\n" }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_db_column(:directive_academy_order).of_type :boolean }
     it { is_expected.to have_db_column(:region).of_type :string }
     it { is_expected.to have_db_column(:academy_urn).of_type :integer }
+    it { is_expected.to have_db_column(:team).of_type :string }
   end
 
   describe "Relationships" do
@@ -501,6 +502,14 @@ RSpec.describe Project, type: :model do
       it "returns nil" do
         expect(subject.director_of_child_services).to be_nil
       end
+    end
+  end
+
+  describe "#team" do
+    subject { described_class.new(team: "regional_casework_services") }
+
+    it "uses the enum suffix as intended" do
+      expect(subject.regional_casework_services_team?).to be true
     end
   end
 end


### PR DESCRIPTION


## Changes

Add a team attribute to Project. Possible values are taken from an enum of regions + the regional casework services team.

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
