### PR TITLE
Add Transfer project counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The handover note when adding a new project is only required if you indicate
   that the project will be handed over.
 - The order of the new project form fields has been improved.
+- All "By" views now include Transfer project counts as well as Conversion
+  project counts
 
 ### Fixed
 

--- a/app/controllers/all/regions/projects_controller.rb
+++ b/app/controllers/all/regions/projects_controller.rb
@@ -12,7 +12,7 @@ class All::Regions::ProjectsController < ApplicationController
     return not_found_error unless Project.regions.include?(region)
 
     @region = region
-    @pager, @projects = pagy(Conversion::Project.not_completed.by_region(region).by_conversion_date.includes(:assigned_to))
+    @pager, @projects = pagy(Project.not_completed.by_region(region).ordered_by_significant_date.includes(:assigned_to))
     AcademiesApiPreFetcherService.new.call!(@projects)
   end
 

--- a/app/controllers/all/regions/projects_controller.rb
+++ b/app/controllers/all/regions/projects_controller.rb
@@ -4,7 +4,7 @@ class All::Regions::ProjectsController < ApplicationController
 
   def index
     authorize Project, :index?
-    @regions = ByRegionProjectFetcherService.new.conversion_counts
+    @regions = ByRegionProjectFetcherService.new.project_counts
   end
 
   def show

--- a/app/controllers/all/trusts/projects_controller.rb
+++ b/app/controllers/all/trusts/projects_controller.rb
@@ -11,7 +11,7 @@ class All::Trusts::ProjectsController < ApplicationController
     authorize Project, :index?
 
     @trust = Api::AcademiesApi::Client.new.get_trust(incoming_trust_ukprn).object
-    @pager, @projects = pagy(Conversion::Project.not_completed.by_trust_ukprn(@trust.ukprn).by_conversion_date.includes(:assigned_to))
+    @pager, @projects = pagy(Project.not_completed.by_trust_ukprn(@trust.ukprn).ordered_by_significant_date.includes(:assigned_to))
 
     AcademiesApiPreFetcherService.new.call!(@projects)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -95,6 +95,10 @@ class Project < ApplicationRecord
     type.parameterize(separator: "_")
   end
 
+  def academy_order_type
+    :not_applicable
+  end
+
   private def fetch_member_of_parliament
     Api::MembersApi::Client.new.member_for_constituency(establishment.parliamentary_constituency)
   end

--- a/app/models/transfer/project.rb
+++ b/app/models/transfer/project.rb
@@ -19,6 +19,11 @@ class Transfer::Project < Project
     false
   end
 
+  def all_conditions_met?
+    # TODO: Replace with task value once task data is added
+    false
+  end
+
   private def outgoing_trust_exists
     outgoing_trust
   rescue Api::AcademiesApi::Client::NotFoundError

--- a/app/services/by_local_authority_project_fetcher_service.rb
+++ b/app/services/by_local_authority_project_fetcher_service.rb
@@ -13,7 +13,7 @@ class ByLocalAuthorityProjectFetcherService
     all_projects = Project.not_completed.select(:id, :urn, :incoming_trust_ukprn)
     projects_for_local_authority = all_projects.select { |p| p.establishment.local_authority_code == local_authority_code }
 
-    Conversion::Project.where(id: projects_for_local_authority.pluck(:id)).includes(:assigned_to).by_conversion_date
+    Project.where(id: projects_for_local_authority.pluck(:id)).includes(:assigned_to).ordered_by_significant_date
   end
 
   private def projects_by_local_authority

--- a/app/services/by_month_project_fetcher_service.rb
+++ b/app/services/by_month_project_fetcher_service.rb
@@ -4,14 +4,14 @@ class ByMonthProjectFetcherService
   end
 
   def confirmed(month, year)
-    projects = Conversion::Project.includes(:tasks_data).confirmed.filtered_by_significant_date(month, year)
+    projects = Project.includes(:tasks_data).confirmed.filtered_by_significant_date(month, year)
 
     AcademiesApiPreFetcherService.new.call!(projects) if @pre_fetch_academies_api
     sort_by_conditions_met_and_name(projects)
   end
 
   def revised(month, year)
