### PR TITLE
Add handed over view to team projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Only show counts of in-progress projects on the Team "By user" projects page
 - Send the new user email when an account is added.
 
+### Added
+
+- Add a "Handed over" view to Team projects area where projects which have been
+  handed over to regional_caseworks_services team can be viewed
+
 ## [Release 33][release-33]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add a "Handed over" view to Team projects area where projects which have been
   handed over to regional_caseworks_services team can be viewed
+- Regional casework services team cannot view the Handed over tab or view
 
 ## [Release 33][release-33]
 

--- a/app/controllers/all/regions/projects_controller.rb
+++ b/app/controllers/all/regions/projects_controller.rb
@@ -4,7 +4,7 @@ class All::Regions::ProjectsController < ApplicationController
 
   def index
     authorize Project, :index?
-    @regions = ByRegionProjectFetcherService.new.call
+    @regions = ByRegionProjectFetcherService.new.conversion_counts
   end
 
   def show

--- a/app/controllers/team/projects_controller.rb
+++ b/app/controllers/team/projects_controller.rb
@@ -19,7 +19,11 @@ class Team::ProjectsController < ApplicationController
   end
 
   def handed_over
-    authorize Project, :handed_over?
+    begin
+      authorize Project, :handed_over?
+    rescue Pundit::NotAuthorizedError
+      return head(:not_found)
+    end
 
     @current_users_team = current_user.team
     @pager, @projects = pagy(ByRegionProjectFetcherService.new.regional_casework_services_projects(@current_users_team))

--- a/app/controllers/team/projects_controller.rb
+++ b/app/controllers/team/projects_controller.rb
@@ -17,4 +17,13 @@ class Team::ProjectsController < ApplicationController
 
     @pager, @projects = pagy_array(ByTeamProjectFetcherService.new(current_user.team).unassigned)
   end
+
+  def handed_over
+    authorize Project, :handed_over?
+
+    @current_users_team = current_user.team
+    @pager, @projects = pagy(ByRegionProjectFetcherService.new.regional_casework_services_projects(@current_users_team))
+
+    AcademiesApiPreFetcherService.new.call!(@projects)
+  end
 end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -76,6 +76,10 @@ class ProjectPolicy
     @user.manage_team?
   end
 
+  def handed_over?
+    true
+  end
+
   private def project_assigned_to_user?
     @record.assigned_to == @user
   end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -77,7 +77,7 @@ class ProjectPolicy
   end
 
   def handed_over?
-    true
+    @user.team != "regional_casework_services"
   end
 
   private def project_assigned_to_user?

--- a/app/services/by_region_project_fetcher_service.rb
+++ b/app/services/by_region_project_fetcher_service.rb
@@ -9,6 +9,10 @@ class ByRegionProjectFetcherService
     end
   end
 
+  def regional_casework_services_projects(region)
+    Conversion::Project.by_region(region).assigned_to_regional_caseworker_team.by_conversion_date
+  end
+
   private def conversion_count_by_region
     projects = Conversion::Project.not_completed
     return false unless projects.any?

--- a/app/services/by_region_project_fetcher_service.rb
+++ b/app/services/by_region_project_fetcher_service.rb
@@ -10,7 +10,7 @@ class ByRegionProjectFetcherService
   end
 
   def regional_casework_services_projects(region)
-    Conversion::Project.by_region(region).assigned_to_regional_caseworker_team.by_conversion_date
+    Conversion::Project.by_region(region).assigned_to_regional_caseworker_team.includes(:assigned_to).by_conversion_date
   end
 
   private def conversion_count_by_region

--- a/app/services/by_region_project_fetcher_service.rb
+++ b/app/services/by_region_project_fetcher_service.rb
@@ -1,5 +1,5 @@
 class ByRegionProjectFetcherService
-  def call
+  def conversion_counts
     conversion_counts = conversion_count_by_region
 
     if conversion_counts

--- a/app/views/projects/shared/_handed_over_table.html.erb
+++ b/app/views/projects/shared/_handed_over_table.html.erb
@@ -1,0 +1,32 @@
+<% if projects.empty? %>
+  <%= govuk_inset_text(text: t("project.table.handed_over.empty")) %>
+<% else %>
+  <table class="govuk-table" name="projects_table" aria-label="Projects table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% projects.each do |project| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+        <td class="govuk-table__cell"><%= project.urn %></td>
+        <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
+        <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
+        <td class="govuk-table__cell">
+          <a href="<%= project_path(project) %>">
+            <%= t("project.table.body.view_html", school_name: project.establishment.name) %>
+          </a>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<%= govuk_pagination(pagy: pager) %>

--- a/app/views/shared/navigation/_team_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_team_projects_primary_navigation.html.erb
@@ -15,6 +15,8 @@
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.by_user"), path: team_users_projects_path, namespace: "/projects/team/user"} %>
 
