### PR TITLE
Move pager out of table element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The DfE frontend javascript is now loaded, the mobile navigation button should
   now work as expected.
+- Move pager on the `by trust` view to the bottom of the page
 
 ## [Release 35][release-35]
 

--- a/app/views/all/trusts/projects/show.html.erb
+++ b/app/views/all/trusts/projects/show.html.erb
@@ -35,9 +35,9 @@
               </tr>
           <% end %>
           </tbody>
-
-          <%= govuk_pagination(pagy: @pager) %>
         </table>
+
+        <%= govuk_pagination(pagy: @pager) %>
       <% end %>
   </div>
 </div>


### PR DESCRIPTION


## Changes

Pager was appearing at the top of the page due to being inside the `table` element.

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
