### PR TITLE
Users can be deactivated and reactivated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   one next time you sign in to the application.
 - The team a user is associated with is now shown on the All projects, by team
   view.
+- User accounts can now be deactivated which prevents the user from accessing
+  the application or from showing up in user selections, inactive accounts can
+  be reactivated.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Only team leaders can see the Unassigned projects page in the Team projects
   view
 - All users with a role and a team can now view the Team projects view
+- The users view is now split into active and inactive user accounts.
 
 ### Fixed
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,9 @@ class SessionsController < ApplicationController
 
       redirect_to root_path
     else
-      redirect_to sign_in_path, alert: I18n.t("unknown_user.message", email_address: authenticated_user_email_address)
+      return redirect_inactive_user if inactive_user?
+
+      redirect_unknown_user
     end
   end
 
@@ -26,7 +28,11 @@ class SessionsController < ApplicationController
   end
 
   private def registered_user
-    @registered_user ||= User.find_by(email: authenticated_user_email_address)
+    @registered_user ||= User.active.find_by(email: authenticated_user_email_address)
+  end
+
+  private def inactive_user?
+    User.inactive.find_by(email: authenticated_user_email_address)
   end
 
   private def create_session
@@ -59,5 +65,13 @@ class SessionsController < ApplicationController
 
   private def authenticated_user_email_address
     authenticated_user_info.email.downcase
+  end
+
+  private def redirect_unknown_user
+    redirect_to sign_in_path, alert: I18n.t("unknown_user.message", email_address: authenticated_user_email_address)
+  end
+
+  private def redirect_inactive_user
+    redirect_to sign_in_path, notice: I18n.t("inactive_user.message", email_address: authenticated_user_email_address)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,10 +2,16 @@ class UsersController < ApplicationController
   after_action :verify_authorized
   rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
 
-  def index
-    authorize User
+  def index_active
+    authorize User, :index?
 
-    @pager, @users = pagy(User.order_by_first_name)
+    @pager, @users = pagy(User.active.order_by_first_name)
+  end
+
+  def index_inactive
+    authorize User, :index?
+
+    @pager, @users = pagy(User.inactive.order_by_first_name)
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -69,7 +69,8 @@ class UsersController < ApplicationController
       :last_name,
       :email,
       :team,
-      :team_leader
+      :team_leader,
+      :active
     )
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,8 +11,10 @@ class User < ApplicationRecord
   scope :team_leaders, -> { where(team_leader: true).order_by_first_name }
   scope :regional_delivery_officers, -> { where(regional_delivery_officer: true).order_by_first_name }
   scope :caseworkers, -> { where(caseworker: true).order_by_first_name }
+  scope :active, -> { where(deactivated_at: nil) }
+  scope :inactive, -> { where.not(deactivated_at: nil) }
 
-  scope :all_assignable_users, -> { where.not(caseworker: false).or(where.not(team_leader: false)).or(where.not(regional_delivery_officer: false)) }
+  scope :all_assignable_users, -> { active.where.not(caseworker: false).or(where.not(team_leader: false)).or(where.not(regional_delivery_officer: false)) }
 
   validates :first_name, :last_name, :email, :team, presence: true
   validates :team, presence: true, on: :set_team

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,18 @@ class User < ApplicationRecord
     false
   end
 
+  def active
+    deactivated_at.nil?
+  end
+
+  def active=(value)
+    if ActiveRecord::Type::Boolean.new.serialize(value)
+      write_attribute(:deactivated_at, nil)
+    else
+      write_attribute(:deactivated_at, DateTime.now)
+    end
+  end
+
   def team_options
     User.teams.keys.map { |team| OpenStruct.new(id: team, name: I18n.t("user.teams.#{team}")) }
   end

--- a/app/views/users/_users_sub_navigation.html.erb
+++ b/app/views/users/_users_sub_navigation.html.erb
@@ -1,0 +1,6 @@
+<nav class="moj-sub-navigation" aria-label="Sub-navigation">
+  <ul class="moj-sub-navigation__list">
+    <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.active_users"), path: users_active_path} %>
+    <%= render partial: "shared/sub_navigation_item", locals: {name: t("subnavigation.inactive_users"), path: users_inactive_path} %>
+  </ul>
+</nav>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -19,6 +19,11 @@
           <%= t("helpers.hint.user.team_lead.html") %>
           <%= form.govuk_check_box :team_leader, 1, 0, multiple: false, link_errors: true, label: {text: t("helpers.label.user.team_lead")} %>
         <% end %>
+
+        <%= form.govuk_check_boxes_fieldset :active, multiple: false, legend: {size: "s"}  do %>
+          <%= t("helpers.hint.user.active.html") %>
+          <%= form.govuk_check_box :active, 1, 0, multiple: false, link_errors: true, label: {text: t("helpers.label.user.active")} %>
+        <% end %>
       </div>
 
       <%= form.govuk_submit t("user.edit.save.button") do %>

