### PR TITLE
Establishment and trust pre-fetcher refactor

### DIFF
--- a/app/controllers/all/completed/projects_controller.rb
+++ b/app/controllers/all/completed/projects_controller.rb
@@ -27,7 +27,7 @@ class All::Completed::ProjectsController < ApplicationController
   end
 
   private def pre_fetch_establishments(projects)
-    EstablishmentsFetcher.new.call(projects)
+    EstablishmentsFetcherService.new(projects).call!
   end
 
   private def pre_fetch_incoming_trusts(projects)

--- a/app/controllers/all/completed/projects_controller.rb
+++ b/app/controllers/all/completed/projects_controller.rb
@@ -31,6 +31,6 @@ class All::Completed::ProjectsController < ApplicationController
   end
 
   private def pre_fetch_incoming_trusts(projects)
-    IncomingTrustsFetcher.new.call(projects)
+    TrustsFetcherService.new(projects).call!
   end
 end

--- a/app/controllers/all/in_progress/projects_controller.rb
+++ b/app/controllers/all/in_progress/projects_controller.rb
@@ -28,6 +28,6 @@ class All::InProgress::ProjectsController < ApplicationController
   end
 
   private def pre_fetch_incoming_trusts(projects)
-    IncomingTrustsFetcher.new.call(projects)
+    TrustsFetcherService.new(projects).call!
   end
 end

--- a/app/controllers/all/in_progress/projects_controller.rb
+++ b/app/controllers/all/in_progress/projects_controller.rb
@@ -24,7 +24,7 @@ class All::InProgress::ProjectsController < ApplicationController
   end
 
   private def pre_fetch_establishments(projects)
-    EstablishmentsFetcher.new.call(projects)
+    EstablishmentsFetcherService.new(projects).call!
   end
 
   private def pre_fetch_incoming_trusts(projects)

--- a/app/controllers/all/local_authorities/projects_controller.rb
+++ b/app/controllers/all/local_authorities/projects_controller.rb
@@ -24,6 +24,6 @@ class All::LocalAuthorities::ProjectsController < ApplicationController
   end
 
   private def pre_fetch_establishments(projects)
-    EstablishmentsFetcher.new.call(projects)
+    EstablishmentsFetcherService.new(projects).call!
   end
 end

--- a/app/controllers/all/local_authorities/projects_controller.rb
+++ b/app/controllers/all/local_authorities/projects_controller.rb
@@ -10,13 +10,17 @@ class All::LocalAuthorities::ProjectsController < ApplicationController
   def show
     authorize Project, :index?
     @local_authority = LocalAuthority.find_by!(code: local_authority_code)
-    @projects = Project.not_completed.to_a.select { |p| p.establishment.local_authority_code == local_authority_code }
-
-    pre_fetch_establishments(@projects)
+    @projects = projects_for_local_authority(local_authority_code)
   end
 
   private def local_authority_code
     params[:local_authority_id]
+  end
+
+  private def projects_for_local_authority(local_authority_code)
+    projects = Project.not_completed
+    pre_fetch_establishments(projects)
+    @projects = projects.to_a.select { |p| p.establishment.local_authority_code == local_authority_code }
   end
 
   private def pre_fetch_establishments(projects)

--- a/app/controllers/all/regions/projects_controller.rb
+++ b/app/controllers/all/regions/projects_controller.rb
@@ -18,7 +18,7 @@ class All::Regions::ProjectsController < ApplicationController
   end
 
   private def pre_fetch_establishments(projects)
-    EstablishmentsFetcher.new.call(projects)
+    EstablishmentsFetcherService.new(projects).call!
   end
 
   private def region

--- a/app/controllers/all/trusts/projects_controller.rb
+++ b/app/controllers/all/trusts/projects_controller.rb
@@ -17,6 +17,6 @@ class All::Trusts::ProjectsController < ApplicationController
   end
 
   private def pre_fetch_establishments(projects)
-    EstablishmentsFetcher.new.call(projects)
+    EstablishmentsFetcherService.new(projects).call!
   end
 end

--- a/app/controllers/conversions/projects_controller.rb
+++ b/app/controllers/conversions/projects_controller.rb
@@ -4,7 +4,7 @@ class Conversions::ProjectsController < ProjectsController
     @pagy, @projects = pagy(Project.conversions.in_progress)
 
     EstablishmentsFetcher.new.call(@projects)
