### PR TITLE
Improve content on sign in page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The new conversion button has moved up the page.
 - The layout and information shown on the Your in-progress projects view has
   been improved.
+- improved content on sign in page to include registraiton, guidance and release
+  notes links
 
 ### Fixed
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,7 +1,23 @@
 <h1 class="govuk-heading-xl">
   Sign in
 </h1>
-
+<p>This product can be used by delivery officers or caseworkers at the Department for Education.</p>
+<p>It can also be used by the Academies Operational Practice Unit and Service Support team, as well as some teams at the Education and Skills Funding Agency.</p>
+<p>You can use this product to manage work that helps DfE to convert schools to academies.</p>
 <%= form_tag("/auth/azure_activedirectory_v2", method: "post") do %>
   <%= button_tag(t("sign_in.button", type: :submit), class: "govuk-button") %>
 <% end %>
+<h2 class="govuk-heading-m">Register for access</h2>
+<p>If you do not have access you can <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-X7F89QcWu5CjlJXwF0TVktUMEpZSU5aTEVYVlIyRE1JSjdMREtIVDhWQiQlQCN0PWcu" class="govuk-link" rel="noreferrer noopener" target="_blank">sign up to use Complete conversions, transfers and changes (opens in new tab)</a>.</p>
+<p>To register, you’ll need to provide your:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>full name</li>
+  <li>@education.gov.uk email address</li>
+  <li>team information</li>
+  <li>job title</li>
+ </ul>
+<h2 class="govuk-heading-m">How to use Complete conversions, transfers and changes</h2>
+<p>You can <a href="https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/using-the-complete-conversions-transfers-and-changes-digital-product.aspx" class="govuk-link" rel="noreferrer noopener" target="_blank">read our guidance about how to use the product (opens in new tab)</a> if you’re new to Complete conversions transfers and changes or just unsure on how to do certain things with it.</p>
+<h2 class="govuk-heading-m">Updates and releases</h2>
+<p>We regularly update the product and release new versions of it, based on user feedback.</p>
+<p>You can <a href="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/releases" class="govuk-link" rel="noreferrer noopener" target="_blank">read our release notes (opens in new tab)</a> to find out what we’ve done to improve the product.</p>


### PR DESCRIPTION
## Changes

This work adds more content to the sign in page so that it functions like a service start page.

![localhost_3000_sign-in](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/039e84a1-0f07-4963-9683-dc20e85d508b)

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
