### PR TITLE
Basic RPA export UI

### DIFF
--- a/app/controllers/all/export/risk_protection_arrangement/projects_controller.rb
+++ b/app/controllers/all/export/risk_protection_arrangement/projects_controller.rb
@@ -5,7 +5,7 @@ class All::Export::RiskProtectionArrangement::ProjectsController < ApplicationCo
     projects = ProjectsForExportService.new.risk_protection_arrangement_projects(month: month, year: year)
     csv = Export::RiskProtectionArrangementCsvExportService.new(projects).call
 
-    send_data csv, filename: "risk_protection_arrangement_export_#{month}_#{year}.csv", type: :csv, disposition: "attachment"
+    send_data csv, filename: "#{year}-#{month}_risk_protection_arrangement_export.csv", type: :csv, disposition: "attachment"
   end
 
   private def month

--- a/app/controllers/all/export/risk_protection_arrangement/projects_controller.rb
+++ b/app/controllers/all/export/risk_protection_arrangement/projects_controller.rb
@@ -1,4 +1,8 @@
 class All::Export::RiskProtectionArrangement::ProjectsController < ApplicationController
+  def index
+    @months = export_months
+  end
+
   def csv
     authorize Project, :index?
 
@@ -14,5 +18,11 @@ class All::Export::RiskProtectionArrangement::ProjectsController < ApplicationCo
 
   private def year
     params[:year]
+  end
+
+  private def export_months
+    6.times.map do |index|
+      Date.today.last_month.at_beginning_of_month + index.months
+    end
   end
 end

--- a/app/controllers/all/export/risk_protection_arrangement/projects_controller.rb
+++ b/app/controllers/all/export/risk_protection_arrangement/projects_controller.rb
@@ -3,6 +3,10 @@ class All::Export::RiskProtectionArrangement::ProjectsController < ApplicationCo
     @months = export_months
   end
 
+  def show
+    @month = Date.parse("#{year}-#{month}-1")
+  end
+
   def csv
     authorize Project, :index?
 

--- a/app/views/all/export/risk_protection_arrangement/projects/index.html.erb
+++ b/app/views/all/export/risk_protection_arrangement/projects/index.html.erb
@@ -3,21 +3,22 @@
 <% end %>
 
 <table class="govuk-table" name="projects_table" aria-label="Risk protection arrangement exports">
+  <caption class="govuk-table__caption govuk-table__caption--l"><%= t("export.risk_protection_arrangement.index.title") %></caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col">Date</th>
-      <th class="govuk-table__header" scope="col">Confirmed</th>
-      <th class="govuk-table__header" scope="col">Revised</th>
-      <th class="govuk-table__header" scope="col">Export</th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.date") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.confirmed") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.revised") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.export") %></th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
     <% @months.each do |month| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell"><%= month.to_fs(:govuk_month) %></td>
-        <td class="govuk-table__header govuk-table__cell"><%= link_to "View projects", "/projects/all/opening/confirmed/#{month.month}/#{month.year}" %></td>
-        <td class="govuk-table__header govuk-table__cell"><%= link_to "View projects", "/projects/all/opening/revised/#{month.month}/#{month.year}" %></td>
-        <td class="govuk-table__header govuk-table__cell"><%= link_to "Export", "/projects/all/export/risk-protection-arrangement/#{month.month}/#{month.year}/csv" %></td>
+        <td class="govuk-table__cell"><%= link_to t("project.table.body.view_projects_for_html", entity: month.to_fs(:govuk_month)), "/projects/all/opening/confirmed/#{month.month}/#{month.year}" %></td>
+        <td class="govuk-table__cell"><%= link_to t("project.table.body.view_projects_for_html", entity: month.to_fs(:govuk_month)), "/projects/all/opening/revised/#{month.month}/#{month.year}" %></td>
+        <td class="govuk-table__cell"><%= link_to t("project.table.body.export_for_html", date: month.to_fs(:govuk_month)), "/projects/all/export/risk-protection-arrangement/#{month.month}/#{month.year}/csv" %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/all/export/risk_protection_arrangement/projects/index.html.erb
+++ b/app/views/all/export/risk_protection_arrangement/projects/index.html.erb
@@ -23,7 +23,7 @@
           <%= link_to t("project.table.body.view_projects_for_html", entity: month.to_fs(:govuk_month)), "/projects/all/opening/revised/#{month.month}/#{month.year}" %>
         </td>
         <td class="govuk-table__cell">
