### PR TITLE
By region view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add a rake task to update the `team` attribute on all existing users
+- Added a view, by region, that shows the region with in-progress projects
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add a rake task to update the `team` attribute on all existing users
 - Added a view, by region, that shows the region with in-progress projects
+- By region view links to the projects in that region
 
 ### Changed
 

--- a/app/controllers/all/regions/projects_controller.rb
+++ b/app/controllers/all/regions/projects_controller.rb
@@ -6,4 +6,22 @@ class All::Regions::ProjectsController < ApplicationController
     authorize Project, :index?
     @regions = ByRegionProjectFetcherService.new.call
   end
+
+  def show
+    authorize Project, :index?
+    return not_found_error unless Project.regions.include?(region)
+
+    @region = region
+    @pager, @projects = pagy(Conversion::Project.not_completed.by_region(region).by_conversion_date)
+
+    pre_fetch_establishments(@projects)
+  end
+
+  private def pre_fetch_establishments(projects)
+    EstablishmentsFetcher.new.call(projects)
+  end
+
+  private def region
+    params[:region_id]
+  end
 end

--- a/app/controllers/all/regions/projects_controller.rb
+++ b/app/controllers/all/regions/projects_controller.rb
@@ -1,0 +1,9 @@
+class All::Regions::ProjectsController < ApplicationController
+  after_action :verify_authorized
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
+
+  def index
+    authorize Project, :index?
+    @regions = ByRegionProjectFetcherService.new.call
+  end
+end

--- a/app/services/by_region_project_fetcher_service.rb
+++ b/app/services/by_region_project_fetcher_service.rb
@@ -1,0 +1,33 @@
+class ByRegionProjectFetcherService
+  def call
+    conversion_counts = conversion_count_by_region
+
+    if conversion_counts
+      sort_view_objects_by_name(build_view_objects(conversion_counts))
+    else
+      []
+    end
+  end
+
+  private def conversion_count_by_region
+    projects = Conversion::Project.not_completed
+    return false unless projects.any?
+
+    projects.group(:region).count
+  end
+
+  private def build_view_objects(conversion_counts)
+    return [] unless conversion_counts.any?
+
+    conversion_counts.keys.map do |region|
+      OpenStruct.new(
+        name: region,
+        conversion_count: conversion_counts.fetch(region)
+      )
+    end
+  end
+
+  private def sort_view_objects_by_name(view_objects)
+    view_objects.sort_by { |view_object| view_object.name }
+  end
+end

--- a/app/views/all/regions/projects/_regions_table.html.erb
+++ b/app/views/all/regions/projects/_regions_table.html.erb
@@ -1,0 +1,21 @@
+<% if regions.empty? %>
+  <%= govuk_inset_text(text: t("project.table.by_region.empty")) %>
+<% else %>
+  <table class="govuk-table" name="projects_table" aria-label="Projects table">
+    <caption class="govuk-table__caption govuk-!-display-none"><%= t("project.table.by_region.caption") %></caption>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.region") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_count") %></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% regions.each do |region| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__header govuk-table__cell"><%= t("project.region.#{region.name}") %></td>
+        <td class="govuk-table__cell"><%= region.conversion_count %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/all/regions/projects/_regions_table.html.erb
+++ b/app/views/all/regions/projects/_regions_table.html.erb
@@ -7,6 +7,7 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.region") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_count") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view_projects") %></th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -14,6 +15,9 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell"><%= t("project.region.#{region.name}") %></td>
         <td class="govuk-table__cell"><%= region.conversion_count %></td>
+        <td class="govuk-table__cell">
+          <%= link_to t("project.table.body.view_projects_for_html", entity: t("project.region.#{region.name}")), by_region_all_regions_projects_path(region.name) %>
+        </td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/all/regions/projects/index.html.erb
+++ b/app/views/all/regions/projects/index.html.erb
@@ -1,0 +1,13 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t("project.all.by_region.title") %>
+    </h1>
+
+    <%= render partial: "regions_table", locals: {regions: @regions} %>
+  </div>
+</div>

