### PR TITLE
Collect a users team if they do not have one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- If your user account is not assigned to a team, you will be asked to choose
+  one next time you sign in to the application.
+
 ### Changed
 
 ### Fixed

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,6 +8,8 @@ class SessionsController < ApplicationController
     if registered_user
       create_session
 
+      return redirect_to users_team_path if current_user.team.nil?
+
       redirect_to root_path
     else
       redirect_to sign_in_path, alert: I18n.t("unknown_user.message", email_address: authenticated_user_email_address)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,6 +44,24 @@ class UsersController < ApplicationController
     end
   end
 
+  def set_team
+    @user = current_user
+    authorize @user
+  end
+
+  def update_team
+    @user = current_user
+    authorize @user
+
+    @user.assign_attributes(team_params)
+    if @user.valid?
+      @user.save!(context: :set_team)
+      redirect_to root_path, notice: I18n.t("user.set_team.success", email: @user.email)
+    else
+      render :set_team
+    end
+  end
+
   private def user_params
     params.require(:user).permit(
       :first_name,
@@ -56,5 +74,9 @@ class UsersController < ApplicationController
 
   private def user_id
     params[:id]
+  end
+
+  private def team_params
+    params.require(:user).permit(:team)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ApplicationRecord
   scope :all_assignable_users, -> { where.not(caseworker: false).or(where.not(team_leader: false)).or(where.not(regional_delivery_officer: false)) }
 
   validates :first_name, :last_name, :email, :team, presence: true
+  validates :team, presence: true, on: :set_team
   validates :email, uniqueness: {case_sensitive: false}
   validates :email, format: {with: /\A\S+@education.gov.uk\z/}
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -25,4 +25,12 @@ class UserPolicy
   def update?
     index?
   end
+
+  def set_team?
+    @user == @user_account
+  end
+
+  def update_team?
+    set_team?
+  end
 end

--- a/app/views/users/_users_table.html.erb
+++ b/app/views/users/_users_table.html.erb
@@ -14,7 +14,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__header govuk-table__cell"><%= account.full_name %></td>
       <td class="govuk-table__cell"><%= account.email %></td>
-      <td class="govuk-table__cell"><%= t("user.teams.#{account.team}") %></td>
+      <td class="govuk-table__cell"><%= t("user.teams.#{account.team}") || "None" %></td>
       <td class="govuk-table__cell"><%= t("user.table.body.team_lead.#{account.team_leader}") %></td>
         <td class="govuk-table__cell">
           <%= link_to t("user.table.body.edit_user_html", user: account.full_name), edit_user_path(account) %>

--- a/app/views/users/set_team.html.erb
+++ b/app/views/users/set_team.html.erb
@@ -1,0 +1,19 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t("user.set_team.title") %></h1>
+    <%= t("user.set_team.hint_html") %>
+
+    <%= form_with model: @user, url: users_team_path, method: :post do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_collection_radio_buttons :team,
+            @user.team_options,
+            :id,
+            :name,
+            legend: {text: t("user.set_team.team.label")},
+            hint: {text: t("user.set_team.team.hint")} %>
+
+      <%= form.govuk_submit t("user.set_team.save.button") %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/user.en.yml
+++ b/config/locales/user.en.yml
@@ -19,6 +19,17 @@ en:
       cancel:
         button: Cancel
       success: User %{email} updated successfully
+    set_team:
+      title: Which team do you work in?
+      hint_html:
+        <p>Choose the team most relevant to the work you do.</p>
+        <p>Contact the service support team if you feel you do not have an option.</p>
+      team:
+        label: Choose your team
+        hint: All users must belong to one of the following teams.
+      save: 
+        button: Save team
+      success: The team for %{email} has been set successfully
     title: Users
     table:
       caption: Table of users
@@ -43,10 +54,10 @@ en:
       north_east: North East
       south_west: South West
       east_midlands: East Midlands
-      regional_casework_services: Regional Casework Services (RCS)
+      regional_casework_services: RCS (Regional Casework Services)
       service_support: Service Support
-      academies_operational_practice_unit: Academies Operational Practice Unit (AOPU)
-      education_and_skills_funding_agency: Education and Skills Funding Agency (ESFA)
+      academies_operational_practice_unit: AOPU (Academies Operational Practice Unit)
+      education_and_skills_funding_agency: ESFA (Education and Skills Funding Agency)
   helpers:
     legend:
       user:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,6 +162,8 @@ Rails.application.routes.draw do
   end
 
   resources :users, only: %w[index new create edit update]
+  get "users/team", to: "users#set_team"
+  post "users/team", to: "users#update_team"
 
   # Defines the root path route ("/")
   root "root#home"

--- a/spec/features/users/user_with_no_team_spec.rb
+++ b/spec/features/users/user_with_no_team_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.feature "Users with no team set" do
+  scenario "are asked to provide one" do
+    user = User.new(
+      first_name: "First",
+      last_name: "Last",
+      email: "first.last@education.gov.uk",
+      team: nil
+    )
+    user.save(validate: false)
+
+    sign_in_with_user(user)
+
+    expect(page).to have_content("Choose the team most relevant to the work you do.")
+
+    choose "North East"
+    click_on "Save team"
+
+    expect(page).to have_content("Success")
+    expect(user.reload.team).to eq "north_east"
+  end
+
+  scenario "they cannot submit no team" do
+    user = User.new(
+      first_name: "First",
+      last_name: "Last",
+      email: "first.last@education.gov.uk",
+      team: nil
+    )
+    user.save(validate: false)
+
+    sign_in_with_user(user)
+
+    click_on "Save team"
+
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Choose a team")
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe User do
       expect(options.first.id).to eql "london"
       expect(options.first.name).to eql "London"
       expect(options.last.id).to eql "education_and_skills_funding_agency"
-      expect(options.last.name).to eql "Education and Skills Funding Agency (ESFA)"
+      expect(options.last.name).to eql "ESFA (Education and Skills Funding Agency)"
     end
   end
 


### PR DESCRIPTION
We have added team to users and have a bunch that we do not know the
value for now.

Here we ask users who have `team: nil` to provide it when their
session is created.

We also updated the team names in line with the RSD content guidelines.

https://trello.com/c/VxmMww9q

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/9c420886-f7a1-4235-9348-b12c7e216f48)