-    IncomingTrustsFetcher.new.call(@projects)
+    TrustsFetcherService.new(@projects).call!
 
     render "/conversions/index"
   end

--- a/app/controllers/conversions/projects_controller.rb
+++ b/app/controllers/conversions/projects_controller.rb
@@ -3,7 +3,7 @@ class Conversions::ProjectsController < ProjectsController
     authorize Project
     @pagy, @projects = pagy(Project.conversions.in_progress)
 
-    EstablishmentsFetcher.new.call(@projects)
+    EstablishmentsFetcherService.new(@projects).call!
     TrustsFetcherService.new(@projects).call!
 
     render "/conversions/index"

--- a/app/controllers/regional/projects_controller.rb
+++ b/app/controllers/regional/projects_controller.rb
@@ -47,7 +47,7 @@ class Regional::ProjectsController < ApplicationController
   end
 
   private def pre_fetch_incoming_trusts(projects)
-    IncomingTrustsFetcher.new.call(projects)
+    TrustsFetcherService.new(projects).call!
   end
 
   private def valid_region?

--- a/app/controllers/regional/projects_controller.rb
+++ b/app/controllers/regional/projects_controller.rb
@@ -43,7 +43,7 @@ class Regional::ProjectsController < ApplicationController
   end
 
   private def pre_fetch_establishments(projects)
-    EstablishmentsFetcher.new.call(projects)
+    EstablishmentsFetcherService.new(projects).call!
   end
 
   private def pre_fetch_incoming_trusts(projects)

--- a/app/controllers/service_support/projects_controller.rb
+++ b/app/controllers/service_support/projects_controller.rb
@@ -23,6 +23,6 @@ class ServiceSupport::ProjectsController < ApplicationController
   end
 
   private def pre_fetch_incoming_trusts(projects)
-    IncomingTrustsFetcher.new.call(projects)
+    TrustsFetcherService.new(projects).call!
   end
 end

--- a/app/controllers/service_support/projects_controller.rb
+++ b/app/controllers/service_support/projects_controller.rb
@@ -19,7 +19,7 @@ class ServiceSupport::ProjectsController < ApplicationController
   end
 
   private def pre_fetch_establishments(projects)
-    EstablishmentsFetcher.new.call(projects)
+    EstablishmentsFetcherService.new(projects).call!
   end
 
   private def pre_fetch_incoming_trusts(projects)

--- a/app/controllers/team/projects_controller.rb
+++ b/app/controllers/team/projects_controller.rb
@@ -27,7 +27,7 @@ class Team::ProjectsController < ApplicationController
   end
 
   private def pre_fetch_establishments(projects)
-    EstablishmentsFetcher.new.call(projects)
+    EstablishmentsFetcherService.new(projects).call!
   end
 
   private def pre_fetch_incoming_trusts(projects)

--- a/app/controllers/team/projects_controller.rb
+++ b/app/controllers/team/projects_controller.rb
@@ -31,6 +31,6 @@ class Team::ProjectsController < ApplicationController
   end
 
   private def pre_fetch_incoming_trusts(projects)
-    IncomingTrustsFetcher.new.call(projects)
+    TrustsFetcherService.new(projects).call!
   end
 end

--- a/app/controllers/user/projects_controller.rb
+++ b/app/controllers/user/projects_controller.rb
@@ -27,7 +27,7 @@ class User::ProjectsController < ApplicationController
   end
 
   private def pre_fetch_establishments(projects)
-    EstablishmentsFetcher.new.call(projects)
+    EstablishmentsFetcherService.new(projects).call!
   end
 
   private def pre_fetch_incoming_trusts(projects)

--- a/app/controllers/user/projects_controller.rb
+++ b/app/controllers/user/projects_controller.rb
@@ -31,6 +31,6 @@ class User::ProjectsController < ApplicationController
   end
 
   private def pre_fetch_incoming_trusts(projects)
-    IncomingTrustsFetcher.new.call(projects)
+    TrustsFetcherService.new(projects).call!
   end
 end

--- a/app/services/by_local_authority_project_fetcher_service.rb
+++ b/app/services/by_local_authority_project_fetcher_service.rb
@@ -12,7 +12,7 @@ class ByLocalAuthorityProjectFetcherService
   private def conversions_count_by_local_authority
     projects = Project.not_completed.select(:id, :urn)
 
