### PR TITLE
Dynamic team projects view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The application now uses the DfE Design System header, footer and buttons.
 - Change the Team projects views to only show projects aligned to the user's
   team
+- Only team leaders can see the Unassigned projects page in the Team projects
+  view
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   team
 - Only team leaders can see the Unassigned projects page in the Team projects
   view
+- All users with a role and a team can now view the Team projects view
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Dates in csv exports are now formated as YYYY-MM-DD.
 - The application now uses the DfE Design System fonts.
 - The application now uses the DfE Design System header, footer and buttons.
+- Change the Team projects views to only show projects aligned to the user's
+  team
 
 ### Fixed
 

--- a/app/controllers/team/projects_controller.rb
+++ b/app/controllers/team/projects_controller.rb
@@ -4,33 +4,17 @@ class Team::ProjectsController < ApplicationController
 
   def in_progress
     authorize Project, :index?
-    @pager, @projects = pagy(Project.assigned_to_regional_caseworker_team.in_progress.includes(:assigned_to))
-
-    pre_fetch_establishments(@projects)
-    pre_fetch_incoming_trusts(@projects)
+    @pager, @projects = pagy_array(ByTeamProjectFetcherService.new(current_user.team).in_progress)
   end
 
   def completed
     authorize Project, :index?
-    @pager, @projects = pagy(Project.assigned_to_regional_caseworker_team.completed)
-
-    pre_fetch_establishments(@projects)
-    pre_fetch_incoming_trusts(@projects)
+    @pager, @projects = pagy_array(ByTeamProjectFetcherService.new(current_user.team).completed)
   end
 
   def unassigned
-    authorize Project, :index?
-    @pagy, @projects = pagy(Project.assigned_to_regional_caseworker_team.unassigned_to_user)
+    authorize Project, :unassigned?
 
-    pre_fetch_establishments(@projects)
-    pre_fetch_incoming_trusts(@projects)
-  end
-
-  private def pre_fetch_establishments(projects)
-    EstablishmentsFetcherService.new(projects).call!
-  end
-
-  private def pre_fetch_incoming_trusts(projects)
-    TrustsFetcherService.new(projects).call!
+    @pagy, @projects = pagy_array(ByTeamProjectFetcherService.new(current_user.team).unassigned)
   end
 end

--- a/app/policies/navigation_policy.rb
+++ b/app/policies/navigation_policy.rb
@@ -21,7 +21,8 @@ class NavigationPolicy
   end
 
   def show_team_projects_header_navigation?
-    return true if @user.team_leader?
+    return false unless @user.has_role?
+    return true unless @user.team.nil?
 
     false
   end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -72,6 +72,10 @@ class ProjectPolicy
     edit_project_closed?
   end
 
+  def unassigned?
+    @user.team_leader?
+  end
+
   private def project_assigned_to_user?
     @record.assigned_to == @user
   end

--- a/app/services/by_team_project_fetcher_service.rb
+++ b/app/services/by_team_project_fetcher_service.rb
@@ -1,0 +1,46 @@
+class ByTeamProjectFetcherService
+  def initialize(team)
+    @team = team
+  end
+
+  def in_progress
+    return [] if @team.nil?
+
+    projects = if @team.eql?("regional_casework_services")
+      Conversion::Project.assigned_to_regional_caseworker_team.in_progress.includes(:assigned_to).by_conversion_date
+    else
+      Conversion::Project.by_region(@team).in_progress.includes(:assigned_to).by_conversion_date
+    end
+    pre_fetch_establishments_and_trusts(projects)
+  end
+
+  def completed
+    return [] if @team.nil?
+
+    projects = if @team.eql?("regional_casework_services")
+      Conversion::Project.assigned_to_regional_caseworker_team.completed.by_conversion_date
+    else
+      Conversion::Project.by_region(@team).completed.by_conversion_date
+    end
+
+    pre_fetch_establishments_and_trusts(projects)
+  end
+
+  def unassigned
+    return [] if @team.nil?
+
+    projects = if @team.eql?("regional_casework_services")
+      Conversion::Project.assigned_to_regional_caseworker_team.unassigned_to_user.by_conversion_date
+    else
+      Conversion::Project.by_region(@team).unassigned_to_user.by_conversion_date
+    end
+
+    pre_fetch_establishments_and_trusts(projects)
+  end
+
+  private def pre_fetch_establishments_and_trusts(projects)
+    EstablishmentsFetcherService.new(projects).call!
+    TrustsFetcherService.new(projects).call!
+    projects
+  end
+end

