### PR TITLE
Users could add a Transfer project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add "2RI" question to the new Conversion project form
 - Remove hint from the "DAO" question on the create Conversion project form
 - Show the "2RI" value on the Project information page
+- Add a very basic create form for Transfer projects
 
 ### Changed
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -6,7 +6,13 @@ class ProjectsController < ApplicationController
     @project = Project.find(params[:id])
     authorize @project
 
-    redirect_to project_conversion_tasks_path(@project)
+    # TODO: Temporary until we add Tasks for Transfer Projects
+    case @project.type
+    when "Conversion::Project"
+      redirect_to project_conversion_tasks_path(@project)
+    when "Transfer::Project"
+      render "transfers/projects/show"
+    end
   end
 
   def index

--- a/app/controllers/transfers/projects_controller.rb
+++ b/app/controllers/transfers/projects_controller.rb
@@ -1,0 +1,30 @@
+class Transfers::ProjectsController < ApplicationController
+  def new
+    authorize Transfer::Project
+    @project = Transfer::CreateProjectForm.new
+  end
+
+  def create
+    authorize Transfer::Project
+    @project = Transfer::CreateProjectForm.new(**project_params, user: current_user)
+
+    if @project.valid?
+      @created_project = @project.save
+
+      redirect_to project_path(@created_project), notice: I18n.t("transfer_project.created.success")
+    else
+      render :new
+    end
+  end
+
+  private def project_params
+    params.require(:transfer_create_project_form).permit(
+      :urn,
+      :incoming_trust_ukprn,
+      :outgoing_trust_ukprn,
+      :establishment_sharepoint_link,
+      :advisory_board_date,
+      :trust_sharepoint_link
+    )
+  end
+end

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -1,19 +1,6 @@
-class Conversion::CreateProjectForm
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-  include ActiveRecord::AttributeAssignment
-
-  SHAREPOINT_URLS = %w[educationgovuk-my.sharepoint.com educationgovuk.sharepoint.com].freeze
-
-  class NegativeValueError < StandardError; end
-
-  attribute :urn, :integer
-  attribute :incoming_trust_ukprn, :integer
-  attribute :establishment_sharepoint_link
-  attribute :trust_sharepoint_link
+class Conversion::CreateProjectForm < CreateProjectForm
   attribute :advisory_board_conditions
   attribute :handover_note_body
-  attribute :user
   attribute :directive_academy_order, :boolean
   attribute :region
   attribute :assigned_to_regional_caseworker_team, :boolean
@@ -28,18 +15,6 @@ class Conversion::CreateProjectForm
     presence: true
 
   validates :provisional_conversion_date, date_in_the_future: true, first_day_of_month: true
-  validates :advisory_board_date, date_in_the_past: true
-
-  validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
-  validates :trust_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
-
-  validates :urn, presence: true, urn: true
-  validates :incoming_trust_ukprn, presence: true, ukprn: true
-
-  validate :multiparameter_date_attributes_values
-
-  validate :establishment_exists, if: -> { urn.present? }
-  validate :trust_exists, if: -> { incoming_trust_ukprn.present? }
 
   validate :urn_unique_for_in_progress_conversions, if: -> { urn.present? }
 
@@ -60,57 +35,14 @@ class Conversion::CreateProjectForm
     @attributes_with_invalid_values << :provisional_conversion_date
   end
 
-  def advisory_board_date=(hash)
-    @advisory_board_date = Date.new(value_at_position(hash, 1), value_at_position(hash, 2), value_at_position(hash, 3))
-  rescue NoMethodError
-    nil
-  rescue TypeError, Date::Error, NegativeValueError
-    @attributes_with_invalid_values << :advisory_board_date
-  end
-
   def region
     @region = establishment.region_code