-    EstablishmentsFetcher.new.call(projects)
+    EstablishmentsFetcherService.new(projects).call!
 
     projects.group_by { |p| p.establishment.local_authority_code }
   end

--- a/app/services/by_local_authority_project_fetcher_service.rb
+++ b/app/services/by_local_authority_project_fetcher_service.rb
@@ -10,7 +10,11 @@ class ByLocalAuthorityProjectFetcherService
   end
 
   private def conversions_count_by_local_authority
-    Project.not_completed.select(:id, :urn).group_by { |p| p.establishment.local_authority_code }
+    projects = Project.not_completed.select(:id, :urn)
+
+    EstablishmentsFetcher.new.call(projects)
+
+    projects.group_by { |p| p.establishment.local_authority_code }
   end
 
   private def build_local_authorities_objects(local_authorities, conversion_counts)

--- a/app/services/establishments_fetcher.rb
+++ b/app/services/establishments_fetcher.rb
@@ -1,12 +1,19 @@
 class EstablishmentsFetcher
+  def initialize
+    @establishments = []
+  end
+
   def call(projects)
     return unless projects&.any?
+    raise ArgumentError unless projects.is_a?(ActiveRecord::Relation)
 
-    urns = projects.map(&:urn)
-    establishments = Api::AcademiesApi::Client.new.get_establishments(urns).object
+    projects.in_batches(of: 20) do |batch_of_projects|
+      urns = batch_of_projects.pluck(:urn)
+      @establishments += Api::AcademiesApi::Client.new.get_establishments(urns).object
+    end
 
     projects.each do |project|
-      project.establishment = establishments.find { |establishment| establishment.urn == project.urn.to_s }
+      project.establishment = @establishments.find { |establishment| establishment.urn == project.urn.to_s }
     end
   end
 end

--- a/app/services/establishments_fetcher_service.rb
+++ b/app/services/establishments_fetcher_service.rb
@@ -6,7 +6,7 @@ class EstablishmentsFetcherService
 
   def call!
     return unless @projects&.any?
-    raise ArgumentError unless @projects.is_a?(ActiveRecord::Relation)
+    raise ArgumentError.new("You must pass in the result of an ActiveRecord query (ActiveRecord::Relation)") unless @projects.is_a?(ActiveRecord::Relation)
 
     @projects.in_batches(of: 20) do |batch_of_projects|
       urns = batch_of_projects.pluck(:urn)

--- a/app/services/establishments_fetcher_service.rb
+++ b/app/services/establishments_fetcher_service.rb
@@ -1,18 +1,19 @@
-class EstablishmentsFetcher
-  def initialize
+class EstablishmentsFetcherService
+  def initialize(projects)
     @establishments = []
+    @projects = projects
   end
 
-  def call(projects)
-    return unless projects&.any?
-    raise ArgumentError unless projects.is_a?(ActiveRecord::Relation)
+  def call!
+    return unless @projects&.any?
+    raise ArgumentError unless @projects.is_a?(ActiveRecord::Relation)
 
-    projects.in_batches(of: 20) do |batch_of_projects|
+    @projects.in_batches(of: 20) do |batch_of_projects|
       urns = batch_of_projects.pluck(:urn)
       @establishments += Api::AcademiesApi::Client.new.get_establishments(urns).object
     end
 
-    projects.each do |project|
+    @projects.each do |project|
       project.establishment = @establishments.find { |establishment| establishment.urn == project.urn.to_s }
     end
   end

--- a/app/services/incoming_trusts_fetcher.rb
+++ b/app/services/incoming_trusts_fetcher.rb
@@ -1,12 +1,19 @@
 class IncomingTrustsFetcher
+  def initialize
+    @trusts = []
+  end
+
   def call(projects)
     return unless projects&.any?
+    raise ArgumentError unless projects.is_a?(ActiveRecord::Relation)
 
-    ukprns = projects.map(&:incoming_trust_ukprn)
-    trusts = Api::AcademiesApi::Client.new.get_trusts(ukprns).object
+    projects.in_batches(of: 20) do |batch_of_projects|
+      ukprns = batch_of_projects.pluck(:incoming_trust_ukprn)
+      @trusts += Api::AcademiesApi::Client.new.get_trusts(ukprns).object
+    end
 
     projects.each do |project|