--- a/app/views/shared/navigation/_dfe_header_navigation.html.erb
+++ b/app/views/shared/navigation/_dfe_header_navigation.html.erb
@@ -17,7 +17,7 @@
 
             <%= if policy(:navigation).show_team_projects_header_navigation?
                   render partial: "shared/navigation/dfe_header_navigation_item",
-                    locals: {title: t("navigation.header.team_projects"), path: unassigned_team_projects_path, namespace: "/projects/team/"}
+                    locals: {title: t("navigation.header.team_projects"), path: (current_user.team_leader? ? unassigned_team_projects_path : in_progress_team_projects_path), namespace: "/projects/team/"}
                 end %>
 
             <%= if policy(:navigation).show_all_projects_header_navigation?

--- a/app/views/shared/navigation/_team_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_team_projects_primary_navigation.html.erb
@@ -7,7 +7,7 @@
       <nav class="moj-primary-navigation" aria-label="Primary navigation">
         <ul class="moj-primary-navigation__list">
 
-          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.unassigned"), path: unassigned_team_projects_path, namespace: "/projects/team/unassigned"} %>
+          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.unassigned"), path: unassigned_team_projects_path, namespace: "/projects/team/unassigned"} if policy(Project).unassigned? %>
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.in_progress"), path: in_progress_team_projects_path, namespace: "/projects/team/in-progress"} %>
 

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -48,7 +48,7 @@ en:
       completed:
         title: Completed
       unassigned:
-        title: Unasssigned
+        title: Unassigned
     regional:
       in_progress:
         title: Regional projects in progress

--- a/spec/features/projects/users_can_view_a_list_of_regional_casework_services_projects_spec.rb
+++ b/spec/features/projects/users_can_view_a_list_of_regional_casework_services_projects_spec.rb
@@ -21,4 +21,40 @@ RSpec.feature "Viewing regional casework services projects" do
       expect(page).to have_content(I18n.t("project.table.unassigned.empty"))
     end
   end
+
+  context "navigation" do
+    before do
+      sign_in_with_user(user)
+    end
+
+    context "when the user is a team_leader" do
+      let(:user) { create(:user, :team_leader) }
+
+      scenario "they can see a link to the unassigned projects page" do
+        visit in_progress_team_projects_path
+
+        expect(page.find("nav.moj-primary-navigation")).to have_content "Unassigned"
+      end
+    end
+
+    context "when the user is a regional delivery officer" do
+      let(:user) { create(:user, :regional_delivery_officer) }
+
+      scenario "they can NOT see a link to the unassigned projects page" do
+        visit in_progress_team_projects_path
+
+        expect(page.find("nav.moj-primary-navigation")).to_not have_content "Unassigned"
+      end
+    end
+
+    context "when the user is a caseworker" do
+      let(:user) { create(:user, :caseworker) }
+
+      scenario "they can NOT see a link to the unassigned projects page" do
+        visit in_progress_team_projects_path
+
+        expect(page.find("nav.moj-primary-navigation")).to_not have_content "Unassigned"
+      end
+    end
+  end
 end

--- a/spec/features/projects/users_can_view_a_list_of_regional_casework_services_projects_spec.rb
+++ b/spec/features/projects/users_can_view_a_list_of_regional_casework_services_projects_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Viewing regional casework services projects" do
   context "when there are no projects" do
     before do
-      user = create(:user, :caseworker)
+      user = create(:user, :team_leader)
       sign_in_with_user(user)
     end
 
@@ -19,112 +19,6 @@ RSpec.feature "Viewing regional casework services projects" do
       visit unassigned_team_projects_path
 
       expect(page).to have_content(I18n.t("project.table.unassigned.empty"))