--- a/app/views/all/regions/projects/show.html.erb
+++ b/app/views/all/regions/projects/show.html.erb
@@ -1,0 +1,41 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t("project.all.by_region.title_with_region", region: t("project.region.#{@region}")) %>
+    </h1>
+      <% if @projects.empty? %>
+        <%= govuk_inset_text(text: t("project.table.empty.projects")) %>
+      <% else %>
+      <table class="govuk-table" name="projects_table" aria-label="Projects table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
+            <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
+            <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
+            <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
+            <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        <% @projects.each do |project| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+            <td class="govuk-table__cell"><%= project.urn %></td>
+            <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
+            <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
+            <td class="govuk-table__cell">
+              <a href="<%= project_path(project) %>">
+                <%= t("project.table.body.view_html", school_name: project.establishment.name) %>
+              </a>
+            </td>
+            </tr>
+        <% end %>
+        </tbody>
+      </table>
+      <% end %>
+  </div>
+</div>

--- a/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
@@ -12,6 +12,8 @@
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.opening"), path: confirmed_all_opening_projects_path, namespace: "/projects/all/opening"} %>
 
+          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_region"), path: all_regions_projects_path, namespace: "/projects/all/regions"} %>
+
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_trust"), path: all_trusts_projects_path, namespace: "/projects/all/trusts"} %>
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_local_authority"), path: all_local_authorities_projects_path, namespace: "/projects/all/local-authorities"} %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,6 +132,7 @@ en:
         opening: Opening
         by_trust: By trust
         by_local_authority: By local authority
+        by_region: By region
         completed: Completed
         statistics: Statistics
       team_projects:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -35,6 +35,9 @@ en:
           title: Projects for %{trust}
       by_local_authority:
         title: All projects by local authority
+      by_region:
+        title: All projects by region
+        title_with_region: Projects for %{region} region
     team:
       in_progress:
         title: In progress
@@ -162,12 +165,14 @@ en:
         local_authority_name: Local authority
         local_authority_code: Code
         conversion_count: Conversions
+        region: Region
       body:
         view_html: View <span class="govuk-visually-hidden">%{school_name}</span> project
         edit_html: Create academy URN <span class="govuk-visually-hidden">for %{school_name}</span>
         assign_html: Assign <span class="govuk-visually-hidden">%{school_name}</span> project
         view_projects_html: View projects <span class="govuk-visually-hidden">for %{trust_name}</span>
         view_projects_for_local_authority_html: View projects<span class="govuk-visually-hidden"> for %{local_authority_name}</span>
+        view_projects_for_html: View projects<span class="govuk-visually-hidden"> for %{entity}</span>
       in_progress:
         empty: There are no projects in progress.
       completed:
@@ -188,6 +193,9 @@ en:
       by_local_authority:
         empty: There are no local authorities with projects
         caption: Table of local authorities that have in-progress projects
+      by_region:
+        empty: There are no regions with projects
+        caption: Table of regions that have in-progress projects
     openers:
       title: Academies opening in %{date}
       subtitle: Schools that are expected to become academies.

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -173,6 +173,8 @@ en:
         view_projects_html: View projects <span class="govuk-visually-hidden">for %{trust_name}</span>
         view_projects_for_local_authority_html: View projects<span class="govuk-visually-hidden"> for %{local_authority_name}</span>
         view_projects_for_html: View projects<span class="govuk-visually-hidden"> for %{entity}</span>
+      empty:
+        projects: There are no projects
       in_progress:
         empty: There are no projects in progress.
       completed:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,10 @@ Rails.application.routes.draw do
             get "/", to: "projects#index"
             get ":local_authority_id", to: "projects#show", as: :by_local_authority
           end
+          namespace :regions do
+            get "/", to: "projects#index"
+            get ":region_id", to: "projects#show", as: :by_region
+          end
         end
         namespace :team, path: "team" do
           get "in-progress", to: "projects#in_progress"

