### PR TITLE
Rename roles

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -25,7 +25,7 @@ class AssignmentsController < ApplicationController
   end
 
   def assign_assigned_to
-    @all_assignable_users = User.all_assignable_users
+    @all_assignable_users = User.assignable
   end
 
   def update_assigned_to

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -4,7 +4,7 @@ class RootController < ApplicationController
 
     return redirect_to without_academy_urn_service_support_projects_path if current_user.service_support?
 
-    return redirect_to in_progress_user_projects_path if current_user.assign_to_project? || current_user.regional_delivery_officer?
+    return redirect_to in_progress_user_projects_path if current_user.assign_to_project? || current_user.add_new_project?
 
     redirect_to all_in_progress_projects_path
   end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -4,7 +4,7 @@ class RootController < ApplicationController
 
     return redirect_to without_academy_urn_service_support_projects_path if current_user.service_support?
 
-    return redirect_to in_progress_user_projects_path if current_user.caseworker? || current_user.regional_delivery_officer?
+    return redirect_to in_progress_user_projects_path if current_user.assign_to_project? || current_user.regional_delivery_officer?
 
     redirect_to all_in_progress_projects_path
   end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -2,7 +2,7 @@ class RootController < ApplicationController
   def home
     return redirect_to unassigned_team_projects_path if current_user.manage_team?
 
-    return redirect_to without_academy_urn_service_support_projects_path if current_user.service_support?
+    return redirect_to without_academy_urn_service_support_projects_path if current_user.service_support_team?
 
     return redirect_to in_progress_user_projects_path if current_user.assign_to_project? || current_user.add_new_project?
 

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,6 +1,6 @@
 class RootController < ApplicationController
   def home
-    return redirect_to unassigned_team_projects_path if current_user.team_leader?
+    return redirect_to unassigned_team_projects_path if current_user.manage_team?
 
     return redirect_to without_academy_urn_service_support_projects_path if current_user.service_support?
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -75,7 +75,7 @@ class UsersController < ApplicationController
       :last_name,
       :email,
       :team,
-      :team_leader,
+      :manage_team,
       :active
     )
   end

--- a/app/models/concerns/teamable.rb
+++ b/app/models/concerns/teamable.rb
@@ -21,4 +21,10 @@ module Teamable
   })
 
   PROJECT_TEAMS = REGIONAL_TEAMS.merge({regional_casework_services: "regional_casework_services"})
+
+  class_methods do
+    def regional_teams
+      REGIONAL_TEAMS.values
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,13 +8,13 @@ class User < ApplicationRecord
   has_many :notes
 
   scope :order_by_first_name, -> { order(first_name: :asc) }
-  scope :team_leaders, -> { where(team_leader: true).order_by_first_name }
+  scope :team_leaders, -> { where(manage_team: true).order_by_first_name }
   scope :regional_delivery_officers, -> { where(add_new_project: true).order_by_first_name }
   scope :caseworkers, -> { where(assign_to_project: true).order_by_first_name }
   scope :active, -> { where(deactivated_at: nil) }
   scope :inactive, -> { where.not(deactivated_at: nil) }
 
-  scope :all_assignable_users, -> { active.where.not(assign_to_project: false).or(where.not(team_leader: false)).or(where.not(add_new_project: false)) }
+  scope :all_assignable_users, -> { active.where.not(assign_to_project: false).or(where.not(manage_team: false)).or(where.not(add_new_project: false)) }
 
   scope :by_team, ->(team) { where(team: team) }
 
@@ -31,7 +31,7 @@ class User < ApplicationRecord
   end
 
   def has_role?
-    return true if assign_to_project? || add_new_project? || team_leader?
+    return true if assign_to_project? || add_new_project? || manage_team?
     false
   end
 
@@ -56,7 +56,7 @@ class User < ApplicationRecord
       assign_to_project: apply_regional_caseworker_role?,
       service_support: apply_service_support_role?,
       add_new_project: apply_regional_delivery_officer_role?,
-      team_leader: apply_team_lead_role?
+      manage_team: apply_team_lead_role?
     )
   end
 
@@ -65,7 +65,7 @@ class User < ApplicationRecord
   end
 
   private def apply_regional_caseworker_role?
-    team == "regional_casework_services" && team_leader == false
+    team == "regional_casework_services" && manage_team == false
   end
 
   private def apply_regional_delivery_officer_role?
@@ -73,7 +73,7 @@ class User < ApplicationRecord
   end
 
   private def apply_team_lead_role?
-    team_leader && can_have_team_lead?
+    manage_team && can_have_team_lead?
   end
 
   private def can_have_team_lead?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,15 @@ class User < ApplicationRecord
     false
   end
 
+  def is_regional_caseworker?
+    team == "regional_casework_services" && manage_team == false
+  end
+
+  def is_regional_delivery_officer?
+    User.regional_teams.include?(team)
+  end
+
+
   def active
     deactivated_at.nil?
   end
@@ -59,11 +68,11 @@ class User < ApplicationRecord
 
   private def apply_roles_based_on_team
     assign_attributes(
-      assign_to_project: apply_regional_caseworker_role?,
+      assign_to_project: is_regional_caseworker? || is_regional_delivery_officer?,
       manage_user_accounts: apply_service_support_role?,
       manage_conversion_urns: apply_service_support_role?,
       manage_local_authorities: apply_service_support_role?,
-      add_new_project: apply_regional_delivery_officer_role?,
+      add_new_project: is_regional_delivery_officer?,
       manage_team: apply_team_lead_role?
     )
   end
@@ -72,19 +81,11 @@ class User < ApplicationRecord
     team == "service_support"
   end
 
-  private def apply_regional_caseworker_role?
-    team == "regional_casework_services" && manage_team == false
-  end
-
-  private def apply_regional_delivery_officer_role?
-    REGIONAL_TEAMS.value?(team)
-  end
-
   private def apply_team_lead_role?
-    manage_team && can_have_team_lead?
+    manage_team && can_be_team_lead?
   end
 
-  private def can_have_team_lead?
-    apply_regional_delivery_officer_role? || team == "regional_casework_services"
+  private def can_be_team_lead?
+    is_regional_delivery_officer? || team == "regional_casework_services"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,11 +10,11 @@ class User < ApplicationRecord
   scope :order_by_first_name, -> { order(first_name: :asc) }
   scope :team_leaders, -> { where(team_leader: true).order_by_first_name }
   scope :regional_delivery_officers, -> { where(regional_delivery_officer: true).order_by_first_name }
-  scope :caseworkers, -> { where(caseworker: true).order_by_first_name }
+  scope :caseworkers, -> { where(assign_to_project: true).order_by_first_name }
   scope :active, -> { where(deactivated_at: nil) }
   scope :inactive, -> { where.not(deactivated_at: nil) }
 
-  scope :all_assignable_users, -> { active.where.not(caseworker: false).or(where.not(team_leader: false)).or(where.not(regional_delivery_officer: false)) }
+  scope :all_assignable_users, -> { active.where.not(assign_to_project: false).or(where.not(team_leader: false)).or(where.not(regional_delivery_officer: false)) }
 
   scope :by_team, ->(team) { where(team: team) }
 
@@ -31,7 +31,7 @@ class User < ApplicationRecord
   end
 
   def has_role?
