### PR TITLE
Raise error in establishment and trust fetchers

### DIFF
--- a/app/services/establishments_fetcher_service.rb
+++ b/app/services/establishments_fetcher_service.rb
@@ -5,16 +5,31 @@ class EstablishmentsFetcherService
   end
 
   def call!
-    return unless @projects&.any?
+    return if @projects.nil? || @projects.empty?
     raise ArgumentError.new("You must pass in the result of an ActiveRecord query (ActiveRecord::Relation)") unless @projects.is_a?(ActiveRecord::Relation)
 
     @projects.in_batches(of: 20) do |batch_of_projects|
       urns = batch_of_projects.pluck(:urn)
-      @establishments += Api::AcademiesApi::Client.new.get_establishments(urns).object
+      response = Api::AcademiesApi::Client.new.get_establishments(urns)
+
+      if response.error.nil?
+        @establishments.concat(response.object)
+      else
+        track_error(response.error)
+        raise Api::AcademiesApi::Client::Error.new
+      end
     end
 
     @projects.each do |project|
       project.establishment = @establishments.find { |establishment| establishment.urn == project.urn.to_s }
+    end
+  end
+
+  private def track_error(error_message)
+    if ENV.fetch("APPLICATION_INSIGHTS_KEY", nil)
+      tc = ApplicationInsights::TelemetryClient.new(ENV.fetch("APPLICATION_INSIGHTS_KEY"))
+      tc.track_event(error_message)
+      tc.flush
     end
   end
 end

--- a/app/services/trusts_fetcher_service.rb
+++ b/app/services/trusts_fetcher_service.rb
@@ -5,16 +5,31 @@ class TrustsFetcherService
   end
 
   def call!
-    return unless @projects&.any?
+    return if @projects.nil? || @projects.empty?
     raise ArgumentError.new("You must pass in the result of an ActiveRecord query (ActiveRecord::Relation)") unless @projects.is_a?(ActiveRecord::Relation)
 
     @projects.in_batches(of: 20) do |batch_of_projects|
       ukprns = batch_of_projects.pluck(:incoming_trust_ukprn)
-      @trusts += Api::AcademiesApi::Client.new.get_trusts(ukprns).object
+      response = Api::AcademiesApi::Client.new.get_trusts(ukprns)
+
+      if response.error.nil?
+        @trusts.concat(response.object)
+      else
+        track_error(response.error)
+        raise Api::AcademiesApi::Client::Error.new
+      end
     end
 
     @projects.each do |project|
       project.incoming_trust = @trusts.find { |trust| trust.ukprn == project.incoming_trust_ukprn.to_s }
+    end
+  end
+
+  private def track_error(error_message)
+    if ENV.fetch("APPLICATION_INSIGHTS_KEY", nil)
+      tc = ApplicationInsights::TelemetryClient.new(ENV.fetch("APPLICATION_INSIGHTS_KEY"))
+      tc.track_event(error_message)
+      tc.flush
     end
   end
 end

--- a/spec/services/trusts_fetcher_service_spec.rb
+++ b/spec/services/trusts_fetcher_service_spec.rb
@@ -61,5 +61,21 @@ RSpec.describe TrustsFetcherService do
     it "returns nil if there are no projects" do
       expect(described_class.new([]).call!).to be_nil
     end
+
+    it "raises when the Academies API has an error" do
+      ClimateControl.modify(APPLICATION_INSIGHTS_KEY: "not-a-real-key") do
+        api_client = Api::AcademiesApi::Client.new
+        allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
+        allow(api_client).to receive(:get_trusts).and_return(Api::AcademiesApi::Client::Result.new(nil, double))
+        allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
+        allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
+        application_insight_client = double(track_event: true, flush: true)
+        allow(ApplicationInsights::TelemetryClient).to receive(:new).and_return(application_insight_client)
+
+        create(:conversion_project)
+
+        expect { described_class.new(Project.all).call! }.to raise_error(Api::AcademiesApi::Client::Error)
+      end
+    end
   end
 end


### PR DESCRIPTION
We've seen some errors in production that seem to relate to not handling errors from the Academies API (timeouts are likely). This work should surface the errror and allow recovery and also log to Application Insights.

https://trello.com/c/jl2qwQTx