### PR TITLE
Academies api pre fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The Team projects views now work when there are more than twenty projects.
+
 ## [Release 34][release-34]
 
 ### Added

--- a/app/services/academies_api_pre_fetcher_service.rb
+++ b/app/services/academies_api_pre_fetcher_service.rb
@@ -1,0 +1,74 @@
+class AcademiesApiPreFetcherService
+  def call!(projects)
+    @projects = projects
+    pre_fetch_academies_api_entities
+    @projects
+  end
+
+  private def pre_fetch_academies_api_entities
+    establishments = []
+    incoming_trusts = []
+
+    # Bullet has to be disabled here to prevent false positives, this code
+    # fetches data from the Academies APi and sets the associations on the
+    # projects but does not use any eager loaded associations that were passed
+    # in and this triggers bullet
+    #
+    # If the calling code then didn't use the eager loading, it would be
+    # captured there.
+    #
+    # We re-enable Bullet once this code has executed
+    Bullet.enable = false if defined?(Bullet)
+    @projects.find_in_batches(batch_size: 10).with_index do |projects, index|
+      establishment_urns = projects.pluck(:urn).compact
+      incoming_trusts_ukprns = projects.pluck(:incoming_trust_ukprn).compact
+
+      if establishment_urns.any?
+        establishments.concat(pre_fetch_establishments(establishment_urns))
+        set_establishments!(establishments)
+      end
+
+      if incoming_trusts_ukprns.any?
+        incoming_trusts.concat(pre_fetch_trusts(incoming_trusts_ukprns))
+        set_incoming_trusts!(incoming_trusts)
+      end
+    end
+    Bullet.enable = true if defined?(Bullet)
+  end
+
+  private def set_establishments!(establishments)
+    @projects.each do |project|
+      project.establishment = establishments.find { |establishment| establishment.urn == project.urn.to_s }
+    end
+  end
+
+  private def set_incoming_trusts!(trusts)
+    @projects.each do |project|
+      project.incoming_trust = trusts.find { |trust| trust.ukprn == project.incoming_trust_ukprn.to_s }
+    end
+  end
+
+  private def pre_fetch_establishments(urns)
+    establishments = []
+    response = Api::AcademiesApi::Client.new.get_establishments(urns)
+
+    if response.error.nil?
+      establishments.concat(response.object)
+    else
+      raise Api::AcademiesApi::Client::Error.new
+    end
+    establishments
+  end
+
+  private def pre_fetch_trusts(ukprns)
+    trusts = []
+    response = Api::AcademiesApi::Client.new.get_trusts(ukprns)
+
+    if response.error.nil?
+      trusts.concat(response.object)
+    else
+      raise Api::AcademiesApi::Client::Error.new
+    end
+    trusts
+  end
+end

--- a/app/services/by_team_project_fetcher_service.rb
+++ b/app/services/by_team_project_fetcher_service.rb
@@ -11,7 +11,8 @@ class ByTeamProjectFetcherService
     else
       Conversion::Project.by_region(@team).in_progress.includes(:assigned_to).by_conversion_date
     end
-    pre_fetch_establishments_and_trusts(projects)
+
+    AcademiesApiPreFetcherService.new.call!(projects)
   end
 
   def completed
@@ -23,7 +24,7 @@ class ByTeamProjectFetcherService
       Conversion::Project.by_region(@team).completed.by_conversion_date
     end
 
-    pre_fetch_establishments_and_trusts(projects)
+    AcademiesApiPreFetcherService.new.call!(projects)
   end
 
   def unassigned
@@ -35,7 +36,7 @@ class ByTeamProjectFetcherService
       Conversion::Project.by_region(@team).unassigned_to_user.by_conversion_date
     end
 
-    pre_fetch_establishments_and_trusts(projects)
+    AcademiesApiPreFetcherService.new.call!(projects)
   end
 
   def users
@@ -49,11 +50,5 @@ class ByTeamProjectFetcherService
         conversion_count: Conversion::Project.in_progress.assigned_to(user).count
       )
     end.sort_by { |object| object.name }
-  end
-
-  private def pre_fetch_establishments_and_trusts(projects)
-    EstablishmentsFetcherService.new(projects).call!
-    TrustsFetcherService.new(projects).call!
-    projects
   end
 end

--- a/spec/features/users_can_assign_a_user_to_a_project_spec.rb
+++ b/spec/features/users_can_assign_a_user_to_a_project_spec.rb
@@ -2,8 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Any user can assign any other user to a project" do
   before do