+          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.handed_over"), path: handed_over_team_projects_path, namespace: "/projects/team/handed-over"} if policy(Project).handed_over? %>
+
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.completed"), path: completed_team_projects_path, namespace: "/projects/team/completed"} %>
 
         </ul>

--- a/app/views/team/projects/handed_over.html.erb
+++ b/app/views/team/projects/handed_over.html.erb
@@ -1,0 +1,15 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/team_projects_primary_navigation" %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">
+      <%= t("project.team.handed_over.title") %>
+    </h1>
+
+    <%= render partial: "/projects/shared/handed_over_table", locals: {projects: @projects, pager: @pager} %>
+
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,7 @@ en:
         completed: Completed
         by_user: By user
         opening: Opening
+        handed_over: Handed over
       your_projects:
         in_progress: In progress
         added_by_you: Added by you

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -52,6 +52,8 @@ en:
         title: Unassigned
       users:
         title: By user
+      handed_over:
+        title: Handed over
     regional:
       in_progress:
         title: Regional projects in progress
@@ -196,6 +198,8 @@ en:
         empty: There are no completed projects.
       unassigned:
         empty: There are no unassigned projects.
+      handed_over:
+        empty: There are no handed over projects.
       new:
         empty: There are no conversions without an academy URN
       with_academy_urn:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,6 +115,7 @@ Rails.application.routes.draw do
           get "in-progress", to: "projects#in_progress"
           get "completed", to: "projects#completed"
           get "unassigned", to: "projects#unassigned"
+          get "handed-over", to: "projects#handed_over"
           namespace :users do
             get "/", to: "projects#index"
             get "/:user_id", to: "projects#show", as: :by_user

--- a/spec/features/projects/team/users_in_regional_teams_can_view_handed_over_projects_spec.rb
+++ b/spec/features/projects/team/users_in_regional_teams_can_view_handed_over_projects_spec.rb
@@ -2,14 +2,16 @@ require "rails_helper"
 
 RSpec.feature "Users in regional teams can view handed over projects" do
   before do
-    sign_in_with_user(user)
     mock_all_academies_api_responses
   end
 
-  let(:user) { create(:user, team: "london") }
+  let(:user_london_team) { create(:user, team: "london", email: "email-#{SecureRandom.uuid}@education.gov.uk") }
+  let(:user_regional_casework_services_team) { create(:user, team: "regional_casework_services", email: "email-#{SecureRandom.uuid}@education.gov.uk") }
 
   context "when no projects have been handed over to the regional casework services team" do
     scenario "they see an empty message" do
+      sign_in_with_user(user_london_team)
+
       create(:conversion_project, urn: "123456", region: "london", team: "london")
       create(:conversion_project, urn: "654321", region: "london", team: "london")
 
@@ -21,6 +23,8 @@ RSpec.feature "Users in regional teams can view handed over projects" do
 
   context "when projects have been handed over to the regional casework services team" do
     scenario "a user of the regional team can see their handed over projects listed on the handed over page" do
+      sign_in_with_user(user_london_team)
+
       handed_over_london_project = create(:conversion_project, urn: "123456", region: "london", team: "regional_casework_services")
       handed_over_london_project_two = create(:conversion_project, urn: "654321", region: "london", team: "regional_casework_services")
       london_project = create(:conversion_project, urn: "987654", region: "london", team: "london")
@@ -30,6 +34,14 @@ RSpec.feature "Users in regional teams can view handed over projects" do
       expect(page).to have_content(handed_over_london_project.urn)
       expect(page).to have_content(handed_over_london_project_two.urn)
       expect(page).not_to have_content(london_project.urn)
+    end
+
+    scenario "a user of the regional casework services team doesn't see a handed over tab" do
+      sign_in_with_user(user_regional_casework_services_team)
+
+      visit handed_over_team_projects_path
+
+      expect(page).to have_http_status(404)
     end
   end
 end

--- a/spec/features/projects/team/users_in_regional_teams_can_view_handed_over_projects_spec.rb
+++ b/spec/features/projects/team/users_in_regional_teams_can_view_handed_over_projects_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.feature "Users in regional teams can view handed over projects" do
+  before do
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  let(:user) { create(:user, team: "london") }
+
+  context "when no projects have been handed over to the regional casework services team" do
+    scenario "they see an empty message" do
+      create(:conversion_project, urn: "123456", region: "london", team: "london")
+      create(:conversion_project, urn: "654321", region: "london", team: "london")
+
+      visit handed_over_team_projects_path
+
+      expect(page).to have_content("There are no handed over projects")
+    end
+  end
+
+  context "when projects have been handed over to the regional casework services team" do
+    scenario "a user of the regional team can see their handed over projects listed on the handed over page" do
+      handed_over_london_project = create(:conversion_project, urn: "123456", region: "london", team: "regional_casework_services")
+      handed_over_london_project_two = create(:conversion_project, urn: "654321", region: "london", team: "regional_casework_services")
+      london_project = create(:conversion_project, urn: "987654", region: "london", team: "london")
+
+      visit handed_over_team_projects_path
+
+      expect(page).to have_content(handed_over_london_project.urn)
+      expect(page).to have_content(handed_over_london_project_two.urn)
+      expect(page).not_to have_content(london_project.urn)
+    end
+  end
+end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -123,4 +123,11 @@ RSpec.describe ProjectPolicy do
       expect(subject).to_not permit(application_user)
     end
   end
