### PR TITLE
Send an email when a new account is added

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,7 @@ class UsersController < ApplicationController
 
     if @user.valid?
       @user.save
+      send_new_account_email(@user)
       redirect_to users_path, notice: I18n.t("user.add.success", email: @user.email)
     else
       render :new
@@ -78,5 +79,9 @@ class UsersController < ApplicationController
 
   private def team_params
     params.require(:user).permit(:team)
+  end
+
+  private def send_new_account_email(user)
+    UserAccountMailer.new_account_added(user)
   end
 end

--- a/app/mailers/user_account_mailer.rb
+++ b/app/mailers/user_account_mailer.rb
@@ -1,0 +1,11 @@
+class UserAccountMailer < ApplicationMailer
+  def new_account_added(user)
+    template_mail(
+      "d55de8f1-ce5a-4498-8229-baac7c0ee45f",
+      to: user.email,
+      personalisation: {
+        first_name: user.first_name
+      }
+    )
+  end
+end

--- a/spec/mailers/user_account_mailer_spec.rb
+++ b/spec/mailers/user_account_mailer_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe UserAccountMailer do
+  describe "#new_account_added" do
+    it "sends an email with the correct personalisation" do
+      user = build(:user, first_name: "First", last_name: "Last", email: "first.last@education.gov.uk")
+
+      expect_any_instance_of(Mail::Notify::Mailer)
+        .to receive(:template_mail)
+        .with("d55de8f1-ce5a-4498-8229-baac7c0ee45f", {to: user.email, personalisation: {first_name: "First"}})
+
+      UserAccountMailer.new_account_added(user).deliver_now
+    end
+  end
+end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe UsersController, type: :request do
+  let(:user) { create(:user, :service_support) }
+
+  before { sign_in_with(user) }
+
+  describe "#create" do
+    it "sends the new account added email" do
+      new_user = build(:user, email: "new.user@education.gov.uk", team: :regional_casework_services)
+
+      expect(UserAccountMailer).to receive(:new_account_added).exactly(1).time
+
+      post users_path(user: new_user.attributes)
+    end
+  end
+end


### PR DESCRIPTION
We currently manually send each new users an email when we onboard them.

This work simply automates this process for a consistent experience for
our users.

https://trello.com/c/tRZMvGXn