### PR TITLE
Add "2 Requires improvement" (2RI) to Conversion Projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add "2RI" question to the new Conversion project form
 - Remove hint from the "DAO" question on the create Conversion project form
+- Show the "2RI" value on the Project information page
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add "2RI" question to the new Conversion project form
+- Remove hint from the "DAO" question on the create Conversion project form
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add "2RI" question to the new Conversion project form
+
 ### Changed
 
 ### Fixed

--- a/app/controllers/conversions/projects_controller.rb
+++ b/app/controllers/conversions/projects_controller.rb
@@ -43,7 +43,8 @@ class Conversions::ProjectsController < ProjectsController
       :trust_sharepoint_link,
       :handover_note_body,
       :assigned_to_regional_caseworker_team,
-      :directive_academy_order
+      :directive_academy_order,
+      :two_requires_improvement
     )
   end
 end

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -17,6 +17,7 @@ class Conversion::CreateProjectForm
   attribute :directive_academy_order, :boolean
   attribute :region
   attribute :assigned_to_regional_caseworker_team, :boolean
+  attribute :two_requires_improvement, :boolean
 
   attr_reader :provisional_conversion_date,
     :advisory_board_date
@@ -42,7 +43,9 @@ class Conversion::CreateProjectForm
 
   validate :urn_unique_for_in_progress_conversions, if: -> { urn.present? }
 
-  validates :directive_academy_order, :assigned_to_regional_caseworker_team, inclusion: {in: [true, false]}
+  validates :directive_academy_order,
+    :assigned_to_regional_caseworker_team,
+    :two_requires_improvement, inclusion: {in: [true, false]}
 
   def initialize(params = {})
     @attributes_with_invalid_values = []
@@ -128,6 +131,13 @@ class Conversion::CreateProjectForm
     ]
   end
 
+  def two_requires_improvement_responses
+    @two_requires_improvement_responses ||= [
+      OpenStruct.new(id: true, name: I18n.t("yes")),
+      OpenStruct.new(id: false, name: I18n.t("no"))
+    ]
+  end
+
   def save
     assigned_to = assigned_to_regional_caseworker_team ? nil : user
     assigned_at = assigned_to_regional_caseworker_team ? nil : DateTime.now
@@ -147,6 +157,7 @@ class Conversion::CreateProjectForm
       assigned_to: assigned_to,
       assigned_at: assigned_at,
       directive_academy_order: directive_academy_order,
+      two_requires_improvement: two_requires_improvement,
       region: region,
       tasks_data: new_tasks_data
     )

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -9,6 +9,7 @@ class Conversion::Project < Project
   validates :conversion_date, presence: true
   validates :conversion_date, first_day_of_month: true
   validates :directive_academy_order, inclusion: {in: [true, false]}
+  validates :two_requires_improvement, inclusion: {in: [true, false]}
 
   scope :no_academy_urn, -> { where(academy_urn: nil) }
   scope :with_academy_urn, -> { where.not(academy_urn: nil) }

--- a/app/views/conversions/projects/new.html.erb
+++ b/app/views/conversions/projects/new.html.erb
@@ -28,6 +28,13 @@
             legend: {text: t("helpers.legend.conversion_project.directive_academy_order")},
             hint: {text: t("helpers.hint.conversion_project.directive_academy_order")},
             form_group: {id: "directive-academy-order"} %>
+      <%= form.govuk_collection_radio_buttons :two_requires_improvement,
+            @project.two_requires_improvement_responses,
+            :id,
+            :name,
+            legend: {text: t("helpers.legend.conversion_project.two_requires_improvement")},
+            hint: {text: t("helpers.hint.conversion_project.two_requires_improvement")},
+            form_group: {id: "two-requires-improvement"} %>
 
       <%= form.govuk_submit %>
     <% end %>

--- a/app/views/conversions/projects/new.html.erb
+++ b/app/views/conversions/projects/new.html.erb
@@ -26,7 +26,6 @@
             :id,
             :name,
             legend: {text: t("helpers.legend.conversion_project.directive_academy_order")},
-            hint: {text: t("helpers.hint.conversion_project.directive_academy_order")},
             form_group: {id: "directive-academy-order"} %>
       <%= form.govuk_collection_radio_buttons :two_requires_improvement,
             @project.two_requires_improvement_responses,

--- a/app/views/project_information/show/_information_list.erb
+++ b/app/views/project_information/show/_information_list.erb
@@ -6,6 +6,12 @@
       row.value { t("project_information.show.project_details.rows.directive_academy_order.#{@project.directive_academy_order}") }
     end
   end %>
+  <%= govuk_summary_list do |summary_list|
+    summary_list.row do |row|
+      row.key { t('project_information.show.project_details.rows.two_requires_improvement.title') }
+      row.value { t("project_information.show.project_details.rows.two_requires_improvement.#{@project.two_requires_improvement}") }
+    end
+  end %>
 </div>
 
 <div id="advisoryBoardDetails">

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -66,7 +66,6 @@ en:
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
         assigned_to_regional_caseworker_team: Are you handing this project over to Regional Casework Services?
-        directive_academy_order: A DAO (directive academy order) is always issued for sponsored conversions. Voluntary conversions are granted an AO (academy order).
         two_requires_improvement: A 2RI conversion is when a local authority maintained school becomes an academy after getting at least 2 overall Requires Improvement ratings from Ofsted.
     responses:
       conversion_project:

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -51,6 +51,7 @@ en:
         provisional_conversion_date: Provisional conversion date
         advisory_board_date: Date of advisory board
         directive_academy_order: What kind of academy order has been used?