-    return true if caseworker? || regional_delivery_officer? || team_leader?
+    return true if assign_to_project? || regional_delivery_officer? || team_leader?
     false
   end
 
@@ -53,7 +53,7 @@ class User < ApplicationRecord
 
   private def apply_roles_based_on_team
     assign_attributes(
-      caseworker: apply_regional_caseworker_role?,
+      assign_to_project: apply_regional_caseworker_role?,
       service_support: apply_service_support_role?,
       regional_delivery_officer: apply_regional_delivery_officer_role?,
       team_leader: apply_team_lead_role?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,7 +54,9 @@ class User < ApplicationRecord
   private def apply_roles_based_on_team
     assign_attributes(
       assign_to_project: apply_regional_caseworker_role?,
-      service_support: apply_service_support_role?,
+      manage_user_accounts: apply_service_support_role?,
+      manage_conversion_urns: apply_service_support_role?,
+      manage_local_authorities: apply_service_support_role?,
       add_new_project: apply_regional_delivery_officer_role?,
       manage_team: apply_team_lead_role?
     )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,15 +8,15 @@ class User < ApplicationRecord
   has_many :notes
 
   scope :order_by_first_name, -> { order(first_name: :asc) }
+
   scope :team_leaders, -> { where(manage_team: true).order_by_first_name }
-  scope :regional_delivery_officers, -> { where(add_new_project: true).order_by_first_name }
-  scope :caseworkers, -> { where(assign_to_project: true).order_by_first_name }
+  scope :regional_delivery_officers, -> { where(team: User.regional_teams).order_by_first_name }
+  scope :caseworkers, -> { where(team: "regional_casework_services").where(manage_team: false).order_by_first_name }
+  scope :by_team, ->(team) { where(team: team) }
+
   scope :active, -> { where(deactivated_at: nil) }
   scope :inactive, -> { where.not(deactivated_at: nil) }
-
   scope :all_assignable_users, -> { active.where.not(assign_to_project: false).or(where.not(manage_team: false)).or(where.not(add_new_project: false)) }
-
-  scope :by_team, ->(team) { where(team: team) }
 
   validates :first_name, :last_name, :email, :team, presence: true
   validates :team, presence: true, on: :set_team

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,12 +9,12 @@ class User < ApplicationRecord
 
   scope :order_by_first_name, -> { order(first_name: :asc) }
   scope :team_leaders, -> { where(team_leader: true).order_by_first_name }
-  scope :regional_delivery_officers, -> { where(regional_delivery_officer: true).order_by_first_name }
+  scope :regional_delivery_officers, -> { where(add_new_project: true).order_by_first_name }
   scope :caseworkers, -> { where(assign_to_project: true).order_by_first_name }
   scope :active, -> { where(deactivated_at: nil) }
   scope :inactive, -> { where.not(deactivated_at: nil) }
 
-  scope :all_assignable_users, -> { active.where.not(assign_to_project: false).or(where.not(team_leader: false)).or(where.not(regional_delivery_officer: false)) }
+  scope :all_assignable_users, -> { active.where.not(assign_to_project: false).or(where.not(team_leader: false)).or(where.not(add_new_project: false)) }
 
   scope :by_team, ->(team) { where(team: team) }
 
@@ -31,7 +31,7 @@ class User < ApplicationRecord
   end
 
   def has_role?
-    return true if assign_to_project? || regional_delivery_officer? || team_leader?
+    return true if assign_to_project? || add_new_project? || team_leader?
     false
   end
 
@@ -55,7 +55,7 @@ class User < ApplicationRecord
     assign_attributes(
       assign_to_project: apply_regional_caseworker_role?,
       service_support: apply_service_support_role?,
-      regional_delivery_officer: apply_regional_delivery_officer_role?,
+      add_new_project: apply_regional_delivery_officer_role?,
       team_leader: apply_team_lead_role?
     )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,11 +18,11 @@ class User < ApplicationRecord
   scope :regional_delivery_officers, -> { where(team: User.regional_teams).order_by_first_name }
   scope :regional_delivery_officer_team_leads, -> { regional_delivery_officers.where(manage_team: true).order_by_first_name }
 
+  scope :assignable, -> { where(assign_to_project: true) }
   scope :by_team, ->(team) { where(team: team) }
 
   scope :active, -> { where(deactivated_at: nil) }
   scope :inactive, -> { where.not(deactivated_at: nil) }
-  scope :all_assignable_users, -> { active.where.not(assign_to_project: false).or(where.not(manage_team: false)).or(where.not(add_new_project: false)) }
 
   validates :first_name, :last_name, :email, :team, presence: true
   validates :team, presence: true, on: :set_team
@@ -48,7 +48,6 @@ class User < ApplicationRecord
   def is_regional_delivery_officer?
     User.regional_teams.include?(team)
   end
-
 
   def active
     deactivated_at.nil?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,8 +10,14 @@ class User < ApplicationRecord
   scope :order_by_first_name, -> { order(first_name: :asc) }
 
   scope :team_leaders, -> { where(manage_team: true).order_by_first_name }
+
+  scope :regional_casework_services, -> { where(team: "regional_casework_services").order_by_first_name }
+  scope :caseworkers, -> { regional_casework_services.where(manage_team: false).order_by_first_name }
+  scope :regional_casework_services_team_leads, -> { regional_casework_services.where(manage_team: true).order_by_first_name }
+
   scope :regional_delivery_officers, -> { where(team: User.regional_teams).order_by_first_name }
-  scope :caseworkers, -> { where(team: "regional_casework_services").where(manage_team: false).order_by_first_name }
+  scope :regional_delivery_officer_team_leads, -> { regional_delivery_officers.where(manage_team: true).order_by_first_name }
+
   scope :by_team, ->(team) { where(team: team) }
 
   scope :active, -> { where(deactivated_at: nil) }

--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -6,7 +6,7 @@ class AssignmentPolicy
   end
 
   def assign_team_leader?
-    @user.team_leader?
+    @user.manage_team?
   end
 
   def update_team_leader?
@@ -14,7 +14,7 @@ class AssignmentPolicy
   end
 
   def assign_regional_delivery_officer?
-    @user.team_leader?
+    @user.manage_team?
   end
 
   def update_regional_delivery_officer?

--- a/app/policies/local_authority_policy.rb
+++ b/app/policies/local_authority_policy.rb
@@ -7,7 +7,7 @@ class LocalAuthorityPolicy
   end
 
   def new?
-    return true if @user.service_support?
+    return true if @user.manage_local_authorities?
     false
   end
 

--- a/app/policies/navigation_policy.rb
+++ b/app/policies/navigation_policy.rb
@@ -36,7 +36,7 @@ class NavigationPolicy
   end
 
   def show_service_support_header_navigation?
-    return true if @user.service_support?
+    return true if @user.service_support_team?
 
     false
   end

--- a/app/policies/navigation_policy.rb
+++ b/app/policies/navigation_policy.rb
@@ -14,7 +14,7 @@ class NavigationPolicy
   end
 
   def show_your_projects_header_navigation?
-    return true if @user.caseworker?
+    return true if @user.assign_to_project?
     return true if @user.regional_delivery_officer?
 
     false

--- a/app/policies/navigation_policy.rb
+++ b/app/policies/navigation_policy.rb
@@ -15,7 +15,7 @@ class NavigationPolicy
 
   def show_your_projects_header_navigation?
     return true if @user.assign_to_project?
-    return true if @user.regional_delivery_officer?
+    return true if @user.add_new_project?
 
     false
   end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -15,7 +15,7 @@ class ProjectPolicy
   end
 
   def create?
-    user.regional_delivery_officer?
+    user.add_new_project?
   end
 
   def edit?

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -73,7 +73,7 @@ class ProjectPolicy
   end
 
   def unassigned?
-    @user.team_leader?
+    @user.manage_team?
   end
 
   private def project_assigned_to_user?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -7,7 +7,7 @@ class UserPolicy
   end
 
   def index?
-    @user.service_support?
+    @user.manage_user_accounts?
   end
 
   def new?

--- a/app/services/assignable_users_data_migration_service.rb
+++ b/app/services/assignable_users_data_migration_service.rb
@@ -1,0 +1,11 @@
+class AssignableUsersDataMigrationService
+  def initialize(users)
+    @users = users
+  end
+
+  def migrate!
+    @users.each do |user|
+      user.write_attribute(:assign_to_project, true) if user.add_new_project?
+    end
+  end
+end

--- a/app/views/shared/navigation/_dfe_header_navigation.html.erb
+++ b/app/views/shared/navigation/_dfe_header_navigation.html.erb
@@ -17,7 +17,7 @@
 
             <%= if policy(:navigation).show_team_projects_header_navigation?
                   render partial: "shared/navigation/dfe_header_navigation_item",
-                    locals: {title: t("navigation.header.team_projects"), path: (current_user.team_leader? ? unassigned_team_projects_path : in_progress_team_projects_path), namespace: "/projects/team/"}
+                    locals: {title: t("navigation.header.team_projects"), path: (current_user.manage_team? ? unassigned_team_projects_path : in_progress_team_projects_path), namespace: "/projects/team/"}
                 end %>
 
             <%= if policy(:navigation).show_all_projects_header_navigation?

--- a/app/views/shared/navigation/_your_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_your_projects_primary_navigation.html.erb
@@ -10,7 +10,7 @@
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.your_projects.in_progress"), path: in_progress_user_projects_path, namespace: "/projects/user/in-progress"} %>
 
-          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.your_projects.added_by_you"), path: added_by_user_projects_path, namespace: "/projects/user/added-by"} if @current_user.regional_delivery_officer? %>
+          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.your_projects.added_by_you"), path: added_by_user_projects_path, namespace: "/projects/user/added-by"} if @current_user.add_new_project? %>
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.your_projects.completed"), path: completed_user_projects_path, namespace: "/projects/user/completed"} %>
 

--- a/app/views/users/_users_table.html.erb
+++ b/app/views/users/_users_table.html.erb
@@ -15,7 +15,7 @@
       <td class="govuk-table__header govuk-table__cell"><%= account.full_name %></td>
       <td class="govuk-table__cell"><%= account.email %></td>
       <td class="govuk-table__cell"><%= account.team.nil? ? "No team" : t("user.teams.#{account.team}") %></td>
-      <td class="govuk-table__cell"><%= t("user.table.body.team_lead.#{account.team_leader}") %></td>
+      <td class="govuk-table__cell"><%= t("user.table.body.team_lead.#{account.manage_team}") %></td>
         <td class="govuk-table__cell">
           <%= link_to t("user.table.body.edit_user_html", user: account.full_name), edit_user_path(account) %>
         </td>

--- a/db/migrate/20230718080143_rename_caseworker.rb
+++ b/db/migrate/20230718080143_rename_caseworker.rb
@@ -1,0 +1,5 @@
+class RenameCaseworker < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :users, :caseworker, :assign_to_project
+  end
+end

--- a/db/migrate/20230718085530_rename_regional_delivery_officer.rb
+++ b/db/migrate/20230718085530_rename_regional_delivery_officer.rb
@@ -1,0 +1,5 @@
+class RenameRegionalDeliveryOfficer < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :users, :regional_delivery_officer, :add_new_project
+  end
+end

--- a/db/migrate/20230718092522_rename_team_leader.rb
+++ b/db/migrate/20230718092522_rename_team_leader.rb
@@ -1,0 +1,5 @@
+class RenameTeamLeader < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :users, :team_leader, :manage_team
+  end
+end

--- a/db/migrate/20230718100806_refine_service_support.rb
+++ b/db/migrate/20230718100806_refine_service_support.rb
@@ -1,0 +1,7 @@
+class RefineServiceSupport < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :manage_conversion_urns, :boolean, default: false
+    add_column :users, :manage_local_authorities, :boolean, default: false
+    rename_column :users, :service_support, :manage_user_accounts
+  end
+end

--- a/db/migrate/20230718141059_assign_to_project_data_migration.rb
+++ b/db/migrate/20230718141059_assign_to_project_data_migration.rb
@@ -1,0 +1,5 @@
+class AssignToProjectDataMigration < ActiveRecord::Migration[7.0]
+  def up
+    AssignableUsersDataMigrationService.new(User.all).migrate!
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_12_113923) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_080143) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -225,7 +225,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_12_113923) do
     t.string "first_name"
     t.string "last_name"
     t.string "active_directory_user_id"
