### PR TITLE
Add more pagers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   view
 - All users with a role and a team can now view the Team projects view
 - The users view is now split into active and inactive user accounts.
+- The number of pages shown in the pager has been increased to 10
 
 ### Fixed
 

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -17,7 +17,7 @@ Pagy::DEFAULT[:items] = 20 # default
 
 # Other Variables
 # See https://ddnexus.github.io/pagy/api/pagy#other-variables
-Pagy::DEFAULT[:size] = [1, 1, 1, 1]
+Pagy::DEFAULT[:size] = [1, 4, 4, 1]
 # Pagy::DEFAULT[:page_param] = :page                           # default
 # The :params can be also set as a lambda e.g ->(params){ params.exclude('useless').merge!('custom' => 'useful') }
 # Pagy::DEFAULT[:params]     = {}                              # default


### PR DESCRIPTION
I am not sure why we went with so few pagers, but we did.

Here we increase the number:

1 = 1 pager to the right of the start
4 = 4 pagers to the left of the current page
4 = 4 pagers to the right of the current page
1 = 1 pager to the left of the end

This gives us a total of 10 pagers on screen, as opposed to the 4 we
have now.