### PR TITLE
Users can complete a Transfer project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Early support to view a transfer project, no user facing changes.
 - Transfer projects can confirm the transfer date.
 - The transfer date is shown in the project summary for transfer projects.
+- A transfer project can be completed.
 
 ### Changed
 

--- a/app/controllers/projects_complete_controller.rb
+++ b/app/controllers/projects_complete_controller.rb
@@ -3,19 +3,14 @@ class ProjectsCompleteController < ApplicationController
     @project = Project.find(project_id)
     authorize @project, :update?
 
-    if project_completable?
+    if @project.completable?
       set_project_completed_at
 
       render :completed
     else
-      flash[:alert] = I18n.t("project.complete.unable_to_complete_html")
+      flash[:alert] = I18n.t("#{@project.type.downcase.gsub("::", "_")}.complete.unable_to_complete_html")
       redirect_to project_tasks_path(@project)
     end
-  end
-
-  private def project_completable?
-    return true if @project.all_conditions_met? && @project.confirmed_date_and_in_the_past? && @project.grant_payment_certificate_received?
-    false
   end
 
   private def set_project_completed_at

--- a/app/controllers/projects_complete_controller.rb
+++ b/app/controllers/projects_complete_controller.rb
@@ -8,7 +8,7 @@ class ProjectsCompleteController < ApplicationController
 
       render :completed
     else
-      flash[:alert] = I18n.t("#{@project.type.downcase.gsub("::", "_")}.complete.unable_to_complete_html")
+      flash[:alert] = I18n.t("#{@project.type_locale}.complete.unable_to_complete_html")
       redirect_to project_tasks_path(@project)
     end
   end

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -50,6 +50,11 @@ class Conversion::Project < Project
     :academy_order
   end
 
+  def completable?
+    return true if all_conditions_met? && confirmed_date_and_in_the_past? && grant_payment_certificate_received?
+    false
+  end
+
   private def fetch_academy(urn)
     Api::AcademiesApi::Client.new.get_establishment(urn)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -93,6 +93,10 @@ class Project < ApplicationRecord
     local_authority&.director_of_child_services
   end
 
+  def type_locale
+    type.parameterize(separator: "_")
+  end
+
   private def fetch_member_of_parliament
     Api::MembersApi::Client.new.member_for_constituency(establishment.parliamentary_constituency)
   end

--- a/app/models/transfer/project.rb
+++ b/app/models/transfer/project.rb
@@ -14,6 +14,11 @@ class Transfer::Project < Project
     @outgoing_trust ||= fetch_trust(outgoing_trust_ukprn)
   end
 
+  def completable?
+    return true if confirmed_date_and_in_the_past?
+    false
+  end
+
   private def outgoing_trust_exists
     outgoing_trust
   rescue Api::AcademiesApi::Client::NotFoundError

--- a/app/views/shared/project_information/_project_details.html.erb
+++ b/app/views/shared/project_information/_project_details.html.erb
@@ -8,7 +8,7 @@
       end %>
   <%= govuk_summary_list do |summary_list|
         summary_list.row do |row|
-          row.key { t("project_information.show.project_details.rows.two_requires_improvement.title") }
+          row.key { t("project_information.show.project_details.rows.two_requires_improvement.#{project.type_locale}.title") }
           row.value { t("project_information.show.project_details.rows.two_requires_improvement.#{project.two_requires_improvement}") }
         end
       end %>

--- a/app/views/transfers/tasks/index.html.erb
+++ b/app/views/transfers/tasks/index.html.erb
@@ -3,3 +3,5 @@
 <%= render partial: "/shared/projects/sub_navigation" %>
 
 <%= render partial: "shared/projects/task_list" %>
+
+<%= render "projects/show/complete" if policy(@project).update? %>

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -36,6 +36,14 @@ en:
         title: Completed by
       unassigned: Unassigned
       assign: Assign
+    complete:
+      unable_to_complete_html:
+        <p>This project cannot be completed until:</p>
+        <ul>
+        <li>The conversion date has been confirmed and is in the past</li>
+        <li>The confirm all conditions have been met task is completed</li>
+        <li>The receive grant payment certificate task is completed</li>
+        </ul>
   helpers:
     label:
       conversion_project:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -120,13 +120,6 @@ en:
           <p>You will not be able to change this project once it is completed.</p>
       submit_button: Complete project
       back_link: Return to project list