-    t.boolean "caseworker", default: false
+    t.boolean "assign_to_project", default: false
     t.boolean "service_support", default: false
     t.string "active_directory_user_group_ids"
     t.string "team"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_092522) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_100806) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -226,10 +226,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_092522) do
     t.string "last_name"
     t.string "active_directory_user_id"
     t.boolean "assign_to_project", default: false
-    t.boolean "service_support", default: false
+    t.boolean "manage_user_accounts", default: false
     t.string "active_directory_user_group_ids"
     t.string "team"
     t.datetime "deactivated_at"
+    t.boolean "manage_conversion_urns", default: false
+    t.boolean "manage_local_authorities", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_100806) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_141059) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_080143) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_085530) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -221,7 +221,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_080143) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "team_leader", default: false
-    t.boolean "regional_delivery_officer", default: false, null: false
+    t.boolean "add_new_project", default: false, null: false
     t.string "first_name"
     t.string "last_name"
     t.string "active_directory_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_085530) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_092522) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -220,7 +220,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_085530) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "team_leader", default: false
+    t.boolean "manage_team", default: false
     t.boolean "add_new_project", default: false, null: false
     t.string "first_name"
     t.string "last_name"

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -43,6 +43,16 @@ FactoryBot.define do
       manage_conversion_urns { true }
     end
 
+    factory :regional_delivery_officer_team_lead_user do
+      first_name { "Regional" }
+      last_name { "Delivery-Officer" }
+      email { "regional.delivery-officer@education.gov.uk" }
+      assign_to_project { true }
+      add_new_project { true }
+      team { "north_west" }
+      manage_team { true }
+    end
+
     factory :regional_delivery_officer_user do
       first_name { "Regional" }
       last_name { "Delivery-Officer" }

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     email { "user@education.gov.uk" }
     first_name { "John" }
     last_name { "Doe" }
-    team_leader { false }
+    manage_team { false }
     add_new_project { false }
     service_support { false }
     assign_to_project { false }
@@ -18,7 +18,7 @@ FactoryBot.define do
     trait :team_leader do
       first_name { "Team" }
       last_name { "Leader" }
