### PR TITLE
Allow CSV export to go ahead when there are data issues with the members API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Allow CSV export to go ahead when a school's parliamentary constituency is
+  unclear
+
 ## [Release 31][release-31]
 
 ### Added

--- a/app/services/opening_projects_csv_exporter.rb
+++ b/app/services/opening_projects_csv_exporter.rb
@@ -57,16 +57,21 @@ class OpeningProjectsCsvExporter
       trust_address_town: project.incoming_trust.address_town,
       trust_address_county: project.incoming_trust.address_county,
       trust_address_postcode: project.incoming_trust.address_postcode,
-      mp_name: mp_details.name,
-      mp_email: mp_details.email,
-      mp_address_line_1: mp_details.address.line1,
-      mp_address_line_2: mp_details.address.line2,
-      mp_address_line_3: mp_details.address.line3,
-      mp_address_postcode: mp_details.address.postcode,
+      mp_name: mp_details&.name,
+      mp_email: mp_details&.email,
+      mp_address_line_1: fetch_address_line(mp_details, :line1),
+      mp_address_line_2: fetch_address_line(mp_details, :line2),
+      mp_address_line_3: fetch_address_line(mp_details, :line3),
+      mp_address_postcode: fetch_address_line(mp_details, :postcode),
       approval_date: project.advisory_board_date.to_formatted_s(:csv),
       project_lead: project.assigned_to.full_name,
       academy_name: project.academy&.name
     }
+  end
+
+  private def fetch_address_line(mp_details, attribute)
+    return nil if mp_details.nil?
+    mp_details.address.send(attribute)
   end
 
   private def fetch_mp_details(project)

--- a/spec/requests/all/opening/projects_controller_spec.rb
+++ b/spec/requests/all/opening/projects_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe All::Opening::ProjectsController, type: :request do
   describe "#download_csv" do
     let!(:project) { create(:conversion_project, conversion_date: Date.new(2025, 5, 1), conversion_date_provisional: false) }
 
-    before { mock_successful_memeber_details }
+    before { mock_successful_member_details }
 
     it "returns the csv with a successful response" do
       get csv_all_opening_projects_path(5, 2025)

--- a/spec/services/opening_projects_csv_exporter_spec.rb
+++ b/spec/services/opening_projects_csv_exporter_spec.rb
@@ -215,6 +215,24 @@ RSpec.describe OpeningProjectsCsvExporter do
       expect(csv_export).to include("SW1A 0AA")
     end
 
+    context "when the Members API returns multiple results" do
+      before do
+        mock_nil_member_for_constituency_response
+      end
+
+      it "returns nil for the member contact details" do
+        project = build(:conversion_project)
+
+        csv_export = OpeningProjectsCsvExporter.new([project]).call
+
+        expect(csv_export).to_not include("Member Parliment")
+        expect(csv_export).to_not include("member.parliment@parliment.uk")
+        expect(csv_export).to_not include("House of Commons")
+        expect(csv_export).to_not include("London")
+        expect(csv_export).to_not include("SW1A 0AA")
+      end
+    end
+
     it "returns a csv with the trust name" do
       trust = build(:academies_api_trust)
       allow(trust).to receive(:name).and_return("Test trust")

--- a/spec/services/opening_projects_csv_exporter_spec.rb
+++ b/spec/services/opening_projects_csv_exporter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe OpeningProjectsCsvExporter do
   describe "#call" do
     before do
       mock_successful_api_response_to_create_any_project
-      mock_successful_memeber_details
+      mock_successful_member_details
     end
 
     it "raises when there are no projects" do
@@ -115,7 +115,7 @@ RSpec.describe OpeningProjectsCsvExporter do
       expect(csv_export).to include("AB1 AB2")
     end
 
-    it "returns a csv with the Director of child serivces name" do
+    it "returns a csv with the Director of child services name" do
       local_authority = create(:local_authority)
       create(:director_of_child_services, name: "Test director of child services name", local_authority: local_authority)
       establishment = build(:academies_api_establishment, local_authority_code: local_authority.code)
@@ -127,7 +127,7 @@ RSpec.describe OpeningProjectsCsvExporter do
       expect(csv_export).to include("Director of child services name")
     end
 
-    it "returns a csv with the Director of child serivces role" do
+    it "returns a csv with the Director of child services role" do
       local_authority = create(:local_authority)
       create(:director_of_child_services, title: "Test director of child services role", local_authority: local_authority)
       establishment = build(:academies_api_establishment, local_authority_code: local_authority.code)
@@ -139,7 +139,7 @@ RSpec.describe OpeningProjectsCsvExporter do
       expect(csv_export).to include("Director of child services role")
     end
 
-    it "returns a csv with the Director of child serivces email" do
+    it "returns a csv with the Director of child services email" do
       local_authority = create(:local_authority)
       create(:director_of_child_services, email: "test@email.com", local_authority: local_authority)
       establishment = build(:academies_api_establishment, local_authority_code: local_authority.code)
@@ -151,7 +151,7 @@ RSpec.describe OpeningProjectsCsvExporter do
       expect(csv_export).to include("Director of child services email")
     end
 
-    it "returns a csv with the Director of child serivces phone" do
+    it "returns a csv with the Director of child services phone" do
       local_authority = create(:local_authority)
       create(:director_of_child_services, phone: "01234 567891", local_authority: local_authority)
       establishment = build(:academies_api_establishment, local_authority_code: local_authority.code)

--- a/spec/support/members_api_helpers.rb
+++ b/spec/support/members_api_helpers.rb
@@ -89,6 +89,12 @@ module MembersApiHelpers
     allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
   end
 
+  def mock_nil_member_for_constituency_response
+    test_client = Api::MembersApi::Client.new
+    allow(test_client).to receive(:member_for_constituency).and_return(nil)
+    allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
+  end
+
   def mock_members_api_unavailable_response
     test_client = Api::MembersApi::Client.new
     error_result = Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::Error)

--- a/spec/support/members_api_helpers.rb
+++ b/spec/support/members_api_helpers.rb
@@ -43,7 +43,7 @@ module MembersApiHelpers
     allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
   end
 
-  def mock_successful_memeber_details
+  def mock_successful_member_details
     address = OpenStruct.new(
       line1: "House of Commons",
       line2: "London",


### PR DESCRIPTION
## Changes

Because of data inconsistencies between GIAS and the Parliamentary Members API,
we have had issues getting the CSV export to work properly when a school's
parliamentary constituency is unclear (e.g. "Middlesbrough" is not a single
constituency, but GIAS insists some schools are in "Middlesbrough")

To get round this, if we query the Members API for a constituency but get
multiple results back, still allow the CSV to be downloaded but with empty
values for the MP details. The CSV requester will then have to fill in the
blanks themselves.

We also send a warning to Application Insights to let us know this has happened. This way we
can track which constituencies are returning multiple results.

The solution for this is a little complex in the CSV exporter, due to the way
the Members details objects are set up, but this should capture everything.
## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