-    mock_successful_api_response_to_create_any_project
-    mock_pre_fetched_api_responses_for_any_establishment_and_trust
+    mock_all_academies_api_responses
     sign_in_with_user(user)
   end
 

--- a/spec/requests/team/opening/projects_controller_spec.rb
+++ b/spec/requests/team/opening/projects_controller_spec.rb
@@ -36,12 +36,10 @@ RSpec.describe Team::Opening::ProjectsController, type: :request do
         mock_successful_api_responses(urn: urn, ukprn: 10061021)
       end
 
-      allow(EstablishmentsFetcherService).to receive(:new).and_return(mock_establishments_fetcher)
-      allow(TrustsFetcherService).to receive(:new).and_return(mock_trusts_fetcher)
+      allow(AcademiesApiPreFetcherService).to receive(:new).and_return(mock_acadmies_api_fetcher)
     end
 
-    let(:mock_establishments_fetcher) { double(EstablishmentsFetcherService, batched!: true) }
-    let(:mock_trusts_fetcher) { double(TrustsFetcherService, batched!: true) }
+    let(:mock_acadmies_api_fetcher) { double(AcademiesApiPreFetcherService, call!: double) }
 
     it "only returns projects assigned to the user's team" do
       project_assigned_to_rcs = create(:conversion_project, urn: 100001, conversion_date: Date.new(2022, 1, 1), conversion_date_provisional: false, team: "regional_casework_services")
@@ -62,12 +60,10 @@ RSpec.describe Team::Opening::ProjectsController, type: :request do
         mock_successful_api_responses(urn: urn, ukprn: 10061021)
       end
 
-      allow(EstablishmentsFetcherService).to receive(:new).and_return(mock_establishments_fetcher)
-      allow(TrustsFetcherService).to receive(:new).and_return(mock_trusts_fetcher)
+      allow(AcademiesApiPreFetcherService).to receive(:new).and_return(mock_acadmies_api_fetcher)
     end
 
-    let(:mock_establishments_fetcher) { double(EstablishmentsFetcherService, batched!: true) }
-    let(:mock_trusts_fetcher) { double(TrustsFetcherService, batched!: true) }
+    let(:mock_acadmies_api_fetcher) { double(AcademiesApiPreFetcherService, call!: double) }
 
     it "only returns projects assigned to the user's team" do
       project_assigned_to_rcs = create(:conversion_project, urn: 100001, conversion_date: Date.new(2022, 1, 1), conversion_date_provisional: false, team: "regional_casework_services")

--- a/spec/services/academies_api_pre_fetcher_service_spec.rb
+++ b/spec/services/academies_api_pre_fetcher_service_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe AcademiesApiPreFetcherService do
+  it "prefetches Academies API data in batches of 10 and populates projects" do
+    api_client = mock_academies_api_client_get_establishments_and_trusts
+
+    25.times do
+      create(:conversion_project, urn: 123456, incoming_trust_ukprn: 10010010)
+    end
+
+    projects = Project.all
+
+    AcademiesApiPreFetcherService.new.call!(projects)
+
+    expect(projects.last.establishment).not_to be_nil
+    expect(projects.last.incoming_trust).not_to be_nil
+
+    expect(api_client).to have_received(:get_establishments).exactly(3).times
+    expect(api_client).to have_received(:get_trusts).exactly(3).times
+
+    expect(api_client).to have_received(:get_establishment).exactly(25).times
+    expect(api_client).to have_received(:get_trust).exactly(25).times
+  end
+
+  it "handles eager loading" do
+    mock_academies_api_client_get_establishments_and_trusts
+
+    create(:conversion_project, urn: 123456, incoming_trust_ukprn: 10010010)
+
+    projects = Project.all.includes(:tasks_data)
+
+    expect(projects.last.establishment).not_to be_nil
+    expect(projects.last.incoming_trust).not_to be_nil
+
+    expect(projects.last.all_conditions_met?).to be false
+  end
+
+  it "raises and Academies API error if the establishments requests fail" do
+    mock_academies_api_client_get_establishments_and_trusts_failure
+
+    10.times do
+      create(:conversion_project, urn: 123456, incoming_trust_ukprn: 10010010)
+    end
+
+    projects = Project.all
+
+    expect { AcademiesApiPreFetcherService.new.call!(projects) }.to raise_error(Api::AcademiesApi::Client::Error)
+  end
+
+  it "raises and Academies API error if the trusts requests fail" do
+    establishment = double("Establishment", name: "Establishment Name", urn: "123456")
+    api_client = mock_academies_api_client_get_establishments_and_trusts_failure
+    allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new([establishment], nil))
+
+    10.times do
+      create(:conversion_project, urn: 123456, incoming_trust_ukprn: 10010010)
+    end
+
+    projects = Project.all
+
+    expect { AcademiesApiPreFetcherService.new.call!(projects) }.to raise_error(Api::AcademiesApi::Client::Error)
+  end
+
+  def mock_academies_api_client_get_establishments_and_trusts
+    api_client = Api::AcademiesApi::Client.new
+
+    establishment = double("Establishment", name: "Establishment Name", urn: "123456")
+    trust = double("Trust", ukprn: "10010010")
+
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
+
+    allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new([establishment], nil))
+    allow(api_client).to receive(:get_trusts).and_return(Api::AcademiesApi::Client::Result.new([trust], nil))
+
+    allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(establishment, nil))
+    allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(trust, nil))
+
+    api_client
+  end
+
+  def mock_academies_api_client_get_establishments_and_trusts_failure
+    api_client = Api::AcademiesApi::Client.new
+
+    establishment = double("Establishment", name: "Establishment Name", urn: "123456")
+    trust = double("Trust", ukprn: "10010010")
+
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
+
+    allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::Error.new))
+    allow(api_client).to receive(:get_trusts).and_return(Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::Error.new))
+
+    allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(establishment, nil))
+    allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(trust, nil))
+
+    api_client
+  end
+end

