### PR TITLE
Add team projects by user view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - User accounts can now be deactivated which prevents the user from accessing
   the application or from showing up in user selections, inactive accounts can
   be reactivated.
+- Add a "Users" view to the Team projects area, to view other users on your
+  team, with their conversion project counts.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   be reactivated.
 - Add a "Users" view to the Team projects area, to view other users on your
   team, with their conversion project counts.
+- Add a "by user" view to the Team projects area, where a user can view projects
+  assigned to another user on the same team.
 
 ### Changed
 

--- a/app/controllers/team/projects_controller.rb
+++ b/app/controllers/team/projects_controller.rb
@@ -17,4 +17,10 @@ class Team::ProjectsController < ApplicationController
 
     @pager, @projects = pagy_array(ByTeamProjectFetcherService.new(current_user.team).unassigned)
   end
+
+  def users
+    authorize Project, :index?
+
+    @pager, @users = pagy_array(ByTeamProjectFetcherService.new(current_user.team).users)
+  end
 end

--- a/app/controllers/team/projects_controller.rb
+++ b/app/controllers/team/projects_controller.rb
@@ -15,6 +15,6 @@ class Team::ProjectsController < ApplicationController
   def unassigned
     authorize Project, :unassigned?
 
-    @pagy, @projects = pagy_array(ByTeamProjectFetcherService.new(current_user.team).unassigned)
+    @pager, @projects = pagy_array(ByTeamProjectFetcherService.new(current_user.team).unassigned)
   end
 end

--- a/app/controllers/team/projects_controller.rb
+++ b/app/controllers/team/projects_controller.rb
@@ -23,4 +23,25 @@ class Team::ProjectsController < ApplicationController
 
     @pager, @users = pagy_array(ByTeamProjectFetcherService.new(current_user.team).users)
   end
+
+  def by_user
+    authorize Project, :index?
+
+    user_id = params[:user_id]
+    @user = User.find(user_id)
+    @pager, @projects = pagy(Conversion::Project.assigned_to(@user)
+                                                .in_progress
+                                                .by_conversion_date)
+
+    pre_fetch_establishments(@projects)
+    pre_fetch_incoming_trusts(@projects)
+  end
+
+  private def pre_fetch_establishments(projects)
+    EstablishmentsFetcherService.new(projects).call!
+  end
+
+  private def pre_fetch_incoming_trusts(projects)
+    TrustsFetcherService.new(projects).call!
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,8 @@ class User < ApplicationRecord
 
   scope :all_assignable_users, -> { active.where.not(caseworker: false).or(where.not(team_leader: false)).or(where.not(regional_delivery_officer: false)) }
 
+  scope :by_team, ->(team) { where(team: team) }
+
   validates :first_name, :last_name, :email, :team, presence: true
   validates :team, presence: true, on: :set_team
   validates :email, uniqueness: {case_sensitive: false}

--- a/app/services/by_team_project_fetcher_service.rb
+++ b/app/services/by_team_project_fetcher_service.rb
@@ -38,6 +38,19 @@ class ByTeamProjectFetcherService
     pre_fetch_establishments_and_trusts(projects)
   end
 
+  def users
+    return [] if @team.nil?
+
+    @users = User.by_team(@team).compact.map do |user|
+      OpenStruct.new(
+        name: user.full_name,
+        email: user.email,
+        id: user.id,
+        conversion_count: Conversion::Project.assigned_to(user).count
+      )
+    end.sort_by { |object| object.name }
+  end
+
   private def pre_fetch_establishments_and_trusts(projects)
     EstablishmentsFetcherService.new(projects).call!
     TrustsFetcherService.new(projects).call!

--- a/app/views/projects/shared/_users_table.html.erb
+++ b/app/views/projects/shared/_users_table.html.erb
@@ -1,0 +1,25 @@
+<table class="govuk-table" name="users_table" aria-label="Projects by user table">
+  <caption class="govuk-table__caption govuk-!-display-none"><%= t("project.table.by_user.caption") %></caption>
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header" scope="col"><%= t("project.table.headers.user") %></th>
+    <th class="govuk-table__header" scope="col"><%= t("project.table.headers.email") %></th>
+    <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_count") %></th>
+    <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view_projects") %></th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% users.each do |user| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header govuk-table__cell"><%= user.name %></td>
+      <td class="govuk-table__cell"><%= user.email %></td>
+      <td class="govuk-table__cell"><%= user.conversion_count %></td>
+      <td class="govuk-table__cell">
+        <%= link_to t("project.table.body.view_projects_html", trust_name: user.name), "" %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
+
+<%= govuk_pagination(pagy: pager) %>