-  end
-
-  private def establishment
-    @establishment || fetch_establishment(urn)
-  end
-
-  private def fetch_establishment(urn)
-    result = Api::AcademiesApi::Client.new.get_establishment(urn)
-    raise result.error if result.error.present?
-
-    result.object
-  end
-
-  private def value_at_position(hash, position)
-    value = hash[position]
-    return NegativeValueError if value.to_i < 0
-    value
-  end
-
-  private def multiparameter_date_attributes_values
-    return if @attributes_with_invalid_values.empty?
-    @attributes_with_invalid_values.each { |attribute| errors.add(attribute, :invalid) }
   end
 
   private def notify_team_leaders(project)
     User.team_leaders.each do |team_leader|
       TeamLeaderMailer.new_project_created(team_leader, project).deliver_later
     end
-  end
-
-  private def establishment_exists
-    establishment
-  rescue Api::AcademiesApi::Client::NotFoundError
-    errors.add(:urn, :no_establishment_found)
-  end
-
-  private def trust_exists
-    result = Api::AcademiesApi::Client.new.get_trust(incoming_trust_ukprn)
-    raise result.error if result.error.present?
-  rescue Api::AcademiesApi::Client::NotFoundError
-    errors.add(:incoming_trust_ukprn, :no_trust_found)
   end
 
   private def urn_unique_for_in_progress_conversions

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -114,7 +114,7 @@ class Conversion::CreateProjectForm
   end
 
   private def urn_unique_for_in_progress_conversions
-    errors.add(:urn, :duplicate) if Project.not_completed.where(urn: urn).any?
+    errors.add(:urn, :duplicate) if Conversion::Project.not_completed.where(urn: urn).any?
   end
 
   def assigned_to_regional_caseworker_team_responses

