### PR TITLE
Offer batch pre fetch and paged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Users without a team show up as 'No team' in the User management list.
+- View with large numbers of projects that batch fetch establishment and trust
+  data from the API should now load on pages after page one.
 
 ## [Release 32][release-32]
 

--- a/app/controllers/all/in_progress/projects_controller.rb
+++ b/app/controllers/all/in_progress/projects_controller.rb
@@ -5,6 +5,9 @@ class All::InProgress::ProjectsController < ApplicationController
   def index
     authorize Project, :index?
     @pager, @projects = pagy(Conversion::Project.in_progress.includes(:assigned_to))
+
+    pre_fetch_establishments(@projects)
+    pre_fetch_incoming_trusts(@projects)
   end
 
   def voluntary

--- a/app/services/by_local_authority_project_fetcher_service.rb
+++ b/app/services/by_local_authority_project_fetcher_service.rb
@@ -12,7 +12,7 @@ class ByLocalAuthorityProjectFetcherService
   private def conversions_count_by_local_authority
     projects = Project.not_completed.select(:id, :urn)
 
-    EstablishmentsFetcherService.new(projects).call!
+    EstablishmentsFetcherService.new(projects).batched!
 
     projects.group_by { |p| p.establishment.local_authority_code }
   end

--- a/app/services/establishments_fetcher_service.rb
+++ b/app/services/establishments_fetcher_service.rb
@@ -5,10 +5,30 @@ class EstablishmentsFetcherService
   end
 
   def call!
+    paged!
+  end
+
+  def paged!
+    return if @projects.nil? || @projects.empty?
+    raise ArgumentError.new("We don't recommend trying to prefetch more than 20 records") if @projects.count > 20
+
+    urns = @projects.pluck(:urn)
+    response = Api::AcademiesApi::Client.new.get_establishments(urns)
+
+    if response.error.nil?
+      @establishments.concat(response.object)
+    else
+      track_error(response.error)
+      raise Api::AcademiesApi::Client::Error.new
+    end
+    populate_projects_with_establishments
+  end
+
+  def batched!
     return if @projects.nil? || @projects.empty?
     raise ArgumentError.new("You must pass in the result of an ActiveRecord query (ActiveRecord::Relation)") unless @projects.is_a?(ActiveRecord::Relation)
 
-    @projects.in_batches(of: 20) do |batch_of_projects|
+    @projects.in_batches(of: 10) do |batch_of_projects|
       urns = batch_of_projects.pluck(:urn)
       response = Api::AcademiesApi::Client.new.get_establishments(urns)
 
@@ -19,7 +39,10 @@ class EstablishmentsFetcherService
         raise Api::AcademiesApi::Client::Error.new
       end
     end
+    populate_projects_with_establishments
+  end
 
+  private def populate_projects_with_establishments
     @projects.each do |project|
       project.establishment = @establishments.find { |establishment| establishment.urn == project.urn.to_s }
     end

--- a/app/services/trusts_fetcher_service.rb
+++ b/app/services/trusts_fetcher_service.rb
@@ -5,10 +5,30 @@ class TrustsFetcherService
   end
 
   def call!
+    paged!
+  end
+
+  def paged!
+    return if @projects.nil? || @projects.empty?
+    raise ArgumentError.new("We don't recommend trying to prefetch more than 20 records") if @projects.count > 20
+
+    ids = @projects.pluck(:incoming_trust_ukprn)
+    response = Api::AcademiesApi::Client.new.get_trusts(ids)
+
+    if response.error.nil?
+      @trusts.concat(response.object)
+    else
+      track_error(response.error)
+      raise Api::AcademiesApi::Client::Error.new
+    end
+    populate_projects_with_trusts
+  end
+
+  def batched!
     return if @projects.nil? || @projects.empty?
     raise ArgumentError.new("You must pass in the result of an ActiveRecord query (ActiveRecord::Relation)") unless @projects.is_a?(ActiveRecord::Relation)
 
-    @projects.in_batches(of: 20) do |batch_of_projects|
+    @projects.in_batches(of: 10) do |batch_of_projects|
       ukprns = batch_of_projects.pluck(:incoming_trust_ukprn)
       response = Api::AcademiesApi::Client.new.get_trusts(ukprns)
 
@@ -19,7 +39,10 @@ class TrustsFetcherService
         raise Api::AcademiesApi::Client::Error.new
       end
     end
+    populate_projects_with_trusts
+  end
 
+  private def populate_projects_with_trusts
     @projects.each do |project|
       project.incoming_trust = @trusts.find { |trust| trust.ukprn == project.incoming_trust_ukprn.to_s }
     end