-    projects = Conversion::Project.significant_date_revised_from(month, year)
+    projects = Project.significant_date_revised_from(month, year)
 
     AcademiesApiPreFetcherService.new.call!(projects) if @pre_fetch_academies_api
     sort_by_conditions_met_and_name(projects)
@@ -19,9 +19,9 @@ class ByMonthProjectFetcherService
 
   def confirmed_openers_by_team(month, year, team)
     projects = if team.eql?("regional_casework_services")
-      Conversion::Project.assigned_to_regional_caseworker_team.includes(:tasks_data).confirmed.filtered_by_significant_date(month, year)
+      Project.assigned_to_regional_caseworker_team.includes(:tasks_data).confirmed.filtered_by_significant_date(month, year)
     else
-      Conversion::Project.not_assigned_to_regional_caseworker_team.by_region(team).includes(:tasks_data).confirmed.filtered_by_significant_date(month, year)
+      Project.not_assigned_to_regional_caseworker_team.by_region(team).includes(:tasks_data).confirmed.filtered_by_significant_date(month, year)
     end
 
     AcademiesApiPreFetcherService.new.call!(projects) if @pre_fetch_academies_api
@@ -30,9 +30,9 @@ class ByMonthProjectFetcherService
 
   def revised_openers_by_team(month, year, team)
     projects = if team.eql?("regional_casework_services")
-      Conversion::Project.assigned_to_regional_caseworker_team.includes(:tasks_data).significant_date_revised_from(month, year)
+      Project.assigned_to_regional_caseworker_team.includes(:tasks_data).significant_date_revised_from(month, year)
     else
-      Conversion::Project.not_assigned_to_regional_caseworker_team.by_region(team).includes(:tasks_data).significant_date_revised_from(month, year)
+      Project.not_assigned_to_regional_caseworker_team.by_region(team).includes(:tasks_data).significant_date_revised_from(month, year)
     end
 
     AcademiesApiPreFetcherService.new.call!(projects) if @pre_fetch_academies_api

--- a/app/services/by_team_project_fetcher_service.rb
+++ b/app/services/by_team_project_fetcher_service.rb
@@ -7,9 +7,9 @@ class ByTeamProjectFetcherService
     return [] if @team.nil?
 
     projects = if @team.eql?("regional_casework_services")
-      Conversion::Project.assigned_to_regional_caseworker_team.in_progress.includes(:assigned_to).by_conversion_date
+      Project.assigned_to_regional_caseworker_team.in_progress.includes(:assigned_to).ordered_by_significant_date
     else
-      Conversion::Project.by_region(@team).in_progress.includes(:assigned_to).by_conversion_date
+      Project.by_region(@team).in_progress.includes(:assigned_to).ordered_by_significant_date
     end
 
     AcademiesApiPreFetcherService.new.call!(projects)
@@ -19,9 +19,9 @@ class ByTeamProjectFetcherService
     return [] if @team.nil?
 
     projects = if @team.eql?("regional_casework_services")
-      Conversion::Project.assigned_to_regional_caseworker_team.completed.by_conversion_date
+      Project.assigned_to_regional_caseworker_team.completed.ordered_by_significant_date
     else
-      Conversion::Project.by_region(@team).completed.by_conversion_date
+      Project.by_region(@team).completed.ordered_by_significant_date
     end
 
     AcademiesApiPreFetcherService.new.call!(projects)
@@ -31,9 +31,9 @@ class ByTeamProjectFetcherService
     return [] if @team.nil?
 
     projects = if @team.eql?("regional_casework_services")
-      Conversion::Project.assigned_to_regional_caseworker_team.unassigned_to_user.by_conversion_date
+      Project.assigned_to_regional_caseworker_team.unassigned_to_user.ordered_by_significant_date
     else
-      Conversion::Project.by_region(@team).unassigned_to_user.by_conversion_date
+      Project.by_region(@team).unassigned_to_user.ordered_by_significant_date
     end
 
     AcademiesApiPreFetcherService.new.call!(projects)
@@ -47,7 +47,8 @@ class ByTeamProjectFetcherService
         name: user.full_name,
         email: user.email,
         id: user.id,
