### PR TITLE
User email validation is case insensitive

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
   validates :first_name, :last_name, :email, :team, presence: true
   validates :team, presence: true, on: :set_team
   validates :email, uniqueness: {case_sensitive: false}
-  validates :email, format: {with: /\A\S+@education.gov.uk\z/}
+  validates :email, format: {with: /\A\S+@education.gov.uk\z/i}
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}
 
   enum :team, USER_TEAMS, suffix: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -112,6 +112,12 @@ RSpec.describe User do
         expect(user).to be_invalid
       end
 
+      it "the validation is not case sensitve" do
+        user = build(:user, email: "USER@EDUCATION.GOV.UK")
+
+        expect(user).to be_valid
+      end
+
       it "must be unique" do
         create(:user, email: "user@education.gov.uk")
         new_user = build(:user, email: "user@education.gov.uk")


### PR DESCRIPTION
We had users struggling to update their team because their email address
was in capitals and so their User was not considered valid.

https://trello.com/c/xpYq3w8O
