### PR TITLE
Always use 'development' build flag

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -65,7 +65,7 @@ jobs:
           context: .
           file: ./Dockerfile
           build-args: |
-            RAILS_ENV=${{ needs.set-env.outputs.environment }}
+            RAILS_ENV=development
           tags: |
             ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.branch }}
             ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:sha-${{ needs.set-env.outputs.checked-out-sha }}


### PR DESCRIPTION
the `RAILS_ENV` needs to be set to `development` during the build. This is then overridden at runtime by the appropriate value based on the environment it is deployed into.