-      team_leader { true }
+      manage_team { true }
       email { "team-leader-#{SecureRandom.uuid}@education.gov.uk" }
       team { "regional_casework_services" }
     end
@@ -46,6 +46,15 @@ FactoryBot.define do
       assign_to_project { true }
       add_new_project { true }
       team { "north_west" }
+    end
+
+    factory :regional_casework_team_lead do
+      first_name { "Regional" }
+      last_name { "Casework-Team-Lead" }
+      email { "regional.casework-team-lead@education.gov.uk" }
+      assign_to_project { false }
+      manage_team { true }
+      team { "regional_casework_services" }
     end
 
     factory :regional_caseworker_user do

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -43,7 +43,7 @@ FactoryBot.define do
       manage_conversion_urns { true }
     end
 
-    factory :regional_delivery_officer do
+    factory :regional_delivery_officer_user do
       first_name { "Regional" }
       last_name { "Delivery-Officer" }
       email { "regional.delivery-officer@education.gov.uk" }
@@ -52,7 +52,7 @@ FactoryBot.define do
       team { "north_west" }
     end
 
-    factory :regional_casework_team_lead do
+    factory :regional_casework_services_team_lead_user do
       first_name { "Regional" }
       last_name { "Casework-Team-Lead" }
       email { "regional.casework-team-lead@education.gov.uk" }
@@ -61,7 +61,7 @@ FactoryBot.define do
       team { "regional_casework_services" }
     end
 
-    factory :regional_caseworker_user do
+    factory :regional_casework_services_user do
       first_name { "Regional" }
       last_name { "Caseworker" }
       email { "regional.caseworker@education.gov.uk" }

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -5,8 +5,10 @@ FactoryBot.define do
     last_name { "Doe" }
     manage_team { false }
     add_new_project { false }
-    service_support { false }
     assign_to_project { false }
+    manage_user_accounts { false }
+    manage_local_authorities { false }
+    manage_conversion_urns { false }
     team { "academies_operational_practice_unit" }
 
     trait :caseworker do
@@ -34,9 +36,11 @@ FactoryBot.define do
     trait :service_support do
       first_name { "Service" }
       last_name { "Support" }
-      service_support { true }
       email { "service-support-#{SecureRandom.uuid}@education.gov.uk" }
       team { "service_support" }
+      manage_user_accounts { true }
+      manage_local_authorities { true }
+      manage_conversion_urns { true }
     end
 
     factory :regional_delivery_officer do
@@ -63,6 +67,16 @@ FactoryBot.define do
       email { "regional.caseworker@education.gov.uk" }
       assign_to_project { true }
       team { "regional_casework_services" }
+    end
+
+    factory :service_support_user do
+      first_name { "Service" }
+      last_name { "Support" }
+      email { "service.support@education.gov.uk" }
+      team { "service_support" }
+      manage_user_accounts { true }
+      manage_local_authorities { true }
+      manage_conversion_urns { true }
     end
 
     factory :inactive_user do

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     first_name { "John" }
     last_name { "Doe" }
     team_leader { false }
-    regional_delivery_officer { false }
+    add_new_project { false }
     service_support { false }
     assign_to_project { false }
     team { "academies_operational_practice_unit" }
@@ -26,7 +26,7 @@ FactoryBot.define do
     trait :regional_delivery_officer do
       first_name { "Regional" }
       last_name { "Delivery-Officer" }
-      regional_delivery_officer { true }
+      add_new_project { true }
       email { "regional-delivery-officer-#{SecureRandom.uuid}@education.gov.uk" }
       team { "london" }
     end
@@ -37,6 +37,15 @@ FactoryBot.define do
       service_support { true }
       email { "service-support-#{SecureRandom.uuid}@education.gov.uk" }
       team { "service_support" }
+    end
+
+    factory :regional_delivery_officer do
+      first_name { "Regional" }
+      last_name { "Delivery-Officer" }
+      email { "regional.delivery-officer@education.gov.uk" }
+      assign_to_project { true }
+      add_new_project { true }
+      team { "north_west" }
     end
 
     factory :regional_caseworker_user do

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -6,12 +6,12 @@ FactoryBot.define do
     team_leader { false }
     regional_delivery_officer { false }
     service_support { false }
-    caseworker { false }
+    assign_to_project { false }
     team { "academies_operational_practice_unit" }
 
     trait :caseworker do
       email { "caseworker-#{SecureRandom.uuid}@education.gov.uk" }
-      caseworker { true }
+      assign_to_project { true }
       team { "regional_casework_services" }
     end
 
@@ -37,6 +37,14 @@ FactoryBot.define do
       service_support { true }
       email { "service-support-#{SecureRandom.uuid}@education.gov.uk" }
       team { "service_support" }
+    end
+
+    factory :regional_caseworker_user do
+      first_name { "Regional" }
+      last_name { "Caseworker" }
+      email { "regional.caseworker@education.gov.uk" }
+      assign_to_project { true }
+      team { "regional_casework_services" }
     end
 
     factory :inactive_user do

--- a/spec/features/team_leaders_can_assign_users_to_project_roles_spec.rb
+++ b/spec/features/team_leaders_can_assign_users_to_project_roles_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Team leaders can assign users to project roles" do
-  let!(:team_leader) { create(:user, team_leader: true) }
+  let!(:team_leader) { create(:user, manage_team: true) }
   let!(:regional_delivery_officer) { create(:user, :regional_delivery_officer, first_name: "John") }
   let!(:caseworker) { create(:user, :caseworker, first_name: "Jane") }
   let(:user) { create(:user, :team_leader, first_name: "Jason") }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,13 +21,14 @@ RSpec.describe User do
     let!(:caseworker_2) { create(:regional_casework_services_user, first_name: "Aaron", email: "aaron-caseworker@education.gov.uk") }
     let!(:team_leader) { create(:regional_casework_services_team_lead_user, first_name: "Zoe") }
     let!(:team_leader_2) { create(:regional_casework_services_team_lead_user, first_name: "Andy", email: "aaron-team-leader@education.gov.uk") }
-    let!(:regional_delivery_officer) { create(:regional_delivery_officer_user) }
+    let!(:regional_delivery_officer_team_lead) { create(:regional_delivery_officer_user, manage_team: true, email: "rdo.lead@education.gov.uk") }
+    let!(:regional_delivery_officer) { create(:regional_delivery_officer_user, first_name: "Zavier") }
     let!(:regional_delivery_officer_2) { create(:regional_delivery_officer_user, first_name: "Adam", email: "aaron-rdo@education.gov.uk") }
     let!(:user_without_role) { create(:user, assign_to_project: false, manage_team: false, add_new_project: false, team: "education_and_skills_funding_agency") }
 
     describe "order_by_first_name" do
       it "orders by first_name" do
-        expect(User.order_by_first_name.count).to be 7
+        expect(User.order_by_first_name.count).to be 8
         expect(User.order_by_first_name.first).to eq caseworker_2
         expect(User.order_by_first_name.last).to eq team_leader
       end
@@ -35,15 +36,22 @@ RSpec.describe User do
 
     describe "regional casework services team leaders" do
       it "only includes users that have the team leader role sorted by first_name" do
