### PR TITLE
Update service support project views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   transfers, no user facing changes.
 - the conversion date is now stored as a more generic significant date ahead of
   support for transfers, no user facing changes.
+- the conversion URN tables no longer include the route, school phase or type.
 
 ### Fixed
 

--- a/app/views/projects/shared/_new_table.html.erb
+++ b/app/views/projects/shared/_new_table.html.erb
@@ -6,10 +6,7 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_type") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_phase") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.route") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.academy_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.academy_urn") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
@@ -20,10 +17,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
         <td class="govuk-table__cell"><%= project.urn %></td>
-        <td class="govuk-table__cell"><%= project.establishment.type %></td>
-        <td class="govuk-table__cell"><%= project.establishment.phase %></td>
-        <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
-        <td class="govuk-table__cell"><%= t("project.table.body.#{project.route}") %></td>
+        <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:significant_date) %></td>
         <td class="govuk-table__cell"><%= academy_name(project) %></td>
         <td class="govuk-table__cell">
           <a href="<%= project_academy_urn_path(project) %>">

--- a/app/views/projects/shared/_with_academy_urn_table.html.erb
+++ b/app/views/projects/shared/_with_academy_urn_table.html.erb
@@ -6,10 +6,7 @@
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
       <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
-      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_type") %></th>
-      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_phase") %></th>
       <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
-      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.route") %></th>
       <th class="govuk-table__header" scope="col"><%= t("project.table.headers.academy_name") %></th>
       <th class="govuk-table__header" scope="col"><%= t("project.table.headers.academy_urn") %></th>
       <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
@@ -20,10 +17,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
         <td class="govuk-table__cell"><%= project.urn %></td>
-        <td class="govuk-table__cell"><%= project.establishment.type %></td>
-        <td class="govuk-table__cell"><%= project.establishment.phase %></td>
-        <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
-        <td class="govuk-table__cell"><%= t("project.table.body.#{project.route}") %></td>
+        <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:significant_date) %></td>
         <td class="govuk-table__cell"><%= project.academy.name %></td>
         <td class="govuk-table__cell"><%= project.academy_urn %></td>
         <td class="govuk-table__cell">

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -5,5 +5,8 @@ Date::DATE_FORMATS[:govuk_weekday] = "%-d %B %Y, %a"
 Date::DATE_FORMATS[:govuk_month] = "%B %Y"
 Date::DATE_FORMATS[:govuk_month_only] = "%B"
 
+# Date format for all significant date (conversion date and transfer date)
+Date::DATE_FORMATS[:significant_date] = "%b %Y"
+
 # date format for csv files
 Date::DATE_FORMATS[:csv] = "%Y-%m-%d"

--- a/spec/features/projects/service_support/users_can_view_a_list_of_new_projects_spec.rb
+++ b/spec/features/projects/service_support/users_can_view_a_list_of_new_projects_spec.rb
@@ -56,10 +56,7 @@ RSpec.feature "Viewing all new projects" do
       within("thead") do
         expect(page).to have_content("School")
         expect(page).to have_content("URN")
-        expect(page).to have_content("School type")
-        expect(page).to have_content("School phase")
         expect(page).to have_content("Conversion date")
-        expect(page).to have_content("Route")
         expect(page).to have_content("Academy name")
         expect(page).to have_content("View project")
       end

--- a/spec/features/projects/service_support/users_can_view_a_list_of_projects_with_academy_urn_spec.rb
+++ b/spec/features/projects/service_support/users_can_view_a_list_of_projects_with_academy_urn_spec.rb
@@ -56,10 +56,7 @@ RSpec.feature "Viewing all projects with an academy URN" do
       within("thead") do
         expect(page).to have_content("School")
         expect(page).to have_content("URN")
-        expect(page).to have_content("School type")
-        expect(page).to have_content("School phase")
         expect(page).to have_content("Conversion date")
-        expect(page).to have_content("Route")
         expect(page).to have_content("Academy URN")
         expect(page).to have_content("Academy URN")
         expect(page).to have_content("View project")


### PR DESCRIPTION
This commit updates the columns shown on the service support specific
project views;

We remove the route because it is not a concept we want to support any
longer.

We remove school type and phase as  whilst they are useful during the
conversion academy URN journey, they are not needed here.

Overall this user journey is blocked by not having 'unpublished' GIAS
data anyway and until that is resolved, we can do no more.

https://trello.com/c/9CYkHIlF