-        conversion_count: Conversion::Project.in_progress.assigned_to(user).count
+        conversion_count: Conversion::Project.in_progress.assigned_to(user).count,
+        transfer_count: Transfer::Project.in_progress.assigned_to(user).count
       )
     end.sort_by { |object| object.name }
   end

--- a/app/views/all/local_authorities/projects/_local_authority_table.html.erb
+++ b/app/views/all/local_authorities/projects/_local_authority_table.html.erb
@@ -8,6 +8,7 @@
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.local_authority_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.local_authority_code") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_count") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.transfer_count") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view_projects") %></th>
       </tr>
     </thead>
@@ -17,6 +18,7 @@
         <td class="govuk-table__header govuk-table__cell"><%= local_authority.name %></td>
         <td class="govuk-table__cell"><%= local_authority.code %></td>
         <td class="govuk-table__cell"><%= local_authority.conversion_count %></td>
+        <td class="govuk-table__cell"><%= local_authority.transfer_count %></td>
         <td class="govuk-table__cell">
           <%= link_to t("project.table.body.view_projects_for_local_authority_html", local_authority_name: local_authority.name), by_local_authority_all_local_authorities_projects_path(local_authority.code) %>
         </td>

--- a/app/views/all/local_authorities/projects/show.html.erb
+++ b/app/views/all/local_authorities/projects/show.html.erb
@@ -15,7 +15,7 @@
             <tr class="govuk-table__row">
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
-              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
+              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.significant_date") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
             </tr>
@@ -25,7 +25,7 @@
             <tr class="govuk-table__row">
               <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
               <td class="govuk-table__cell"><%= project.urn %></td>
-              <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
+              <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:govuk) %></td>
               <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
               <td class="govuk-table__cell">
                 <a href="<%= project_path(project) %>">

--- a/app/views/all/regions/projects/_regions_table.html.erb
+++ b/app/views/all/regions/projects/_regions_table.html.erb
@@ -7,6 +7,7 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.region") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_count") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.transfer_count") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view_projects") %></th>
       </tr>
     </thead>
@@ -15,6 +16,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell"><%= t("project.region.#{region.name}") %></td>
         <td class="govuk-table__cell"><%= region.conversion_count %></td>
+        <td class="govuk-table__cell"><%= region.transfer_count %></td>
         <td class="govuk-table__cell">
           <%= link_to t("project.table.body.view_projects_for_html", entity: t("project.region.#{region.name}")), by_region_all_regions_projects_path(region.name) %>
         </td>

--- a/app/views/all/regions/projects/show.html.erb
+++ b/app/views/all/regions/projects/show.html.erb
@@ -15,7 +15,7 @@
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
             <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
-            <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
+            <th class="govuk-table__header" scope="col"><%= t("project.table.headers.significant_date") %></th>
             <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
             <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
           </tr>
@@ -25,7 +25,7 @@
           <tr class="govuk-table__row">
             <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
             <td class="govuk-table__cell"><%= project.urn %></td>
-            <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
+            <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:govuk) %></td>
             <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
             <td class="govuk-table__cell">
               <a href="<%= project_path(project) %>">

--- a/app/views/all/trusts/projects/_trust_table.html.erb
+++ b/app/views/all/trusts/projects/_trust_table.html.erb
@@ -8,6 +8,7 @@
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.trust_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.group_identifier") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_count") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.transfer_count") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view_projects") %></th>
       </tr>
     </thead>
@@ -17,6 +18,7 @@
         <td class="govuk-table__header govuk-table__cell"><%= trust.name %></td>
         <td class="govuk-table__cell"><%= trust.group_id %></td>
         <td class="govuk-table__cell"><%= trust.conversion_count %></td>
+        <td class="govuk-table__cell"><%= trust.transfer_count %></td>
         <td class="govuk-table__cell">
           <%= link_to t("project.table.body.view_projects_html", trust_name: trust.name), by_trust_all_trusts_projects_path(trust.ukprn) %>
         </td>

--- a/app/views/all/trusts/projects/show.html.erb
+++ b/app/views/all/trusts/projects/show.html.erb
@@ -15,7 +15,7 @@
             <tr class="govuk-table__row">
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
-              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
+              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.significant_date") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
             </tr>
@@ -25,7 +25,7 @@
             <tr class="govuk-table__row">
               <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
               <td class="govuk-table__cell"><%= project.urn %></td>
