### PR TITLE
Update transfer create form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   been improved.
 - improved content on sign in page to include registraiton, guidance and release
   notes links
+- The handover note when adding a new project is only required if you indicate
+  that the project will be handed over.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - A transfer project can be completed.
 - All three SharePoint links are now shown on the transfer project summary.
 - A transfer project can be displayed on the Your in-progress projects view.
+- The new transfer project form is now complete and ready for the point transfer
+  projects are enabled.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   notes links
 - The handover note when adding a new project is only required if you indicate
   that the project will be handed over.
+- The order of the new project form fields has been improved.
 
 ### Fixed
 

--- a/app/controllers/transfers/projects_controller.rb
+++ b/app/controllers/transfers/projects_controller.rb
@@ -24,6 +24,7 @@ class Transfers::ProjectsController < ApplicationController
       :outgoing_trust_ukprn,
       :establishment_sharepoint_link,
       :advisory_board_date,
+      :advisory_board_conditions,
       :provisional_transfer_date,
       :incoming_trust_sharepoint_link,
       :outgoing_trust_sharepoint_link,

--- a/app/controllers/transfers/projects_controller.rb
+++ b/app/controllers/transfers/projects_controller.rb
@@ -27,6 +27,7 @@ class Transfers::ProjectsController < ApplicationController
       :provisional_transfer_date,
       :incoming_trust_sharepoint_link,
       :outgoing_trust_sharepoint_link,
+      :assigned_to_regional_caseworker_team,
       :handover_note_body
     )
   end

--- a/app/controllers/transfers/projects_controller.rb
+++ b/app/controllers/transfers/projects_controller.rb
@@ -26,7 +26,8 @@ class Transfers::ProjectsController < ApplicationController
       :advisory_board_date,
       :provisional_transfer_date,
       :incoming_trust_sharepoint_link,
-      :outgoing_trust_sharepoint_link
+      :outgoing_trust_sharepoint_link,
+      :handover_note_body
     )
   end
 end

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -1,19 +1,11 @@
 class Conversion::CreateProjectForm < CreateProjectForm
-  attribute :advisory_board_conditions
-  attribute :handover_note_body
   attribute :directive_academy_order, :boolean
   attribute :region
-  attribute :assigned_to_regional_caseworker_team, :boolean
   attribute :two_requires_improvement, :boolean
 
-  attr_reader :provisional_conversion_date,
-    :advisory_board_date
+  attr_reader :provisional_conversion_date
 
-  validates :provisional_conversion_date,
-    :advisory_board_date,
-    :handover_note_body,
-    presence: true
-
+  validates :provisional_conversion_date, presence: true
   validates :provisional_conversion_date, date_in_the_future: true, first_day_of_month: true
 
   validate :urn_unique_for_in_progress_conversions, if: -> { urn.present? }
@@ -47,13 +39,6 @@ class Conversion::CreateProjectForm < CreateProjectForm
 
   private def urn_unique_for_in_progress_conversions
     errors.add(:urn, :duplicate) if Conversion::Project.not_completed.where(urn: urn).any?
-  end
-
-  def assigned_to_regional_caseworker_team_responses
-    @assigned_to_regional_caseworker_team_responses ||= [
-      OpenStruct.new(id: true, name: I18n.t("yes")),
-      OpenStruct.new(id: false, name: I18n.t("no"))
-    ]
   end
 
   def directive_academy_order_responses

--- a/app/forms/create_project_form.rb
+++ b/app/forms/create_project_form.rb
@@ -11,16 +11,22 @@ class CreateProjectForm
   attribute :establishment_sharepoint_link
   attribute :incoming_trust_sharepoint_link
   attribute :user
+  attribute :advisory_board_conditions
+  attribute :handover_note_body
+  attribute :assigned_to_regional_caseworker_team, :boolean
 
   attr_reader :advisory_board_date
 
   validates :urn, presence: true, urn: true
   validates :incoming_trust_ukprn, presence: true, ukprn: true
