### PR TITLE
Release 33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release 33][release-33]
+
 ### Added
 
 - If your user account is not assigned to a team, you will be asked to choose
@@ -1081,7 +1083,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-32...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-33...HEAD
+[release-33]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-32...release-33
 [release-32]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-31...release-32
 [release-31]:


### PR DESCRIPTION
Added

- If your user account is not assigned to a team, you will be asked to choose one next time you sign in to the application.
- The team a user is associated with is now shown on the All projects, by team view.
- User accounts can now be deactivated which prevents the user from accessing the application or from showing up in user selections, inactive accounts can be reactivated.
- Add a "Users" view to the Team projects area, to view other users on your team, with their conversion project counts.
- Add a "by user" view to the Team projects area, where a user can view projects assigned to another user on the same team.

Changed

- the opening list now prefetches establishment and trust details, improving the performance of the view.
- Dates in csv exports are now formated as YYYY-MM-DD.
- The application now uses the DfE Design System fonts.
- The application now uses the DfE Design System header, footer and buttons.
- Change the Team projects views to only show projects aligned to the user's team
- Only team leaders can see the Unassigned projects page in the Team projects view
- All users with a role and a team can now view the Team projects view
- The users view is now split into active and inactive user accounts.
- The number of pages shown in the pager has been increased to 10
- Updated to Rails 7.0.6

Fixed

- Users without a team show up as 'No team' in the User management list.
- View with large numbers of projects that batch fetch establishment and trust data from the API should now load on pages after page one.

## Checklist

- [x] Check that this pull request has the correct version number.
- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` to move Unreleased changes into a new version.
- [x] Update the release links at the bottom of `CHANGELOG.md` to reflect the
      new version.