-              <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
+              <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:govuk) %></td>
               <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
               <td class="govuk-table__cell">
                 <a href="<%= project_path(project) %>">

--- a/app/views/all/users/projects/_users_table.html.erb
+++ b/app/views/all/users/projects/_users_table.html.erb
@@ -9,6 +9,7 @@
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.email") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.team") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_count") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.transfer_count") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view_projects") %></th>
       </tr>
     </thead>
@@ -19,6 +20,7 @@
         <td class="govuk-table__cell"><%= user.email %></td>
         <td class="govuk-table__cell"><%= user.team.nil? ? "No team" : t("user.teams.#{user.team}") %></td>
         <td class="govuk-table__cell"><%= user.conversion_count %></td>
+        <td class="govuk-table__cell"><%= user.transfer_count %></td>
         <td class="govuk-table__cell">
           <%= link_to t("project.table.body.view_projects_for_html", entity: user.name), by_user_all_users_projects_path(user.id) %>
         </td>

--- a/app/views/projects/shared/_completed_table.html.erb
+++ b/app/views/projects/shared/_completed_table.html.erb
@@ -17,7 +17,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
         <td class="govuk-table__cell"><%= project.urn %></td>
-        <td class="govuk-table__cell">Conversion</td>
+        <td class="govuk-table__cell"><%= project.type.humanize.split("::")[0] %></td>
         <td class="govuk-table__cell"><%= project.completed_at.to_formatted_s(:govuk_date_time_date_only) %></td>
         <td class="govuk-table__cell">
           <a href="<%= project_path(project) %>">

--- a/app/views/projects/shared/_handed_over_table.html.erb
+++ b/app/views/projects/shared/_handed_over_table.html.erb
@@ -6,7 +6,7 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.significant_date") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
       </tr>
@@ -16,7 +16,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
         <td class="govuk-table__cell"><%= project.urn %></td>
-        <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
+        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:govuk) %></td>
         <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
         <td class="govuk-table__cell">
           <a href="<%= project_path(project) %>">

--- a/app/views/projects/shared/_in_progress_table.html.erb
+++ b/app/views/projects/shared/_in_progress_table.html.erb
@@ -6,7 +6,7 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.significant_date") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
       </tr>
@@ -16,7 +16,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
         <td class="govuk-table__cell"><%= project.urn %></td>
-        <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
+        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:govuk) %></td>
         <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
         <td class="govuk-table__cell">
           <a href="<%= project_path(project) %>">

--- a/app/views/projects/shared/_unassigned_table.html.erb
+++ b/app/views/projects/shared/_unassigned_table.html.erb
@@ -8,7 +8,7 @@
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.added_by") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.significant_date") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.region") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assign") %></th>
@@ -20,7 +20,7 @@
         <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
         <td class="govuk-table__cell"><%= project.urn %></td>
         <td class="govuk-table__cell"><%= project.regional_delivery_officer.full_name %></td>
-        <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
+        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:govuk) %></td>
         <td class="govuk-table__cell"><%= project.establishment.region_name %></td>
         <td class="govuk-table__cell">
           <%= link_to t("project.table.body.view_html", school_name: project.establishment.name), project_path(project) %>

--- a/app/views/your/projects/_table.html.erb
+++ b/app/views/your/projects/_table.html.erb
@@ -6,7 +6,7 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.significant_date") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
       </tr>
     </thead>
@@ -15,7 +15,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
         <td class="govuk-table__cell"><%= project.urn %></td>
-        <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:govuk) %></td>
+        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:govuk) %></td>
         <td class="govuk-table__cell">
           <a href="<%= project_path(project) %>">
             <%= t("project.table.body.view_html", school_name: project.establishment.name) %>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -240,6 +240,7 @@ en:
           academy_order_type:
             academy_order: AO (Academy Order)
             directive_academy_order: DAO (Directive Academy Order)
+            not_applicable: Not applicable
       route:
         voluntary: Voluntary
         sponsored: Sponsored

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -174,10 +174,10 @@ en:
         trust_name: Trust
         group_identifier: Group identifier
         conversion_count: Conversions
+        transfer_count: Transfers
         view_projects: View projects
         local_authority_name: Local authority
         local_authority_code: Code