--- a/app/views/projects/shared/_users_table.html.erb
+++ b/app/views/projects/shared/_users_table.html.erb
@@ -15,7 +15,7 @@
       <td class="govuk-table__cell"><%= user.email %></td>
       <td class="govuk-table__cell"><%= user.conversion_count %></td>
       <td class="govuk-table__cell">
-        <%= link_to t("project.table.body.view_projects_html", trust_name: user.name), "" %>
+        <%= link_to t("project.table.body.view_projects_html", trust_name: user.name), by_user_team_projects_path(user.id) %>
       </td>
     </tr>
   <% end %>

--- a/app/views/shared/navigation/_team_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_team_projects_primary_navigation.html.erb
@@ -11,6 +11,8 @@
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.in_progress"), path: in_progress_team_projects_path, namespace: "/projects/team/in-progress"} %>
 
+          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.by_user"), path: users_team_projects_path, namespace: "/projects/team/user"} %>
+
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.completed"), path: completed_team_projects_path, namespace: "/projects/team/completed"} %>
 
         </ul>

--- a/app/views/team/projects/by_user.html.erb
+++ b/app/views/team/projects/by_user.html.erb
@@ -1,0 +1,15 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/team_projects_primary_navigation" %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">
+      <%= t("project.user.by_user.title", user: @user.full_name) %>
+    </h1>
+
+    <%= render partial: "user/projects/table", locals: {projects: @projects, pager: @pager} %>
+
+  </div>
+</div>

--- a/app/views/team/projects/users.html.erb
+++ b/app/views/team/projects/users.html.erb
@@ -1,0 +1,15 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/team_projects_primary_navigation" %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">
+      <%= t("project.team.users.title") %>
+    </h1>
+
+    <%= render partial: "/projects/shared/users_table", locals: {users: @users, pager: @pager} %>
+
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,6 +146,7 @@ en:
         in_progress: In progress
         unassigned: Unassigned
         completed: Completed
+        by_user: By user
       your_projects:
         in_progress: In progress
         added_by_you: Added by you

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -49,6 +49,8 @@ en:
         title: Completed
       unassigned:
         title: Unassigned
+      users:
+        title: By user
     regional:
       in_progress:
         title: Regional projects in progress

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,6 +115,7 @@ Rails.application.routes.draw do
           get "in-progress", to: "projects#in_progress"
           get "completed", to: "projects#completed"
           get "unassigned", to: "projects#unassigned"
+          get "users", to: "projects#users"
         end
         namespace :regional, path: "regional" do
           get "in-progress", to: "projects#in_progress"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,7 @@ Rails.application.routes.draw do
           get "completed", to: "projects#completed"
           get "unassigned", to: "projects#unassigned"
           get "users", to: "projects#users"
+          get "user/:user_id", to: "projects#by_user", as: :by_user
         end
         namespace :regional, path: "regional" do
           get "in-progress", to: "projects#in_progress"

--- a/spec/features/projects/team/users_can_view_others_users_in_their_team_spec.rb
+++ b/spec/features/projects/team/users_can_view_others_users_in_their_team_spec.rb
@@ -3,15 +3,27 @@ require "rails_helper"
 RSpec.feature "Users can view the other users in their team" do
   before do
     sign_in_with_user(user)
+    mock_all_academies_api_responses
   end
 
   let(:user) { create(:user, :caseworker, team: "regional_casework_services") }
 
-  scenario "they cannot see users from other teams" do
+  scenario "they don't see users from other teams" do
     other_user = create(:user, :regional_delivery_officer, team: "london")
 
     visit users_team_projects_path
 
     expect(page).to_not have_content(other_user.full_name)
+  end
+
+  scenario "they can navigate to a by_user page and see projects assigned to another user in the same team" do
+    other_user = create(:user, :caseworker, first_name: "Amy", team: "regional_casework_services")
+    project = create(:conversion_project, assigned_to: other_user)
+
+    visit users_team_projects_path
+    expect(page).to have_content(other_user.full_name)
+    click_on "View projects for #{other_user.full_name}"
+    expect(page).to have_content("Projects assigned to #{other_user.full_name}")
+    expect(page).to have_content(project.establishment.name)
   end
 end