--- a/spec/services/establishments_fetcher_service_spec.rb
+++ b/spec/services/establishments_fetcher_service_spec.rb
@@ -1,32 +1,62 @@
 require "rails_helper"
 
 RSpec.describe EstablishmentsFetcherService do
-  describe "#call" do
+  describe "#paged!" do
     it "fetches the establishments and updates the projects" do
-      api_client = Api::AcademiesApi::Client.new
-      allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
-      allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new([], nil))
-      allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
-      allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
+      mock_academies_api_client_get_establsihements_success
 
       create(:conversion_project, establishment: nil)
       projects = Project.all
-      described_class.new(projects).call!
+      described_class.new(projects).paged!
+
+      expect(projects.first.establishment).not_to be_nil
+    end
+
+    it "raises when more records than are " do
+      projects = build_list(:conversion_project, 21)
+
+      expect { described_class.new(projects).paged! }.to raise_error(ArgumentError)
+    end
+
+    it "returns nil if passed nil" do
+      expect(described_class.new(nil).paged!).to be_nil
+    end
+
+    it "returns nil if there are no projects" do
+      expect(described_class.new([]).paged!).to be_nil
+    end
+
+    it "raises when the Academies API has an error and logs an event" do
+      ClimateControl.modify(APPLICATION_INSIGHTS_KEY: "not-a-real-key") do
+        mock_academies_api_client_get_establsihements_error
+        mock_application_insights_client
+
+        create(:conversion_project)
+
+        expect { described_class.new(Project.all).paged! }.to raise_error(Api::AcademiesApi::Client::Error)
+        expect(ApplicationInsights::TelemetryClient).to have_received(:new).exactly(1).time
+      end
+    end
+  end
+
+  describe "#batched!" do
+    it "fetches the establishments and updates the projects" do
+      mock_academies_api_client_get_establsihements_success
+
+      create(:conversion_project, establishment: nil)
+      projects = Project.all
+      described_class.new(projects).batched!
 
       expect(projects.first.establishment).not_to be_nil
     end
 
     context "when there is a single batch of 10 projects or less" do
       it "calls the API once" do
-        api_client = Api::AcademiesApi::Client.new
-        allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
-        allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new([], nil))
-        allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
-        allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
+        api_client = mock_academies_api_client_get_establsihements_success
 
         create_list(:conversion_project, 6)
         projects = Project.all
-        described_class.new(projects).call!
+        described_class.new(projects).batched!
 
         expect(api_client).to have_received(:get_establishments).exactly(1).times
       end
@@ -34,49 +64,66 @@ RSpec.describe EstablishmentsFetcherService do
 
     context "whent there are multiple batches of projects" do
       it "calls the API the appropriate number of times" do
-        api_client = Api::AcademiesApi::Client.new
-        allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
-        allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new([], nil))
-        allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
-        allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
+        api_client = mock_academies_api_client_get_establsihements_success
         create_list(:conversion_project, 21)
 
         projects = Project.all
-        described_class.new(projects).call!
+        described_class.new(projects).batched!
 
-        expect(api_client).to have_received(:get_establishments).exactly(2).times
+        expect(api_client).to have_received(:get_establishments).exactly(3).times
       end
     end
 
     it "raises unless an ActiveRecord relation is passed in" do
       project = build(:conversion_project)
 
-      expect { described_class.new([project]).call! }.to raise_error(ArgumentError)
+      expect { described_class.new([project]).batched! }.to raise_error(ArgumentError)
     end
 
     it "returns nil if passed nil" do
-      expect(described_class.new(nil).call!).to be_nil
+      expect(described_class.new(nil).batched!).to be_nil
     end
 
     it "returns nil if there are no projects" do
-      expect(described_class.new([]).call!).to be_nil
+      expect(described_class.new([]).batched!).to be_nil
     end
 
-    it "raises when the Academies API has an error" do
+    it "raises when the Academies API has an error and logs an event" do
       ClimateControl.modify(APPLICATION_INSIGHTS_KEY: "not-a-real-key") do
-        api_client = Api::AcademiesApi::Client.new
-        allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
-        allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new(nil, double))
-        allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
-        allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
-        application_insight_client = double(track_event: true, flush: true)
-        allow(ApplicationInsights::TelemetryClient).to receive(:new).and_return(application_insight_client)
+        mock_academies_api_client_get_establsihements_error
+        mock_application_insights_client
 
         create(:conversion_project)
 
-        expect { described_class.new(Project.all).call! }.to raise_error(Api::AcademiesApi::Client::Error)
+        expect { described_class.new(Project.all).batched! }.to raise_error(Api::AcademiesApi::Client::Error)
         expect(ApplicationInsights::TelemetryClient).to have_received(:new).exactly(1).time
       end
     end