--- a/app/views/users/index_active.html.erb
+++ b/app/views/users/index_active.html.erb
@@ -15,6 +15,12 @@
             data: {module: "govuk-button"} %>
     </div>
 
+    <%= render partial: "users_sub_navigation" %>
+
+    <h2 class="govuk-heading-m">
+      <%= t("user.active.title") %>
+    </h2>
+
     <%= render partial: "users_table", locals: {user_accounts: @users, pager: @pager} %>
 
   </div>

--- a/app/views/users/index_inactive.html.erb
+++ b/app/views/users/index_inactive.html.erb
@@ -1,0 +1,20 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/service_support_primary_navigation" %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t("user.title") %>
+    </h1>
+
+    <%= render partial: "users_sub_navigation" %>
+
+    <h2 class="govuk-heading-m">
+      <%= t("user.inactive.title") %>
+    </h2>
+
+    <%= render partial: "users_table", locals: {user_accounts: @users, pager: @pager} %>
+
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,8 @@ en:
     message: You are signed in with the email address %{email_address}.
   unknown_user:
     message: The email address %{email_address} is not registered to use this service.
+  inactive_user:
+    message: The email address %{email_address} is inactive, if you believe this is in error, contact support.
   unauthorised_action:
     message: You are not authorised to perform this action.
   project_list:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,8 @@ en:
     added_by_projects: Added by you
     openers: Opening as planned
     revised: Revised conversion date
+    active_users: Active users
+    inactive_users: Inactive users
   pages:
     academies_api_client_timeout:
       title: Sorry, there was a problem

--- a/config/locales/user.en.yml
+++ b/config/locales/user.en.yml
@@ -27,7 +27,7 @@ en:
       team:
         label: Choose your team
         hint: All users must belong to one of the following teams.
-      save: 
+      save:
         button: Save team
       success: The team for %{email} has been set successfully
     title: Users
@@ -63,18 +63,23 @@ en:
       user:
         team: User team
         team_leader: Team lead
+        active: Active user
     label:
       user:
         first_name: First name
         last_name: Last name
         email: Email address
         team_lead: User is a team lead or manager
+        active: Active user
     hint:
       user:
         email: "@education.gov.uk email addresses only"
         team: All users must belong in one of the following teams. Sub-teams within these are not required.
         team_lead:
           html: <p>If the user is a lead or manager within the team, check this box.</p>
+        active:
+          html:
+            <p>Inactive users cannot access the application and will not show up in list of users.</p>
   errors:
     attributes:
       first_name:

--- a/config/locales/user.en.yml
+++ b/config/locales/user.en.yml
@@ -31,6 +31,10 @@ en:
         button: Save team
       success: The team for %{email} has been set successfully
     title: Users
+    active:
+      title: Active users
+    inactive:
+      title: Inactive users
     table:
       caption: Table of users
       headers:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,7 +165,10 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :users, only: %w[index new create edit update]
+  resources :users, only: %w[new create edit update]
+  get "users", to: redirect("users/active")
+  get "users/active", to: "users#index_active"
+  get "users/inactive", to: "users#index_inactive"
   get "users/team", to: "users#set_team"
   post "users/team", to: "users#update_team"
 

--- a/db/migrate/20230710091311_add_deactivated_at_to_user.rb
+++ b/db/migrate/20230710091311_add_deactivated_at_to_user.rb
@@ -1,0 +1,5 @@
+class AddDeactivatedAtToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :deactived_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_29_154941) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_10_091311) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -222,6 +222,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_29_154941) do
     t.boolean "service_support", default: false
     t.string "active_directory_user_group_ids"
     t.string "team"
+    t.datetime "deactivated_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -38,5 +38,12 @@ FactoryBot.define do
       email { "service-support-#{SecureRandom.uuid}@education.gov.uk" }
       team { "service_support" }
     end
+
+    factory :inactive_user do
+      first_name { "Inactive" }
+      last_name { "User" }
+      email { "inactive.user@education.gov.uk" }
+      deactivated_at { Date.today }
+    end
   end
 end

--- a/spec/features/users/users_can_manage_user_accounts_spec.rb
+++ b/spec/features/users/users_can_manage_user_accounts_spec.rb
@@ -86,6 +86,12 @@ RSpec.feature "Users can manage user accounts" do
     click_on "Save user"
 
     expect(existing_user.reload.active).to be false
+
+    click_on "Inactive users"
+
+    within("tbody") do
+      expect(page).to have_content(existing_user.email)
+    end
   end
 
   scenario "inactive users can be activated" do