-          <%= link_to t("project.table.body.export_for_html", date: month.to_fs(:govuk_month)), "/projects/all/export/risk-protection-arrangement/#{month.month}/#{month.year}" %>
+          <%= link_to t("project.table.body.export_for_html", date: month.to_fs(:govuk_month)), show_all_export_risk_protection_arrangement_projects_path(month.month, month.year) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/all/export/risk_protection_arrangement/projects/index.html.erb
+++ b/app/views/all/export/risk_protection_arrangement/projects/index.html.erb
@@ -16,9 +16,15 @@
     <% @months.each do |month| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell"><%= month.to_fs(:govuk_month) %></td>
-        <td class="govuk-table__cell"><%= link_to t("project.table.body.view_projects_for_html", entity: month.to_fs(:govuk_month)), "/projects/all/opening/confirmed/#{month.month}/#{month.year}" %></td>
-        <td class="govuk-table__cell"><%= link_to t("project.table.body.view_projects_for_html", entity: month.to_fs(:govuk_month)), "/projects/all/opening/revised/#{month.month}/#{month.year}" %></td>
-        <td class="govuk-table__cell"><%= link_to t("project.table.body.export_for_html", date: month.to_fs(:govuk_month)), "/projects/all/export/risk-protection-arrangement/#{month.month}/#{month.year}/csv" %></td>
+        <td class="govuk-table__cell">
+          <%= link_to t("project.table.body.view_projects_for_html", entity: month.to_fs(:govuk_month)), "/projects/all/opening/confirmed/#{month.month}/#{month.year}" %>
+        </td>
+        <td class="govuk-table__cell">
+          <%= link_to t("project.table.body.view_projects_for_html", entity: month.to_fs(:govuk_month)), "/projects/all/opening/revised/#{month.month}/#{month.year}" %>
+        </td>
+        <td class="govuk-table__cell">
+          <%= link_to t("project.table.body.export_for_html", date: month.to_fs(:govuk_month)), "/projects/all/export/risk-protection-arrangement/#{month.month}/#{month.year}" %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/all/export/risk_protection_arrangement/projects/show.html.erb
+++ b/app/views/all/export/risk_protection_arrangement/projects/show.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_back_link(href: all_export_risk_protection_arrangement_projects_path) %>
+    <h1 class="govuk-heading-xl"><%= t("export.risk_protection_arrangement.show.title", date: @month.to_fs(:govuk_month)) %></h1>
+    <div class="govuk-body">
+      <%= t("export.risk_protection_arrangement.show.body_html") %>
+    </div>
+    <div class="govuk-form-group">
+      <%= govuk_button_link_to t("export.risk_protection_arrangement.show.button"), "/projects/all/export/risk-protection-arrangement/#{@month.month}/#{@month.year}/csv" %>
+    </div>
+  </div>
+</div>

--- a/config/locales/export/risk_protection_arrangement_csv_export.en.yml
+++ b/config/locales/export/risk_protection_arrangement_csv_export.en.yml
@@ -3,6 +3,11 @@ en:
     risk_protection_arrangement:
       index:
         title: RPA (Risk Protection Arrangement) exports
+      show:
+        title: "%{date} RPA (Risk Protection Arrangement) export"
+        body_html:
+          <p>Export downloads can take time to prepare, please be patient.</p>
+        button: Download csv file
       csv:
         headers:
           school_urn: School URN

--- a/config/locales/export/risk_protection_arrangement_csv_export.en.yml
+++ b/config/locales/export/risk_protection_arrangement_csv_export.en.yml
@@ -1,6 +1,8 @@
 en:
   export:
     risk_protection_arrangement:
+      index:
+        title: RPA (Risk Protection Arrangement) exports
       csv:
         headers:
           school_urn: School URN

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -176,6 +176,9 @@ en:
         region: Region
         email: Email
         user: User name
+        date: Date
+        confirmed: Confirmed
+        revised: Revised
       body:
         view_html: View <span class="govuk-visually-hidden">%{school_name}</span> project
         edit_html: Create academy URN <span class="govuk-visually-hidden">for %{school_name}</span>
@@ -183,6 +186,7 @@ en:
         view_projects_html: View projects <span class="govuk-visually-hidden">for %{trust_name}</span>
         view_projects_for_local_authority_html: View projects<span class="govuk-visually-hidden"> for %{local_authority_name}</span>
         view_projects_for_html: View projects<span class="govuk-visually-hidden"> for %{entity}</span>
+        export_for_html: Export<span class="govuk-visually-hidden"> for %{date}</span>
       empty:
         projects: There are no projects
       in_progress:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,7 @@ Rails.application.routes.draw do
             end
             namespace :risk_protection_arrangement, path: "risk-protection-arrangement" do
               get "/", to: "projects#index"
