### PR TITLE
Fix the default opening date routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow CSV export to go ahead when a school's parliamentary constituency is
   unclear
 - Fix date ordering on project index pages
+- the confirmed and revised opening lists now correctly change month
 
 ## [Release 31][release-31]
 

--- a/app/controllers/all/opening/projects_controller.rb
+++ b/app/controllers/all/opening/projects_controller.rb
@@ -6,11 +6,23 @@ class All::Opening::ProjectsController < ApplicationController
     @date = "#{Date::MONTHNAMES[month.to_i]} #{year}"
   end
 
+  def confirmed_next_month
+    month = Date.today.next_month.month
+    year = Date.today.next_month.year
+    redirect_to action: "confirmed", month: month, year: year
+  end
+
   def revised
     authorize Project, :index?
 
     @projects = Conversion::Project.conversion_date_revised_from(month, year)
     @date = "#{Date::MONTHNAMES[month.to_i]} #{year}"
+  end
+
+  def revised_next_month
+    month = Date.today.next_month.month
+    year = Date.today.next_month.year
+    redirect_to action: "revised", month: month, year: year
   end
 
   def download_csv

--- a/app/views/shared/_sub_navigation_item.html.erb
+++ b/app/views/shared/_sub_navigation_item.html.erb
@@ -1,3 +1,3 @@
 <li class="moj-sub-navigation__item">
-<%= link_to name, path, class: "moj-sub-navigation__link", "aria-current": ((request.path == path) ? "page" : nil) %>
+  <%= link_to name, path, class: "moj-sub-navigation__link", "aria-current": (request.path.include?(path) ? "page" : nil) %>
 </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,9 +78,11 @@ Rails.application.routes.draw do
             get "sponsored", to: "projects#sponsored"
           end
           namespace :opening do
-            get "confirmed/:month/:year", to: "projects#confirmed", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :confirmed, defaults: {month: Date.today.next_month.month, year: Date.today.next_month.year}
-            get "revised/:month/:year", to: "projects#revised", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :revised, defaults: {month: Date.today.next_month.month, year: Date.today.next_month.year}
+            get "confirmed/", to: "projects#confirmed_next_month"
+            get "confirmed/:month/:year", to: "projects#confirmed", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}
             get "confirmed/:month/:year/csv", to: "projects#download_csv", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :csv
+            get "revised/:month/:year", to: "projects#revised", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}
+            get "revised/", to: "projects#revised_next_month"
           end
           namespace :statistics do
             get "/", to: "projects#index"

--- a/spec/features/projects/revised_conversion_date/viewing_projects_with_a_revised_converison_date_spec.rb
+++ b/spec/features/projects/revised_conversion_date/viewing_projects_with_a_revised_converison_date_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Viewing projects with a revised conversion date" do
     create(:date_history, project: project_with_matching_date, previous_date: Date.today.at_beginning_of_month, revised_date: Date.today.at_beginning_of_month + 3.months)
     create(:date_history, project: project_with_matching_date, previous_date: Date.today.at_beginning_of_month + 3.months, revised_date: Date.today.at_beginning_of_month + 4.months)
 
-    visit revised_all_opening_projects_path((Date.today + 3.months).month, Date.today.year)
+    visit "/projects/all/opening/revised/#{(Date.today + 3.months).month}/#{(Date.today + 3.months).year}"
 
     expect(page).to have_content I18n.t("project.revised_conversion_date.title", date: (Date.today + 3.months).to_fs(:govuk_month))
     expect(page).to have_content project_with_matching_date.urn

--- a/spec/features/users_can_view_a_table_of_project_openers_spec.rb
+++ b/spec/features/users_can_view_a_table_of_project_openers_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Users can view project openers in table form" do
         tasks_data = create(:conversion_tasks_data, conditions_met_confirm_all_conditions_met: true)
         _project = create(:conversion_project, tasks_data: tasks_data, conversion_date: Date.new(2023, 1, 1), conversion_date_provisional: false)
 
-        visit confirmed_all_opening_projects_path(1, 2023)
+        visit "/projects/all/opening/confirmed/1/2023"
         expect(page).to have_content("Yes")
       end
     end
