### PR TITLE
Show team on by users view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - If your user account is not assigned to a team, you will be asked to choose
   one next time you sign in to the application.
+- The team a user is associated with is now shown on the All projects, by team
+  view.
 
 ### Changed
 

--- a/app/services/by_user_project_fetcher_service.rb
+++ b/app/services/by_user_project_fetcher_service.rb
@@ -20,6 +20,7 @@ class ByUserProjectFetcherService
       OpenStruct.new(
         name: user.full_name,
         email: user.email,
+        team: user.team,
         id: user.id,
         conversion_count: conversion_counts.fetch(user.id)
       )

--- a/app/views/all/users/projects/_users_table.html.erb
+++ b/app/views/all/users/projects/_users_table.html.erb
@@ -7,18 +7,20 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.user") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.email") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.team") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_count") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view_projects") %></th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-    <% users.each do |trust| %>
+    <% users.each do |user| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__header govuk-table__cell"><%= trust.name %></td>
-        <td class="govuk-table__cell"><%= trust.email %></td>
-        <td class="govuk-table__cell"><%= trust.conversion_count %></td>
+        <td class="govuk-table__header govuk-table__cell"><%= user.name %></td>
+        <td class="govuk-table__cell"><%= user.email %></td>
+        <td class="govuk-table__cell"><%= user.team.nil? ? "No team" : t("user.teams.#{user.team}") %></td>
+        <td class="govuk-table__cell"><%= user.conversion_count %></td>
         <td class="govuk-table__cell">
-          <%= link_to t("project.table.body.view_projects_for_html", entity: trust.name), by_user_all_users_projects_path(trust.id) %>
+          <%= link_to t("project.table.body.view_projects_for_html", entity: user.name), by_user_all_users_projects_path(user.id) %>
         </td>
     <% end %>
     </tbody>

--- a/spec/features/projects/users/users_can_view_projects_by_user_spec.rb
+++ b/spec/features/projects/users/users_can_view_projects_by_user_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Users can view a list users" do
     mock_all_academies_api_responses
   end
 
-  let(:user) { create(:user, email: "user@education.gov.uk") }
+  let(:user) { create(:user, email: "user@education.gov.uk", team: :london) }
 
   context "when there are no projects to fetch users for" do
     scenario "they see an empty message" do
@@ -24,6 +24,7 @@ RSpec.feature "Users can view a list users" do
 
       within("tbody > tr:first-child") do
         expect(page).to have_content(user.full_name)
+        expect(page).to have_content("London")
         expect(page).to have_content("1")
         expect(page).to have_link("View projects", href: by_user_all_users_projects_path(user))
       end

--- a/spec/services/by_user_project_fetcher_service_spec.rb
+++ b/spec/services/by_user_project_fetcher_service_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe ByUserProjectFetcherService do
   it "returns a sorted list of simple user objects with projects" do
     mock_successful_api_response_to_create_any_project
 
-    user = create(:user, first_name: "A", last_name: "User", email: "a.user@education.gov.uk")
-    another_user = create(:user, first_name: "B", last_name: "User", email: "b.user@education.gov.uk")
-    yet_another_user = create(:user, first_name: "C", last_name: "User", email: "c.user@education.gov.uk")
+    user = create(:user, first_name: "A", last_name: "User", email: "a.user@education.gov.uk", team: :london)
+    another_user = create(:user, first_name: "B", last_name: "User", email: "b.user@education.gov.uk", team: :north_west)
+    yet_another_user = create(:user, first_name: "C", last_name: "User", email: "c.user@education.gov.uk", team: :service_support)
 
     create(:conversion_project, urn: 121813, assigned_to: user)
     create(:conversion_project, urn: 121102, assigned_to: user)
@@ -21,11 +21,13 @@ RSpec.describe ByUserProjectFetcherService do
     first_result = result.first
 
     expect(first_result.name).to eql "A User"
+    expect(first_result.team).to eql "london"
     expect(first_result.conversion_count).to eql 2
 
     last_result = result.last
 
     expect(last_result.name).to eql "C User"
+    expect(last_result.team).to eql "service_support"
     expect(last_result.conversion_count).to eql 1
   end
 


### PR DESCRIPTION
When viewing all users, it is helpful to know which team a user is
associtated with.

To achieve this we had to update the ByUserProjectFetcherService to
include `team`.

https://trello.com/c/geXJm8K9

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/12ea85f2-f5c9-4d78-8a76-199a1d0f4361)
