### PR TITLE
Fixing spelling error on project information page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- removed erroneous additional s from Address on the project information page
+
 ### Fixed
 
 ## [Release 37][release-37]

--- a/config/locales/project_information.en.yml
+++ b/config/locales/project_information.en.yml
@@ -33,7 +33,7 @@ en:
         rows:
           original_school_name: Original school name
           view_in_gias: View the school's information in GIAS (opens in new tab)
-          address: Addresss
+          address: Address
           dfe_number: DfE number
           old_urn: Old Unique Reference Number
           school_type: School type


### PR DESCRIPTION
## Changes

This corrects `Addresss` to `Address` in the project information page

![Screenshot 2023-08-03 at 3 31 59 pm](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/90ccf855-e077-4ee8-a6f0-6662c0dd7950)

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