-      project.incoming_trust = trusts.find { |trust| trust.ukprn == project.incoming_trust_ukprn.to_s }
+      project.incoming_trust = @trusts.find { |trust| trust.ukprn == project.incoming_trust_ukprn.to_s }
     end
   end
 end

--- a/app/services/trusts_fetcher_service.rb
+++ b/app/services/trusts_fetcher_service.rb
@@ -1,18 +1,19 @@
-class IncomingTrustsFetcher
-  def initialize
+class TrustsFetcherService
+  def initialize(projects)
     @trusts = []
+    @projects = projects
   end
 
-  def call(projects)
-    return unless projects&.any?
-    raise ArgumentError unless projects.is_a?(ActiveRecord::Relation)
+  def call!
+    return unless @projects&.any?
+    raise ArgumentError unless @projects.is_a?(ActiveRecord::Relation)
 
-    projects.in_batches(of: 20) do |batch_of_projects|
+    @projects.in_batches(of: 20) do |batch_of_projects|
       ukprns = batch_of_projects.pluck(:incoming_trust_ukprn)
       @trusts += Api::AcademiesApi::Client.new.get_trusts(ukprns).object
     end
 
-    projects.each do |project|
+    @projects.each do |project|
       project.incoming_trust = @trusts.find { |trust| trust.ukprn == project.incoming_trust_ukprn.to_s }
     end
   end

--- a/app/services/trusts_fetcher_service.rb
+++ b/app/services/trusts_fetcher_service.rb
@@ -6,7 +6,7 @@ class TrustsFetcherService
 
   def call!
     return unless @projects&.any?
-    raise ArgumentError unless @projects.is_a?(ActiveRecord::Relation)
+    raise ArgumentError.new("You must pass in the result of an ActiveRecord query (ActiveRecord::Relation)") unless @projects.is_a?(ActiveRecord::Relation)
 
     @projects.in_batches(of: 20) do |batch_of_projects|
       ukprns = batch_of_projects.pluck(:incoming_trust_ukprn)

--- a/spec/accessibility/projects_spec.rb
+++ b/spec/accessibility/projects_spec.rb
@@ -3,14 +3,14 @@ require "axe-rspec"
 
 RSpec.feature "Test projects accessibility", driver: :headless_firefox, accessibility: true do
   let(:user) { create(:user, :regional_delivery_officer) }
-  let(:mock_establishments_fetcher) { double(EstablishmentsFetcher, call: true) }
+  let(:mock_establishments_fetcher) { double(EstablishmentsFetcherService, call!: true) }
   let(:mock_trusts_fetcher) { double(TrustsFetcherService, call!: true) }
 
   before do
     mock_successful_api_responses(urn: 123456, ukprn: 10061021)
     sign_in_with_user(user)
 
-    allow(EstablishmentsFetcher).to receive(:new).and_return(mock_establishments_fetcher)
+    allow(EstablishmentsFetcherService).to receive(:new).and_return(mock_establishments_fetcher)
     allow(TrustsFetcherService).to receive(:new).and_return(mock_trusts_fetcher)
   end
 

--- a/spec/accessibility/projects_spec.rb
+++ b/spec/accessibility/projects_spec.rb
@@ -4,14 +4,14 @@ require "axe-rspec"
 RSpec.feature "Test projects accessibility", driver: :headless_firefox, accessibility: true do
   let(:user) { create(:user, :regional_delivery_officer) }
   let(:mock_establishments_fetcher) { double(EstablishmentsFetcher, call: true) }
-  let(:mock_trusts_fetcher) { double(IncomingTrustsFetcher, call: true) }
+  let(:mock_trusts_fetcher) { double(TrustsFetcherService, call!: true) }
 
   before do
     mock_successful_api_responses(urn: 123456, ukprn: 10061021)
     sign_in_with_user(user)
 
     allow(EstablishmentsFetcher).to receive(:new).and_return(mock_establishments_fetcher)
-    allow(IncomingTrustsFetcher).to receive(:new).and_return(mock_trusts_fetcher)
+    allow(TrustsFetcherService).to receive(:new).and_return(mock_trusts_fetcher)
   end
 
   scenario "in progress projects page" do