+
   validates :advisory_board_date, presence: true
   validates :advisory_board_date, date_in_the_past: true
 
   validates :establishment_sharepoint_link, presence: true, sharepoint_url: true
   validates :incoming_trust_sharepoint_link, presence: true, sharepoint_url: true
+
+  validates :handover_note_body, presence: true
 
   validate :establishment_exists, if: -> { urn.present? }
   validate :trust_exists, if: -> { incoming_trust_ukprn.present? }
@@ -37,6 +43,13 @@ class CreateProjectForm
     nil
   rescue TypeError, Date::Error, NegativeValueError
     @attributes_with_invalid_values << :advisory_board_date
+  end
+
+  def assigned_to_regional_caseworker_team_responses
+    @assigned_to_regional_caseworker_team_responses ||= [
+      OpenStruct.new(id: true, name: I18n.t("yes")),
+      OpenStruct.new(id: false, name: I18n.t("no"))
+    ]
   end
 
   private def establishment

--- a/app/forms/create_project_form.rb
+++ b/app/forms/create_project_form.rb
@@ -26,7 +26,7 @@ class CreateProjectForm
   validates :establishment_sharepoint_link, presence: true, sharepoint_url: true
   validates :incoming_trust_sharepoint_link, presence: true, sharepoint_url: true
 
-  validates :handover_note_body, presence: true
+  validates :handover_note_body, presence: true, if: -> { assigned_to_regional_caseworker_team.eql?(true) }
 
   validate :establishment_exists, if: -> { urn.present? }
   validate :trust_exists, if: -> { incoming_trust_ukprn.present? }

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -25,6 +25,7 @@ class Transfer::CreateProjectForm < CreateProjectForm
       incoming_trust_sharepoint_link: incoming_trust_sharepoint_link,
       outgoing_trust_sharepoint_link: outgoing_trust_sharepoint_link,
       advisory_board_date: advisory_board_date,
+      advisory_board_conditions: advisory_board_conditions,
       transfer_date: provisional_transfer_date,
       regional_delivery_officer_id: user.id,
       team: user.team,

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -35,11 +35,14 @@ class Transfer::CreateProjectForm < CreateProjectForm
       tasks_data: Transfer::TasksData.new
     )
 
-    if valid?
-      @project.save!
-      return @project
+    return nil unless valid?
+
+    ActiveRecord::Base.transaction do
+      @project.save
+      @note = Note.create(body: handover_note_body, project: @project, user: user, task_identifier: :handover) if handover_note_body
     end
-    nil
+
+    @project
   end
 
   def provisional_transfer_date=(hash)

--- a/app/views/conversions/projects/new.html.erb
+++ b/app/views/conversions/projects/new.html.erb
@@ -7,33 +7,50 @@
     <%= form_with model: @project, url: conversions_path do |form| %>
       <%= form.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l"><%= t("conversion_project.voluntary.new.title") %></h1>
+      <h1 class="govuk-heading-xl"><%= t("conversion_project.voluntary.new.title") %></h1>
       <%= t("conversion_project.voluntary.new.hint_html") %>
 