+        two_requires_improvement: Is this conversion due to intervention following 2RI?
     hint:
       conversion_project:
         urn: |
@@ -66,6 +67,7 @@ en:
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
         assigned_to_regional_caseworker_team: Are you handing this project over to Regional Casework Services?
         directive_academy_order: A DAO (directive academy order) is always issued for sponsored conversions. Voluntary conversions are granted an AO (academy order).
+        two_requires_improvement: A 2RI conversion is when a local authority maintained school becomes an academy after getting at least 2 overall Requires Improvement ratings from Ofsted.
     responses:
       conversion_project:
         directive_academy_order:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -416,6 +416,8 @@ en:
         inclusion: Select directive academy order or academy order, whichever has been used for this conversion
       assigned_to_regional_caseworker_team:
         inclusion: Select yes or no
+      two_requires_improvement:
+        inclusion: Select yes or no
       academy_urn:
         blank: Please enter an Academy URN
         invalid_urn: Please enter a valid URN. The URN must be 6 digits long. For example, 123456.

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -283,6 +283,10 @@ en:
             title: Has a directive academy order been issued?
             "true": "Yes"
             "false": "No"
+          two_requires_improvement:
+            title: Is this conversion due to intervention following 2RI?
+            "true": "Yes"
+            "false": "No"
       advisory_board_details:
         title: Advisory board details
         rows:

--- a/db/migrate/20230720145221_add2ri_to_projects.rb
+++ b/db/migrate/20230720145221_add2ri_to_projects.rb
@@ -1,0 +1,5 @@
+class Add2riToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :two_requires_improvement, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_141059) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_20_145221) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -204,6 +204,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_141059) do
     t.uuid "funding_agreement_contact_id"
     t.integer "outgoing_trust_ukprn"
     t.string "team"
+    t.boolean "two_requires_improvement", default: false
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"

--- a/spec/factories/conversion/create_project_form_factory.rb
+++ b/spec/factories/conversion/create_project_form_factory.rb
@@ -10,5 +10,6 @@ FactoryBot.define do
     handover_note_body { "Handover notes" }
     directive_academy_order { false }
     assigned_to_regional_caseworker_team { false }
+    two_requires_improvement { false }
   end
 end

--- a/spec/features/project_information/users_can_view_project_details_spec.rb
+++ b/spec/features/project_information/users_can_view_project_details_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Users can view project details" do
   let(:user) { create(:user, :caseworker) }
-  let(:project) { create(:conversion_project, directive_academy_order: true) }
+  let(:project) { create(:conversion_project, directive_academy_order: true, two_requires_improvement: true) }
 
   before do
     mock_successful_api_responses(urn: any_args, ukprn: any_args)
@@ -11,7 +11,13 @@ RSpec.feature "Users can view project details" do
   end
 
   scenario "they can see if it has had a directive academy order issued" do
-    within("#projectDetails .govuk-summary-list__row:first-of-type") do
+    within("#projectDetails .govuk-summary-list__row:contains('Has a directive academy order been issued?')") do
+      expect(page).to have_content("Yes")
+    end
+  end
+
+  scenario "they can see if it has had two 'Requires improvement' ratings" do
+    within("#projectDetails .govuk-summary-list__row:contains('Is this conversion due to intervention following 2RI?')") do
       expect(page).to have_content("Yes")
     end
   end

--- a/spec/features/users_can_create_conversion_projects_spec.rb
+++ b/spec/features/users_can_create_conversion_projects_spec.rb
@@ -62,5 +62,8 @@ RSpec.feature "Users can create new conversion projects" do
     within("#directive-academy-order") do
       choose "Academy order"
     end
+    within("#two-requires-improvement") do
+      choose "No"
+    end
   end
 end

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe Conversion::Project do
         end
       end
     end
+
+    describe "#two_requires_improvement" do
+      it { is_expected.to allow_value(true).for(:two_requires_improvement) }
+      it { is_expected.to allow_value(false).for(:two_requires_improvement) }
+      it { is_expected.to_not allow_value(nil).for(:two_requires_improvement) }
+
+      context "error messages" do
+        it "adds an appropriate error message if the value is nil" do
+          subject.assign_attributes(two_requires_improvement: nil)
+          subject.valid?
+          expect(subject.errors[:two_requires_improvement]).to include("Select yes or no")
+        end
+      end
+    end
   end
 
   describe "scopes" do

--- a/spec/requests/conversions/projects_controller_spec.rb
+++ b/spec/requests/conversions/projects_controller_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Conversions::ProjectsController do
       "advisory_board_date(2i)": "1",
       "advisory_board_date(1i)": "2022",
       regional_delivery_officer: nil,
-      directive_academy_order: "false")
+      directive_academy_order: "false",
+      two_requires_improvement: "false")
   }
 
   describe "#index" do


### PR DESCRIPTION
## Changes

Add a new question to the create Conversion project form to indicate if a school is converting because it has received two "requires improvement" ratings. This question is mandatory for conversion projects.

<img width="1056" alt="Screenshot 2023-07-20 at 16 45 03" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/d101c27f-fdd9-49e3-b162-02768228544e">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