--- a/app/forms/create_project_form.rb
+++ b/app/forms/create_project_form.rb
@@ -1,0 +1,82 @@
+class CreateProjectForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
+  SHAREPOINT_URLS = %w[educationgovuk-my.sharepoint.com educationgovuk.sharepoint.com].freeze
+
+  class NegativeValueError < StandardError; end
+
+  attribute :urn, :integer
+  attribute :incoming_trust_ukprn, :integer
+  attribute :outgoing_trust_ukprn, :integer
+  attribute :establishment_sharepoint_link
+  attribute :trust_sharepoint_link
+  attribute :user
+
+  attr_reader :advisory_board_date
+
+  validates :urn, presence: true, urn: true
+  validates :incoming_trust_ukprn, presence: true, ukprn: true
+  validates :advisory_board_date, presence: true
+  validates :advisory_board_date, date_in_the_past: true
+
+  validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
+  validates :trust_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
+
+  validate :establishment_exists, if: -> { urn.present? }
+  validate :trust_exists, if: -> { incoming_trust_ukprn.present? }
+
+  validate :multiparameter_date_attributes_values
+
+  def region
+    @region = establishment.region_code
+  end
+
+  def advisory_board_date=(hash)
+    @advisory_board_date = Date.new(value_at_position(hash, 1), value_at_position(hash, 2), value_at_position(hash, 3))
+  rescue NoMethodError
+    nil
+  rescue TypeError, Date::Error, NegativeValueError
+    @attributes_with_invalid_values << :advisory_board_date
+  end
+
+  private def establishment
+    @establishment || fetch_establishment(urn)
+  end
+
+  private def establishment_exists
+    establishment
+  rescue Api::AcademiesApi::Client::NotFoundError
+    errors.add(:urn, :no_establishment_found)
+  end
+
+  private def trust_exists
+    result = Api::AcademiesApi::Client.new.get_trust(incoming_trust_ukprn)
+    raise result.error if result.error.present?
+  rescue Api::AcademiesApi::Client::NotFoundError
+    errors.add(:incoming_trust_ukprn, :no_trust_found)
+  end
+
+  private def fetch_establishment(urn)
+    result = Api::AcademiesApi::Client.new.get_establishment(urn)
+    raise result.error if result.error.present?
+
+    result.object
+  end
+
+  private def urn_unique_for_in_progress_transfers
+    errors.add(:urn, :duplicate) if Transfer::Project.not_completed.where(urn: urn).any?
+  end
+
+  private def value_at_position(hash, position)
+    value = hash[position]
+    return NegativeValueError if value.to_i < 0
+    value
+  end
+
+  private def multiparameter_date_attributes_values
+    return if @attributes_with_invalid_values.empty?
+    @attributes_with_invalid_values.each { |attribute| errors.add(attribute, :invalid) }
+  end
+end

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -1,0 +1,115 @@
+class Transfer::CreateProjectForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
+  SHAREPOINT_URLS = %w[educationgovuk-my.sharepoint.com educationgovuk.sharepoint.com].freeze
+
+  class NegativeValueError < StandardError; end
+
+  attribute :urn, :integer
+  attribute :incoming_trust_ukprn, :integer
+  attribute :outgoing_trust_ukprn, :integer
+  attribute :establishment_sharepoint_link
+  attribute :trust_sharepoint_link
+  attribute :user
+
+  attr_reader :advisory_board_date
+
+  validates :urn, presence: true, urn: true
+  validates :incoming_trust_ukprn, presence: true, ukprn: true
+  validates :outgoing_trust_ukprn, presence: true, ukprn: true
+  validates :advisory_board_date, presence: true
+  validates :advisory_board_date, date_in_the_past: true
+
+  validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
+  validates :trust_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
+
+  validate :establishment_exists, if: -> { urn.present? }
+  validate :trust_exists, if: -> { incoming_trust_ukprn.present? }
+
+  validate :urn_unique_for_in_progress_transfers, if: -> { urn.present? }
+
+  validate :multiparameter_date_attributes_values
+
+  def initialize(params = {})
+    @attributes_with_invalid_values = []
+    super(params)
+  end
+
+  def save
+    @project = Transfer::Project.new(
+      urn: urn,
+      incoming_trust_ukprn: incoming_trust_ukprn,
+      outgoing_trust_ukprn: incoming_trust_ukprn,
+      establishment_sharepoint_link: establishment_sharepoint_link,
+      trust_sharepoint_link: trust_sharepoint_link,
+      advisory_board_date: advisory_board_date,
+      regional_delivery_officer_id: user.id,
+      team: user.team,
+      assigned_to: user,
+      assigned_at: DateTime.now,
+      region: region,
+      tasks_data: Transfer::TasksData.new
+    )
+
+    return nil unless valid?
+
+    ActiveRecord::Base.transaction do
+      @project.save
+    end
+
+    @project
+  end
+
+  def region
+    @region = establishment.region_code
+  end
+
+  def advisory_board_date=(hash)
+    @advisory_board_date = Date.new(value_at_position(hash, 1), value_at_position(hash, 2), value_at_position(hash, 3))
+  rescue NoMethodError
+    nil
+  rescue TypeError, Date::Error, NegativeValueError
+    @attributes_with_invalid_values << :advisory_board_date
+  end
+
+  private def establishment
+    @establishment || fetch_establishment(urn)
+  end
+
+  private def establishment_exists
+    establishment
+  rescue Api::AcademiesApi::Client::NotFoundError
+    errors.add(:urn, :no_establishment_found)
+  end
+
+  private def trust_exists
+    result = Api::AcademiesApi::Client.new.get_trust(incoming_trust_ukprn)
+    raise result.error if result.error.present?
+  rescue Api::AcademiesApi::Client::NotFoundError
+    errors.add(:incoming_trust_ukprn, :no_trust_found)
+  end
+
+  private def fetch_establishment(urn)
+    result = Api::AcademiesApi::Client.new.get_establishment(urn)
+    raise result.error if result.error.present?
+
+    result.object
+  end
+
+  private def urn_unique_for_in_progress_transfers
+    errors.add(:urn, :duplicate) if Transfer::Project.not_completed.where(urn: urn).any?
+  end
+
+  private def value_at_position(hash, position)
+    value = hash[position]
+    return NegativeValueError if value.to_i < 0
+    value
+  end
+
+  private def multiparameter_date_attributes_values
+    return if @attributes_with_invalid_values.empty?
+    @attributes_with_invalid_values.each { |attribute| errors.add(attribute, :invalid) }
+  end
+end

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -1,36 +1,7 @@
-class Transfer::CreateProjectForm
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-  include ActiveRecord::AttributeAssignment
-
-  SHAREPOINT_URLS = %w[educationgovuk-my.sharepoint.com educationgovuk.sharepoint.com].freeze
-
-  class NegativeValueError < StandardError; end
-
-  attribute :urn, :integer
-  attribute :incoming_trust_ukprn, :integer
-  attribute :outgoing_trust_ukprn, :integer
-  attribute :establishment_sharepoint_link
-  attribute :trust_sharepoint_link
-  attribute :user
-
-  attr_reader :advisory_board_date
-
-  validates :urn, presence: true, urn: true
-  validates :incoming_trust_ukprn, presence: true, ukprn: true
+class Transfer::CreateProjectForm < CreateProjectForm
   validates :outgoing_trust_ukprn, presence: true, ukprn: true