--- a/spec/features/projects/team/users_can_view_others_users_in_their_team_spec.rb
+++ b/spec/features/projects/team/users_can_view_others_users_in_their_team_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.feature "Users can view the other users in their team" do
+  before do
+    sign_in_with_user(user)
+  end
+
+  let(:user) { create(:user, :caseworker, team: "regional_casework_services") }
+
+  scenario "they cannot see users from other teams" do
+    other_user = create(:user, :regional_delivery_officer, team: "london")
+
+    visit users_team_projects_path
+
+    expect(page).to_not have_content(other_user.full_name)
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe User do
   end
 
   describe "scopes" do
-    let!(:caseworker) { create(:user, :caseworker) }
+    let!(:caseworker) { create(:user, :caseworker, team: "regional_casework_services") }
     let!(:caseworker_2) { create(:user, :caseworker, first_name: "Aaron", email: "aaron-caseworker@education.gov.uk") }
-    let!(:team_leader) { create(:user, :team_leader) }
+    let!(:team_leader) { create(:user, :team_leader, team: "regional_casework_services") }
     let!(:team_leader_2) { create(:user, :team_leader, first_name: "Andy", email: "aaron-team-leader@education.gov.uk") }
-    let!(:regional_delivery_officer) { create(:user, :regional_delivery_officer) }
+    let!(:regional_delivery_officer) { create(:user, :regional_delivery_officer, team: "london") }
     let!(:regional_delivery_officer_2) { create(:user, :regional_delivery_officer, first_name: "Adam", email: "aaron-rdo@education.gov.uk") }
     let!(:user_without_role) { create(:user, caseworker: false, team_leader: false, regional_delivery_officer: false, team: "education_and_skills_funding_agency") }
 
@@ -83,6 +83,13 @@ RSpec.describe User do
 
         expect(scoped_users).to include(inactive_user)
         expect(scoped_users).not_to include(active_user)
+      end
+    end
+
+    describe "by_team" do
+      it "returns users in the desired team" do
+        expect(User.by_team("london")).to include(regional_delivery_officer)
+        expect(User.by_team("regional_casework_services")).to include(caseworker, team_leader)
       end
     end
   end

--- a/spec/services/by_team_project_fetcher_service_spec.rb
+++ b/spec/services/by_team_project_fetcher_service_spec.rb
@@ -103,4 +103,35 @@ RSpec.describe ByTeamProjectFetcherService do
       expect(described_class.new(user.team).unassigned).to eq([])
     end
   end
+
+  describe "#users" do
+    it "returns a sorted list of users in the user's team, with their assigned_to project counts" do
+      user_1 = create(:user, :caseworker, team: "regional_casework_services", first_name: "Abbie")
+      user_2 = create(:user, :caseworker, team: "regional_casework_services", first_name: "Ben")
+      user_3 = create(:user, :caseworker, team: "regional_casework_services", first_name: "Claire")
+      _user_4 = create(:user, :caseworker, team: "regional_casework_services", first_name: "Danniella")
+      user_5 = create(:user, team: "london")
+      _project_1 = create(:conversion_project, assigned_to: user_1)
+      _project_2 = create(:conversion_project, assigned_to: user_2)
+      _project_3 = create(:conversion_project, assigned_to: user_3)
+      _project_4 = create(:conversion_project, assigned_to: user_1)
+      _project_5 = create(:conversion_project, assigned_to: user_5)
+
+      result = described_class.new(user_1.team).users
+      expect(result[0].name).to eq("Abbie Doe")
+      expect(result[0].conversion_count).to eq(2)
+      expect(result[1].name).to eq("Ben Doe")
+      expect(result[1].conversion_count).to eq(1)
+      expect(result[2].name).to eq("Claire Doe")
+      expect(result[2].conversion_count).to eq(1)
+      expect(result[3].name).to eq("Danniella Doe")
+      expect(result[3].conversion_count).to eq(0)
+      expect(result).to_not include(user_5.full_name)
+    end
+
+    it "returns an empty array when the user's team is nil" do
+      user = build(:user, team: nil)
+      expect(described_class.new(user.team).users).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
## Changes

Add a "Users" page to the Team projects area, showing a list of all users on the current_user's team, with a list of their conversion project counts (ordered by user name).

<img width="1298" alt="Screenshot 2023-07-12 at 10 13 24" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/a735289c-4b18-4415-a23a-62d6ed38aa0f">

The current_user can then click through to view a list of user's projects. This view reuses the table view from the Your projects area, as it is essentially the same data (projects assigned to a certain user). 

<img width="1288" alt="Screenshot 2023-07-12 at 10 13 33" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/727587b5-3167-46b5-bbff-04637bb1f589">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