--- a/spec/services/by_month_project_fetcher_service_spec.rb
+++ b/spec/services/by_month_project_fetcher_service_spec.rb
@@ -2,25 +2,19 @@ require "rails_helper"
 
 RSpec.describe ByMonthProjectFetcherService do
   describe "#sorted_openers" do
-    context "with pre fetching disabled for this test" do
-      before do
-        allow(Conversion::Project).to receive(:opening_by_month_year).and_return(projects)
-      end
-
-      let(:establishment_a) { double(name: "A School") }
-      let(:establishment_b) { double(name: "B School") }
-      let(:establishment_c) { double(name: "C School") }
-      let(:establishment_d) { double(name: "D School") }
-      let(:project_a) { double(all_conditions_met?: true, establishment: establishment_a) }
-      let(:project_b) { double(all_conditions_met?: false, establishment: establishment_b) }
-      let(:project_c) { double(all_conditions_met?: true, establishment: establishment_c) }
-      let(:project_d) { double(all_conditions_met?: false, establishment: establishment_d) }
-      let(:projects) { [project_d, project_b, project_a, project_c] }
-
+    context "with pre fetching disable for this spec" do
       it "sorts the projects by conditions_met? true and then by school name" do
-        projects_fetcher = described_class.new(prefetch: false)
-        expected_result = [project_a, project_c, project_b, project_d]
-        expect(projects_fetcher.sorted_openers(1, 2023)).to eq expected_result
+        project_one = double(Conversion::Project, all_conditions_met?: false, establishment: double("Establishment", name: "Y school"))
+        project_two = double(Conversion::Project, all_conditions_met?: false, establishment: double("Establishment", name: "B school"))
+        project_three = double(Conversion::Project, all_conditions_met?: false, establishment: double("Establishment", name: "A school"))
+        project_four = double(Conversion::Project, all_conditions_met?: true, establishment: double("Establishment", name: "Z school"))
+
+        allow(Conversion::Project).to receive(:opening_by_month_year).and_return([project_one, project_two, project_three, project_four])
+
+        sorted_projects = described_class.new(pre_fetch_academies_api: false).sorted_openers(1, 2025)
+
+        expect(sorted_projects.first).to eq project_four
+        expect(sorted_projects.last).to eq project_one
       end
     end
 
@@ -28,17 +22,13 @@ RSpec.describe ByMonthProjectFetcherService do
       mock_all_academies_api_responses
       create_list(:conversion_project, 21, conversion_date: Date.parse("2023-1-1"), conversion_date_provisional: false)
 
-      establishments_fetcher = double(batched!: true)
-      allow(EstablishmentsFetcherService).to receive(:new).and_return(establishments_fetcher)
-
-      trusts_fetcher = double(batched!: true)
-      allow(TrustsFetcherService).to receive(:new).and_return(trusts_fetcher)
+      academies_api_pre_fetcher = double(call!: true)
+      allow(AcademiesApiPreFetcherService).to receive(:new).and_return(academies_api_pre_fetcher)
 
       projects_fetcher = described_class.new
       projects_fetcher.sorted_openers(1, 2023)
 
-      expect(establishments_fetcher).to have_received(:batched!)
-      expect(trusts_fetcher).to have_received(:batched!)
+      expect(academies_api_pre_fetcher).to have_received(:call!).once
     end
   end
 