-  validates :advisory_board_date, presence: true
-  validates :advisory_board_date, date_in_the_past: true
-
-  validates :establishment_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
-  validates :trust_sharepoint_link, presence: true, url: {hostnames: SHAREPOINT_URLS}
-
-  validate :establishment_exists, if: -> { urn.present? }
-  validate :trust_exists, if: -> { incoming_trust_ukprn.present? }
 
   validate :urn_unique_for_in_progress_transfers, if: -> { urn.present? }
-
-  validate :multiparameter_date_attributes_values
 
   def initialize(params = {})
     @attributes_with_invalid_values = []
@@ -60,56 +31,5 @@ class Transfer::CreateProjectForm
     end
 
     @project
-  end
-
-  def region
-    @region = establishment.region_code
-  end
-
-  def advisory_board_date=(hash)
-    @advisory_board_date = Date.new(value_at_position(hash, 1), value_at_position(hash, 2), value_at_position(hash, 3))
-  rescue NoMethodError
-    nil
-  rescue TypeError, Date::Error, NegativeValueError
-    @attributes_with_invalid_values << :advisory_board_date
-  end
-
-  private def establishment
-    @establishment || fetch_establishment(urn)
-  end
-
-  private def establishment_exists
-    establishment
-  rescue Api::AcademiesApi::Client::NotFoundError
-    errors.add(:urn, :no_establishment_found)
-  end
-
-  private def trust_exists
-    result = Api::AcademiesApi::Client.new.get_trust(incoming_trust_ukprn)
-    raise result.error if result.error.present?
-  rescue Api::AcademiesApi::Client::NotFoundError
-    errors.add(:incoming_trust_ukprn, :no_trust_found)
-  end
-
-  private def fetch_establishment(urn)
-    result = Api::AcademiesApi::Client.new.get_establishment(urn)
-    raise result.error if result.error.present?
-
-    result.object
-  end
-
-  private def urn_unique_for_in_progress_transfers
-    errors.add(:urn, :duplicate) if Transfer::Project.not_completed.where(urn: urn).any?
-  end
-
-  private def value_at_position(hash, position)
-    value = hash[position]
-    return NegativeValueError if value.to_i < 0
-    value
-  end
-
-  private def multiparameter_date_attributes_values
-    return if @attributes_with_invalid_values.empty?
-    @attributes_with_invalid_values.each { |attribute| errors.add(attribute, :invalid) }
   end
 end

