### PR TITLE
Used batched prefetcher for exports

### DIFF
--- a/app/controllers/all/export/funding_agreement_letters/projects_controller.rb
+++ b/app/controllers/all/export/funding_agreement_letters/projects_controller.rb
@@ -2,7 +2,7 @@ class All::Export::FundingAgreementLetters::ProjectsController < ApplicationCont
   def csv
     authorize Project, :index?
 
-    projects = ConversionProjectsFetcherService.new.sorted_openers(month, year)
+    projects = ProjectsForExportService.new.funding_agreement_letters_projects(month: month, year: year)
     csv = Export::FundingAgreementLettersCsvExporterService.new(projects).call
 
     send_data csv, filename: "opening_#{month}_#{year}.csv", type: :csv, disposition: "attachment"

--- a/app/controllers/all/export/risk_protection_arrangement/projects_controller.rb
+++ b/app/controllers/all/export/risk_protection_arrangement/projects_controller.rb
@@ -2,7 +2,7 @@ class All::Export::RiskProtectionArrangement::ProjectsController < ApplicationCo
   def csv
     authorize Project, :index?
 
-    projects = ConversionProjectsFetcherService.new.sorted_openers(month, year)
+    projects = ProjectsForExportService.new.risk_protection_arrangement_projects(month: month, year: year)
     csv = Export::RiskProtectionArrangementCsvExportService.new(projects).call
 
     send_data csv, filename: "risk_protection_arrangement_export_#{month}_#{year}.csv", type: :csv, disposition: "attachment"

--- a/app/services/projects_for_export_service.rb
+++ b/app/services/projects_for_export_service.rb
@@ -1,0 +1,22 @@
+class ProjectsForExportService
+  def risk_protection_arrangement_projects(month:, year:)
+    projects = projects_by_month_and_year(month, year)
+    pre_fetch_entities!(projects)
+    projects
+  end
+
+  def funding_agreement_letters_projects(month:, year:)
+    projects = projects_by_month_and_year(month, year)
+    pre_fetch_entities!(projects)
+    projects
+  end
+
+  private def projects_by_month_and_year(month, year)
+    Conversion::Project.opening_by_month_year(month, year)
+  end
+
+  private def pre_fetch_entities!(projects)
+    EstablishmentsFetcherService.new(projects).batched!
+    TrustsFetcherService.new(projects).batched!
+  end
+end

--- a/spec/factories/transfer/project_factory.rb
+++ b/spec/factories/transfer/project_factory.rb
@@ -12,5 +12,6 @@ FactoryBot.define do
     region { Project.regions["london"] }
     regional_delivery_officer { association :user, :regional_delivery_officer }
     tasks_data { association :transfer_tasks_data }
+    outgoing_trust_ukprn { 10059062 }
   end
 end

--- a/spec/services/projects_for_export_service_spec.rb
+++ b/spec/services/projects_for_export_service_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe ProjectsForExportService do
+  describe "#risk_protection_arrangement_projects" do
+    it "returns only conversion projects" do
+      mock_academies_api_client_get_establishments_and_trusts
+
+      transfer_project = create(:transfer_project, conversion_date_provisional: false, conversion_date: Date.parse("2025-1-1"))
+      conversion_project = create(:conversion_project, conversion_date_provisional: false, conversion_date: Date.parse("2025-1-1"))
+
+      projects_for_export = described_class.new.risk_protection_arrangement_projects(month: 1, year: 2025)
+
+      expect(projects_for_export).to include(conversion_project)
+      expect(projects_for_export).not_to include(transfer_project)
+    end
+
+    it "returns only confirmed projects" do
+      mock_academies_api_client_get_establishments_and_trusts
+
+      confirmed_project = create(:conversion_project, conversion_date_provisional: false, conversion_date: Date.parse("2025-1-1"))
+      unconfirmed_project = create(:conversion_project, conversion_date_provisional: true, conversion_date: Date.parse("2025-1-1"))
+
+      projects_for_export = described_class.new.risk_protection_arrangement_projects(month: 1, year: 2025)
+
+      expect(projects_for_export).to include(confirmed_project)
+      expect(projects_for_export).not_to include(unconfirmed_project)
+    end
+
+    it "returns only projects opening on the supplied month and year" do
+      mock_academies_api_client_get_establishments_and_trusts
+
+      matching_project = create(:conversion_project, conversion_date_provisional: false, conversion_date: Date.parse("2025-1-1"))
+      mismatching_project = create(:conversion_project, conversion_date_provisional: false, conversion_date: Date.parse("2026-2-1"))
+
+      projects_for_export = described_class.new.risk_protection_arrangement_projects(month: 1, year: 2025)
+
+      expect(projects_for_export).to include(matching_project)
+      expect(projects_for_export).not_to include(mismatching_project)
+    end
+
+    it "prefetches entities" do
+      mock_academies_api_client_get_establishments_and_trusts
+
+      create(:conversion_project, conversion_date_provisional: false, conversion_date: Date.parse("2025-1-1"))
+
+      projects_for_export = described_class.new.risk_protection_arrangement_projects(month: 1, year: 2025)
+
+      expect(projects_for_export.first.establishment).not_to be_nil
+      expect(projects_for_export.first.incoming_trust).not_to be_nil
+    end
+  end
+
+  def mock_academies_api_client_get_establishments_and_trusts
+    api_client = Api::AcademiesApi::Client.new
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
+    allow(api_client).to receive(:get_trusts).and_return(Api::AcademiesApi::Client::Result.new([double("Trust", ukprn: true)], nil))
+
+    allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double("Trust"), nil))
+    allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double("Establishment"), nil))
+
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
+    allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new([double("Establishment", urn: true)], nil))
+
+    allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(double("Establishment"), nil))
+    allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(double("Trust"), nil))
+    api_client
+  end
+end


### PR DESCRIPTION
Off the back of #869 we need to use the bacthed version of the prefetching when the projects are no paged.

To do this cleanly, we've encapsulated the business logic of which projects and the correct prefetching in an object clearly labelled for exporting - this sets a presedence that we have one way of prefetching for views and another for exports - which feels solid.

You'll noticed I keep including new api mocks - I am planning to try and unpick these across the test suite and ragionalise - but not here!

https://trello.com/c/h30FfOmP