--- a/spec/requests/all/opening/projects_controller_spec.rb
+++ b/spec/requests/all/opening/projects_controller_spec.rb
@@ -44,11 +44,11 @@ RSpec.describe All::Opening::ProjectsController, type: :request do
         end
 
         allow(EstablishmentsFetcher).to receive(:new).and_return(mock_establishments_fetcher)
-        allow(IncomingTrustsFetcher).to receive(:new).and_return(mock_trusts_fetcher)
+        allow(TrustsFetcherService).to receive(:new).and_return(mock_trusts_fetcher)
       end
 
       let(:mock_establishments_fetcher) { double(EstablishmentsFetcher, call: true) }
-      let(:mock_trusts_fetcher) { double(IncomingTrustsFetcher, call: true) }
+      let(:mock_trusts_fetcher) { double(TrustsFetcherService, call!: true) }
 
       it "shows a page title with the month & year" do
         get confirmed_all_opening_projects_path(1, 2022)

--- a/spec/requests/all/opening/projects_controller_spec.rb
+++ b/spec/requests/all/opening/projects_controller_spec.rb
@@ -43,11 +43,11 @@ RSpec.describe All::Opening::ProjectsController, type: :request do
           mock_successful_api_responses(urn: urn, ukprn: 10061021)
         end
 
-        allow(EstablishmentsFetcher).to receive(:new).and_return(mock_establishments_fetcher)
+        allow(EstablishmentsFetcherService).to receive(:new).and_return(mock_establishments_fetcher)
         allow(TrustsFetcherService).to receive(:new).and_return(mock_trusts_fetcher)
       end
 
-      let(:mock_establishments_fetcher) { double(EstablishmentsFetcher, call: true) }
+      let(:mock_establishments_fetcher) { double(EstablishmentsFetcherService, call!: true) }
       let(:mock_trusts_fetcher) { double(TrustsFetcherService, call!: true) }
 
       it "shows a page title with the month & year" do

--- a/spec/services/by_local_authority_project_fetcher_service_spec.rb
+++ b/spec/services/by_local_authority_project_fetcher_service_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe ByLocalAuthorityProjectFetcherService do
     allow(fake_client).to receive(:get_establishment).with(establishment.urn).and_return(Api::AcademiesApi::Client::Result.new(establishment, nil))
     allow(fake_client).to receive(:get_establishment).with(another_establishment.urn).and_return(Api::AcademiesApi::Client::Result.new(another_establishment, nil))
     allow(fake_client).to receive(:get_establishment).with(yet_another_establishment.urn).and_return(Api::AcademiesApi::Client::Result.new(yet_another_establishment, nil))
+    allow(fake_client).to receive(:get_establishments).with(any_args).and_return(Api::AcademiesApi::Client::Result.new([establishment, another_establishment, establishment, yet_another_establishment], nil))
 
     create(:local_authority, code: "909", name: "Cumbria County Council")
     create(:local_authority, code: "213", name: "Westminster City Council")

--- a/spec/services/establishments_fetcher_service_spec.rb
+++ b/spec/services/establishments_fetcher_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe EstablishmentsFetcher do
+RSpec.describe EstablishmentsFetcherService do
   describe "#call" do
     it "fetches the establishments and updates the projects" do
       api_client = Api::AcademiesApi::Client.new
@@ -11,7 +11,7 @@ RSpec.describe EstablishmentsFetcher do
 
       create(:conversion_project, establishment: nil)
       projects = Project.all
-      described_class.new.call(projects)
+      described_class.new(projects).call!
 
       expect(projects.first.establishment).not_to be_nil
     end
@@ -26,7 +26,7 @@ RSpec.describe EstablishmentsFetcher do
 
         create_list(:conversion_project, 6)
         projects = Project.all
-        described_class.new.call(projects)
+        described_class.new(projects).call!
 
         expect(api_client).to have_received(:get_establishments).exactly(1).times
       end
@@ -42,7 +42,7 @@ RSpec.describe EstablishmentsFetcher do
         create_list(:conversion_project, 21)
 
         projects = Project.all
-        described_class.new.call(projects)
+        described_class.new(projects).call!
 
         expect(api_client).to have_received(:get_establishments).exactly(2).times
       end
@@ -51,15 +51,15 @@ RSpec.describe EstablishmentsFetcher do
     it "raises unless an ActiveRecord relation is passed in" do
       project = build(:conversion_project)
 
