### PR TITLE
Update Project.team

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add a rake task to update the `team` attribute on all existing users
 - Added a view, by region, that shows the region with in-progress projects
 - By region view links to the projects in that region
+- Add a rake task to update the `team` attribute on all existing projects
 
 ### Changed
 

--- a/app/services/project_team_updater.rb
+++ b/app/services/project_team_updater.rb
@@ -1,0 +1,21 @@
+class ProjectTeamUpdater
+  class ProjectTeamError < StandardError; end
+
+  def initialize(project:)
+    @project = project
+  end
+
+  def update!
+    ActiveRecord::Base.transaction do
+      if @project.assigned_to_regional_caseworker_team
+        @project.update!(team: Project.teams["regional_casework_services"])
+      else
+        raise ProjectTeamError.new("Project region is nil, project_id: #{@project.id}") if Project.teams[@project.region].nil?
+
+        @project.update!(team: Project.teams[@project.region])
+      end
+    rescue ActiveRecord::RecordInvalid
+      raise ProjectTeamError.new("Project team update failed, project_id: #{@project.id}")
+    end
+  end
+end

--- a/lib/tasks/teams/update_projects.rake
+++ b/lib/tasks/teams/update_projects.rake
@@ -1,0 +1,8 @@
+namespace :update_teams do
+  desc ">> Update teams information"
+  task projects: :environment do
+    Project.all.each do |project|
+      ProjectTeamUpdater.new(project: project).update!
+    end
+  end
+end

--- a/spec/lib/tasks/teams/update_projects_spec.rb
+++ b/spec/lib/tasks/teams/update_projects_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "rake update_teams:projects", type: :task do
+  subject { Rake::Task["update_teams:projects"] }
+
+  let(:mock_project_team_updater) { double(ProjectTeamUpdater, update!: true) }
+
+  before do
+    allow(ProjectTeamUpdater).to receive(:new).and_return(mock_project_team_updater)
+    mock_successful_api_response_to_create_any_project
+  end
+
+  let!(:project) { create(:conversion_project) }
+
+  it "calls ProjectTeamUpdater service on all projects" do
+    subject.invoke
+    expect(mock_project_team_updater).to have_received(:update!)
+  end
+end

--- a/spec/services/project_team_updater_spec.rb
+++ b/spec/services/project_team_updater_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe ProjectTeamUpdater do
+  let(:user) { create(:user, :caseworker) }
+  let(:region) { "yorkshire_and_the_humber" }
+  let(:assigned_to_regional_caseworker_team) { false }
+  let(:project) { create(:conversion_project, team: nil, region: region, assigned_to_regional_caseworker_team: assigned_to_regional_caseworker_team) }
+  let(:updater) { described_class.new(project: project) }
+
+  before do
+    mock_successful_api_calls(establishment: any_args, trust: any_args)
+  end
+
+  describe "#update" do
+    context "when the project has a region set and assigned_to_regional_caseworker_team is false" do
+      it "sets the team to match the region" do
+        updater.update!
+        expect(project.team).to eq("yorkshire_and_the_humber")
+      end
+    end
+
+    context "when when the project has a region set and assigned_to_regional_caseworker_team is true" do
+      let(:region) { "west_midlands" }
+      let(:assigned_to_regional_caseworker_team) { true }
+
+      it "sets the team to regional_casework_services" do
+        updater.update!
+        expect(project.team).to eq("regional_casework_services")
+      end
+    end
+
+    context "when the project has no region set and assigned_to_regional_caseworker_team is false" do
+      let(:region) { nil }
+      let(:assigned_to_regional_caseworker_team) { false }
+
+      it "raises an error" do
+        expect { updater.update! }.to raise_error(ProjectTeamUpdater::ProjectTeamError)
+          .with_message("Project region is nil, project_id: #{project.id}")
+      end
+    end
+
+    it "raises an error when the transaction fails for any reason" do
+      allow(project).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+
+      expect { updater.update! }.to raise_error(ProjectTeamUpdater::ProjectTeamError)
+        .with_message("Project team update failed, project_id: #{project.id}")
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Add a service to populate the `team` attribute on Projects. If the project has `assigned_to_regional_casework_team` set to true, set its team to be `regional_casework_services`. 

Otherwise set its team to the the same as its region.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
