### PR TITLE
Send the new user email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Only show counts of in-progress projects on the Team "By user" projects page
+- Send the new user email when an account is added.
 
 ## [Release 33][release-33]
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -89,6 +89,6 @@ class UsersController < ApplicationController
   end
 
   private def send_new_account_email(user)
-    UserAccountMailer.new_account_added(user)
+    UserAccountMailer.new_account_added(user).deliver_later
   end
 end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -8,8 +8,10 @@ RSpec.describe UsersController, type: :request do
   describe "#create" do
     it "sends the new account added email" do
       new_user = build(:user, email: "new.user@education.gov.uk", team: :regional_casework_services)
+      mock_mailer = double(UserAccountMailer, deliver_later: true)
 
-      expect(UserAccountMailer).to receive(:new_account_added).exactly(1).time
+      expect(UserAccountMailer).to receive(:new_account_added).and_return(mock_mailer)
+      expect(mock_mailer).to receive(:deliver_later).exactly(1).time
 
       post users_path(user: new_user.attributes)
     end


### PR DESCRIPTION
When we added the UserAccountMailer we missed actually sending it, here
we fix that!