--- a/spec/features/projects/regions/users_can_view_a_list_of_projects_for_a_given_region_spec.rb
+++ b/spec/features/projects/regions/users_can_view_a_list_of_projects_for_a_given_region_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.feature "Users can view a list of projects for a given region" do
+  before do
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  let(:user) { create(:user, email: "user@education.gov.uk") }
+
+  context "when a region has a project" do
+    scenario "they see the project listed" do
+      project = create(:conversion_project, region: "london", urn: 103835)
+      completed_project = create(:conversion_project, completed_at: Date.today, region: "london", urn: 121813)
+
+      visit by_region_all_regions_projects_path("london")
+
+      expect(page).to have_content(project.urn)
+      expect(page).not_to have_content(completed_project.urn)
+    end
+  end
+
+  context "when a project is unassigned" do
+    scenario "they see the project listed" do
+      project = create(:conversion_project, region: "london", urn: 103835, assigned_to: nil)
+
+      visit by_region_all_regions_projects_path("london")
+
+      expect(page).to have_content(project.urn)
+      expect(page).to have_content("Not yet assigned")
+    end
+  end
+
+  context "when there are no projects for the region" do
+    scenario "they see an helpful message" do
+      create(:conversion_project, completed_at: Date.today, region: "london", urn: 121813)
+
+      visit by_region_all_regions_projects_path("london")
+
+      expect(page).to have_content("There are no projects")
+    end
+  end
+
+  context "when the region not valid" do
+    scenario "they see a 404 error" do
+      visit by_region_all_regions_projects_path("not_a_region")
+
+      expect(page).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/features/projects/regions/users_can_view_projects_by_trust_spec.rb
+++ b/spec/features/projects/regions/users_can_view_projects_by_trust_spec.rb
@@ -25,6 +25,7 @@ RSpec.feature "Users can view a list regions that have projects" do
       within("tbody > tr:first-child") do
         expect(page).to have_content("North West")
         expect(page).to have_content("1")
+        expect(page).to have_link("View projects", href: by_region_all_regions_projects_path("north_west"))
       end
     end
   end

--- a/spec/features/projects/regions/users_can_view_projects_by_trust_spec.rb
+++ b/spec/features/projects/regions/users_can_view_projects_by_trust_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.feature "Users can view a list regions that have projects" do
+  before do
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  let(:user) { create(:user, email: "user@education.gov.uk") }
+
+  context "when there are no projects to fetch region for" do
+    scenario "they see an empty message" do
+      visit all_regions_projects_path
+
+      expect(page).to have_content("There are no regions")
+    end
+  end
+
+  context "when there are projects to fetch trusts for" do
+    scenario "they see the trust listed and a link" do
+      create(:conversion_project, region: "north_west")
+
+      visit all_regions_projects_path
+
+      within("tbody > tr:first-child") do
+        expect(page).to have_content("North West")
+        expect(page).to have_content("1")
+      end
+    end
+  end
+end

--- a/spec/services/by_region_project_fetcher_service_spec.rb
+++ b/spec/services/by_region_project_fetcher_service_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe ByRegionProjectFetcherService do
+  it "returns a sorted list of simple view objects with project counts" do
+    mock_successful_api_response_to_create_any_project
+
+    create(:conversion_project, region: "south_west")
+    create(:conversion_project, region: "london")
+    create(:conversion_project, region: "south_west")
+    create(:conversion_project, region: "north_west")
+
+    result = described_class.new.call
+
+    expect(result.count).to eql 3
+
+    first_result = result.first
+
+    expect(first_result.name).to eql "london"
+    expect(first_result.conversion_count).to eql 1
+
+    last_result = result.last
+
+    expect(last_result.name).to eql "south_west"
+    expect(last_result.conversion_count).to eql 2
+  end
+
+  it "returns an empty array when there are no projects to source trusts" do
+    expect(described_class.new.call).to eql []
+  end
+end


### PR DESCRIPTION
This is the third 'by' view that takes the existing pattern and applies it to region, every project is in a region based on the schools location.

We fetch all the in-progress projects and group them by region, we then add two views, one shows the regions with counts of conversion projects, the second shows the projects in a given region.

https://trello.com/c/eSU9aea0

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/76a8cbfb-4477-4a6f-8232-ff3b5830e890)

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/4b08f454-441b-49cd-abdd-22a8d5b390fa)
