### PR TITLE
Update all table views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - do not send any mails to deactivated users
 - Amended all table views to be able to display a conversion project as well as
   a transfer project
+- Remove the View project column from the table views and make the school name
+  link to the project view instead
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - updated grants team email address
 - added C of E/cofe issue to accessibility statement
 - do not send any mails to deactivated users
+- Amended all table views to be able to display a conversion project as well as
+  a transfer project
 
 ### Fixed
 

--- a/app/controllers/all/in_progress/projects_controller.rb
+++ b/app/controllers/all/in_progress/projects_controller.rb
@@ -5,7 +5,7 @@ class All::InProgress::ProjectsController < ApplicationController
   def index
     authorize Project, :index?
 
-    @pager, @projects = pagy(Conversion::Project.in_progress.includes(:assigned_to).ordered_by_significant_date)
+    @pager, @projects = pagy(Project.in_progress.includes(:assigned_to).ordered_by_significant_date)
     AcademiesApiPreFetcherService.new.call!(@projects)
   end
 end

--- a/app/views/all/local_authorities/projects/show.html.erb
+++ b/app/views/all/local_authorities/projects/show.html.erb
@@ -15,7 +15,8 @@
             <tr class="govuk-table__row">
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
-              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.significant_date") %></th>
+              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
+              <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
             </tr>
@@ -25,7 +26,8 @@
             <tr class="govuk-table__row">
               <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
               <td class="govuk-table__cell"><%= project.urn %></td>
-              <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:govuk) %></td>
+              <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
+              <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
               <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
               <td class="govuk-table__cell">
                 <a href="<%= project_path(project) %>">

--- a/app/views/all/local_authorities/projects/show.html.erb
+++ b/app/views/all/local_authorities/projects/show.html.erb
@@ -18,22 +18,18 @@
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
-              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
             </tr>
           </thead>
           <tbody class="govuk-table__body">
           <% @projects.each do |project| %>
             <tr class="govuk-table__row">
-              <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+              <td class="govuk-table__header govuk-table__cell">
+                <%= link_to project.establishment.name, project_path(project) %>
+              </td>
               <td class="govuk-table__cell"><%= project.urn %></td>
               <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
               <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
               <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
-              <td class="govuk-table__cell">
-                <a href="<%= project_path(project) %>">
-                  <%= t("project.table.body.view_html", school_name: project.establishment.name) %>
-                </a>
-              </td>
               </tr>
           <% end %>
           </tbody>

--- a/app/views/all/regions/projects/show.html.erb
+++ b/app/views/all/regions/projects/show.html.erb
@@ -15,7 +15,8 @@
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
             <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
-            <th class="govuk-table__header" scope="col"><%= t("project.table.headers.significant_date") %></th>
+            <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
+            <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
             <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
             <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
           </tr>
@@ -25,7 +26,8 @@
           <tr class="govuk-table__row">
             <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
             <td class="govuk-table__cell"><%= project.urn %></td>
-            <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:govuk) %></td>
+            <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
+            <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
             <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
             <td class="govuk-table__cell">
               <a href="<%= project_path(project) %>">

--- a/app/views/all/regions/projects/show.html.erb
+++ b/app/views/all/regions/projects/show.html.erb
@@ -18,22 +18,18 @@
             <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
             <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
             <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
-            <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">
         <% @projects.each do |project| %>
           <tr class="govuk-table__row">
-            <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+            <td class="govuk-table__header govuk-table__cell">
+              <%= link_to project.establishment.name, project_path(project) %>
+            </td>
             <td class="govuk-table__cell"><%= project.urn %></td>
             <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
             <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
             <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
-            <td class="govuk-table__cell">
-              <a href="<%= project_path(project) %>">
-                <%= t("project.table.body.view_html", school_name: project.establishment.name) %>
-              </a>
-            </td>
             </tr>
         <% end %>
         </tbody>

--- a/app/views/all/trusts/projects/show.html.erb
+++ b/app/views/all/trusts/projects/show.html.erb
@@ -15,7 +15,8 @@
             <tr class="govuk-table__row">
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
-              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.significant_date") %></th>
+              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
+              <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
             </tr>
@@ -25,7 +26,8 @@
             <tr class="govuk-table__row">
               <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
               <td class="govuk-table__cell"><%= project.urn %></td>
-              <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:govuk) %></td>
+              <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
+              <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
               <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
               <td class="govuk-table__cell">
                 <a href="<%= project_path(project) %>">

--- a/app/views/all/trusts/projects/show.html.erb
+++ b/app/views/all/trusts/projects/show.html.erb
@@ -18,22 +18,18 @@
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
               <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
-              <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
             </tr>
           </thead>
           <tbody class="govuk-table__body">
           <% @projects.each do |project| %>
             <tr class="govuk-table__row">
-              <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+              <td class="govuk-table__header govuk-table__cell">
+                <%= link_to project.establishment.name, project_path(project) %>
+              </td>
               <td class="govuk-table__cell"><%= project.urn %></td>
               <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
               <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
               <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
-              <td class="govuk-table__cell">
-                <a href="<%= project_path(project) %>">
-                  <%= t("project.table.body.view_html", school_name: project.establishment.name) %>
-                </a>
-              </td>
               </tr>
           <% end %>
           </tbody>

--- a/app/views/projects/shared/_handed_over_table.html.erb
+++ b/app/views/projects/shared/_handed_over_table.html.erb
@@ -9,22 +9,18 @@
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
     <% projects.each do |project| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+        <td class="govuk-table__header govuk-table__cell">
+          <%= link_to project.establishment.name, project_path(project) %>
+        </td>
         <td class="govuk-table__cell"><%= project.urn %></td>
         <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
         <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
         <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