-    end
-  end
-
-  context "when there are projects" do
-    before do
-      sign_in_with_user(user)
-      mock_successful_api_response_to_create_any_project
-      mock_pre_fetched_api_responses_for_any_establishment_and_trust
-    end
-
-    let!(:completed_regional_project) { create(:conversion_project, urn: 126041, team: "london", completed_at: Date.yesterday) }
-    let!(:in_progress_regional_project) { create(:conversion_project, urn: 126041, team: "london", assigned_to: user) }
-
-    let!(:completed_project) { create(:conversion_project, urn: 121583, completed_at: Date.yesterday, team: "regional_casework_services", assigned_to: user) }
-    let!(:in_progress_project) { create(:conversion_project, urn: 115652, team: "regional_casework_services", assigned_to: user) }
-
-    let!(:unassigned_project) { create(:conversion_project, urn: 103835, team: "regional_casework_services", assigned_to: nil) }
-
-    context "when signed in as a Regional caseworker" do
-      let(:user) { create(:user, :caseworker) }
-
-      scenario "they can view all in progress projects" do
-        view_in_progress_projects
-      end
-
-      scenario "they can view all in progress projects" do
-        view_completed_projects
-      end
-
-      scenario "they can view unassigned projects" do
-        view_unassigned_projects
-      end
-    end
-
-    context "when signed in as a Regional caseworker team lead" do
-      let(:user) { create(:user, :team_leader) }
-
-      scenario "they can view all in progress projects" do
-        view_in_progress_projects
-      end
-
-      scenario "they can view all in progress projects" do
-        view_completed_projects
-      end
-
-      scenario "they can view unassigned projects" do
-        view_unassigned_projects
-      end
-    end
-
-    context "when signed in as a Regional delivery officer" do
-      let(:user) { create(:user, :regional_delivery_officer) }
-
-      scenario "they can view all in progress projects" do
-        view_in_progress_projects
-      end
-
-      scenario "they can view all in progress projects" do
-        view_completed_projects
-      end
-
-      scenario "they can view unassigned projects" do
-        view_unassigned_projects
-      end
-    end
-
-    def view_in_progress_projects
-      visit in_progress_team_projects_path
-
-      expect(page).to have_content(I18n.t("project.team.in_progress.title"))
-
-      within("tbody") do
-        expect(page).to have_content(in_progress_project.urn)
-        expect(page).not_to have_content(in_progress_regional_project.urn)
-
-        expect(page).not_to have_content(completed_project.urn)
-        expect(page).not_to have_content(completed_regional_project.urn)
-      end
-    end
-
-    def view_completed_projects
-      visit completed_team_projects_path
-
-      expect(page).to have_content(I18n.t("project.team.completed.title"))
-
-      within("tbody") do
-        expect(page).to have_content(completed_project.urn)
-        expect(page).not_to have_content(completed_regional_project.urn)
-
-        expect(page).not_to have_content(in_progress_project.urn)
-        expect(page).not_to have_content(in_progress_regional_project.urn)
-      end
-    end
-
-    def view_unassigned_projects
-      visit unassigned_team_projects_path
-
-      expect(page).to have_content(I18n.t("project.team.unassigned.title"))
-
-      within("tbody") do
-        expect(page).not_to have_content(completed_project.urn)
-        expect(page).not_to have_content(completed_regional_project.urn)
-
-        expect(page).not_to have_content(in_progress_project.urn)
-        expect(page).not_to have_content(in_progress_regional_project.urn)
-      end
     end
   end
 end

--- a/spec/features/projects/users_can_view_a_list_of_regional_casework_services_projects_spec.rb
+++ b/spec/features/projects/users_can_view_a_list_of_regional_casework_services_projects_spec.rb
@@ -35,6 +35,14 @@ RSpec.feature "Viewing regional casework services projects" do
 
         expect(page.find("nav.moj-primary-navigation")).to have_content "Unassigned"
       end
+
+      scenario "the Team projects link leads to the unassigned page" do
+        visit root_path
+
+        click_on "Team projects"
+
+        expect(page.find("h1")).to have_content("Unassigned")
+      end
     end
 
     context "when the user is a regional delivery officer" do