-        expect(User.team_leaders.count).to be 2
-        expect(User.team_leaders.first).to eq team_leader_2
-        expect(User.team_leaders.last).to eq team_leader
+        expect(User.regional_casework_services_team_leads.count).to be 2
+        expect(User.regional_casework_services_team_leads.first).to eq team_leader_2
+        expect(User.regional_casework_services_team_leads.last).to eq team_leader
+      end
+    end
+
+    describe "regional delivery officer team leaders" do
+      it "only includes users that have the team leader role sorted by first_name" do
+        expect(User.regional_delivery_officer_team_leads.count).to be 1
+        expect(User.regional_delivery_officer_team_leads.first).to eq regional_delivery_officer_team_lead
       end
     end
 
     describe "regional_delivery_officers" do
       it "only includes users that have the regional delivery officer role sorted by first_name" do
-        expect(User.regional_delivery_officers.count).to be 2
+        expect(User.regional_delivery_officers.count).to be 3
         expect(User.regional_delivery_officers.first).to eq regional_delivery_officer_2
         expect(User.regional_delivery_officers.last).to eq regional_delivery_officer
       end
@@ -59,7 +67,7 @@ RSpec.describe User do
 
     describe "all_assignable_users" do
       it "only includes users who have a role" do
-        expect(User.all_assignable_users.count).to eq 6
+        expect(User.all_assignable_users.count).to eq 7
         expect(User.all_assignable_users).to_not include(user_without_role)
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe User do
     it { is_expected.to have_db_column(:email).of_type :string }
     it { is_expected.to have_db_column(:first_name).of_type :string }
     it { is_expected.to have_db_column(:last_name).of_type :string }
-    it { is_expected.to have_db_column(:team_leader).of_type :boolean }
+    it { is_expected.to have_db_column(:manage_team).of_type :boolean }
     it { is_expected.to have_db_column(:add_new_project).of_type :boolean }
     it { is_expected.to have_db_column(:assign_to_project).of_type :boolean }
     it { is_expected.to have_db_column(:service_support).of_type :boolean }
@@ -21,7 +21,7 @@ RSpec.describe User do
     let!(:team_leader_2) { create(:user, :team_leader, first_name: "Andy", email: "aaron-team-leader@education.gov.uk") }
     let!(:regional_delivery_officer) { create(:user, :regional_delivery_officer, team: "london") }
     let!(:regional_delivery_officer_2) { create(:user, :regional_delivery_officer, first_name: "Adam", email: "aaron-rdo@education.gov.uk") }
-    let!(:user_without_role) { create(:user, assign_to_project: false, team_leader: false, add_new_project: false, team: "education_and_skills_funding_agency") }
+    let!(:user_without_role) { create(:user, assign_to_project: false, manage_team: false, add_new_project: false, team: "education_and_skills_funding_agency") }
 
     describe "order_by_first_name" do
       it "orders by first_name" do
@@ -128,12 +128,12 @@ RSpec.describe User do
           it "assigns the caseworker role correctly" do
             user_attributes = valid_user_attributes
             user_attributes[:team] = "regional_casework_services"
-            user_attributes[:team_leader] = false
+            user_attributes[:manage_team] = false
 
             user = described_class.create!(user_attributes)
 
             expect(user.assign_to_project).to be true
-            expect(user.team_leader).to be false
+            expect(user.manage_team).to be false
             expect(user.add_new_project).to be false
             expect(user.service_support).to be false
           end
@@ -143,12 +143,12 @@ RSpec.describe User do
           it "assigns the team leader role correctly" do
             user_attributes = valid_user_attributes
             user_attributes[:team] = "regional_casework_services"
-            user_attributes[:team_leader] = true
+            user_attributes[:manage_team] = true
 
             user = described_class.create!(user_attributes)
 
             expect(user.assign_to_project).to be false
-            expect(user.team_leader).to be true
+            expect(user.manage_team).to be true
             expect(user.add_new_project).to be false
             expect(user.service_support).to be false
           end
@@ -160,12 +160,12 @@ RSpec.describe User do
           it "assigns the regional delivery officer and team leader role correctly" do
             user_attributes = valid_user_attributes
             user_attributes[:team] = "london"
-            user_attributes[:team_leader] = false
+            user_attributes[:manage_team] = false
 
             user = described_class.create!(user_attributes)
 
             expect(user.assign_to_project).to be false
-            expect(user.team_leader).to be false
+            expect(user.manage_team).to be false
             expect(user.add_new_project).to be true
             expect(user.service_support).to be false
           end
@@ -175,12 +175,12 @@ RSpec.describe User do
           it "assigns the regional delivery officer and team leader role correctly" do
             user_attributes = valid_user_attributes
             user_attributes[:team] = "london"
-            user_attributes[:team_leader] = true
+            user_attributes[:manage_team] = true
 
             user = described_class.create!(user_attributes)
 
             expect(user.assign_to_project).to be false
-            expect(user.team_leader).to be true
+            expect(user.manage_team).to be true
             expect(user.add_new_project).to be true
             expect(user.service_support).to be false
           end
@@ -191,12 +191,12 @@ RSpec.describe User do
         it "assigns the service support role correctly" do
           user_attributes = valid_user_attributes
           user_attributes[:team] = "service_support"
-          user_attributes[:team_leader] = false
+          user_attributes[:manage_team] = false
 
           user = described_class.create!(user_attributes)
 
           expect(user.assign_to_project).to be false
-          expect(user.team_leader).to be false
+          expect(user.manage_team).to be false
           expect(user.add_new_project).to be false
           expect(user.service_support).to be true
         end
@@ -206,11 +206,11 @@ RSpec.describe User do
         it "cannot be a team lead" do
           user_attributes = valid_user_attributes
           user_attributes[:team] = "service_support"
-          user_attributes[:team_leader] = true
+          user_attributes[:manage_team] = true
 
           user = described_class.create!(user_attributes)
 
-          expect(user.team_leader).to be false
+          expect(user.manage_team).to be false
         end
       end
     end
@@ -312,7 +312,7 @@ RSpec.describe User do
       last_name: "Last",
       email: "first.last@education.gov.uk",
       team: "london",
-      team_leader: false
+      manage_team: false
     }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe User do
     it { is_expected.to have_db_column(:last_name).of_type :string }
     it { is_expected.to have_db_column(:team_leader).of_type :boolean }
     it { is_expected.to have_db_column(:regional_delivery_officer).of_type :boolean }
-    it { is_expected.to have_db_column(:caseworker).of_type :boolean }
+    it { is_expected.to have_db_column(:assign_to_project).of_type :boolean }
     it { is_expected.to have_db_column(:service_support).of_type :boolean }
     it { is_expected.to have_db_column(:active_directory_user_group_ids).of_type :string }
     it { is_expected.to have_db_column(:team).of_type :string }
@@ -21,7 +21,7 @@ RSpec.describe User do
     let!(:team_leader_2) { create(:user, :team_leader, first_name: "Andy", email: "aaron-team-leader@education.gov.uk") }
     let!(:regional_delivery_officer) { create(:user, :regional_delivery_officer, team: "london") }
     let!(:regional_delivery_officer_2) { create(:user, :regional_delivery_officer, first_name: "Adam", email: "aaron-rdo@education.gov.uk") }