@@ -27,7 +27,7 @@ RSpec.feature "Users can view project openers in table form" do
         tasks_data = create(:conversion_tasks_data, conditions_met_confirm_all_conditions_met: nil)
         _project = create(:conversion_project, tasks_data: tasks_data, conversion_date: Date.new(2023, 1, 1), conversion_date_provisional: false)
 
-        visit confirmed_all_opening_projects_path(1, 2023)
+        visit "/projects/all/opening/confirmed/1/2023"
         expect(page).to have_content("Not yet")
       end
     end

--- a/spec/requests/all/opening/projects_controller_spec.rb
+++ b/spec/requests/all/opening/projects_controller_spec.rb
@@ -8,77 +8,116 @@ RSpec.describe All::Opening::ProjectsController, type: :request do
     sign_in_with(team_leader)
   end
 
-  describe "#index" do
-    context "when the month and year are missing" do
-      it "returns a 404" do
-        get "/projects/all/opening"
-        expect(response).to have_http_status(:not_found)
+  describe "#confirmed_next_month" do
+    it "redirects to next month" do
+      get confirmed_all_opening_projects_path
+      follow_redirect!
+
+      expect(response).to have_http_status(:success)
+      expect(request.params.fetch(:month)).to eq Date.today.next_month.month.to_s
+      expect(request.params.fetch(:year)).to eq Date.today.next_month.year.to_s
+
+      travel_to Date.today + 2.months do
+        get confirmed_all_opening_projects_path
+        follow_redirect!
+
+        expect(response).to have_http_status(:success)
+        expect(request.params.fetch(:month)).to eq Date.today.next_month.month.to_s
+        expect(request.params.fetch(:year)).to eq Date.today.next_month.year.to_s
       end
     end
 
-    context "when the year is missing" do
-      it "returns a 404" do
-        get "/projects/all/opening/1"
-        expect(response).to have_http_status(:not_found)
-      end
-    end
-
-    context "when the month isn't in the scope 1..12" do
-      it "returns a 404" do
-        get "/projects/all/opening/13/2022"
-        expect(response).to have_http_status(:not_found)
-      end
-    end
-
-    context "when the year isn't in the scope 2000-2499" do
-      it "returns a 404" do
-        get "/projects/all/opening/12/2555"
-        expect(response).to have_http_status(:not_found)
-      end
-    end
-
-    context "when the month and year are present and in scope" do
-      before do
-        (100001..100002).each do |urn|
-          mock_successful_api_responses(urn: urn, ukprn: 10061021)
+    describe "#confirmed" do
+      context "when supplying a month and year" do
+        context "when the year is missing" do
+          it "returns a 404" do
+            get "/projects/all/opening/confirmed/1"
+            expect(response).to have_http_status(:not_found)
+          end
         end
 
-        allow(EstablishmentsFetcherService).to receive(:new).and_return(mock_establishments_fetcher)
-        allow(TrustsFetcherService).to receive(:new).and_return(mock_trusts_fetcher)
-      end
-
-      let(:mock_establishments_fetcher) { double(EstablishmentsFetcherService, call!: true) }
-      let(:mock_trusts_fetcher) { double(TrustsFetcherService, call!: true) }
-
-      it "shows a page title with the month & year" do
-        get confirmed_all_opening_projects_path(1, 2022)
-        expect(response.body).to include("Academies opening in January 2022")
-      end
-
-      it "returns project details in table form" do
-        conversion_project = create(:conversion_project, conversion_date: Date.new(2022, 1, 1), conversion_date_provisional: false)
-        get confirmed_all_opening_projects_path(1, 2022)
-        expect(response.body).to include(
-          conversion_project.establishment.name,
-          conversion_project.urn.to_s,
-          I18n.t("project.openers.route.#{conversion_project.route}")
-        )
-      end
-
-      it "only returns projects whose confirmed conversion date is in that month & year" do
-        project_in_scope = create(:conversion_project, urn: 100001, conversion_date: Date.new(2022, 1, 1), conversion_date_provisional: false)
-        project_not_in_scope = create(:conversion_project, urn: 100002, conversion_date: Date.new(2022, 2, 1), conversion_date_provisional: false)
-
-        get confirmed_all_opening_projects_path(1, 2022)
-        expect(response.body).to include(project_in_scope.urn.to_s)
-        expect(response.body).to_not include(project_not_in_scope.urn.to_s)
-      end
-
-      context "when there are no academies opening in that month & year" do
-        it "shows a helpful message" do
-          get confirmed_all_opening_projects_path(1, 2022)
-          expect(response.body).to include("There are currently no schools expected to become academies in January 2022")
+        context "when the month isn't in the scope 1..12" do
+          it "returns a 404" do
+            get "/projects/all/opening/confirmed/13/2022"
+            expect(response).to have_http_status(:not_found)
+          end
         end