-      <%= form.govuk_text_field :urn, label: {size: "m", text: t("helpers.label.conversion_project.urn")}, hint: {text: t("helpers.hint.project.urn").html_safe}, width: 10 %>
-      <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m", text: t("helpers.label.conversion_project.incoming_trust_ukprn")}, hint: {text: t("helpers.hint.project.incoming_trust_ukprn").html_safe}, width: 10 %>
-      <%= form.govuk_date_field :advisory_board_date, legend: {text: t("helpers.legend.project.advisory_board_date")}, form_group: {id: "advisory-board-date"}, hint: {text: t("helpers.hint.project.advisory_board_date").html_safe} %>
-      <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m", text: t("helpers.label.conversion_project.advisory_board_conditions")} %>
-      <%= form.govuk_date_field :provisional_conversion_date, legend: {text: t("helpers.legend.conversion_project.provisional_conversion_date")}, omit_day: true, form_group: {id: "provisional-conversion-date"}, hint: {text: t("helpers.hint.conversion_project.provisional_conversion_date")} %>
-      <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m", text: t("helpers.label.conversion_project.establishment_sharepoint_link")} %>
-      <%= form.govuk_text_field :incoming_trust_sharepoint_link, label: {size: "m", text: t("helpers.label.conversion_project.trust_sharepoint_link")} %>
-      <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, @project.assigned_to_regional_caseworker_team_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>
-      <%= form.govuk_text_area :handover_note_body,
-            label: {text: t("project.new.handover_comments_label"), size: "m"},
-            hint: {text: t("project.new.handover_comments_hint").html_safe} %>
-      <%= form.govuk_collection_radio_buttons :directive_academy_order,
-            @project.directive_academy_order_responses,
-            :id,
-            :name,
-            legend: {text: t("helpers.legend.conversion_project.directive_academy_order")},
-            form_group: {id: "directive-academy-order"} %>
-      <%= form.govuk_collection_radio_buttons :two_requires_improvement,
-            @project.two_requires_improvement_responses,
-            :id,
-            :name,
-            legend: {text: t("helpers.legend.conversion_project.two_requires_improvement")},
-            hint: {text: t("helpers.hint.conversion_project.two_requires_improvement")},
-            form_group: {id: "two-requires-improvement"} %>
+      <div class="govuk-form-group">
+        <%= form.govuk_text_field :urn, label: {size: "m", text: t("helpers.label.conversion_project.urn")}, hint: {text: t("helpers.hint.project.urn").html_safe}, width: 10 %>
+        <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m", text: t("helpers.label.conversion_project.incoming_trust_ukprn")}, hint: {text: t("helpers.hint.project.incoming_trust_ukprn").html_safe}, width: 10 %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_date_field :advisory_board_date, legend: {text: t("helpers.legend.project.advisory_board_date")}, form_group: {id: "advisory-board-date"}, hint: {text: t("helpers.hint.project.advisory_board_date").html_safe} %>
+        <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m", text: t("helpers.label.conversion_project.advisory_board_conditions")} %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_date_field :provisional_conversion_date, legend: {text: t("helpers.legend.conversion_project.provisional_conversion_date")}, omit_day: true, form_group: {id: "provisional-conversion-date"}, hint: {text: t("helpers.hint.conversion_project.provisional_conversion_date")} %>
+        </div>
+
+        <div class="govuk-form-group">
+        <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m", text: t("helpers.label.conversion_project.establishment_sharepoint_link")} %>
+        <%= form.govuk_text_field :incoming_trust_sharepoint_link, label: {size: "m", text: t("helpers.label.conversion_project.trust_sharepoint_link")} %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, @project.assigned_to_regional_caseworker_team_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>
+        <%= form.govuk_text_area :handover_note_body,
+              label: {text: t("project.new.handover_comments_label"), size: "m"},
+              hint: {text: t("project.new.handover_comments_hint").html_safe} %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_collection_radio_buttons :directive_academy_order,
+              @project.directive_academy_order_responses,
+              :id,
+              :name,
+              legend: {text: t("helpers.legend.conversion_project.directive_academy_order")},
+              form_group: {id: "directive-academy-order"} %>
+        <%= form.govuk_collection_radio_buttons :two_requires_improvement,
+              @project.two_requires_improvement_responses,
+              :id,
+              :name,
+              legend: {text: t("helpers.legend.conversion_project.two_requires_improvement")},
+              hint: {text: t("helpers.hint.conversion_project.two_requires_improvement")},
+              form_group: {id: "two-requires-improvement"} %>
+      </div>
 
       <%= form.govuk_submit %>
     <% end %>

--- a/app/views/conversions/projects/new.html.erb
+++ b/app/views/conversions/projects/new.html.erb
@@ -17,10 +17,10 @@
       <%= form.govuk_date_field :provisional_conversion_date, legend: {text: t("helpers.legend.conversion_project.provisional_conversion_date")}, omit_day: true, form_group: {id: "provisional-conversion-date"}, hint: {text: t("helpers.hint.conversion_project.provisional_conversion_date")} %>
       <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m", text: t("helpers.label.conversion_project.establishment_sharepoint_link")} %>
       <%= form.govuk_text_field :incoming_trust_sharepoint_link, label: {size: "m", text: t("helpers.label.conversion_project.trust_sharepoint_link")} %>
