### PR TITLE
Remove back link from conversion project show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   amend the guidance on the first checkbox to be more explicit.
 - remove Route from project summaries.
 - 'Trust' is now 'Incoming trust' on conversions and transfers.
+- The back link on a single conversion project has been removed as it does not
+  link back to the expected location in all cases.
 
 ### Fixed
 

--- a/app/views/conversions/external_contacts/index.html.erb
+++ b/app/views/conversions/external_contacts/index.html.erb
@@ -1,7 +1,3 @@
-<% content_for :pre_content_nav do %>
-  <% render partial: "shared/back_link", locals: {href: root_path} %>
-<% end %>
-
 <%= render partial: "shared/project_summary" %>
 
 <%= render partial: "shared/projects/sub_navigation" %>

--- a/app/views/conversions/internal_contacts/index.html.erb
+++ b/app/views/conversions/internal_contacts/index.html.erb
@@ -1,7 +1,3 @@
-<% content_for :pre_content_nav do %>
-  <% render partial: "shared/back_link", locals: {href: root_path} %>
-<% end %>
-
 <%= render partial: "shared/project_summary" %>
 
 <%= render partial: "shared/projects/sub_navigation" %>

--- a/app/views/conversions/notes/index.html.erb
+++ b/app/views/conversions/notes/index.html.erb
@@ -1,7 +1,3 @@
-<% content_for :pre_content_nav do %>
-  <% render partial: "shared/back_link", locals: {href: root_path} %>
-<% end %>
-
 <%= render partial: "shared/project_summary" %>
 
 <%= render partial: "shared/projects/sub_navigation" %>

--- a/app/views/conversions/project_information/show.html.erb
+++ b/app/views/conversions/project_information/show.html.erb
@@ -1,7 +1,3 @@
-<% content_for :pre_content_nav do %>
-  <% render partial: "shared/back_link", locals: {href: root_path} %>
-<% end %>
-
 <%= render partial: "shared/project_summary" %>
 
 <%= render partial: "shared/projects/sub_navigation" %>

--- a/app/views/conversions/tasks/index.html.erb
+++ b/app/views/conversions/tasks/index.html.erb
@@ -1,7 +1,3 @@
-<% content_for :pre_content_nav do %>
-  <% render partial: "shared/back_link", locals: {href: root_path} %>
-<% end %>
-
 <%= render partial: "shared/project_summary" %>
 
 <%= render partial: "shared/projects/sub_navigation" %>


### PR DESCRIPTION
The back link is hard wired to a specific view which is not what users
expect in all cases.

As we have the back button and primary nav, we are removing this to
prevent confusion but deffering a long term solution.

https://trello.com/c/L7cFxs16