--- a/app/views/transfers/projects/new.html.erb
+++ b/app/views/transfers/projects/new.html.erb
@@ -1,0 +1,23 @@
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: root_path} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @project, url: transfers_path do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l"><%= t("transfer_project.new.title") %></h1>
+      <%= t("transfer_project.new.hint_html") %>
+
+      <%= form.govuk_text_field :urn, label: {size: "m", text: t("helpers.label.transfer_project.urn")}, hint: {text: t("helpers.hint.transfer_project.urn").html_safe}, width: 10 %>
+      <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.incoming_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.incoming_trust_ukprn").html_safe}, width: 10 %>
+      <%= form.govuk_text_field :outgoing_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.outgoing_trust_ukprn").html_safe}, width: 10 %>
+      <%= form.govuk_date_field :advisory_board_date, legend: {text: t("helpers.legend.transfer_project.advisory_board_date")}, form_group: {id: "advisory-board-date"}, hint: {text: t("helpers.hint.project.advisory_board_date").html_safe} %>
+      <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.establishment_sharepoint_link")} %>
+      <%= form.govuk_text_field :trust_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.trust_sharepoint_link")} %>
+
+      <%= form.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -1,0 +1,41 @@
+en:
+  transfer_project:
+    add:
+      title: Add a transfer
+    new:
+      title: Create a new transfer
+      hint_html: <p class="govuk-body">Enter information about the school, trust and the advisory board decision.</p><p class="govuk-body">This will create a new transfer project.</p>
+    created:
+      success: Transfer project successfully created
+  helpers:
+    label:
+      transfer_project:
+        urn: School URN (Unique Reference Number)
+        incoming_trust_ukprn: Incoming trust UKPRN (UK Provider Reference Number)
+        outgoing_trust_ukprn: Outgoing trust UKPRN (UK Provider Reference Number)
+        caseworker_id: Caseworker
+        regional_delivery_officer_id: Regional delivery officer
+        advisory_board_conditions: Advisory board conditions
+        establishment_sharepoint_link: School SharePoint link
+        trust_sharepoint_link: Trust SharePoint link
+    legend:
+      transfer_project:
+        advisory_board_date: Date of advisory board
+        provisional_transfer_date: Provisional transfer date
+    hint:
+      transfer_project:
+        urn: |
+          This is the URN of the existing school which is transferring. A URN is a 6-digit number. You can find it in the advisory board template.
+        incoming_trust_ukprn: |
+          A UKPRN is an 8-digit number that always starts with a 1.
+          <br /><br />
+          <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in a new tab)</a>.
+        outgoing_trust_ukprn: |
+          A UKPRN is an 8-digit number that always starts with a 1.
+          <br /><br />
+          <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the outgoing trust's UKPRN (opens in a new tab)</a>.
+        provisional_tranfer_date: You can find this in the advisory board template.
+        advisory_board_conditions: Enter details of conditions that must be met before the school can transfer.
+        establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
+        trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,6 +170,10 @@ Rails.application.routes.draw do
       post "/", to: "projects#create"
       get "new", to: "projects#new"
     end
+    namespace :transfers do
+      get "new", to: "projects#new"
+      post "/", to: "projects#create"
+    end
   end
 
   resources :users, only: %w[new create edit update]

--- a/spec/factories/conversion/create_project_form_factory.rb
+++ b/spec/factories/conversion/create_project_form_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :create_project_form, class: "Conversion::CreateProjectForm" do
+  factory :create_conversion_project_form, class: "Conversion::CreateProjectForm", aliases: [:create_project_form] do
     urn { 123456 }
     incoming_trust_ukprn { 10061021 }
     provisional_conversion_date { {3 => 1, 2 => 1, 1 => 2030} }