+      <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, @project.assigned_to_regional_caseworker_team_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>
       <%= form.govuk_text_area :handover_note_body,
             label: {text: t("project.new.handover_comments_label"), size: "m"},
             hint: {text: t("project.new.handover_comments_hint").html_safe} %>
-      <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, @project.assigned_to_regional_caseworker_team_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>
       <%= form.govuk_collection_radio_buttons :directive_academy_order,
             @project.directive_academy_order_responses,
             :id,

--- a/app/views/transfers/projects/new.html.erb
+++ b/app/views/transfers/projects/new.html.erb
@@ -7,22 +7,38 @@
     <%= form_with model: @project, url: transfers_path do |form| %>
       <%= form.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l"><%= t("transfer_project.new.title") %></h1>
+      <h1 class="govuk-heading-xl"><%= t("transfer_project.new.title") %></h1>
       <%= t("transfer_project.new.hint_html") %>
 
-      <%= form.govuk_text_field :urn, label: {size: "m", text: t("helpers.label.transfer_project.urn")}, hint: {text: t("helpers.hint.transfer_project.urn").html_safe}, width: 10 %>
-      <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.incoming_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.incoming_trust_ukprn").html_safe}, width: 10 %>
-      <%= form.govuk_text_field :outgoing_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.outgoing_trust_ukprn").html_safe}, width: 10 %>
-      <%= form.govuk_date_field :advisory_board_date, legend: {text: t("helpers.legend.transfer_project.advisory_board_date")}, form_group: {id: "advisory-board-date"}, hint: {text: t("helpers.hint.project.advisory_board_date").html_safe} %>
-      <%= form.govuk_date_field :provisional_transfer_date, legend: {text: t("helpers.legend.transfer_project.provisional_transfer_date")}, omit_day: true, form_group: {id: "provisional-transfer-date"}, hint: {text: t("helpers.hint.transfer_project.provisional_transfer_date")} %>
-      <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.establishment_sharepoint_link")} %>
-      <%= form.govuk_text_field :incoming_trust_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.incoming_trust_sharepoint_link")} %>
-      <%= form.govuk_text_field :outgoing_trust_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_sharepoint_link")} %>
+      <div class="govuk-form-group">
+        <%= form.govuk_text_field :urn, label: {size: "m", text: t("helpers.label.transfer_project.urn")}, hint: {text: t("helpers.hint.transfer_project.urn").html_safe}, width: 10 %>
+        <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.incoming_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.incoming_trust_ukprn").html_safe}, width: 10 %>
+        <%= form.govuk_text_field :outgoing_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.outgoing_trust_ukprn").html_safe}, width: 10 %>
+      </div>
 