-    let!(:user_without_role) { create(:user, caseworker: false, team_leader: false, regional_delivery_officer: false, team: "education_and_skills_funding_agency") }
+    let!(:user_without_role) { create(:user, assign_to_project: false, team_leader: false, regional_delivery_officer: false, team: "education_and_skills_funding_agency") }
 
     describe "order_by_first_name" do
       it "orders by first_name" do
@@ -132,7 +132,7 @@ RSpec.describe User do
 
             user = described_class.create!(user_attributes)
 
-            expect(user.caseworker).to be true
+            expect(user.assign_to_project).to be true
             expect(user.team_leader).to be false
             expect(user.regional_delivery_officer).to be false
             expect(user.service_support).to be false
@@ -147,7 +147,7 @@ RSpec.describe User do
 
             user = described_class.create!(user_attributes)
 
-            expect(user.caseworker).to be false
+            expect(user.assign_to_project).to be false
             expect(user.team_leader).to be true
             expect(user.regional_delivery_officer).to be false
             expect(user.service_support).to be false
@@ -164,7 +164,7 @@ RSpec.describe User do
 
             user = described_class.create!(user_attributes)
 
-            expect(user.caseworker).to be false
+            expect(user.assign_to_project).to be false
             expect(user.team_leader).to be false
             expect(user.regional_delivery_officer).to be true
             expect(user.service_support).to be false
@@ -179,7 +179,7 @@ RSpec.describe User do
 
             user = described_class.create!(user_attributes)
 
-            expect(user.caseworker).to be false
+            expect(user.assign_to_project).to be false
             expect(user.team_leader).to be true
             expect(user.regional_delivery_officer).to be true
             expect(user.service_support).to be false
@@ -195,7 +195,7 @@ RSpec.describe User do
 
           user = described_class.create!(user_attributes)
 
-          expect(user.caseworker).to be false
+          expect(user.assign_to_project).to be false
           expect(user.team_leader).to be false
           expect(user.regional_delivery_officer).to be false
           expect(user.service_support).to be true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe User do
     it { is_expected.to have_db_column(:first_name).of_type :string }
     it { is_expected.to have_db_column(:last_name).of_type :string }
     it { is_expected.to have_db_column(:team_leader).of_type :boolean }
-    it { is_expected.to have_db_column(:regional_delivery_officer).of_type :boolean }
+    it { is_expected.to have_db_column(:add_new_project).of_type :boolean }
     it { is_expected.to have_db_column(:assign_to_project).of_type :boolean }
     it { is_expected.to have_db_column(:service_support).of_type :boolean }
     it { is_expected.to have_db_column(:active_directory_user_group_ids).of_type :string }
@@ -21,7 +21,7 @@ RSpec.describe User do
     let!(:team_leader_2) { create(:user, :team_leader, first_name: "Andy", email: "aaron-team-leader@education.gov.uk") }
     let!(:regional_delivery_officer) { create(:user, :regional_delivery_officer, team: "london") }
     let!(:regional_delivery_officer_2) { create(:user, :regional_delivery_officer, first_name: "Adam", email: "aaron-rdo@education.gov.uk") }
-    let!(:user_without_role) { create(:user, assign_to_project: false, team_leader: false, regional_delivery_officer: false, team: "education_and_skills_funding_agency") }
+    let!(:user_without_role) { create(:user, assign_to_project: false, team_leader: false, add_new_project: false, team: "education_and_skills_funding_agency") }
 
     describe "order_by_first_name" do
       it "orders by first_name" do
@@ -134,7 +134,7 @@ RSpec.describe User do
 
             expect(user.assign_to_project).to be true
             expect(user.team_leader).to be false
-            expect(user.regional_delivery_officer).to be false
+            expect(user.add_new_project).to be false
             expect(user.service_support).to be false
           end
         end
@@ -149,7 +149,7 @@ RSpec.describe User do
 
             expect(user.assign_to_project).to be false
             expect(user.team_leader).to be true
-            expect(user.regional_delivery_officer).to be false
+            expect(user.add_new_project).to be false
             expect(user.service_support).to be false
           end
         end
@@ -166,7 +166,7 @@ RSpec.describe User do
 
             expect(user.assign_to_project).to be false
             expect(user.team_leader).to be false
-            expect(user.regional_delivery_officer).to be true
+            expect(user.add_new_project).to be true
             expect(user.service_support).to be false
           end
         end
@@ -181,7 +181,7 @@ RSpec.describe User do
 
             expect(user.assign_to_project).to be false
             expect(user.team_leader).to be true
-            expect(user.regional_delivery_officer).to be true
+            expect(user.add_new_project).to be true
             expect(user.service_support).to be false
           end
         end
@@ -197,7 +197,7 @@ RSpec.describe User do
 
           expect(user.assign_to_project).to be false
           expect(user.team_leader).to be false
-          expect(user.regional_delivery_officer).to be false
+          expect(user.add_new_project).to be false
           expect(user.service_support).to be true
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe User do
 
             user = described_class.create!(user_attributes)
 
-            expect(user.assign_to_project).to be false
+            expect(user.assign_to_project).to be true
             expect(user.manage_team).to be false
             expect(user.add_new_project).to be true
             expect(user.manage_user_accounts).to be false
@@ -195,7 +195,7 @@ RSpec.describe User do
 
             user = described_class.create!(user_attributes)
 
-            expect(user.assign_to_project).to be false
+            expect(user.assign_to_project).to be true
             expect(user.manage_team).to be true
             expect(user.add_new_project).to be true
             expect(user.manage_user_accounts).to be false
@@ -323,6 +323,34 @@ RSpec.describe User do
       user.update!(active: true)
 
       expect(user.active).to be true
+    end
+  end
+
+  describe "#is_regional_caseworker?" do
+    it "returns true when the user is in the RCS team and is not a team lead" do
+      caseworker_user = build(:regional_casework_services_user)
+      other_user = build(:regional_casework_services_team_lead_user)
+
+      expect(caseworker_user.is_regional_caseworker?).to be true
+      expect(other_user.is_regional_caseworker?).to be false
+    end
+  end
+
+  describe "#is_regional_delivery_officer?" do
+    it "returns true when the user is in one of the regional teams" do
+      regional_delivery_officer_user = build(:regional_delivery_officer_user)
+      other_user = build(:regional_casework_services_team_lead_user)
+
+      expect(regional_delivery_officer_user.is_regional_delivery_officer?).to be true
+      expect(other_user.is_regional_caseworker?).to be false
+    end
+
+    it "returns true when the regional delivery officer is also a team lead" do
+      rdo_user = build(:regional_delivery_officer_user)
+      rdo_team_lead_user = build(:regional_delivery_officer_team_lead_user)
+
+      expect(rdo_user.is_regional_delivery_officer?).to be true
+      expect(rdo_team_lead_user.is_regional_delivery_officer?).to be true
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -65,10 +65,10 @@ RSpec.describe User do
       end
     end
 
-    describe "all_assignable_users" do
-      it "only includes users who have a role" do
-        expect(User.all_assignable_users.count).to eq 7
-        expect(User.all_assignable_users).to_not include(user_without_role)
+    describe "assignable" do
+      it "only includes users who have the assign_to_projects flag" do
+        expect(User.assignable.count).to eq 5
+        expect(User.assignable).to_not include(user_without_role)
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe User do
     it { is_expected.to have_db_column(:manage_team).of_type :boolean }
     it { is_expected.to have_db_column(:add_new_project).of_type :boolean }
     it { is_expected.to have_db_column(:assign_to_project).of_type :boolean }