--- a/spec/factories/transfer/create_project_form_factory.rb
+++ b/spec/factories/transfer/create_project_form_factory.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :create_transfer_project_form, class: "Transfer::CreateProjectForm" do
+    urn { 123456 }
+    incoming_trust_ukprn { 10061021 }
+    outgoing_trust_ukprn { 10066123 }
+    advisory_board_date { {3 => 1, 2 => 10, 1 => 2022} }
+    establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/establishment-folder" }
+    trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }
+    user { association :user, :regional_delivery_officer }
+  end
+end

--- a/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
+++ b/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.feature "Users can create new conversion projects" do
+  let(:regional_delivery_officer) { create(:user, :regional_delivery_officer) }
+
+  before do
+    sign_in_with_user(regional_delivery_officer)
+    visit transfers_new_path
+  end
+
+  context "when the URN and UKPRN are valid" do
+    let(:urn) { 123456 }
+    let(:incoming_ukprn) { 10061021 }
+    let(:outgoing_ukprn) { 10090252 }
+    let(:two_weeks_ago) { Date.today - 2.weeks }
+
+    before { mock_all_academies_api_responses }
+
+    scenario "a new project is created" do
+      fill_in_form
+
+      click_button("Continue")
+
+      expect(page).to have_content(I18n.t("transfer_project.created.success"))
+      expect(Transfer::Project.count).to eq(1)
+    end
+  end
+
+  context "when required values are not supplied" do
+    scenario "error messages are shown to the user" do
+      click_button("Continue")
+
+      expect(page).to have_content("There is a problem")
+    end
+  end
+
+  def fill_in_form
+    fill_in "School URN", with: urn
+    fill_in "Incoming trust UKPRN (UK Provider Reference Number)", with: incoming_ukprn
+    fill_in "Outgoing trust UKPRN (UK Provider Reference Number)", with: outgoing_ukprn
+
+    fill_in "School SharePoint link", with: "https://educationgovuk-my.sharepoint.com/school-folder"
+    fill_in "Trust SharePoint link", with: "https://educationgovuk-my.sharepoint.com/trust-folder"
+
+    within("#advisory-board-date") do
+      fill_in "Day", with: two_weeks_ago.day
+      fill_in "Month", with: two_weeks_ago.month
+      fill_in "Year", with: two_weeks_ago.year
+    end
+  end
+end

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe Conversion::CreateProjectForm, type: :model do
   let(:form_factory) { "create_project_form" }
-  let(:task_list_class) { Conversion::Voluntary::TaskList }
 
   context "when the project is successfully created" do
     let(:establishment) { build(:academies_api_establishment) }

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -312,6 +312,16 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
         expect(form.errors.messages[:urn]).to include I18n.t("errors.attributes.urn.duplicate")
       end
     end
+
+    context "when there is a Transfer project with the same urn" do
+      it "is valid" do
+        _project_with_urn = create(:transfer_project, urn: 121813, assigned_to: nil)
+        form = build(:create_conversion_project_form)
+
+        form.urn = 121813
+        expect(form).to be_valid
+      end
+    end
   end
 
   describe "incoming_trust_ukprn" do

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -122,6 +122,16 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
         expect(form.errors.messages[:urn]).to include I18n.t("errors.attributes.urn.duplicate")
       end
     end
