### PR TITLE
Enforce date ordering in Project index pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Allow CSV export to go ahead when a school's parliamentary constituency is
   unclear
+- Fix date ordering on project index pages
 
 ## [Release 31][release-31]
 

--- a/app/controllers/all/completed/projects_controller.rb
+++ b/app/controllers/all/completed/projects_controller.rb
@@ -4,7 +4,7 @@ class All::Completed::ProjectsController < ApplicationController
 
   def index
     authorize Project, :index?
-    @pager, @projects = pagy(Project.completed)
+    @pager, @projects = pagy(Conversion::Project.completed)
 
     pre_fetch_establishments(@projects)
     pre_fetch_incoming_trusts(@projects)

--- a/app/controllers/all/in_progress/projects_controller.rb
+++ b/app/controllers/all/in_progress/projects_controller.rb
@@ -4,7 +4,7 @@ class All::InProgress::ProjectsController < ApplicationController
 
   def index
     authorize Project, :index?
-    @pager, @projects = pagy(Project.in_progress.includes(:assigned_to))
+    @pager, @projects = pagy(Conversion::Project.in_progress.includes(:assigned_to))
   end
 
   def voluntary

--- a/app/controllers/user/projects_controller.rb
+++ b/app/controllers/user/projects_controller.rb
@@ -4,7 +4,7 @@ class User::ProjectsController < ApplicationController
 
   def in_progress
     authorize Project, :index?
-    @pager, @projects = pagy(Project.assigned_to(current_user).in_progress.includes(:assigned_to), items: 10)
+    @pager, @projects = pagy(Conversion::Project.assigned_to(current_user).in_progress.includes(:assigned_to), items: 10)
 
     pre_fetch_establishments(@projects)
     pre_fetch_incoming_trusts(@projects)
@@ -20,7 +20,7 @@ class User::ProjectsController < ApplicationController
 
   def completed
     authorize Project, :index?
-    @pager, @projects = pagy(Project.assigned_to(current_user).completed)
+    @pager, @projects = pagy(Conversion::Project.assigned_to(current_user).completed)
 
     pre_fetch_establishments(@projects)
     pre_fetch_incoming_trusts(@projects)

--- a/spec/features/projects/users_can_view_a_list_of_assigned_projects_spec.rb
+++ b/spec/features/projects/users_can_view_a_list_of_assigned_projects_spec.rb
@@ -30,7 +30,8 @@ RSpec.feature "Viewing assigned projects" do
   end
 
   context "when there are projects" do
-    let!(:in_progress_assigned_project) { create(:conversion_project, urn: 103835, assigned_to: user) }
+    let!(:in_progress_assigned_project) { create(:conversion_project, urn: 103835, assigned_to: user, conversion_date: (Date.today + 1.month).at_beginning_of_month) }
+    let!(:in_progress_assigned_project_next_year) { create(:conversion_project, urn: 103835, assigned_to: user, conversion_date: (Date.today + 1.year).at_beginning_of_month) }
     let!(:completed_assigned_project) { create(:conversion_project, urn: 114067, assigned_to: user, completed_at: Date.yesterday) }
 
     context "when signed in as a Regional caseworker" do
@@ -83,6 +84,9 @@ RSpec.feature "Viewing assigned projects" do
 
         expect(page).not_to have_content(completed_other_user_project.urn)
         expect(page).not_to have_content(completed_unassigned_project.urn)
+
+        expect(page.find("h2.govuk-heading-m:first-of-type").text).to eq((Date.today + 1.month).at_beginning_of_month.strftime("%B %Y openers"))
+        expect(page.find("h2.govuk-heading-m:last-of-type").text).to eq((Date.today + 1.year).at_beginning_of_month.strftime("%B %Y openers"))
       end
     end
 


### PR DESCRIPTION


## Changes

We recently moved the `conversion_date` attribute onto Conversion::Project, and as a result any Project index pages using plain Project objects lost the expected date ordering.

Make all the project index pages use Conversion::Project, and add a test to make sure the date ordering is working as expected.

TODO: Figure out how these controllers will work when we have more than one project type.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