-        conversion_count: Conversions
         region: Region
         email: Email
         user: User name

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -165,6 +165,7 @@ en:
         assign: Assign project
         added_by: Added by
         conversion_date: Conversion date
+        significant_date: Significant date
         revised_conversion_date: Revised conversion date
         route: Route
         school_phase: School phase

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -156,7 +156,7 @@ en:
         success: Project has been assigned to team successfully
     table:
       headers:
-        school_name: School
+        school_name: School or academy
         school_urn: URN
         type: Type of project
         completed_at: Completed at
@@ -165,7 +165,7 @@ en:
         assign: Assign project
         added_by: Added by
         conversion_date: Conversion date
-        significant_date: Significant date
+        significant_date: Conversion or transfer date
         revised_conversion_date: Revised conversion date
         route: Route
         school_phase: School phase

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -185,6 +185,7 @@ en:
         date: Date
         confirmed: Confirmed
         revised: Revised
+        team: Team
       body:
         view_html: View <span class="govuk-visually-hidden">%{school_name}</span> project
         edit_html: Create academy URN <span class="govuk-visually-hidden">for %{school_name}</span>

--- a/spec/models/transfer/project_spec.rb
+++ b/spec/models/transfer/project_spec.rb
@@ -39,4 +39,10 @@ RSpec.describe Transfer::Project do
       end
     end
   end
+
+  describe "#all_conditions_met" do
+    it "returns false" do
+      expect(described_class.new.all_conditions_met?).to be false
+    end
+  end
 end

--- a/spec/requests/all/opening/projects_controller_spec.rb
+++ b/spec/requests/all/opening/projects_controller_spec.rb
@@ -26,63 +26,68 @@ RSpec.describe All::Opening::ProjectsController, type: :request do
         expect(request.params.fetch(:year)).to eq Date.today.next_month.year.to_s
       end
     end
+  end
 
-    describe "#confirmed" do
-      context "when supplying a month and year" do
-        context "when the year is missing" do
-          it "returns a 404" do
-            get "/projects/all/opening/confirmed/1"
-            expect(response).to have_http_status(:not_found)
-          end
+  describe "#confirmed" do
+    context "when supplying a month and year" do
+      context "when the year is missing" do
+        it "returns a 404" do
+          get "/projects/all/opening/confirmed/1"
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when the month isn't in the scope 1..12" do
+        it "returns a 404" do
+          get "/projects/all/opening/confirmed/13/2022"
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when the year isn't in the scope 2000-2499" do
+        it "returns a 404" do
+          get "/projects/all/opening/confirmed/12/2555"
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when the month and year are present and in scope" do
+        it "shows a page title with the month & year" do
+          get "/projects/all/opening/confirmed/1/2022"
+
+          expect(response.body).to include("Academies opening in January 2022")
         end
 
-        context "when the month isn't in the scope 1..12" do
-          it "returns a 404" do
-            get "/projects/all/opening/confirmed/13/2022"
-            expect(response).to have_http_status(:not_found)
-          end
+        it "returns project details in table form" do
+          conversion_project = create(:conversion_project, conversion_date: Date.new(2022, 1, 1), conversion_date_provisional: false, urn: 100001)
+          transfer_project = create(:transfer_project, transfer_date: Date.new(2022, 1, 1), transfer_date_provisional: false, urn: 100002)
+          get "/projects/all/opening/confirmed/1/2022"
+
+          expect(response.body).to include(
+            conversion_project.establishment.name,
+            conversion_project.urn.to_s,
+            transfer_project.establishment.name,
+            transfer_project.urn.to_s
+          )
         end
 
-        context "when the year isn't in the scope 2000-2499" do
-          it "returns a 404" do
-            get "/projects/all/opening/confirmed/12/2555"
-            expect(response).to have_http_status(:not_found)
-          end
+        it "only returns projects whose confirmed significant date is in that month & year" do
+          conversion_project_in_scope = create(:conversion_project, urn: 100001, conversion_date: Date.new(2022, 1, 1), conversion_date_provisional: false)
+          transfer_project_in_scope = create(:conversion_project, urn: 100003, conversion_date: Date.new(2022, 1, 1), conversion_date_provisional: false)
+          project_not_in_scope = create(:conversion_project, urn: 100002, conversion_date: Date.new(2022, 2, 1), conversion_date_provisional: false)
+
+          get "/projects/all/opening/confirmed/1/2022"
+
+          expect(response.body).to include(conversion_project_in_scope.urn.to_s)
+          expect(response.body).to include(transfer_project_in_scope.urn.to_s)
+          expect(response.body).to_not include(project_not_in_scope.urn.to_s)
         end
 