@@ -57,14 +47,14 @@ RSpec.describe ByMonthProjectFetcherService do
 
       context "when the user is in the regional_casework_services team" do
         it "returns only projects where the team is regional_casework_services" do
-          projects_fetcher = described_class.new(prefetch: false)
+          projects_fetcher = described_class.new
           expect(projects_fetcher.confirmed_openers_by_team(1, 2023, user_1.team)).to include(project_a, project_b)
         end
       end
 
       context "when the user is in a regional team" do
         it "returns only projects where the region matches the user's team" do
-          projects_fetcher = described_class.new(prefetch: false)
+          projects_fetcher = described_class.new
           expect(projects_fetcher.confirmed_openers_by_team(1, 2023, user_2.team)).to include(project_c)
         end
       end
@@ -74,17 +64,13 @@ RSpec.describe ByMonthProjectFetcherService do
       mock_all_academies_api_responses
       create_list(:conversion_project, 21, conversion_date: Date.parse("2023-1-1"), conversion_date_provisional: false)
 
-      establishments_fetcher = double(batched!: true)
-      allow(EstablishmentsFetcherService).to receive(:new).and_return(establishments_fetcher)
-
-      trusts_fetcher = double(batched!: true)
-      allow(TrustsFetcherService).to receive(:new).and_return(trusts_fetcher)
+      academies_api_pre_fetcher = double(call!: true)
+      allow(AcademiesApiPreFetcherService).to receive(:new).and_return(academies_api_pre_fetcher)
 
       projects_fetcher = described_class.new
       projects_fetcher.confirmed_openers_by_team(1, 2023, "regional_casework_services")
 
-      expect(establishments_fetcher).to have_received(:batched!)
-      expect(trusts_fetcher).to have_received(:batched!)
+      expect(academies_api_pre_fetcher).to have_received(:call!).once
     end
   end
 
@@ -110,14 +96,14 @@ RSpec.describe ByMonthProjectFetcherService do
 
       context "when the user is in the regional_casework_services team" do
         it "returns only projects where the team is regional_casework_services" do
-          projects_fetcher = described_class.new(prefetch: false)
+          projects_fetcher = described_class.new
           expect(projects_fetcher.revised_openers_by_team(2, 2023, user_1.team)).to eq([project_a])
         end
       end
 
       context "when the user is in a regional team" do
         it "returns only projects where the region matches the user's team" do
-          projects_fetcher = described_class.new(prefetch: false)
+          projects_fetcher = described_class.new
           expect(projects_fetcher.revised_openers_by_team(2, 2023, user_2.team)).to eq([project_c])
         end
       end
@@ -127,17 +113,13 @@ RSpec.describe ByMonthProjectFetcherService do
       mock_all_academies_api_responses
       create_list(:conversion_project, 21, conversion_date: Date.parse("2023-1-1"), conversion_date_provisional: false)
 
-      establishments_fetcher = double(batched!: true)
-      allow(EstablishmentsFetcherService).to receive(:new).and_return(establishments_fetcher)
-
-      trusts_fetcher = double(batched!: true)
-      allow(TrustsFetcherService).to receive(:new).and_return(trusts_fetcher)
+      academies_api_pre_fetcher = double(call!: true)
+      allow(AcademiesApiPreFetcherService).to receive(:new).and_return(academies_api_pre_fetcher)
 
       projects_fetcher = described_class.new
       projects_fetcher.revised_openers_by_team(1, 2023, "regional_casework_services")
 
-      expect(establishments_fetcher).to have_received(:batched!)
-      expect(trusts_fetcher).to have_received(:batched!)
+      expect(academies_api_pre_fetcher).to have_received(:call!).once
     end
   end
 end


### PR DESCRIPTION
Our approach to batch fetching from the Academies API to speed up the application has grown organically, this has caused us some problems with various things including eager loading and paging.

This work sets out to resolve this by offering a single object that takes care of it all with a simple method call.

Because this object can be passed ActiveRecord results with eager loading, we have to disbale Bullet inside it to prevent false positives caused by bullet thinking we are not using the the eager loaded association, when we are just passing them on to what does use them.

We continue with the idea of 'dependancy injection' and allow the pre fetching to be diisabled to allow testing of any class that utilising pre fetching without having to deal with the pre fetching as it can make mocking really difficult.

This object can also handle any number of projects and splits them up into batches of 10 it also works when passed to Pagy, this resolves the two main issues we have faced previously.

Here we only switch the currently broken 'Team projects' - with the intention of verifying the behaviour and then switching over to this new object everywhere.