+
+    context "when there is a Conversion project with the same urn" do
+      it "is valid" do
+        _project_with_urn = create(:conversion_project, urn: 121813, assigned_to: nil)
+        form = build(:create_transfer_project_form)
+
+        form.urn = 121813
+        expect(form).to be_valid
+      end
+    end
   end
 
   describe "incoming_trust_ukprn" do

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -1,0 +1,204 @@
+require "rails_helper"
+
+RSpec.describe Transfer::CreateProjectForm, type: :model do
+  before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:establishment_sharepoint_link) }
+    it { is_expected.to validate_presence_of(:trust_sharepoint_link) }
+
+    describe "advisory_board_date" do
+      it { is_expected.to validate_presence_of(:advisory_board_date) }
+
+      it "must be in the past" do
+        form = build(:create_transfer_project_form)
+        expect(form).to be_valid
+
+        form.advisory_board_date = {3 => 1, 2 => 1, 1 => 2030}
+        expect(form).to be_invalid
+      end
+
+      it "cannot be in the future" do
+        form = build(:create_transfer_project_form, advisory_board_date: {3 => 1, 2 => 1, 1 => 2020})
+        expect(form).to be_valid
+
+        form.advisory_board_date = {3 => 1, 2 => 1, 1 => 2030}
+        expect(form).to be_invalid
+      end
+
+      context "when the date parameters are partially complete" do
+        it "treats the date as invalid" do
+          form = build(:create_transfer_project_form, advisory_board_date: {3 => nil, 2 => 10, 1 => 1})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :invalid)).to be true
+
+          form = build(:create_transfer_project_form, advisory_board_date: {3 => 2022, 2 => nil, 1 => 1})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :invalid)).to be true
+
+          form = build(:create_transfer_project_form, advisory_board_date: {3 => 2022, 2 => 10, 1 => nil})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :invalid)).to be true
+        end
+      end
+
+      context "when all the date parameters are missing" do
+        it "treats the date as blank" do
+          form = build(:create_transfer_project_form, advisory_board_date: {3 => nil, 2 => nil, 1 => nil})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :blank)).to be true
+        end
+      end
+
+      context "when no date value is set" do
+        it "treats the date as blank" do
+          form = build(:create_transfer_project_form, advisory_board_date: nil)
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :blank)).to be true
+        end
+      end
+
+      context "when the date doesn't exist" do
+        it "treats the date as invalid" do
+          form = build(:create_transfer_project_form, advisory_board_date: {3 => 31, 2 => 2, 1 => 2030})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :invalid)).to be true
+        end
+      end
+
+      context "when the isn't a date" do
+        it "treats the date as invalid" do
+          form = build(:create_transfer_project_form, advisory_board_date: {3 => -1, 2 => -1, 1 => 0})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :invalid)).to be true
+
+          form = build(:create_transfer_project_form, advisory_board_date: {3 => "not", 2 => "a", 1 => "date"})
+          expect(form).to be_invalid
+          expect(form.errors.of_kind?(:advisory_board_date, :invalid)).to be true
+        end
+      end
+    end
+  end
+
+  describe "urn" do
+    it { is_expected.to validate_presence_of(:urn) }
+    it { is_expected.to allow_value(123456).for(:urn) }
+    it { is_expected.not_to allow_values(12345, 1234567).for(:urn) }
+
+    context "when no establishment with that URN exists in the API" do
+      let(:no_establishment_found_result) do
+        Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::NotFoundError.new("Could not find establishment with URN: 12345"))
+      end
+
+      before do
+        allow_any_instance_of(Api::AcademiesApi::Client).to \
+          receive(:get_establishment) { no_establishment_found_result }
+      end
+
+      it "is invalid" do
+        form = build(:create_transfer_project_form)
+        expect(form).to be_invalid
+      end
+    end
+
+    context "when there is another in-progress project with the same urn" do
+      it "is invalid" do
+        _project_with_urn = create(:transfer_project, urn: 121813)
+        form = build(:create_transfer_project_form)
+
+        form.urn = 121813
+        expect(form).to be_invalid
+        expect(form.errors.messages[:urn]).to include I18n.t("errors.attributes.urn.duplicate")
+      end
+    end
+
+    context "when there is another project with the same urn which is not completed" do
+      it "is invalid" do
+        _project_with_urn = create(:transfer_project, urn: 121813, assigned_to: nil)
+        form = build(:create_transfer_project_form)
+
+        form.urn = 121813
+        expect(form).to be_invalid
+        expect(form.errors.messages[:urn]).to include I18n.t("errors.attributes.urn.duplicate")
+      end
+    end
+  end
+
+  describe "incoming_trust_ukprn" do
+    before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+    it { is_expected.to validate_presence_of(:incoming_trust_ukprn) }
+
+    context "when no trust with that UKPRN exists in the API" do
+      let(:no_trust_found_result) do
+        Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::NotFoundError.new("No trust found with that UKPRN. Enter a valid UKPRN."))
+      end
+
+      before do
+        allow_any_instance_of(Api::AcademiesApi::Client).to \
+          receive(:get_trust) { no_trust_found_result }
+      end
+
+      it "is invalid" do
+        form = build(:create_transfer_project_form)
+        expect(form).to be_invalid
+      end
+    end
+  end
+
+  describe "outgoing_trust_ukprn" do
+    before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+    it { is_expected.to validate_presence_of(:outgoing_trust_ukprn) }
+
+    context "when no trust with that UKPRN exists in the API" do
+      let(:no_trust_found_result) do
+        Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::NotFoundError.new("No trust found with that UKPRN. Enter a valid UKPRN."))
+      end
+
+      before do
+        allow_any_instance_of(Api::AcademiesApi::Client).to \
+          receive(:get_trust) { no_trust_found_result }
+      end
+
+      it "is invalid" do
+        form = build(:create_transfer_project_form)
+        expect(form).to be_invalid
+      end
+    end
+  end
+
+  describe "region" do
+    it "sets the region code from the establishment" do
+      project = build(:create_transfer_project_form).save
+      expect(project.region).to eq("west_midlands")
+    end
+  end
+
+  describe "#save" do
+    let(:establishment) { build(:academies_api_establishment) }
+
+    before do
+      mock_successful_api_establishment_response(urn: 123456, establishment:)
+      mock_successful_api_trust_response(ukprn: 10061021)
+    end
+
+    context "when the form is valid" do
+      it "returns a project" do
+        project = build(:create_transfer_project_form).save
+        expect(project.class.name).to eq("Transfer::Project")
+      end
+
+      it "also creates a tasks data" do
+        project = build(:create_transfer_project_form).save
+        expect(project.tasks_data).to be_a(Transfer::TasksData)
+      end
+    end
+
+    context "when the form is invalid" do
+      it "returns nil" do
+        expect(build(:create_transfer_project_form, urn: nil).save).to be_nil
+      end
+    end
+  end
+end