-      expect { described_class.new.call([project]) }.to raise_error(ArgumentError)
+      expect { described_class.new([project]).call! }.to raise_error(ArgumentError)
     end
 
     it "returns nil if passed nil" do
-      expect(described_class.new.call(nil)).to be_nil
+      expect(described_class.new(nil).call!).to be_nil
     end
 
     it "returns nil if there are no projects" do
-      expect(described_class.new.call([])).to be_nil
+      expect(described_class.new([]).call!).to be_nil
     end
   end
 end

--- a/spec/services/establishments_fetcher_spec.rb
+++ b/spec/services/establishments_fetcher_spec.rb
@@ -1,45 +1,65 @@
 require "rails_helper"
 
 RSpec.describe EstablishmentsFetcher do
-  let(:establishments_fetcher) { described_class.new }
-
   describe "#call" do
-    let(:projects) do
-      [
-        build(:conversion_project, urn: 123456),
-        build(:conversion_project, urn: 234567)
-      ]
-    end
-    let(:mock_client) { Api::AcademiesApi::Client.new }
-    let(:establishment) { build(:academies_api_establishment, urn: "123456") }
-    let(:establishment_2) { build(:academies_api_establishment, urn: "234567") }
-    let(:establishment_result) { Api::AcademiesApi::Client::Result.new([establishment, establishment_2], nil) }
+    it "fetches the establishments and updates the projects" do
+      api_client = Api::AcademiesApi::Client.new
+      allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
+      allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new([], nil))
+      allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
+      allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
 
-    before do
-      allow(Api::AcademiesApi::Client).to receive(:new).and_return(mock_client)
-      allow(mock_client).to receive(:get_establishment).and_return(true)
-      allow(mock_client).to receive(:get_establishments).with([123456, 234567]).and_return(establishment_result)
+      create(:conversion_project, establishment: nil)
+      projects = Project.all
+      described_class.new.call(projects)
+
+      expect(projects.first.establishment).not_to be_nil
     end
 
-    subject! { establishments_fetcher.call(projects) }
+    context "when there is a single batch of 10 projects or less" do
+      it "calls the API once" do
+        api_client = Api::AcademiesApi::Client.new
+        allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
+        allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new([], nil))
+        allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
+        allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
 
-    context "when projects is nil" do
-      let(:projects) { nil }
+        create_list(:conversion_project, 6)
+        projects = Project.all
+        described_class.new.call(projects)
 
-      it { expect(subject).to be_nil }
+        expect(api_client).to have_received(:get_establishments).exactly(1).times
+      end
     end
 
-    context "when projects is an empty array" do
-      let(:projects) { [] }
+    context "whent there are multiple batches of projects" do
+      it "calls the API the appropriate number of times" do
+        api_client = Api::AcademiesApi::Client.new
+        allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
+        allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new([], nil))
+        allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
+        allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
+        create_list(:conversion_project, 21)
 
-      it { expect(subject).to be_nil }
+        projects = Project.all
+        described_class.new.call(projects)
+
+        expect(api_client).to have_received(:get_establishments).exactly(2).times
+      end
     end
 
-    it "fetches Establishment data and assigns it to the projects" do
-      expect(projects.find { |project| project.urn == 123456 }.establishment).to eq establishment
-      expect(projects.find { |project| project.urn == 234567 }.establishment).to eq establishment_2
+    it "raises unless an ActiveRecord relation is passed in" do
+      project = build(:conversion_project)
 
-      expect(mock_client).to_not have_received(:get_establishment)
+      expect { described_class.new.call([project]) }.to raise_error(ArgumentError)
+    end
+
+    it "returns nil if passed nil" do
+      expect(described_class.new.call(nil)).to be_nil
+    end
+
+    it "returns nil if there are no projects" do
+      expect(described_class.new.call([])).to be_nil
     end
   end
 end

--- a/spec/services/trusts_fetcher_service_spec.rb
+++ b/spec/services/trusts_fetcher_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe IncomingTrustsFetcher do
+RSpec.describe TrustsFetcherService do
   describe "#call" do
     it "fetches the trusts and updates the projects" do
       api_client = Api::AcademiesApi::Client.new
@@ -9,9 +9,9 @@ RSpec.describe IncomingTrustsFetcher do
       allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
       allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
 