@@ -45,6 +53,14 @@ RSpec.feature "Viewing regional casework services projects" do
 
         expect(page.find("nav.moj-primary-navigation")).to_not have_content "Unassigned"
       end
+
+      scenario "the Team projects link leads to the in-progress page" do
+        visit root_path
+
+        click_on "Team projects"
+
+        expect(page.find("h1")).to have_content("In progress")
+      end
     end
 
     context "when the user is a caseworker" do
@@ -54,6 +70,14 @@ RSpec.feature "Viewing regional casework services projects" do
         visit in_progress_team_projects_path
 
         expect(page.find("nav.moj-primary-navigation")).to_not have_content "Unassigned"
+      end
+
+      scenario "the Team projects link leads to the in-progress page" do
+        visit root_path
+
+        click_on "Team projects"
+
+        expect(page.find("h1")).to have_content("In progress")
       end
     end
   end

--- a/spec/features/users_can_assign_a_user_to_a_project_spec.rb
+++ b/spec/features/users_can_assign_a_user_to_a_project_spec.rb
@@ -17,8 +17,8 @@ RSpec.feature "Any user can assign any other user to a project" do
       assign_user_from_internal_contacts
     end
 
-    scenario "they can assign a user from the unassigned projects view" do
-      assign_user_from_unassigned_projects
+    scenario "they can NOT assign a user from the unassigned projects view" do
+      cannot_assign_user_from_unassigned_projects
     end
   end
 
@@ -41,8 +41,8 @@ RSpec.feature "Any user can assign any other user to a project" do
       assign_user_from_internal_contacts
     end
 
-    scenario "they can assign a user from the unassigned projects view" do
-      assign_user_from_unassigned_projects
+    scenario "they can NOT assign a user from the unassigned projects view" do
+      cannot_assign_user_from_unassigned_projects
     end
   end
 
@@ -72,5 +72,10 @@ RSpec.feature "Any user can assign any other user to a project" do
     expect(page).to have_content("Project has been assigned successfully")
     expect(page).to have_current_path(unassigned_team_projects_path)
     expect(project.reload.assigned_to).to eql another_user
+  end
+
+  def cannot_assign_user_from_unassigned_projects
+    visit unassigned_team_projects_path
+    expect(page).to have_content(I18n.t("unauthorised_action.message"))
   end
 end

--- a/spec/policies/navigation_policy_spec.rb
+++ b/spec/policies/navigation_policy_spec.rb
@@ -61,14 +61,19 @@ RSpec.describe NavigationPolicy do
       expect(described_class).not_to permit(user)
     end
 
-    it "does not permit for a user that has the caseworker role" do
-      user = build(:user, :caseworker)
+    it "does not permit a user that has no team" do
+      user = build(:user, :caseworker, team: nil)
       expect(described_class).not_to permit(user)
     end
 
-    it "does not permit for a user that has the regional delivery officer role" do
+    it "permits for a user that has the caseworker role" do
+      user = build(:user, :caseworker)
+      expect(described_class).to permit(user)
+    end
+
+    it "permits for a user that has the regional delivery officer role" do
       user = build(:user, :regional_delivery_officer)
-      expect(described_class).not_to permit(user)
+      expect(described_class).to permit(user)
     end
 
     it "permits for a user that has the regional casework services team lead role" do

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -116,4 +116,11 @@ RSpec.describe ProjectPolicy do
       expect(subject).not_to permit(application_user, project)
     end
   end
+
+  permissions :unassigned? do
+    it "denies access to anyone who is not a team leader" do
+      expect(subject).to permit(build(:user, :team_leader))
+      expect(subject).to_not permit(application_user)
+    end
+  end
 end