+              get ":month/:year", to: "projects#show", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}
               get ":month/:year/csv", to: "projects#csv", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :csv
             end
           end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,7 @@ Rails.application.routes.draw do
               get ":month/:year/csv", to: "projects#csv", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :csv
             end
             namespace :risk_protection_arrangement, path: "risk-protection-arrangement" do
+              get "/", to: "projects#index"
               get ":month/:year/csv", to: "projects#csv", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :csv
             end
           end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,7 +108,7 @@ Rails.application.routes.draw do
             end
             namespace :risk_protection_arrangement, path: "risk-protection-arrangement" do
               get "/", to: "projects#index"
-              get ":month/:year", to: "projects#show", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}
+              get ":month/:year", to: "projects#show", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :show
               get ":month/:year/csv", to: "projects#csv", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :csv
             end
           end

--- a/spec/features/projects/export/risk_protection_arrangement/users_can_export_rpa_data_spec.rb
+++ b/spec/features/projects/export/risk_protection_arrangement/users_can_export_rpa_data_spec.rb
@@ -38,4 +38,15 @@ RSpec.feature "Users can export rpa data" do
     expect(page).to have_content(four_months_time.to_fs(:govuk_month))
     expect(page).to have_link("Export")
   end
+
+  scenario "they can view a download page for a month" do
+    mock_all_academies_api_responses
+    this_month = Date.today.at_beginning_of_month
+    create(:conversion_project, conversion_date: this_month, conversion_date_provisional: false)
+
+    visit "/projects/all/export/risk-protection-arrangement/#{this_month.month}/#{this_month.year}"
+
+    expect(page).to have_content(this_month.to_fs(:govuk_month))
+    expect(page).to have_link("Download")
+  end
 end

--- a/spec/features/projects/export/risk_protection_arrangement/users_can_export_rpa_data_spec.rb
+++ b/spec/features/projects/export/risk_protection_arrangement/users_can_export_rpa_data_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.feature "Users can export rpa data" do
+  before do
+    user = create(:user)
+    sign_in_with(user)
+  end
+
+  scenario "they can view the data for last month" do
+    mock_all_academies_api_responses
+    last_month = Date.today.last_month.at_beginning_of_month
+    create(:conversion_project, conversion_date: last_month, conversion_date_provisional: false)
+
+    visit "/projects/all/export/risk-protection-arrangement/"
+
+    expect(page).to have_content(last_month.to_fs(:govuk_month))
+    expect(page).to have_link("Export")
+  end
+
+  scenario "they can view the data for this month" do
+    mock_all_academies_api_responses
+    this_month = Date.today.at_beginning_of_month
+    create(:conversion_project, conversion_date: this_month, conversion_date_provisional: false)
+
+    visit "/projects/all/export/risk-protection-arrangement/"
+
+    expect(page).to have_content(this_month.to_fs(:govuk_month))
+    expect(page).to have_link("Export")
+  end
+
+  scenario "they can view the data for four months ahead" do
+    mock_all_academies_api_responses
+    four_months_time = (Date.today + 4.months).at_beginning_of_month
+    create(:conversion_project, conversion_date: four_months_time, conversion_date_provisional: false)
+
+    visit "/projects/all/export/risk-protection-arrangement/"
+
+    expect(page).to have_content(four_months_time.to_fs(:govuk_month))
+    expect(page).to have_link("Export")
+  end
+end

--- a/spec/requests/all/export/risk_protection_arrangement/projects_controller_spec.rb
+++ b/spec/requests/all/export/risk_protection_arrangement/projects_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe All::Export::RiskProtectionArrangement::ProjectsController, type:
 
     it "formats the csv filename with the month & year" do
       get csv_all_export_risk_protection_arrangement_projects_path(5, 2025)
-      expect(response.header["Content-Disposition"]).to include("risk_protection_arrangement_export_5_2025.csv")
+      expect(response.header["Content-Disposition"]).to include("2025-5_risk_protection_arrangement_export.csv")
     end
   end
 end


### PR DESCRIPTION
This work introduces a proposed way for users to navigate exports. Their needs a centred around the idea of projects that will 'open' in a given month.

The first view starts last month and then goes forward for a total of six months. Each month links to the opening list for that month, both confirmed and revised to allow validation of the project that will be in the export.

The export itself moves to it's own page where ther actual download is triggered, this gives us the opportunity to set expecations for the download process and potentially later, documentation about the contents of the file and its use.

All this is NOT linked in navigation just yet, whilst we are confident this is right enough, we want to see it with live data to really get a sense for how it feels. Once happy, we can just add this to the primary navigation.

https://trello.com/c/Qe1AgI6a 

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/2235a665-3dd3-4a27-a9d8-3d0a61246a2e)

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/e562b00c-1b2d-47c5-bea0-5e9dcd2c63a7)