+
+        context "when the year isn't in the scope 2000-2499" do
+          it "returns a 404" do
+            get "/projects/all/opening/confirmed/12/2555"
+            expect(response).to have_http_status(:not_found)
+          end
+        end
+
+        context "when the month and year are present and in scope" do
+          before do
+            (100001..100002).each do |urn|
+              mock_successful_api_responses(urn: urn, ukprn: 10061021)
+            end
+
+            allow(EstablishmentsFetcherService).to receive(:new).and_return(mock_establishments_fetcher)
+            allow(TrustsFetcherService).to receive(:new).and_return(mock_trusts_fetcher)
+          end
+
+          let(:mock_establishments_fetcher) { double(EstablishmentsFetcherService, call!: true) }
+          let(:mock_trusts_fetcher) { double(TrustsFetcherService, call!: true) }
+
+          it "shows a page title with the month & year" do
+            get "/projects/all/opening/confirmed/1/2022"
+
+            expect(response.body).to include("Academies opening in January 2022")
+          end
+
+          it "returns project details in table form" do
+            conversion_project = create(:conversion_project, conversion_date: Date.new(2022, 1, 1), conversion_date_provisional: false)
+            get "/projects/all/opening/confirmed/1/2022"
+
+            expect(response.body).to include(
+              conversion_project.establishment.name,
+              conversion_project.urn.to_s,
+              I18n.t("project.openers.route.#{conversion_project.route}")
+            )
+          end
+
+          it "only returns projects whose confirmed conversion date is in that month & year" do
+            project_in_scope = create(:conversion_project, urn: 100001, conversion_date: Date.new(2022, 1, 1), conversion_date_provisional: false)
+            project_not_in_scope = create(:conversion_project, urn: 100002, conversion_date: Date.new(2022, 2, 1), conversion_date_provisional: false)
+
+            get "/projects/all/opening/confirmed/1/2022"
+
+            expect(response.body).to include(project_in_scope.urn.to_s)
+            expect(response.body).to_not include(project_not_in_scope.urn.to_s)
+          end
+
+          context "when there are no academies opening in that month & year" do
+            it "shows a helpful message" do
+              get "/projects/all/opening/confirmed/1/2022"
+
+              expect(response.body).to include("There are currently no schools expected to become academies in January 2022")
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "#revised_next_month" do
+    it "redirects to next month" do
+      get revised_all_opening_projects_path
+      follow_redirect!
+
+      expect(response).to have_http_status(:success)
+      expect(request.params.fetch(:month)).to eq Date.today.next_month.month.to_s
+      expect(request.params.fetch(:year)).to eq Date.today.next_month.year.to_s
+
+      travel_to Date.today + 2.months do
+        get revised_all_opening_projects_path
+        follow_redirect!
+
+        expect(response).to have_http_status(:success)
+        expect(request.params.fetch(:month)).to eq Date.today.next_month.month.to_s
+        expect(request.params.fetch(:year)).to eq Date.today.next_month.year.to_s
       end
     end
   end


### PR DESCRIPTION
Previously we used a default set of parameters in the routes file, but
this was only called once during Rails initialisation (we think) and so
was locked to a single month the application was deplyed.

Here we switch to a redirect based on the current month and year, me
moved the path helpers as we don't actually use the specific month and
year paths excpet from the redirect.

https://trello.com/c/sCpYdjeR