--- a/spec/services/by_team_project_fetcher_service_spec.rb
+++ b/spec/services/by_team_project_fetcher_service_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe ByTeamProjectFetcherService do
+  before { mock_successful_api_response_to_create_any_project }
+
+  describe "#in_progress" do
+    let(:project_rcs) { create(:conversion_project, team: "regional_casework_services", region: "north_east", conversion_date: Date.today.at_beginning_of_month) }
+    let(:project_london) { create(:conversion_project, team: "regional_casework_services", region: "london") }
+
+    context "when the user is in the 'regional_casework_services' team" do
+      let(:project_rcs_2) { create(:conversion_project, team: "regional_casework_services", region: "north_east", conversion_date: (Date.today + 1.month).at_beginning_of_month) }
+
+      it "returns all projects where the project's team is regional_casework_services" do
+        user = build(:user, team: "regional_casework_services")
+
+        result = described_class.new(user.team).in_progress
+        expect(result).to include(project_rcs, project_london)
+      end
+
+      it "orders projects by conversion date" do
+        user = build(:user, team: "regional_casework_services")
+
+        result = described_class.new(user.team).in_progress
+        expect(result).to eq([project_rcs, project_rcs_2])
+      end
+    end
+
+    context "when the user's team is a region" do
+      it "returns all projects where the project's region is the same as the user's team" do
+        user = build(:user, team: "london")
+
+        result = described_class.new(user.team).in_progress
+        expect(result).to include(project_london)
+        expect(result).to_not include(project_rcs)
+      end
+    end
+
+    it "returns an empty array when the user's team is nil" do
+      user = build(:user, team: nil)
+      expect(described_class.new(user.team).in_progress).to eq([])
+    end
+
+    it "returns an empty array when the user's team is not RCS or a region" do
+      user = create(:user, team: "service_support")
+      expect(described_class.new(user.team).in_progress).to eq([])
+    end
+  end
+
+  describe "#completed" do
+    let(:project_rcs) { create(:conversion_project, team: "regional_casework_services", region: "north_east", completed_at: Date.yesterday) }
+    let(:project_london) { create(:conversion_project, team: "regional_casework_services", region: "london", completed_at: Date.yesterday) }
+
+    context "when the user is in the 'regional_casework_services' team" do
+      it "returns all completed projects where the project's team is regional_casework_services" do
+        user = build(:user, team: "regional_casework_services")
+
+        result = described_class.new(user.team).completed
+        expect(result).to include(project_rcs, project_london)
+      end
+    end
+
+    context "when the user's team is a region" do
+      it "returns all projects where the project's region is the same as the user's team" do
+        user = build(:user, team: "london")
+
+        result = described_class.new(user.team).completed
+        expect(result).to include(project_london)
+        expect(result).to_not include(project_rcs)
+      end
+    end
+
+    it "returns an empty array when the user's team is nil" do
+      user = build(:user, team: nil)
+      expect(described_class.new(user.team).completed).to eq([])
+    end
+  end
+
+  describe "#unassigned" do
+    let(:project_rcs) { create(:conversion_project, team: "regional_casework_services", region: "north_east", assigned_to: nil) }
+    let(:project_london) { create(:conversion_project, team: "regional_casework_services", region: "london", assigned_to: nil) }
+
+    context "when the user is in the 'regional_casework_services' team" do
+      it "returns all in-progress projects where the project's team is regional_casework_services" do
+        user = build(:user, team: "regional_casework_services")
+
+        result = described_class.new(user.team).unassigned
+        expect(result).to include(project_rcs, project_london)
+      end
+    end
+
+    context "when the user's team is a region" do
+      it "returns all projects where the project's region is the same as the user's team" do
+        user = build(:user, team: "london")
+
+        result = described_class.new(user.team).unassigned
+        expect(result).to include(project_london)
+        expect(result).to_not include(project_rcs)
+      end
+    end
+
+    it "returns an empty array when the user's team is nil" do
+      user = build(:user, team: nil)
+      expect(described_class.new(user.team).unassigned).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Scope the Team projects views to reflect the current user's team.

If the user's team is `regional_casework_services`, then they see all projects
there the Project.team is `regional_casework_services`

If the user's team is a region, then they see all projects where Project.region
is the same as the user's team (note that it is the project's REGION).

Change the navigation within the Team projects view so that only team_leader
users can view the Unassigned projects view.

All users with a role and a team can now view the Team projects views.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
