### PR TITLE
Refactor team definitions into "Teamable" module

### DIFF
--- a/app/models/concerns/teamable.rb
+++ b/app/models/concerns/teamable.rb
@@ -1,0 +1,24 @@
+module Teamable
+  extend ActiveSupport::Concern
+
+  REGIONAL_TEAMS = {
+    london: "london",
+    south_east: "south_east",
+    yorkshire_and_the_humber: "yorkshire_and_the_humber",
+    north_west: "north_west",
+    east_of_england: "east_of_england",
+    west_midlands: "west_midlands",
+    north_east: "north_east",
+    south_west: "south_west",
+    east_midlands: "east_midlands"
+  }
+
+  USER_TEAMS = REGIONAL_TEAMS.merge({
+    regional_casework_services: "regional_casework_services",
+    service_support: "service_support",
+    academies_operational_practice_unit: "academies_operational_practice_unit",
+    education_and_skills_funding_agency: "education_and_skills_funding_agency"
+  })
+
+  PROJECT_TEAMS = REGIONAL_TEAMS.merge({regional_casework_services: "regional_casework_services"})
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,5 @@
 class Project < ApplicationRecord
+  include Teamable
   SHAREPOINT_URLS = %w[educationgovuk-my.sharepoint.com educationgovuk.sharepoint.com].freeze
 
   attr_writer :establishment, :incoming_trust
@@ -60,18 +61,7 @@ class Project < ApplicationRecord
     east_midlands: "E"
   }, suffix: true
 
-  enum :team, {
-    london: "london",
-    south_east: "south_east",
-    yorkshire_and_the_humber: "yorkshire_and_the_humber",
-    north_west: "north_west",
-    east_of_england: "east_of_england",
-    west_midlands: "west_midlands",
-    north_east: "north_east",
-    south_west: "south_west",
-    east_midlands: "east_midlands",
-    regional_casework_services: "regional_casework_services"
-  }, suffix: true
+  enum :team, PROJECT_TEAMS, suffix: true
 
   def establishment
     @establishment ||= fetch_establishment(urn)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  include Teamable
   serialize :active_directory_user_group_ids, Array
 
   has_many :projects, foreign_key: "caseworker"
@@ -16,21 +17,7 @@ class User < ApplicationRecord
 
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}
 
-  enum :team, {
-    london: "london",
-    south_east: "south_east",
-    yorkshire_and_the_humber: "yorkshire_and_the_humber",
-    north_west: "north_west",
-    east_of_england: "east_of_england",
-    west_midlands: "west_midlands",
-    north_east: "north_east",
-    south_west: "south_west",
-    east_midlands: "east_midlands",
-    regional_casework_services: "regional_casework_services",
-    service_support: "service_support",
-    academies_operational_practice_unit: "academies_operational_practice_unit",
-    education_and_skills_funding_agency: "education_and_skills_funding_agency"
-  }, suffix: true
+  enum :team, USER_TEAMS, suffix: true
 
   def full_name
     "#{first_name} #{last_name}"

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -510,5 +510,9 @@ RSpec.describe Project, type: :model do
     it "uses the enum suffix as intended" do
       expect(subject.regional_casework_services_team?).to be true
     end
+
+    it "has the expected enum values" do
+      expect(Project.teams.count).to eq(10)
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -106,5 +106,9 @@ RSpec.describe User do
 
       expect(user.london_team?).to be true
     end
+
+    it "has the expected enum values" do
+      expect(User.teams.count).to eq(13)
+    end
   end
 end


### PR DESCRIPTION


## Changes

Move the shared User & Project teams into a shared "Teamable" module. This way we can manage the teams in one place, should we need to add/remove any.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