-        context "when the month and year are present and in scope" do
-          it "shows a page title with the month & year" do
+        context "when there are no academies opening in that month & year" do
+          it "shows a helpful message" do
             get "/projects/all/opening/confirmed/1/2022"
 
-            expect(response.body).to include("Academies opening in January 2022")
-          end
-
-          it "returns project details in table form" do
-            conversion_project = create(:conversion_project, conversion_date: Date.new(2022, 1, 1), conversion_date_provisional: false)
-            get "/projects/all/opening/confirmed/1/2022"
-
-            expect(response.body).to include(
-              conversion_project.establishment.name,
-              conversion_project.urn.to_s
-            )
-          end
-
-          it "only returns projects whose confirmed conversion date is in that month & year" do
-            project_in_scope = create(:conversion_project, urn: 100001, conversion_date: Date.new(2022, 1, 1), conversion_date_provisional: false)
-            project_not_in_scope = create(:conversion_project, urn: 100002, conversion_date: Date.new(2022, 2, 1), conversion_date_provisional: false)
-
-            get "/projects/all/opening/confirmed/1/2022"
-
-            expect(response.body).to include(project_in_scope.urn.to_s)
-            expect(response.body).to_not include(project_not_in_scope.urn.to_s)
-          end
-
-          context "when there are no academies opening in that month & year" do
-            it "shows a helpful message" do
-              get "/projects/all/opening/confirmed/1/2022"
-
-              expect(response.body).to include("There are currently no schools expected to become academies in January 2022")
-            end
+            expect(response.body).to include("There are currently no schools expected to become academies in January 2022")
           end
         end
       end

--- a/spec/services/by_local_authority_project_fetcher_service_spec.rb
+++ b/spec/services/by_local_authority_project_fetcher_service_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ByLocalAuthorityProjectFetcherService do
-  it "returns a sorted list of simple local authority objects with projects" do
+  it "returns a sorted list of simple local authority objects with conversion and transfer projects" do
     establishment = build(:academies_api_establishment, local_authority_code: "909", urn: 121813)
     another_establishment = build(:academies_api_establishment, local_authority_code: "213", urn: 121102)
     yet_another_establishment = build(:academies_api_establishment, local_authority_code: "926", urn: 121583)
@@ -23,7 +23,9 @@ RSpec.describe ByLocalAuthorityProjectFetcherService do
     create(:conversion_project, urn: establishment.urn)
     create(:conversion_project, urn: another_establishment.urn)
     create(:conversion_project, urn: establishment.urn)
-    create(:conversion_project, urn: yet_another_establishment.urn)
+
+    create(:transfer_project, urn: establishment.urn)
+    create(:transfer_project, urn: yet_another_establishment.urn)
 
     result = described_class.new.local_authorities_with_projects
 
@@ -34,12 +36,21 @@ RSpec.describe ByLocalAuthorityProjectFetcherService do
     expect(first_result.name).to eql "Cumbria County Council"
     expect(first_result.code).to eql "909"
     expect(first_result.conversion_count).to eql 2
+    expect(first_result.transfer_count).to eql 1
+
+    middle_result = result[1]
+
+    expect(middle_result.name).to eql "Norfolk County Council"
+    expect(middle_result.code).to eql "926"
+    expect(middle_result.conversion_count).to eql 0
+    expect(middle_result.transfer_count).to eql 1
 
     last_result = result.last
 
     expect(last_result.name).to eql "Westminster City Council"
     expect(last_result.code).to eql "213"
     expect(last_result.conversion_count).to eql 1
+    expect(last_result.transfer_count).to eql 0
   end
 
   it "returns an empty array when there are no projects to source trusts" do