+  end
+
+  def mock_application_insights_client
+    application_insight_client = double(track_event: true, flush: true)
+    allow(ApplicationInsights::TelemetryClient).to receive(:new).and_return(application_insight_client)
+    application_insight_client
+  end
+
+  def mock_academies_api_client_get_establsihements_success
+    api_client = Api::AcademiesApi::Client.new
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
+    allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new([double("Establishment", urn: true)], nil))
+
+    allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double("Establishment"), nil))
+    allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double("Trust"), nil))
+    api_client
+  end
+
+  def mock_academies_api_client_get_establsihements_error
+    api_client = Api::AcademiesApi::Client.new
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
+    allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new(nil, double("Academies API error")))
+
+    allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double("Establishment"), nil))
+    allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double("Trust"), nil))
+    api_client
   end
 end

--- a/spec/services/trusts_fetcher_service_spec.rb
+++ b/spec/services/trusts_fetcher_service_spec.rb
@@ -1,32 +1,62 @@
 require "rails_helper"
 
 RSpec.describe TrustsFetcherService do
-  describe "#call" do
+  describe "#paged!" do
     it "fetches the trusts and updates the projects" do
-      api_client = Api::AcademiesApi::Client.new
-      allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
-      allow(api_client).to receive(:get_trusts).and_return(Api::AcademiesApi::Client::Result.new([], nil))
-      allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
-      allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
+      mock_academies_api_client_get_trusts_success
 
       create(:conversion_project, incoming_trust: nil)
       projects = Project.all
-      described_class.new(projects).call!
+      described_class.new(projects).paged!
+
+      expect(projects.first.incoming_trust).not_to be_nil
+    end
+
+    it "raises when more records are passed in that is acceptable to prefetch without batching" do
+      projects = build_list(:conversion_project, 21)
+
+      expect { described_class.new(projects).paged! }.to raise_error(ArgumentError)
+    end
+
+    it "returns nil if passed nil" do
+      expect(described_class.new(nil).paged!).to be_nil
+    end
+
+    it "returns nil if there are no projects" do
+      expect(described_class.new([]).paged!).to be_nil
+    end
+
+    it "raises when the Academies API has an error and logs to Application Insights" do
+      ClimateControl.modify(APPLICATION_INSIGHTS_KEY: "not-a-real-key") do
+        mock_academies_api_client_get_trusts_error
+        mock_application_insight_client
+
+        create(:conversion_project)
+
+        expect { described_class.new(Project.all).paged! }.to raise_error(Api::AcademiesApi::Client::Error)
+        expect(ApplicationInsights::TelemetryClient).to have_received(:new).exactly(1).time
+      end
+    end
+  end
+
+  describe "#batched!" do
+    it "fetches the trusts and updates the projects" do
+      mock_academies_api_client_get_trusts_success
+      create(:conversion_project, incoming_trust: nil)
+      projects = Project.all
+
+      described_class.new(projects).batched!
 
       expect(projects.first.incoming_trust).not_to be_nil
     end
 
     context "when there is a single batch of 10 projects or less" do
       it "calls the API once" do
-        api_client = Api::AcademiesApi::Client.new
-        allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
-        allow(api_client).to receive(:get_trusts).and_return(Api::AcademiesApi::Client::Result.new([], nil))
-        allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
-        allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
-
+        api_client = mock_academies_api_client_get_trusts_success
         create_list(:conversion_project, 6)
         projects = Project.all
-        described_class.new(projects).call!
+
+        described_class.new(projects).batched!
 
         expect(api_client).to have_received(:get_trusts).exactly(1).times
       end
@@ -34,48 +64,66 @@ RSpec.describe TrustsFetcherService do
 
     context "when there are multiple batches of projects" do
       it "calls the API the appropriate number of times" do
-        api_client = Api::AcademiesApi::Client.new
-        allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
-        allow(api_client).to receive(:get_trusts).and_return(Api::AcademiesApi::Client::Result.new([], nil))
-        allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
-        allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
+        api_client = mock_academies_api_client_get_trusts_success
         create_list(:conversion_project, 21)
-
         projects = Project.all
-        described_class.new(projects).call!
 
-        expect(api_client).to have_received(:get_trusts).exactly(2).times
+        described_class.new(projects).batched!
+
+        expect(api_client).to have_received(:get_trusts).exactly(3).times
       end
     end
 
     it "raises unless an ActiveRecord relation is passed in" do
       project = build(:conversion_project)
 
