### PR TITLE
Refactor Project.assigned_to_regional_caseworker_team

### DIFF
--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -132,6 +132,8 @@ class Conversion::CreateProjectForm
     assigned_to = assigned_to_regional_caseworker_team ? nil : user
     assigned_at = assigned_to_regional_caseworker_team ? nil : DateTime.now
 
+    team = assigned_to_regional_caseworker_team ? "regional_casework_services" : Project.teams[Project.regions.key(region)]
+
     @project = Conversion::Project.new(
       urn: urn,
       incoming_trust_ukprn: incoming_trust_ukprn,
@@ -142,6 +144,7 @@ class Conversion::CreateProjectForm
       advisory_board_date: advisory_board_date,
       regional_delivery_officer_id: user.id,
       assigned_to_regional_caseworker_team: assigned_to_regional_caseworker_team,
+      team: team,
       assigned_to: assigned_to,
       assigned_at: assigned_at,
       directive_academy_order: directive_academy_order,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -38,8 +38,8 @@ class Project < ApplicationRecord
   scope :assigned_to_regional_delivery_officer, ->(user) { where(assigned_to: user).or(where(regional_delivery_officer: user)) }
 
   scope :unassigned_to_user, -> { where assigned_to: nil }
-  scope :assigned_to_regional_caseworker_team, -> { where(assigned_to_regional_caseworker_team: true) }
-  scope :not_assigned_to_regional_caseworker_team, -> { where.not(assigned_to_regional_caseworker_team: true) }
+  scope :assigned_to_regional_caseworker_team, -> { where(team: "regional_casework_services") }
+  scope :not_assigned_to_regional_caseworker_team, -> { where.not(team: "regional_casework_services") }
 
   scope :assigned_to, ->(user) { where(assigned_to_id: user.id) }
   scope :added_by, ->(user) { where(regional_delivery_officer: user) }

--- a/spec/accessibility/team_projects_spec.rb
+++ b/spec/accessibility/team_projects_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Team projects", driver: :headless_firefox, accessibility: true do
   end
 
   scenario "> In progress" do
-    project = create(:conversion_project, assigned_to: user, assigned_to_regional_caseworker_team: true, urn: 123456)
+    project = create(:conversion_project, assigned_to: user, team: "regional_casework_services", urn: 123456)
 
     visit in_progress_team_projects_path
 
@@ -20,7 +20,7 @@ RSpec.feature "Team projects", driver: :headless_firefox, accessibility: true do
   end
 
   scenario "> Completed" do
-    project = create(:conversion_project, assigned_to: user, completed_at: Date.yesterday, assigned_to_regional_caseworker_team: true, urn: 123434)
+    project = create(:conversion_project, assigned_to: user, completed_at: Date.yesterday, team: "regional_casework_services", urn: 123434)
 
     visit completed_team_projects_path
 
@@ -30,7 +30,7 @@ RSpec.feature "Team projects", driver: :headless_firefox, accessibility: true do
   end
 
   scenario "> Unassigned" do
-    create(:conversion_project, assigned_to: nil, urn: 123434, assigned_to_regional_caseworker_team: true)
+    create(:conversion_project, assigned_to: nil, urn: 123434, team: "regional_casework_services")
 
     visit unassigned_team_projects_path
 

--- a/spec/features/projects/users_can_view_a_list_of_regional_casework_services_projects_spec.rb
+++ b/spec/features/projects/users_can_view_a_list_of_regional_casework_services_projects_spec.rb
@@ -29,13 +29,13 @@ RSpec.feature "Viewing regional casework services projects" do
       mock_pre_fetched_api_responses_for_any_establishment_and_trust
     end
 
-    let!(:completed_regional_project) { create(:conversion_project, urn: 126041, assigned_to_regional_caseworker_team: false, completed_at: Date.yesterday) }
-    let!(:in_progress_regional_project) { create(:conversion_project, urn: 126041, assigned_to_regional_caseworker_team: false, assigned_to: user) }
+    let!(:completed_regional_project) { create(:conversion_project, urn: 126041, team: "london", completed_at: Date.yesterday) }
+    let!(:in_progress_regional_project) { create(:conversion_project, urn: 126041, team: "london", assigned_to: user) }
 
-    let!(:completed_project) { create(:conversion_project, urn: 121583, completed_at: Date.yesterday, assigned_to_regional_caseworker_team: true, assigned_to: user) }
-    let!(:in_progress_project) { create(:conversion_project, urn: 115652, assigned_to_regional_caseworker_team: true, assigned_to: user) }
+    let!(:completed_project) { create(:conversion_project, urn: 121583, completed_at: Date.yesterday, team: "regional_casework_services", assigned_to: user) }
+    let!(:in_progress_project) { create(:conversion_project, urn: 115652, team: "regional_casework_services", assigned_to: user) }
 
-    let!(:unassigned_project) { create(:conversion_project, urn: 103835, assigned_to_regional_caseworker_team: true, assigned_to: nil) }
+    let!(:unassigned_project) { create(:conversion_project, urn: 103835, team: "regional_casework_services", assigned_to: nil) }
 
     context "when signed in as a Regional caseworker" do
       let(:user) { create(:user, :caseworker) }

--- a/spec/features/projects/users_can_view_a_list_of_regional_projects_spec.rb
+++ b/spec/features/projects/users_can_view_a_list_of_regional_projects_spec.rb
@@ -26,11 +26,11 @@ RSpec.feature "Viewing regional projects" do
         mock_pre_fetched_api_responses_for_any_establishment_and_trust
       end
 
-      let!(:completed_regional_project) { create(:conversion_project, urn: 101133, assigned_to_regional_caseworker_team: false, completed_at: Date.yesterday) }
-      let!(:in_progress_regional_project) { create(:conversion_project, urn: 126041, assigned_to_regional_caseworker_team: false, assigned_to: user) }
+      let!(:completed_regional_project) { create(:conversion_project, urn: 101133, team: "london", completed_at: Date.yesterday) }
+      let!(:in_progress_regional_project) { create(:conversion_project, urn: 126041, team: "london", assigned_to: user) }
 
-      let!(:completed_project) { create(:conversion_project, urn: 121583, completed_at: Date.yesterday, assigned_to_regional_caseworker_team: true, assigned_to: user) }
-      let!(:in_progress_project) { create(:conversion_project, urn: 115652, assigned_to_regional_caseworker_team: true, assigned_to: user) }
+      let!(:completed_project) { create(:conversion_project, urn: 121583, completed_at: Date.yesterday, team: "regional_casework_services", assigned_to: user) }
+      let!(:in_progress_project) { create(:conversion_project, urn: 115652, team: "regional_casework_services", assigned_to: user) }
 
       scenario "they can view all in progress projects" do
         visit in_progress_regional_projects_path

--- a/spec/features/projects/view_unassigend_team_projects_spec.rb
+++ b/spec/features/projects/view_unassigend_team_projects_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Viewing unassigned team projects" do
     let(:user) { create(:user, :team_leader) }
 
     scenario "they can view all unassigned projects in the team" do
-      matching_project = create(:conversion_project, assigned_to: nil, assigned_to_regional_caseworker_team: true)
+      matching_project = create(:conversion_project, assigned_to: nil, team: "regional_casework_services")
 
       visit unassigned_team_projects_path
 

--- a/spec/features/users_can_assign_a_project_spec.rb
+++ b/spec/features/users_can_assign_a_project_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Any user can assign any other user to a project" do
     sign_in_with_user(user)
   end
 
-  let!(:project) { create(:conversion_project, assigned_to_regional_caseworker_team: true, assigned_to: nil) }
+  let!(:project) { create(:conversion_project, team: "regional_casework_services", assigned_to: nil) }
   let!(:another_user) { create(:user, :caseworker, first_name: "Another", last_name: "User") }
 
   context "when the user is a regional caseworker" do

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
 
         expect(project.assigned_to).to be_nil
       end
+
+      it "sets the team attribute on the project to regional_casework_services" do
+        project = build(:create_project_form, assigned_to_regional_caseworker_team: true).save
+        expect(project.team).to eq("regional_casework_services")
+      end
     end
 
     context "when the project is NOT being assigned to the Regional Caseworker Team" do
@@ -56,6 +61,11 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
         freeze_time
         project = build(:create_project_form, assigned_to_regional_caseworker_team: false).save
         expect(project.assigned_at).to eq DateTime.now
+      end
+
+      it "sets the team attribute on the project to the region of the establishment" do
+        project = build(:create_project_form, assigned_to_regional_caseworker_team: false).save
+        expect(project.team).to eq("west_midlands")
       end
     end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -388,9 +388,9 @@ RSpec.describe Project, type: :model do
     describe "assigned_to_regional_casework_team scope" do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 
-      it "returns projects which have `assigned_to_regional_casework_team` set to `true`" do
-        assigned_project = create(:conversion_project, assigned_to_regional_caseworker_team: true)
-        unassigned_project = create(:conversion_project, assigned_to_regional_caseworker_team: false)
+      it "returns projects which are in the `regional_casework_services` team" do
+        assigned_project = create(:conversion_project, team: "regional_casework_services")
+        unassigned_project = create(:conversion_project, team: "london")
 
         projects = Project.assigned_to_regional_caseworker_team
         expect(projects).to include(assigned_project)
@@ -402,8 +402,8 @@ RSpec.describe Project, type: :model do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 
       it "returns projects which have `assigned_to_regional_casework_team` set to `false`" do
-        not_assigned_to_regional_caseworker = create(:conversion_project, assigned_to_regional_caseworker_team: false)
-        assigned_to_regional_caseworker = create(:conversion_project, assigned_to_regional_caseworker_team: true)
+        not_assigned_to_regional_caseworker = create(:conversion_project, team: "west_midlands")
+        assigned_to_regional_caseworker = create(:conversion_project, team: "regional_casework_services")
 
         projects = Project.not_assigned_to_regional_caseworker_team
         expect(projects).to include(not_assigned_to_regional_caseworker)

--- a/spec/models/project_statistics_spec.rb
+++ b/spec/models/project_statistics_spec.rb
@@ -49,11 +49,11 @@ RSpec.describe ProjectStatistics, type: :model do
   end
 
   describe "Regional casework services projects" do
-    let!(:voluntary_in_progress_project_with_regional_casework_services_1) { create(:conversion_project, assigned_to_regional_caseworker_team: true, completed_at: nil) }
-    let!(:voluntary_completed_project_with_regional_casework_services_2) { create(:conversion_project, assigned_to_regional_caseworker_team: true, completed_at: Date.today + 2.years) }
-    let!(:sponsored_in_progress_project_with_regional_casework_services_1) { create(:conversion_project, :sponsored, assigned_to_regional_caseworker_team: true, completed_at: nil) }
-    let!(:sponsored_completed_project_with_regional_casework_services_2) { create(:conversion_project, :sponsored, assigned_to_regional_caseworker_team: true, completed_at: Date.today + 2.years) }
-    let!(:unassigned_projects_with_regional_casework_services) { create(:conversion_project, assigned_to_regional_caseworker_team: true, assigned_to: nil) }
+    let!(:voluntary_in_progress_project_with_regional_casework_services_1) { create(:conversion_project, team: "regional_casework_services", completed_at: nil) }
+    let!(:voluntary_completed_project_with_regional_casework_services_2) { create(:conversion_project, team: "regional_casework_services", completed_at: Date.today + 2.years) }
+    let!(:sponsored_in_progress_project_with_regional_casework_services_1) { create(:conversion_project, :sponsored, team: "regional_casework_services", completed_at: nil) }
+    let!(:sponsored_completed_project_with_regional_casework_services_2) { create(:conversion_project, :sponsored, team: "regional_casework_services", completed_at: Date.today + 2.years) }
+    let!(:unassigned_projects_with_regional_casework_services) { create(:conversion_project, team: "regional_casework_services", assigned_to: nil) }
 
     describe "#total_projects_with_regional_casework_services" do
       it "returns the total number of all projects within regional casework services" do
@@ -93,11 +93,11 @@ RSpec.describe ProjectStatistics, type: :model do
   end
 
   describe "Regional projects that are not with regional casework services" do
-    let!(:voluntary_in_progress_project_not_with_regional_casework_services_1) { create(:conversion_project, assigned_to_regional_caseworker_team: false, completed_at: nil) }
-    let!(:voluntary_completed_project_not_with_regional_casework_services_2) { create(:conversion_project, assigned_to_regional_caseworker_team: false, completed_at: Date.today + 2.years) }
-    let!(:sponsored_in_progress_project_not_with_regional_casework_services_1) { create(:conversion_project, assigned_to_regional_caseworker_team: false, completed_at: nil, directive_academy_order: true) }
-    let!(:sponsored_completed_project_not_with_regional_casework_services_2) { create(:conversion_project, assigned_to_regional_caseworker_team: false, completed_at: Date.today + 2.years, directive_academy_order: true) }
-    let!(:unassigned_project_not_with_regional_casework_services) { create(:conversion_project, assigned_to_regional_caseworker_team: false, assigned_to: nil) }
+    let!(:voluntary_in_progress_project_not_with_regional_casework_services_1) { create(:conversion_project, team: "london", completed_at: nil) }
+    let!(:voluntary_completed_project_not_with_regional_casework_services_2) { create(:conversion_project, team: "london", completed_at: Date.today + 2.years) }
+    let!(:sponsored_in_progress_project_not_with_regional_casework_services_1) { create(:conversion_project, team: "london", completed_at: nil, directive_academy_order: true) }
+    let!(:sponsored_completed_project_not_with_regional_casework_services_2) { create(:conversion_project, team: "london", completed_at: Date.today + 2.years, directive_academy_order: true) }
+    let!(:unassigned_project_not_with_regional_casework_services) { create(:conversion_project, team: "london", assigned_to: nil) }
 
     describe "#total_projects_not_with_regional_casework_services" do
       it "returns the total number of projects not with regional casework services" do


### PR DESCRIPTION
## Changes

To be merged after https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/823

This PR changes the behaviour of the CreateProjectForm. When a project creator selects "Assigned to regional caseworker team", the Project's team is set to "regional_casework_services". Otherwise, the team is set to be the same as the establishment's region.

Then, update two scopes on Project to use the project's team attribute, not the assigned_to_regional_caseworker_team attribute. Behaviour should remain identical.

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
