### PR TITLE
Replace route on the opening lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - All views that pre fetch data from the Academies API do so via the new method.
+- the Opening list now shows the academy order type instead of the route.
 
 ### Fixed
 

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -76,6 +76,11 @@ class Conversion::Project < Project
     academy.present?
   end
 
+  def academy_order_type
+    return :directive_academy_order if directive_academy_order?
+    :academy_order
+  end
+
   private def fetch_academy(urn)
     Api::AcademiesApi::Client.new.get_establishment(urn)
   end

--- a/app/views/all/opening/projects/_confirmed_table.html.erb
+++ b/app/views/all/opening/projects/_confirmed_table.html.erb
@@ -6,7 +6,6 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t("project.openers.table.headers.school") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.openers.table.headers.urn") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.openers.table.headers.route") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.openers.table.headers.all_conditions_met") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.openers.table.headers.view_project") %></th>
       </tr>
@@ -16,7 +15,6 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
         <td class="govuk-table__cell"><%= project.urn %></td>
-        <td class="govuk-table__cell"><%= t("project.openers.route.#{project.route}") %></td>
         <td class="govuk-table__cell"><%= all_conditions_met_value(project) %></td>
        <td class="govuk-table__cell">
          <a href="<%= project_path(project) %>">

--- a/app/views/all/opening/projects/_confirmed_table.html.erb
+++ b/app/views/all/opening/projects/_confirmed_table.html.erb
@@ -6,6 +6,7 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t("project.openers.table.headers.school") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.openers.table.headers.urn") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.openers.table.headers.academy_order_type") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.openers.table.headers.all_conditions_met") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.openers.table.headers.view_project") %></th>
       </tr>
@@ -15,6 +16,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
         <td class="govuk-table__cell"><%= project.urn %></td>
+        <td class="govuk-table__header"><%= t("project.openers.table.values.academy_order_type.#{project.academy_order_type}") %></td>
         <td class="govuk-table__cell"><%= all_conditions_met_value(project) %></td>
        <td class="govuk-table__cell">
          <a href="<%= project_path(project) %>">

--- a/app/views/all/opening/projects/_revised_table.html.erb
+++ b/app/views/all/opening/projects/_revised_table.html.erb
@@ -6,7 +6,6 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.route") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.revised_conversion_date") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
       </tr>
@@ -16,7 +15,6 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
         <td class="govuk-table__cell"><%= project.urn %></td>
-        <td class="govuk-table__cell"><%= t("project.revised_conversion_date.table.route.#{project.route}") %></td>
         <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
         <td class="govuk-table__cell">
           <%= link_to t("project.table.body.view_html", school_name: project.establishment.name), project_path(project) %>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -226,10 +226,13 @@ en:
           school: School
           urn: URN
           route: Route
-          direction_to_transfer: Direction to transfer
-          trust_modification_order: Trust modification order
+          academy_order_type: Academy order type
           all_conditions_met: All conditions met
           view_project: View project
+        values:
+          academy_order_type:
+            academy_order: AO (Academy Order)
+            directive_academy_order: DAO (Directive Academy Order)
       route:
         voluntary: Voluntary
         sponsored: Sponsored

--- a/spec/all_projects/by_month/users_can_view_confrimed_projects_spec.rb
+++ b/spec/all_projects/by_month/users_can_view_confrimed_projects_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.feature "Users can view confirmed projects" do
+  scenario "they can see the academy order type" do
+    sign_in_with_user(create(:user))
+    mock_all_academies_api_responses
+    create(:conversion_project, conversion_date: Date.today.next_month.at_beginning_of_month, conversion_date_provisional: false)
+
+    visit confirmed_all_opening_projects_path
+
+    within("thead") do
+      expect(page).to have_content("Academy order type")
+    end
+    within("tbody") do
+      expect(page).to have_content("AO (Academy Order)")
+    end
+  end
+end

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -426,4 +426,14 @@ RSpec.describe Conversion::Project do
       expect(projects).not_to include not_matching_project
     end
   end
+
+  describe "#academy_order_type" do
+    it "returns the correct type for the project" do
+      directive_academy_order_project = build(:conversion_project, directive_academy_order: true)
+      academy_order_project = build(:conversion_project, directive_academy_order: false)
+
+      expect(directive_academy_order_project.academy_order_type).to eql :directive_academy_order
+      expect(academy_order_project.academy_order_type).to eql :academy_order
+    end
+  end
 end

--- a/spec/requests/all/opening/projects_controller_spec.rb
+++ b/spec/requests/all/opening/projects_controller_spec.rb
@@ -63,8 +63,7 @@ RSpec.describe All::Opening::ProjectsController, type: :request do
 
             expect(response.body).to include(
               conversion_project.establishment.name,
-              conversion_project.urn.to_s,
-              I18n.t("project.openers.route.#{conversion_project.route}")
+              conversion_project.urn.to_s
             )
           end
 

--- a/spec/team_projects/by_month/users_can_view_confrimed_projects_spec.rb
+++ b/spec/team_projects/by_month/users_can_view_confrimed_projects_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.feature "Users can view confirmed projects" do
+  scenario "they can see the academy order type" do
+    sign_in_with_user(create(:regional_delivery_officer_user, team: :london))
+    mock_all_academies_api_responses
+    create(:conversion_project, conversion_date: Date.today.next_month.at_beginning_of_month, conversion_date_provisional: false, team: :london)
+
+    visit confirmed_team_opening_projects_path
+
+    within("thead") do
+      expect(page).to have_content("Academy order type")
+    end
+    within("tbody") do
+      expect(page).to have_content("AO (Academy Order)")
+    end
+  end
+end


### PR DESCRIPTION
We no longer want to support the concept of voluntary or sponsored conversions,
instead we hold the actual attributes of a project that would lead to these
terms.

This work removes the 'route' column from the opening table on both all projects
and team projects and adds 'academy order type'.

We leave the locales and various other bits of code as we cannot remove it all until no views are using 'route'.

https://trello.com/c/BRwrYkYD