-    it { is_expected.to have_db_column(:service_support).of_type :boolean }
+    it { is_expected.to have_db_column(:manage_user_accounts).of_type :boolean }
+    it { is_expected.to have_db_column(:manage_user_accounts).of_type :boolean }
+    it { is_expected.to have_db_column(:manage_local_authorities).of_type :boolean }
     it { is_expected.to have_db_column(:active_directory_user_group_ids).of_type :string }
     it { is_expected.to have_db_column(:team).of_type :string }
     it { is_expected.to have_db_column(:deactivated_at).of_type :datetime }
@@ -135,7 +137,9 @@ RSpec.describe User do
             expect(user.assign_to_project).to be true
             expect(user.manage_team).to be false
             expect(user.add_new_project).to be false
-            expect(user.service_support).to be false
+            expect(user.manage_user_accounts).to be false
+            expect(user.manage_local_authorities).to be false
+            expect(user.manage_conversion_urns).to be false
           end
         end
 
@@ -150,7 +154,9 @@ RSpec.describe User do
             expect(user.assign_to_project).to be false
             expect(user.manage_team).to be true
             expect(user.add_new_project).to be false
-            expect(user.service_support).to be false
+            expect(user.manage_user_accounts).to be false
+            expect(user.manage_local_authorities).to be false
+            expect(user.manage_conversion_urns).to be false
           end
         end
       end
@@ -167,7 +173,9 @@ RSpec.describe User do
             expect(user.assign_to_project).to be false
             expect(user.manage_team).to be false
             expect(user.add_new_project).to be true
-            expect(user.service_support).to be false
+            expect(user.manage_user_accounts).to be false
+            expect(user.manage_local_authorities).to be false
+            expect(user.manage_conversion_urns).to be false
           end
         end
 
@@ -182,7 +190,9 @@ RSpec.describe User do
             expect(user.assign_to_project).to be false
             expect(user.manage_team).to be true
             expect(user.add_new_project).to be true
-            expect(user.service_support).to be false
+            expect(user.manage_user_accounts).to be false
+            expect(user.manage_local_authorities).to be false
+            expect(user.manage_conversion_urns).to be false
           end
         end
       end
@@ -198,7 +208,9 @@ RSpec.describe User do
           expect(user.assign_to_project).to be false
           expect(user.manage_team).to be false
           expect(user.add_new_project).to be false
-          expect(user.service_support).to be true
+          expect(user.manage_user_accounts).to be true
+          expect(user.manage_local_authorities).to be true
+          expect(user.manage_conversion_urns).to be true
         end
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe User do
   end
 
   describe "scopes" do
-    let!(:caseworker) { create(:user, :caseworker, team: "regional_casework_services") }
-    let!(:caseworker_2) { create(:user, :caseworker, first_name: "Aaron", email: "aaron-caseworker@education.gov.uk") }
-    let!(:team_leader) { create(:user, :team_leader, team: "regional_casework_services") }
-    let!(:team_leader_2) { create(:user, :team_leader, first_name: "Andy", email: "aaron-team-leader@education.gov.uk") }
-    let!(:regional_delivery_officer) { create(:user, :regional_delivery_officer, team: "london") }
-    let!(:regional_delivery_officer_2) { create(:user, :regional_delivery_officer, first_name: "Adam", email: "aaron-rdo@education.gov.uk") }
+    let!(:caseworker) { create(:regional_casework_services_user) }
+    let!(:caseworker_2) { create(:regional_casework_services_user, first_name: "Aaron", email: "aaron-caseworker@education.gov.uk") }
+    let!(:team_leader) { create(:regional_casework_services_team_lead_user, first_name: "Zoe") }
+    let!(:team_leader_2) { create(:regional_casework_services_team_lead_user, first_name: "Andy", email: "aaron-team-leader@education.gov.uk") }
+    let!(:regional_delivery_officer) { create(:regional_delivery_officer_user) }
+    let!(:regional_delivery_officer_2) { create(:regional_delivery_officer_user, first_name: "Adam", email: "aaron-rdo@education.gov.uk") }
     let!(:user_without_role) { create(:user, assign_to_project: false, manage_team: false, add_new_project: false, team: "education_and_skills_funding_agency") }
 
     describe "order_by_first_name" do
@@ -33,7 +33,7 @@ RSpec.describe User do
       end
     end
 
-    describe "team_leaders" do
+    describe "regional casework services team leaders" do
       it "only includes users that have the team leader role sorted by first_name" do
         expect(User.team_leaders.count).to be 2
         expect(User.team_leaders.first).to eq team_leader_2
@@ -90,7 +90,7 @@ RSpec.describe User do
 
     describe "by_team" do
       it "returns users in the desired team" do
-        expect(User.by_team("london")).to include(regional_delivery_officer)
+        expect(User.by_team("north_west")).to include(regional_delivery_officer)
         expect(User.by_team("regional_casework_services")).to include(caseworker, team_leader)
       end
     end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -2,13 +2,13 @@ require "rails_helper"
 
 RSpec.describe UserPolicy do
   permissions :index?, :new?, :create?, :edit?, :update? do
-    it "grants access if the user has the service_support flag" do
-      user = build(:user, :service_support)
+    it "grants access if the user has the manage_user_accounts flag" do
+      user = build(:user, manage_user_accounts: true)
       expect(described_class).to permit(user)
     end
 
-    it "denies access if the user does not have service_support flag" do
-      user = build(:user, service_support: false)
+    it "denies access if the user does not have manage_user_accounts flag" do
+      user = build(:user, manage_user_accounts: false)
       expect(described_class).not_to permit(user)
     end
   end

--- a/spec/services/assignable_users_data_migration_service_spec.rb
+++ b/spec/services/assignable_users_data_migration_service_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe AssignableUsersDataMigrationService do
+  it "set any regional delivery officers asssign_to_project flag to true" do
+    user = create(:regional_delivery_officer_user, assign_to_project: false)
+
+    described_class.new(User.all).migrate!
+
+    expect(user.reload.assign_to_project).to be true
+  end
+
+  it "only acts on regional delivery officer users via the add_new_project attribute" do
+    user = create(:regional_delivery_officer_user, assign_to_project: false)
+    other_user = create(:service_support_user)
+
+    described_class.new(User.all).migrate!
+
+    expect(user.reload.assign_to_project).to be true
+    expect(other_user.reload.assign_to_project).to be false
+  end
+end

--- a/spec/services/user_importer_spec.rb
+++ b/spec/services/user_importer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe UserImporter do
   let(:user_importer) { UserImporter.new }
   let(:users_csv) do
     <<~CSV
-      email,first_name,last_name,team,team_leader,add_new_project,assign_to_project
+      email,first_name,last_name,team,manage_team,add_new_project,assign_to_project
       john.doe@education.gov.uk,John,Doe,regional_casework_services,1,0,0
       jane.doe@education.gov.uk,Jane,Doe,london,0,1,0
     CSV
@@ -29,7 +29,7 @@ RSpec.describe UserImporter do
           email: "john.doe@education.gov.uk",
           first_name: "John",
           last_name: "Doe",