--- a/spec/services/by_region_project_fetcher_service_spec.rb
+++ b/spec/services/by_region_project_fetcher_service_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ByRegionProjectFetcherService do
-  describe "#conversion_count" do
+  describe "#project_counts" do
     it "returns a sorted list of simple view objects with project counts" do
       mock_successful_api_response_to_create_any_project
 
@@ -9,8 +9,10 @@ RSpec.describe ByRegionProjectFetcherService do
       create(:conversion_project, region: "london")
       create(:conversion_project, region: "south_west")
       create(:conversion_project, region: "north_west")
+      create(:transfer_project, region: "south_west")
+      create(:transfer_project, region: "london")
 
-      result = described_class.new.conversion_counts
+      result = described_class.new.project_counts
 
       expect(result.count).to eql 3
 
@@ -18,15 +20,17 @@ RSpec.describe ByRegionProjectFetcherService do
 
       expect(first_result.name).to eql "london"
       expect(first_result.conversion_count).to eql 1
+      expect(first_result.transfer_count).to eql 1
 
       last_result = result.last
 
       expect(last_result.name).to eql "south_west"
       expect(last_result.conversion_count).to eql 2
+      expect(last_result.transfer_count).to eql 1
     end
 
     it "returns an empty array when there are no projects to source trusts" do
-      expect(described_class.new.conversion_counts).to eql []
+      expect(described_class.new.project_counts).to eql []
     end
   end
 

--- a/spec/services/by_trust_project_fetcher_service_spec.rb
+++ b/spec/services/by_trust_project_fetcher_service_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe ByTrustProjectFetcherService do
     create(:conversion_project, incoming_trust_ukprn: another_trust.ukprn)
     create(:conversion_project, incoming_trust_ukprn: trust.ukprn)
     create(:conversion_project, incoming_trust_ukprn: yet_another_trust.ukprn)
+    create(:transfer_project, incoming_trust_ukprn: trust.ukprn)
+    create(:transfer_project, incoming_trust_ukprn: yet_another_trust.ukprn)
 
     result = described_class.new.call
 
@@ -45,6 +47,7 @@ RSpec.describe ByTrustProjectFetcherService do
     expect(first_result.ukprn).to eql 10059745
     expect(first_result.group_id).to eql "TR00796"
     expect(first_result.conversion_count).to eql 2
+    expect(first_result.transfer_count).to eql 1
 
     last_result = result.last
 
@@ -52,6 +55,7 @@ RSpec.describe ByTrustProjectFetcherService do
     expect(last_result.ukprn).to eql 10066123
     expect(last_result.group_id).to eql "TR03819"
     expect(last_result.conversion_count).to eql 1
+    expect(last_result.transfer_count).to eql 1
   end
 
   it "returns an empty array when there are no projects to source trusts" do

--- a/spec/services/by_user_project_fetcher_service_spec.rb
+++ b/spec/services/by_user_project_fetcher_service_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe ByUserProjectFetcherService do
     create(:conversion_project, urn: 117574, assigned_to: another_user)
     create(:conversion_project, urn: 121583, assigned_to: nil)
     create(:conversion_project, urn: 121583, assigned_to: yet_another_user)
+    create(:transfer_project, urn: 101133, assigned_to: user)
+    create(:transfer_project, urn: 112209, assigned_to: yet_another_user)
 
     result = described_class.new.call
 
@@ -23,12 +25,14 @@ RSpec.describe ByUserProjectFetcherService do
     expect(first_result.name).to eql "A User"
     expect(first_result.team).to eql "london"
     expect(first_result.conversion_count).to eql 2
+    expect(first_result.transfer_count).to eql 1
 
     last_result = result.last
 
     expect(last_result.name).to eql "C User"
     expect(last_result.team).to eql "service_support"
     expect(last_result.conversion_count).to eql 1
+    expect(last_result.transfer_count).to eql 1
   end
 
   it "returns an empty array when there are no projects to source trusts" do


### PR DESCRIPTION
## Changes

All "By" index views (By user, By trust etc) now include counts for Transfer projects as well as Conversion projects.

The associated "show" views (show projects by user or by trust etc) now include a mix of Trust and Conversion projects.

The table headers have been updated to reflect that "Conversion date" could be Conversion or transfer date, and "School" could be School or academy.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