-      <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, @project.assigned_to_regional_caseworker_team_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>
-      <%= form.govuk_text_area :handover_note_body,
-            label: {text: t("project.new.handover_comments_label"), size: "m"},
-            hint: {text: t("project.new.handover_comments_hint").html_safe} %>
+      <div class="govuk-form-group">
+        <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.establishment_sharepoint_link")} %>
+        <%= form.govuk_text_field :incoming_trust_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.incoming_trust_sharepoint_link")} %>
+        <%= form.govuk_text_field :outgoing_trust_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_sharepoint_link")} %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_date_field :advisory_board_date, legend: {text: t("helpers.legend.transfer_project.advisory_board_date")}, form_group: {id: "advisory-board-date"}, hint: {text: t("helpers.hint.project.advisory_board_date").html_safe} %>
+        <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m", text: t("helpers.label.transfer_project.advisory_board_conditions")} %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_date_field :provisional_transfer_date, legend: {text: t("helpers.legend.transfer_project.provisional_transfer_date")}, omit_day: true, form_group: {id: "provisional-transfer-date"}, hint: {text: t("helpers.hint.transfer_project.provisional_transfer_date")} %>
+      </div>
+
+
+
+      <div class="govuk-form-group">
+        <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, @project.assigned_to_regional_caseworker_team_responses, :id, :name, legend: {text: t("helpers.hint.transfer_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>
+        <%= form.govuk_text_area :handover_note_body,
+              label: {text: t("project.new.handover_comments_label"), size: "m"},
+              hint: {text: t("project.new.handover_comments_hint").html_safe} %>
+      </div>
 
       <%= form.govuk_submit %>
     <% end %>

--- a/app/views/transfers/projects/new.html.erb
+++ b/app/views/transfers/projects/new.html.erb
@@ -12,8 +12,8 @@
 
       <div class="govuk-form-group">
         <%= form.govuk_text_field :urn, label: {size: "m", text: t("helpers.label.transfer_project.urn")}, hint: {text: t("helpers.hint.transfer_project.urn").html_safe}, width: 10 %>
-        <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.incoming_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.incoming_trust_ukprn").html_safe}, width: 10 %>
         <%= form.govuk_text_field :outgoing_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.outgoing_trust_ukprn").html_safe}, width: 10 %>
+        <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.incoming_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.incoming_trust_ukprn").html_safe}, width: 10 %>
       </div>
 
       <div class="govuk-form-group">
@@ -31,13 +31,16 @@
         <%= form.govuk_date_field :provisional_transfer_date, legend: {text: t("helpers.legend.transfer_project.provisional_transfer_date")}, omit_day: true, form_group: {id: "provisional-transfer-date"}, hint: {text: t("helpers.hint.transfer_project.provisional_transfer_date")} %>
       </div>
 
-
-
       <div class="govuk-form-group">
-        <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, @project.assigned_to_regional_caseworker_team_responses, :id, :name, legend: {text: t("helpers.hint.transfer_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>
+        <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team,
+              @project.assigned_to_regional_caseworker_team_responses,
+              :id,
+              :name,
+              form_group: {id: "assigned-to-regional-caseworker-team"},
+              legend: {text: t("helpers.legend.transfer_project.assigned_to_regional_caseworker_team")} %>
         <%= form.govuk_text_area :handover_note_body,
-              label: {text: t("project.new.handover_comments_label"), size: "m"},
-              hint: {text: t("project.new.handover_comments_hint").html_safe} %>
+              label: {text: t("helpers.label.transfer_project.handover_note_body"), size: "m"},
+              hint: {text: t("helpers.hint.transfer_project.handover_note_body_html")} %>
       </div>
 
       <%= form.govuk_submit %>

--- a/app/views/transfers/projects/new.html.erb
+++ b/app/views/transfers/projects/new.html.erb
@@ -19,6 +19,10 @@
       <%= form.govuk_text_field :incoming_trust_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.incoming_trust_sharepoint_link")} %>
       <%= form.govuk_text_field :outgoing_trust_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_sharepoint_link")} %>
 
+      <%= form.govuk_text_area :handover_note_body,
+            label: {text: t("project.new.handover_comments_label"), size: "m"},
+            hint: {text: t("project.new.handover_comments_hint").html_safe} %>
+
       <%= form.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/transfers/projects/new.html.erb
+++ b/app/views/transfers/projects/new.html.erb
@@ -19,6 +19,7 @@
       <%= form.govuk_text_field :incoming_trust_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.incoming_trust_sharepoint_link")} %>
       <%= form.govuk_text_field :outgoing_trust_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_sharepoint_link")} %>
 
+      <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, @project.assigned_to_regional_caseworker_team_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>
       <%= form.govuk_text_area :handover_note_body,
             label: {text: t("project.new.handover_comments_label"), size: "m"},
             hint: {text: t("project.new.handover_comments_hint").html_safe} %>

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -4,8 +4,9 @@ en:
     add:
       title: Add a transfer
     new:
-      title: Create a new transfer
-      hint_html: <p class="govuk-body">Enter information about the school, trust and the advisory board decision.</p><p class="govuk-body">This will create a new transfer project.</p>
+      title: Add a transfer
+      hint_html: <p>Enter information about the academy, incoming trust, outgoing trust and advisory board decision.</p>
+        <p>This will create a new transfer project.</p>
     created:
       success: Transfer project successfully created
     complete:
@@ -23,35 +24,45 @@ en:
   helpers:
     label:
       transfer_project:
-        urn: School URN (Unique Reference Number)
-        incoming_trust_ukprn: Incoming trust UKPRN (UK Provider Reference Number)
+        urn: Academy URN (Unique Reference Number)
+        incoming_trust_ukprn: Incoming trust UKPRN
         outgoing_trust_ukprn: Outgoing trust UKPRN (UK Provider Reference Number)
         caseworker_id: Caseworker
         regional_delivery_officer_id: Regional delivery officer
         advisory_board_conditions: Advisory board conditions
-        establishment_sharepoint_link: School SharePoint link
+        establishment_sharepoint_link: Academy SharePoint link
         incoming_trust_sharepoint_link: Incoming trust SharePoint link
         outgoing_trust_sharepoint_link: Outgoing trust SharePoint link
+        handover_note_body: Handover comments
     legend:
       transfer_project:
         advisory_board_date: Date of advisory board
         provisional_transfer_date: Provisional transfer date
+        assigned_to_regional_caseworker_team: Are you handing this project over to Regional Casework Services?
     hint:
       transfer_project:
-        urn: |
-          This is the URN of the existing school which is transferring. A URN is a 6-digit number. You can find it in the advisory board template.
-        incoming_trust_ukprn: |
-          A UKPRN is an 8-digit number that always starts with a 1.
-          <br /><br />
-          <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in a new tab)</a>.
-        outgoing_trust_ukprn: |
-          A UKPRN is an 8-digit number that always starts with a 1.
-          <br /><br />
-          <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the outgoing trust's UKPRN (opens in a new tab)</a>.
+        urn:
+          <p>This is the URN of the existing academy which is converting to an academy. A URN is a 6-digit number.</p>
+          <p>You can find the academy URN in the advisory board template.</p>
+        incoming_trust_ukprn:
+          <p>A UKPRN is an 8-digit number that always starts with a 1.</p>
+          <p><a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in new tab).</a>.</p>
+        outgoing_trust_ukprn:
+          <p>A UKPRN is an 8-digit number that always starts with a 1.</p>
+          <p><a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the outgoing trust's UKPRN (opens in new tab).</a>.</p>
         provisional_transfer_date: You can find this in the advisory board template.
         advisory_board_conditions: Enter details of conditions that must be met before the school can transfer.
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
         incoming_trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
+        handover_note_body_html:
+          <p>You must describe how the project has progressed so far and highlight any issues or concerns.</p>
+          <p>Include information about:</p>
+          <ul>
+            <li>which version of the master funding agreement the the incoming trust uses</li>
+            <li>if the introduction and next steps email been sent to the trusts</li>
+            <li>who the Schools Financial Support and Oversight lead is</li>
+            <li>any finanical package that has been finalised and agreed</li>
+          </ul>
   errors:
     attributes:
       provisional_transfer_date:

--- a/spec/factories/transfer/create_project_form_factory.rb
+++ b/spec/factories/transfer/create_project_form_factory.rb
@@ -9,5 +9,6 @@ FactoryBot.define do
     incoming_trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/incoming-trust-folder" }
     outgoing_trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/outgoing-trust-folder" }
     user { association :user, :regional_delivery_officer }
+    handover_note_body { "This is a handover note." }
   end
 end

--- a/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
+++ b/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
@@ -50,6 +50,8 @@ RSpec.feature "Users can create new conversion projects" do
       fill_in "Year", with: two_weeks_ago.year
     end
 
+    fill_in "Handover comments", with: "This is a handover note."
+
     within("#provisional-transfer-date") do
       fill_in "Month", with: two_months_time.month
       fill_in "Year", with: two_months_time.year

--- a/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
+++ b/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
@@ -36,11 +36,11 @@ RSpec.feature "Users can create new conversion projects" do
   end
 
   def fill_in_form
-    fill_in "School URN", with: urn
-    fill_in "Incoming trust UKPRN (UK Provider Reference Number)", with: incoming_ukprn
+    fill_in "Academy URN", with: urn
+    fill_in "Incoming trust UKPRN", with: incoming_ukprn
     fill_in "Outgoing trust UKPRN (UK Provider Reference Number)", with: outgoing_ukprn
 
-    fill_in "School SharePoint link", with: "https://educationgovuk-my.sharepoint.com/school-folder"
+    fill_in "Academy SharePoint link", with: "https://educationgovuk-my.sharepoint.com/school-folder"
     fill_in "Incoming trust SharePoint link", with: "https://educationgovuk-my.sharepoint.com/incoming-trust-folder"
     fill_in "Outgoing trust SharePoint link", with: "https://educationgovuk-my.sharepoint.com/outgoing-trust-folder"
 

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -258,12 +258,25 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
     end
 
     describe "handover note body" do
-      it "is required" do
-        form = build(
-          form_factory.to_sym,
-          handover_note_body: ""
-        )
-        expect(form).to be_invalid
+      context "when the project is being handed over" do
+        it "is required" do
+          form = build(
+            form_factory.to_sym,
+            handover_note_body: ""
+          )
+          form.assigned_to_regional_caseworker_team = true
+          expect(form).to be_invalid
+        end
+      end
+      context "when the project is not being handed over" do
+        it "is not required" do
+          form = build(
+            form_factory.to_sym,
+            handover_note_body: ""
+          )
+          form.assigned_to_regional_caseworker_team = false
+          expect(form).to be_valid
+        end
       end
     end
   end

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -232,6 +232,16 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
         project = build(:create_transfer_project_form, outgoing_trust_ukprn: 10061008).save
         expect(project.reload.outgoing_trust_ukprn).to eql(10061008)
       end
+
+      it "creates a note associated to the handover task" do
+        form = build(:create_transfer_project_form, handover_note_body: "This is the handover note.")
+
+        form.save
+
+        expect(Note.count).to eq(1)
+        expect(Note.last.body).to eq("This is the handover note.")
+        expect(Note.last.task_identifier).to eq("handover")
+      end
     end
 
     context "when the form is invalid" do

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -199,6 +199,16 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
     end
   end
 
+  describe "advisory board conditions" do
+    it "saves any that are provided" do
+      form = build(:create_transfer_project_form, advisory_board_conditions: "These are the conditions.")
+
+      project = form.save
+
+      expect(project.advisory_board_conditions).to eql("These are the conditions.")
+    end
+  end
+
   describe "#save" do
     let(:establishment) { build(:academies_api_establishment) }
 

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:establishment_sharepoint_link) }
     it { is_expected.to validate_presence_of(:incoming_trust_sharepoint_link) }
+    it { is_expected.to validate_presence_of(:outgoing_trust_sharepoint_link) }
 
     describe "advisory_board_date" do
       it { is_expected.to validate_presence_of(:advisory_board_date) }

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -180,6 +180,25 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
     end
   end
 
+  describe "handover note body" do
+    context "when the project is being handed over" do
+      it "is required" do
+        form = build(:create_transfer_project_form, handover_note_body: "")
+        form.assigned_to_regional_caseworker_team = true
+
+        expect(form).to be_invalid
+      end
+    end
+    context "when the project is not being handed over" do
+      it "is not required" do
+        form = build(:create_transfer_project_form, handover_note_body: "")
+        form.assigned_to_regional_caseworker_team = false
+
+        expect(form).to be_valid
+      end
+    end
+  end
+
   describe "#save" do
     let(:establishment) { build(:academies_api_establishment) }
 


### PR DESCRIPTION
We went ahead and added transfer behaviour before we had fully designed some aspects of it (and that is okay!!)

This work brings the new transfer project form up to scratch, using the supplied design for layout and content.

We tweaked a few things in the spririt of 'leave it better'.

https://trello.com/c/9xjVW2bS

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/3fc93446-d76b-4f6b-b89a-3241d1850f4d)

