### PR TITLE
Limit line lengths to 75 characters in 1200px app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Limit line lengths to 75 characters after increasing app width to 1200px
 - Only show counts of in-progress projects on the Team "By user" projects page
 - Send the new user email when an account is added.
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,7 @@ $govuk-button-background-colour: $dfe-blue;
 @import "components/task-list";
 @import "components/task_list/check-box-action-component";
 @import "components/notification-banner";
+@import "components/app-content";
 
 // The accessible autocomplete component does not use
 // GOV.UK fonts by default for suggestions.

--- a/app/assets/stylesheets/components/app-content.scss
+++ b/app/assets/stylesheets/components/app-content.scss
@@ -1,0 +1,23 @@
+.app-content {
+  h4,
+  h5,
+  h6,
+  p,
+  ul:not(.app-task-list):not(.app-tabs):not(.moj-sub-navigation__list):not(
+      .app-task-list__items
+    ):not(.projects-list),
+  ol:not(.app-task-list),
+  .app-table--constrained,
+  .govuk-checkboxes__label,
+  .govuk-details__summary-text,
+  .govuk-details__text,
+  .govuk-notification-banner .govuk-notification-banner__content > div p,
+  .govuk-notification-banner .govuk-notification-banner__content > div,
+  .govuk-checkboxes__item .guidance p {
+    max-width: 38rem;
+  }
+
+  .govuk-details__summary-text {
+    display: inline-block;
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,7 +48,7 @@
 
     <div class="govuk-width-container ">
       <%= yield :pre_content_nav %>
-      <main class="govuk-main-wrapper " id="main-content" role="main">
+      <main class="govuk-main-wrapper app-content" id="main-content" role="main">
         <%= render(NotificationBanner.new(flashes: flash)) %>
 
         <%= yield %>


### PR DESCRIPTION
## Changes

This change adjusts line lengths within the application to approximately 75 characters. It comes in response to the expansion of the app's width from 1024px to 1200px. By constraining the line lengths, the update ensures optimal readability and consistency across the wider layout.

The class is adapted from the Design System documentation app. Adaptations include limitations to checkbox label and detail component texts to ensure consistency with the 1200px app layout.

### Before

![Screenshot 2023-07-18 at 16 05 21](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/10995619/10728fdd-39c9-45b2-a439-960f795603a1)

### After

![Screenshot 2023-07-18 at 16 05 33](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/10995619/922be7b2-3101-4b87-a306-3c894d1cb5f1)

### To test

Go to tasks views from within the task list.

## Checklist

- [X] Attach this pull request to the appropriate card in Trello.
- [X] Update the `CHANGELOG.md` if needed.