-        <td class="govuk-table__cell">
-          <a href="<%= project_path(project) %>">
-            <%= t("project.table.body.view_html", school_name: project.establishment.name) %>
-          </a>
-        </td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/projects/shared/_handed_over_table.html.erb
+++ b/app/views/projects/shared/_handed_over_table.html.erb
@@ -6,7 +6,8 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.significant_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
       </tr>
@@ -16,7 +17,8 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
         <td class="govuk-table__cell"><%= project.urn %></td>
-        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:govuk) %></td>
+        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
+        <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
         <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
         <td class="govuk-table__cell">
           <a href="<%= project_path(project) %>">

--- a/app/views/projects/shared/_in_progress_table.html.erb
+++ b/app/views/projects/shared/_in_progress_table.html.erb
@@ -9,22 +9,18 @@
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
     <% projects.each do |project| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+        <td class="govuk-table__header govuk-table__cell">
+          <%= link_to project.establishment.name, project_path(project) %>
+        </td>
         <td class="govuk-table__cell"><%= project.urn %></td>
         <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
         <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
         <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
-        <td class="govuk-table__cell">
-          <a href="<%= project_path(project) %>">
-            <%= t("project.table.body.view_html", school_name: project.establishment.name) %>
-          </a>
-        </td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/projects/shared/_in_progress_table.html.erb
+++ b/app/views/projects/shared/_in_progress_table.html.erb
@@ -6,7 +6,8 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.significant_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
       </tr>
@@ -16,7 +17,8 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
         <td class="govuk-table__cell"><%= project.urn %></td>
-        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:govuk) %></td>
+        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
+        <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
         <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
         <td class="govuk-table__cell">
           <a href="<%= project_path(project) %>">

--- a/app/views/projects/shared/_unassigned_table.html.erb
+++ b/app/views/projects/shared/_unassigned_table.html.erb
@@ -8,7 +8,8 @@
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.added_by") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.significant_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.region") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assign") %></th>
@@ -20,7 +21,8 @@
         <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
         <td class="govuk-table__cell"><%= project.urn %></td>
         <td class="govuk-table__cell"><%= project.regional_delivery_officer.full_name %></td>
-        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:govuk) %></td>
+        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
+        <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
         <td class="govuk-table__cell"><%= project.establishment.region_name %></td>
         <td class="govuk-table__cell">
           <%= link_to t("project.table.body.view_html", school_name: project.establishment.name), project_path(project) %>

--- a/app/views/projects/shared/_unassigned_table.html.erb
+++ b/app/views/projects/shared/_unassigned_table.html.erb
@@ -11,22 +11,20 @@
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.region") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assign") %></th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
     <% projects.each do |project| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+        <td class="govuk-table__header govuk-table__cell">
+          <%= link_to project.establishment.name, project_path(project) %>
+        </td>
         <td class="govuk-table__cell"><%= project.urn %></td>
         <td class="govuk-table__cell"><%= project.regional_delivery_officer.full_name %></td>
         <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
         <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
         <td class="govuk-table__cell"><%= project.establishment.region_name %></td>
-        <td class="govuk-table__cell">
-          <%= link_to t("project.table.body.view_html", school_name: project.establishment.name), project_path(project) %>
-        </td>
         <td class="govuk-table__cell">
           <%= link_to t("project.table.body.assign_html", school_name: project.establishment.name), project_assign_assigned_to_path(project) %>
         </td>

--- a/app/views/your/projects/_table.html.erb
+++ b/app/views/your/projects/_table.html.erb
@@ -6,7 +6,8 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.significant_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
       </tr>
     </thead>
@@ -15,7 +16,8 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
         <td class="govuk-table__cell"><%= project.urn %></td>
-        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:govuk) %></td>
+        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
+        <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
         <td class="govuk-table__cell">
           <a href="<%= project_path(project) %>">
             <%= t("project.table.body.view_html", school_name: project.establishment.name) %>

--- a/app/views/your/projects/_table.html.erb
+++ b/app/views/your/projects/_table.html.erb
@@ -8,21 +8,17 @@
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
     <% projects.each do |project| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+        <td class="govuk-table__header govuk-table__cell">
+          <%= link_to project.establishment.name, project_path(project) %>
+        </td>
         <td class="govuk-table__cell"><%= project.urn %></td>
         <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
         <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
-        <td class="govuk-table__cell">
-          <a href="<%= project_path(project) %>">
-            <%= t("project.table.body.view_html", school_name: project.establishment.name) %>
-          </a>
-        </td>
         </tr>
     <% end %>
     </tbody>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -165,7 +165,7 @@ en:
         assign: Assign project
         added_by: Added by
         conversion_date: Conversion date
-        significant_date: Conversion or transfer date
+        conversion_or_transfer_date: Conversion or transfer date
         revised_conversion_date: Revised conversion date
         route: Route
         school_phase: School phase
@@ -187,6 +187,9 @@ en:
         revised: Revised
         team: Team
       body:
+        type_name:
+          conversion_project: Conversion
+          transfer_project: Transfer
         view_html: View <span class="govuk-visually-hidden">%{school_name}</span> project
         edit_html: Create academy URN <span class="govuk-visually-hidden">for %{school_name}</span>
         assign_html: Assign <span class="govuk-visually-hidden">%{school_name}</span> project


### PR DESCRIPTION
## Changes

On the back of adding `transfer` projects to the service, we need our table views to be able to reflect the two project types they will be displaying.

There was a slight overlap with PR https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/946, so the work around making the `conversion_date` and associated controllers step away from being solely conversion projects now happens within that work. 

This PR builds on that by adding in a new table column `Type` to display whether it is a conversion project or transfer prioject and formats the `conversion or transfer date` using the `significant_date` format.
This PR also updates the table view by removing the `View project` column and adds in the project link to the school name


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