-      unable_to_complete_html:
-        <p>This project cannot be completed until:</p>
-        <ul>
-        <li>The conversion date has been confirmed and is in the past</li>
-        <li>The confirm all conditions have been met task is completed</li>
-        <li>The receive grant payment certificate task is completed</li>
-        </ul>
     summary:
       type:
         title: Type

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -140,6 +140,8 @@ en:
         title: Trust SharePoint folder
         value: Open the trust SharePoint folder in a new tab
       completed_at: Project completed
+      transfer_date:
+        title: Transferring on
     assign:
       regional_delivery_officer:
         success: Regional delivery officer has been assigned

--- a/config/locales/project_information.en.yml
+++ b/config/locales/project_information.en.yml
@@ -16,7 +16,10 @@ en:
             "true": "Yes"
             "false": "No"
           two_requires_improvement:
-            title: Is this conversion due to intervention following 2RI?
+            conversion_project:
+              title: Is this conversion due to intervention following 2RI?
+            transfer_project:
+              title: Is this transfer due to intervention following 2RI?
             "true": "Yes"
             "false": "No"
       advisory_board_details:

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -7,6 +7,12 @@ en:
       hint_html: <p class="govuk-body">Enter information about the school, trust and the advisory board decision.</p><p class="govuk-body">This will create a new transfer project.</p>
     created:
       success: Transfer project successfully created
+    complete:
+      unable_to_complete_html:
+        <p>This project cannot be completed until:</p>
+        <ul>
+        <li>The transfer date has been confirmed and is in the past</li>
+        </ul>
   helpers:
     label:
       transfer_project:

--- a/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
+++ b/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Users can complete a project" do
+RSpec.feature "Users can complete a conversion project" do
   let(:user) { create(:user, :caseworker) }
 
   before do

--- a/spec/features/transfers/users_can_complete_a_transfer_project_spec.rb
+++ b/spec/features/transfers/users_can_complete_a_transfer_project_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.feature "Users can complete a transfer project" do
+  let(:user) { create(:user, :caseworker) }
+
+  before do
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  context "when the academy has transferred" do
+    let(:project) {
+      create(:transfer_project,
+        assigned_to: user,
+        significant_date: 2.months.ago.at_beginning_of_month,
+        significant_date_provisional: false)
+    }
+
+    scenario "the project is completed successfully" do
+      visit project_path(project)
+
+      click_on I18n.t("project.complete.submit_button")
+
+      expect(page).to have_content("Project completed")
+      expect(page).to have_content("You have completed the project for #{project.establishment.name} #{project.urn}.")
+      expect(project.reload.completed_at).not_to be_nil
+
+      expect(page).to have_link "short survey", href: "https://forms.office.com/e/xf0k4LcWVN"
+    end
+  end
+
+  context "when the academy has not transferred" do
+    let(:project) { create(:transfer_project, assigned_to: user) }
+
+    scenario "the project cannot be completed" do
+      visit project_path(project)
+
+      click_on I18n.t("project.complete.submit_button")
+
+      expect(page).to_not have_content("Project completed")
+      expect(page).to have_content("This project cannot be completed")
+      expect(project.reload.completed_at).to be_nil
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -291,6 +291,16 @@ RSpec.describe Project, type: :model do
     end
   end
 
+  describe "#type_locale" do
+    it "returns the project type as a string we can use in locales" do
+      conversion_project = build(:conversion_project)
+      expect(conversion_project.type_locale).to eq("conversion_project")
+
+      transfer_project = build(:transfer_project)
+      expect(transfer_project.type_locale).to eq("transfer_project")
+    end
+  end
+
   describe "Scopes" do
     describe "conversions" do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }


### PR DESCRIPTION

## Changes

A Transfer project can be completed if its transfer date is confirmed and in the past. 

This PR includes some refactoring to allow for Conversion and Transfer projects to be completed under different sets of conditions.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