-          team_leader: true,
+          manage_team: true,
           add_new_project: false,
           team: "regional_casework_services"
         )
@@ -40,7 +40,7 @@ RSpec.describe UserImporter do
           email: existing_user_email,
           first_name: "Jane",
           last_name: "Doe",
-          team_leader: false,
+          manage_team: false,
           add_new_project: true,
           team: "london"
         )
@@ -50,7 +50,7 @@ RSpec.describe UserImporter do
     context "when an existing user has been updated" do
       let(:users_csv) do
         <<~CSV
-          email,first_name,last_name,team,team_leader,add_new_project,assign_to_project
+          email,first_name,last_name,team,manage_team,add_new_project,assign_to_project
           john.doe@education.gov.uk,John,Doe,regional_casework_services,1,0,0
           jane.doe@education.gov.uk,Jane,Doe,regional_casework_services,1,0,0
         CSV
@@ -60,14 +60,14 @@ RSpec.describe UserImporter do
         call_user_importer
 
         expect(User.find_by(email: existing_user_email).add_new_project).to be false
-        expect(User.find_by(email: existing_user_email).team_leader).to be true
+        expect(User.find_by(email: existing_user_email).manage_team).to be true
       end
     end
 
     context "when an error occurs" do
       let(:users_csv) do
         <<~CSV
-          email,first_name,last_name,team_leader,add_new_project
+          email,first_name,last_name,manage_team,add_new_project
           #{existing_user_email},Josephine,Doe,0,1
           ,Malformed,Record,,
         CSV
@@ -83,7 +83,7 @@ RSpec.describe UserImporter do
             email: existing_user_email,
             first_name: "Jane",
             last_name: "Doe",
-            team_leader: false,
+            manage_team: false,
             add_new_project: false
           )
         ).to exist
@@ -93,7 +93,7 @@ RSpec.describe UserImporter do
     context "when an email address is invalid" do
       let(:users_csv) do
         <<~CSV
-          email,first_name,last_name,team_leader,add_new_project
+          email,first_name,last_name,manage_team,add_new_project
           john.doe.education.gov.uk,John,Doe,1,0
           jane.doe@education.gov.uk,Jane,Doe,1,0
         CSV

--- a/spec/services/user_importer_spec.rb
+++ b/spec/services/user_importer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe UserImporter do
   let(:user_importer) { UserImporter.new }
   let(:users_csv) do
     <<~CSV
-      email,first_name,last_name,team,team_leader,regional_delivery_officer,assign_to_project
+      email,first_name,last_name,team,team_leader,add_new_project,assign_to_project
       john.doe@education.gov.uk,John,Doe,regional_casework_services,1,0,0
       jane.doe@education.gov.uk,Jane,Doe,london,0,1,0
     CSV
@@ -30,7 +30,7 @@ RSpec.describe UserImporter do
           first_name: "John",
           last_name: "Doe",
           team_leader: true,
-          regional_delivery_officer: false,
+          add_new_project: false,
           team: "regional_casework_services"
         )
       ).to exist
@@ -41,7 +41,7 @@ RSpec.describe UserImporter do
           first_name: "Jane",
           last_name: "Doe",
           team_leader: false,
-          regional_delivery_officer: true,
+          add_new_project: true,
           team: "london"
         )
       ).to exist
@@ -50,7 +50,7 @@ RSpec.describe UserImporter do
     context "when an existing user has been updated" do
       let(:users_csv) do
         <<~CSV
-          email,first_name,last_name,team,team_leader,regional_delivery_officer,assign_to_project
+          email,first_name,last_name,team,team_leader,add_new_project,assign_to_project
           john.doe@education.gov.uk,John,Doe,regional_casework_services,1,0,0
           jane.doe@education.gov.uk,Jane,Doe,regional_casework_services,1,0,0
         CSV
@@ -59,7 +59,7 @@ RSpec.describe UserImporter do
       it "updates the existing user in place" do
         call_user_importer
 
-        expect(User.find_by(email: existing_user_email).regional_delivery_officer).to be false
+        expect(User.find_by(email: existing_user_email).add_new_project).to be false
         expect(User.find_by(email: existing_user_email).team_leader).to be true
       end
     end
@@ -67,7 +67,7 @@ RSpec.describe UserImporter do
     context "when an error occurs" do
       let(:users_csv) do
         <<~CSV
-          email,first_name,last_name,team_leader,regional_delivery_officer
+          email,first_name,last_name,team_leader,add_new_project
           #{existing_user_email},Josephine,Doe,0,1
           ,Malformed,Record,,
         CSV
@@ -84,7 +84,7 @@ RSpec.describe UserImporter do
             first_name: "Jane",
             last_name: "Doe",
             team_leader: false,
-            regional_delivery_officer: false
+            add_new_project: false
           )
         ).to exist
       end
@@ -93,7 +93,7 @@ RSpec.describe UserImporter do
     context "when an email address is invalid" do
       let(:users_csv) do
         <<~CSV
-          email,first_name,last_name,team_leader,regional_delivery_officer
+          email,first_name,last_name,team_leader,add_new_project
           john.doe.education.gov.uk,John,Doe,1,0
           jane.doe@education.gov.uk,Jane,Doe,1,0
         CSV

--- a/spec/services/user_importer_spec.rb
+++ b/spec/services/user_importer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe UserImporter do
   let(:user_importer) { UserImporter.new }
   let(:users_csv) do
     <<~CSV
-      email,first_name,last_name,team,team_leader,regional_delivery_officer,caseworker
+      email,first_name,last_name,team,team_leader,regional_delivery_officer,assign_to_project
       john.doe@education.gov.uk,John,Doe,regional_casework_services,1,0,0
       jane.doe@education.gov.uk,Jane,Doe,london,0,1,0
     CSV
@@ -50,7 +50,7 @@ RSpec.describe UserImporter do
     context "when an existing user has been updated" do
       let(:users_csv) do
         <<~CSV
-          email,first_name,last_name,team,team_leader,regional_delivery_officer,caseworker
+          email,first_name,last_name,team,team_leader,regional_delivery_officer,assign_to_project
           john.doe@education.gov.uk,John,Doe,regional_casework_services,1,0,0
           jane.doe@education.gov.uk,Jane,Doe,regional_casework_services,1,0,0
         CSV


### PR DESCRIPTION
When we set out we had very little understanding of the groups of people who might use the application. Right now, we have a far better understanding and have started to see the limits of the models we had.

Our old 'role' based permission is now looking a bit odd alongside the teams we now model.

This work sets out to name the attributes that model permissions to align to those permissions, rather than a specific group of users.

- caseworker becomes `assign_to_project`
- regional_delivery_officer becomes `add_new_project`
- team_leader becomes `manage_team`
- service_support becomes 3 new permissions: `manage_local_authorities`, `manage_user_accounts` and `manage_conversion_urns`

Changing anything to do with the User model has a big impact across the test suite. For this reason, this work tries to strike a balance of doing just enough. There is far more we could do here, but the value quickly dimishes.

I wanted to add new factories that document each of our users, which I have done here. I personally find these clearer than the current triats we have - this means we now have both, I would like us to migrate away from the traits to the factories over time - but happy to be challenged on this.

With the ground work done. we make a couple of minor tweaks, making scopes simpler and clearer and running a data migration to make sure regional delivery officers can still be assigned to projects.