+
+  permissions :handed_over? do
+    it "denies access to anyone who is in the regional casework services team" do
+      expect(subject).to_not permit(build(:user, team: "regional_casework_services"))
+      expect(subject).to permit(build(:user, :regional_delivery_officer))
+    end
+  end
 end

--- a/spec/services/by_region_project_fetcher_service_spec.rb
+++ b/spec/services/by_region_project_fetcher_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ByRegionProjectFetcherService do
     create(:conversion_project, region: "south_west")
     create(:conversion_project, region: "north_west")
 
-    result = described_class.new.call
+    result = described_class.new.conversion_counts
 
     expect(result.count).to eql 3
 
@@ -25,6 +25,6 @@ RSpec.describe ByRegionProjectFetcherService do
   end
 
   it "returns an empty array when there are no projects to source trusts" do
-    expect(described_class.new.call).to eql []
+    expect(described_class.new.conversion_counts).to eql []
   end
 end

--- a/spec/services/by_region_project_fetcher_service_spec.rb
+++ b/spec/services/by_region_project_fetcher_service_spec.rb
@@ -1,30 +1,54 @@
 require "rails_helper"
 
 RSpec.describe ByRegionProjectFetcherService do
-  it "returns a sorted list of simple view objects with project counts" do
-    mock_successful_api_response_to_create_any_project
+  describe "#conversion_count" do
+    it "returns a sorted list of simple view objects with project counts" do
+      mock_successful_api_response_to_create_any_project
 
-    create(:conversion_project, region: "south_west")
-    create(:conversion_project, region: "london")
-    create(:conversion_project, region: "south_west")
-    create(:conversion_project, region: "north_west")
+      create(:conversion_project, region: "south_west")
+      create(:conversion_project, region: "london")
+      create(:conversion_project, region: "south_west")
+      create(:conversion_project, region: "north_west")
 
-    result = described_class.new.conversion_counts
+      result = described_class.new.conversion_counts
 
-    expect(result.count).to eql 3
+      expect(result.count).to eql 3
 
-    first_result = result.first
+      first_result = result.first
 
-    expect(first_result.name).to eql "london"
-    expect(first_result.conversion_count).to eql 1
+      expect(first_result.name).to eql "london"
+      expect(first_result.conversion_count).to eql 1
 
-    last_result = result.last
+      last_result = result.last
 
-    expect(last_result.name).to eql "south_west"
-    expect(last_result.conversion_count).to eql 2
+      expect(last_result.name).to eql "south_west"
+      expect(last_result.conversion_count).to eql 2
+    end
+
+    it "returns an empty array when there are no projects to source trusts" do
+      expect(described_class.new.conversion_counts).to eql []
+    end
   end
 
-  it "returns an empty array when there are no projects to source trusts" do
-    expect(described_class.new.conversion_counts).to eql []
+  describe "#regional_casework_services_projects" do
+    before do
+      mock_successful_api_response_to_create_any_project
+    end
+
+    it "returns all projects in the specificed region which are assigned to regional casework services" do
+      user = create(:user, team: "london")
+      conversion_project = create(:conversion_project, region: "london", team: "regional_casework_services")
+      conversion_project_2 = create(:conversion_project, region: "north_west", team: "regional_casework_services")
+      conversion_project_3 = create(:conversion_project, region: "london", team: "london")
+
+      expect(described_class.new.regional_casework_services_projects(user.team)).to include(conversion_project)
+      expect(described_class.new.regional_casework_services_projects(user.team)).to_not include(conversion_project_2, conversion_project_3)
+    end
+
+    it "returns an empty array if there are no matching projects" do
+      user = create(:user, team: "london")
+
+      expect(described_class.new.regional_casework_services_projects(user.team)).to match_array []
+    end
   end
 end


### PR DESCRIPTION
## Changes

This work adds in a `Handed over` view to the Team projects area which displays the projects that have been handed over to the Regional casework services team.
Each regional team can view this `Handed over` view and will see all their handed over regional projects.
The view is restricted to the Regional casework services team who won't see the `Handed over` tab.


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
