### PR TITLE
Update Contact category "Trust" to be "Incoming trust"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add "Outgoing trust" category to External contacts
+
 ### Changed
 
 ### Fixed

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -8,7 +8,8 @@ class Contact < ApplicationRecord
 
   enum category: {
     school: 1,
-    trust: 2,
+    incoming_trust: 2,
+    outgoing_trust: 6,
     local_authority: 3,
     solicitor: 5,
     diocese: 4,

--- a/spec/features/users_can_manage_contacts_spec.rb
+++ b/spec/features/users_can_manage_contacts_spec.rb
@@ -27,7 +27,8 @@ RSpec.feature "Users can manage contacts" do
   scenario "the contact groups are in the order users might expect to use them" do
     create(:project_contact, category: :other, project: project)
     create(:project_contact, category: :school, project: project)
-    create(:project_contact, category: :trust, project: project)
+    create(:project_contact, category: :incoming_trust, project: project)
+    create(:project_contact, category: :outgoing_trust, project: project)
     create(:project_contact, category: :solicitor, project: project)
     create(:project_contact, category: :diocese, project: project)
     create(:project_contact, category: :local_authority, project: project)
@@ -38,7 +39,8 @@ RSpec.feature "Users can manage contacts" do
 
     %i[
       school
-      trust
+      incoming_trust
+      outgoing_trust
       local_authority
       solicitor
       diocese
@@ -56,7 +58,7 @@ RSpec.feature "Users can manage contacts" do
 
     expect(page).to have_select("Contact for", selected: "Choose category")
 
-    select "Trust", from: "Contact for"
+    select "Incoming trust", from: "Contact for"
     fill_in "Name", with: "Some One"
     fill_in "Organisation", with: "Trust Name"
     fill_in "Role", with: "Chief of Knowledge"
@@ -65,7 +67,7 @@ RSpec.feature "Users can manage contacts" do
 
     click_button("Add contact")
 
-    expect(page).to have_content("Trust contacts")
+    expect(page).to have_content("Incoming trust contacts")
 
     expect_page_to_have_contact(
       name: "Some One",


### PR DESCRIPTION


## Changes

Change the "Trust" contact category to be "Incoming trust", and add new category "Outgoing trust".

This does not require a database migration, as the category is stored on the Contact in the database as the integer value, not the label.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
