### PR TITLE
Rename User.deactived_at to User.deactivated_at

### DIFF
--- a/db/migrate/20230712100251_rename_user_deactivated_at_column.rb
+++ b/db/migrate/20230712100251_rename_user_deactivated_at_column.rb
@@ -1,0 +1,5 @@
+class RenameUserDeactivatedAtColumn < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :users, :deactived_at, :deactivated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_10_091311) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_12_100251) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false


### PR DESCRIPTION
In an earlier commit we accidentally committed a migration with an incorrect column name. Add another migration to fix this.

https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/859

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