-      expect { described_class.new([project]).call! }.to raise_error(ArgumentError)
+      expect { described_class.new([project]).batched! }.to raise_error(ArgumentError)
     end
 
     it "returns nil if passed nil" do
-      expect(described_class.new(nil).call!).to be_nil
+      expect(described_class.new(nil).batched!).to be_nil
     end
 
     it "returns nil if there are no projects" do
-      expect(described_class.new([]).call!).to be_nil
+      expect(described_class.new([]).batched!).to be_nil
     end
 
     it "raises when the Academies API has an error" do
       ClimateControl.modify(APPLICATION_INSIGHTS_KEY: "not-a-real-key") do
-        api_client = Api::AcademiesApi::Client.new
-        allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
-        allow(api_client).to receive(:get_trusts).and_return(Api::AcademiesApi::Client::Result.new(nil, double))
-        allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
-        allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double, nil))
-        application_insight_client = double(track_event: true, flush: true)
-        allow(ApplicationInsights::TelemetryClient).to receive(:new).and_return(application_insight_client)
+        mock_academies_api_client_get_trusts_error
+        mock_application_insight_client
 
         create(:conversion_project)
 
-        expect { described_class.new(Project.all).call! }.to raise_error(Api::AcademiesApi::Client::Error)
+        expect { described_class.new(Project.all).batched! }.to raise_error(Api::AcademiesApi::Client::Error)
+        expect(ApplicationInsights::TelemetryClient).to have_received(:new).exactly(1).time
       end
     end
+  end
+
+  def mock_application_insight_client
+    application_insight_client = double(track_event: true, flush: true)
+    allow(ApplicationInsights::TelemetryClient).to receive(:new).and_return(application_insight_client)
+    application_insight_client
+  end
+
+  def mock_academies_api_client_get_trusts_success
+    api_client = Api::AcademiesApi::Client.new
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
+    allow(api_client).to receive(:get_trusts).and_return(Api::AcademiesApi::Client::Result.new([double("Trust", ukprn: true)], nil))
+
+    allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double("Trust"), nil))
+    allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double("Establishment"), nil))
+    api_client
+  end
+
+  def mock_academies_api_client_get_trusts_error
+    api_client = Api::AcademiesApi::Client.new
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
+    allow(api_client).to receive(:get_trusts).and_return(Api::AcademiesApi::Client::Result.new(nil, double("Academies API Error")))
+
+    allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double("Trust"), nil))
+    allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double("Establishment"), nil))
+    api_client
   end
 end

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -64,6 +64,8 @@ module AcademiesApiHelpers
     allow(TrustsFetcherService).to receive(:new).and_return(fake_trust_fetcher)
     allow(fake_establishment_fetcher).to receive(:call!).and_return([])
     allow(fake_trust_fetcher).to receive(:call!).and_return([])
+    allow(fake_establishment_fetcher).to receive(:batched!).and_return([])
+    allow(fake_trust_fetcher).to receive(:batched!).and_return([])
   end
 
   def mock_timeout_api_responses(urn:, ukprn:)


### PR DESCRIPTION
Gah! back again.

We've been seeing errors due to the shoddy work in the two 'prefetching' objects (mine) when we added batch support we added some really bad code.

We also introduced an issue that is hard to pin down, it only happens when you load more projects than the pager is calling for, so 20 by default and 10 for the Your projects view. It has also proven pretty inconsitent, which we think is casued by the Academies API timing out and then the shoddy code not allowing a revcovery.

There appears to be an issue with the pager and the `in_batches` that both use offsets and we see the issue when these are working together - it's difficult to be sure though.

After much fiddling, this is the propsed short term solution. Essentially we have two prefetching methods, one for paged views and the other not. The theory goes that paged views are limited to a maximum of 20 projects, which we are happy to fetch on the Academies API. For the paged prefetecher, we do not batch and so we side step the issue.

For times went we want to load more than 20 projects we call the prefetcher with batching, this should no be used with the pager as this is where the problems seem to start, but can be used in circumstance where you want to prefetch lots of records without paging them - usually this is etither some pre-rendering task, like the By local authority view or preparing a csv file to download.

There are lessons here, as usual:

- it is hard and slow to test the paging due to the high number of projects required
- the use of `in_batches` was maybe premature - although it does work wonders in the right context
- the brittleness of the Academies API still bites us, this issue only comes about because the API timesout, we should probably wait a little longer in production to time out to give it more time at the cost of our percieved performace

We know we'll be back to the prefetching soon anyway as we have the 'outgoing trust' on a transfer project to manage very soon, hopefully we will have the opportunity to make this better then. We prefetch everywhere, because it has performance benefits and there is a lot of duplicated code kicking about which we should dry out and make more approachable.