@@ -97,6 +103,12 @@ RSpec.feature "Users can manage user accounts" do
     click_on "Save user"
 
     expect(existing_user.reload.active).to be true
+
+    click_on "Active users"
+
+    within("tbody") do
+      expect(page).to have_content(existing_user.email)
+    end
   end
 
   context "then the users team is nil becuase it is a legacy account" do

--- a/spec/features/users/users_can_manage_user_accounts_spec.rb
+++ b/spec/features/users/users_can_manage_user_accounts_spec.rb
@@ -77,6 +77,28 @@ RSpec.feature "Users can manage user accounts" do
     expect(page).to have_content("There is a problem")
   end
 
+  scenario "existing users can be deactivated" do
+    existing_user = create(:user)
+
+    visit edit_user_path(existing_user)
+    uncheck "Active"
+
+    click_on "Save user"
+
+    expect(existing_user.reload.active).to be false
+  end
+
+  scenario "inactive users can be activated" do
+    existing_user = create(:inactive_user)
+
+    visit edit_user_path(existing_user)
+    check "Active"
+
+    click_on "Save user"
+
+    expect(existing_user.reload.active).to be true
+  end
+
   context "then the users team is nil becuase it is a legacy account" do
     scenario "no team is shown" do
       other_user = User.new(

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -261,6 +261,44 @@ RSpec.describe User do
     end
   end
 
+  describe "#active" do
+    it "returns true when deactivated_at is nil" do
+      user = build(:user)
+
+      expect(user.active).to be true
+    end
+
+    it "returns false when deactivated_at has a value" do
+      user = build(:inactive_user)
+
+      expect(user.active).to be false
+    end
+
+    it "can be set with 1 and 0 strings" do
+      user = build(:user)
+
+      user.update!(active: "0")
+
+      expect(user.active).to be false
+
+      user.update!(active: "1")
+
+      expect(user.active).to be true
+    end
+
+    it "can be set with true and false" do
+      user = build(:user)
+
+      user.update!(active: false)
+
+      expect(user.active).to be false
+
+      user.update!(active: true)
+
+      expect(user.active).to be true
+    end
+  end
+
   def valid_user_attributes
     {
       first_name: "First",

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe User do
     it { is_expected.to have_db_column(:service_support).of_type :boolean }
     it { is_expected.to have_db_column(:active_directory_user_group_ids).of_type :string }
     it { is_expected.to have_db_column(:team).of_type :string }
+    it { is_expected.to have_db_column(:deactivated_at).of_type :datetime }
   end
 
   describe "scopes" do
@@ -58,6 +59,30 @@ RSpec.describe User do
       it "only includes users who have a role" do
         expect(User.all_assignable_users.count).to eq 6
         expect(User.all_assignable_users).to_not include(user_without_role)
+      end
+    end
+
+    describe "active" do
+      it "contains only active users" do
+        active_user = create(:user, deactivated_at: nil, email: "active.user@education.gov.uk")
+        inactive_user = create(:inactive_user)
+
+        scoped_users = User.active
+
+        expect(scoped_users).to include(active_user)
+        expect(scoped_users).not_to include(inactive_user)
+      end
+    end
+
+    describe "inactive" do
+      it "contains only inactive users" do
+        active_user = create(:user, deactivated_at: nil, email: "active.user@education.gov.uk")
+        inactive_user = create(:inactive_user)
+
+        scoped_users = User.inactive
+
+        expect(scoped_users).to include(inactive_user)
+        expect(scoped_users).not_to include(active_user)
       end
     end
   end

--- a/spec/requests/sign_in_spec.rb
+++ b/spec/requests/sign_in_spec.rb
@@ -64,4 +64,17 @@ RSpec.describe "Sign in" do
       expect(flash.to_h.values).to include I18n.t("unknown_user.message", email_address: "user@education.gov.uk")
     end
   end
+
+  context "but the user is inactive" do
+    it "redirects to the sign in view and shows a helpful message" do
+      inactive_user = create(:inactive_user)
+      mock_successful_authentication(inactive_user.email)
+
+      get "/auth/azure_activedirectory_v2/callback"
+
+      expect(request).to redirect_to(sign_in_path)
+      expect(flash.notice).to include("inactive")
+      expect(flash.notice).to include(inactive_user.email)
+    end
+  end
 end


### PR DESCRIPTION
This works allows users to be deactivated. A deactivated user:

- cannot access the application
- does not appear in list of users when assgining projects
- may have done these things in the past

We store the `deactivated_at` date and time and wrap it with a `active` method so we can treat it like a boolean in the interface.

https://trello.com/c/g6tlmXfG

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/15d3b2e0-f1be-4c22-99e9-76f2c8350de7)