--- a/spec/requests/transfers/projects_controller_spec.rb
+++ b/spec/requests/transfers/projects_controller_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe Transfers::ProjectsController do
+  let(:regional_delivery_officer) { create(:user, :regional_delivery_officer) }
+  let(:project_form) { build(:create_transfer_project_form) }
+  let(:project_form_params) {
+    attributes_for(:create_project_form,
+      "advisory_board_date(3i)": "1",
+      "advisory_board_date(2i)": "1",
+      "advisory_board_date(1i)": "2022",
+      regional_delivery_officer: nil)
+  }
+
+  describe "#create" do
+    let(:project) { build(:transfer_project) }
+
+    before do
+      mock_all_academies_api_responses
+      sign_in_with(regional_delivery_officer)
+    end
+
+    subject(:perform_request) do
+      post transfers_path, params: {transfer_create_project_form: {**project_form_params}}
+      response
+    end
+
+    context "when the project is not valid" do
+      before do
+        allow(Transfer::CreateProjectForm).to receive(:new).and_return(project_form)
+        allow(project_form).to receive(:valid?).and_return false
+      end
+
+      it "re-renders the new template" do
+        expect(perform_request).to render_template :new
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes

**Content TBC**

Add a very basic create form for Transfer projects. Once the project is created, the user is redirected to a blank `show` page. Once we have created Tasks for Transfer projects the user will be redirected to the Tasks page, but this is out of scope for this ticket.

This PR also contains some refactoring to support the creation of two project types.

<img width="496" alt="Screenshot 2023-07-25 at 15 24 43" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/bd0438d6-674d-4ffa-b015-78ebbf52fc4f">


## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