-      create(:conversion_project,incoming_trust: nil)
+      create(:conversion_project, incoming_trust: nil)
       projects = Project.all
-      described_class.new.call(projects)
+      described_class.new(projects).call!
 
       expect(projects.first.incoming_trust).not_to be_nil
     end
@@ -26,13 +26,13 @@ RSpec.describe IncomingTrustsFetcher do
 
         create_list(:conversion_project, 6)
         projects = Project.all
-        described_class.new.call(projects)
+        described_class.new(projects).call!
 
         expect(api_client).to have_received(:get_trusts).exactly(1).times
       end
     end
 
-    context "whent there are multiple batches of projects" do
+    context "when there are multiple batches of projects" do
       it "calls the API the appropriate number of times" do
         api_client = Api::AcademiesApi::Client.new
         allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
@@ -42,7 +42,7 @@ RSpec.describe IncomingTrustsFetcher do
         create_list(:conversion_project, 21)
 
         projects = Project.all
-        described_class.new.call(projects)
+        described_class.new(projects).call!
 
         expect(api_client).to have_received(:get_trusts).exactly(2).times
       end
@@ -51,15 +51,15 @@ RSpec.describe IncomingTrustsFetcher do
     it "raises unless an ActiveRecord relation is passed in" do
       project = build(:conversion_project)
 
-      expect { described_class.new.call([project]) }.to raise_error(ArgumentError)
+      expect { described_class.new([project]).call! }.to raise_error(ArgumentError)
     end
 
     it "returns nil if passed nil" do
-      expect(described_class.new.call(nil)).to be_nil
+      expect(described_class.new(nil).call!).to be_nil
     end
 
     it "returns nil if there are no projects" do
-      expect(described_class.new.call([])).to be_nil
+      expect(described_class.new([]).call!).to be_nil
     end
   end
 end

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -58,11 +58,11 @@ module AcademiesApiHelpers
   end
 
   def mock_pre_fetched_api_responses_for_any_establishment_and_trust
-    fake_establishment_fetcher = double(EstablishmentsFetcher)
+    fake_establishment_fetcher = double(EstablishmentsFetcherService)
     fake_trust_fetcher = double(TrustsFetcherService)
-    allow(EstablishmentsFetcher).to receive(:new).and_return(fake_establishment_fetcher)
+    allow(EstablishmentsFetcherService).to receive(:new).and_return(fake_establishment_fetcher)
     allow(TrustsFetcherService).to receive(:new).and_return(fake_trust_fetcher)
-    allow(fake_establishment_fetcher).to receive(:call).and_return([])
+    allow(fake_establishment_fetcher).to receive(:call!).and_return([])
     allow(fake_trust_fetcher).to receive(:call!).and_return([])
   end
 

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -59,12 +59,11 @@ module AcademiesApiHelpers
 
   def mock_pre_fetched_api_responses_for_any_establishment_and_trust
     fake_establishment_fetcher = double(EstablishmentsFetcher)
-    fake_trust_fetcher = double(IncomingTrustsFetcher)
+    fake_trust_fetcher = double(TrustsFetcherService)
     allow(EstablishmentsFetcher).to receive(:new).and_return(fake_establishment_fetcher)
-    allow(IncomingTrustsFetcher).to receive(:new).and_return(fake_establishment_fetcher)
-
+    allow(TrustsFetcherService).to receive(:new).and_return(fake_trust_fetcher)
     allow(fake_establishment_fetcher).to receive(:call).and_return([])
-    allow(fake_trust_fetcher).to receive(:call).and_return([])
+    allow(fake_trust_fetcher).to receive(:call!).and_return([])
   end
 
   def mock_timeout_api_responses(urn:, ukprn:)


### PR DESCRIPTION
Initially the ByLocalAuthoirtyProjectsFetcher called the academies API for each project it was given - this takes a long, long time in prod (~10s on ~150 projects).

To make things much quciker we can bulk fetch and pre-load the projects with their establishments.

Before this work, it was generally true that we would never fetch more than 20 trust or establishments due to paging, but here we could suddenly be fetching hundreds.

This work refactors the fetchers to batch fetch in sets of 20 for both establishments and trusts.

Whilst we were here we move some things around and renamed in an effort to make this two service objects more obvious.

https://trello.com/c/iQlgA47w
