### PR TITLE
Removes 2 instances of "the the" in content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - removed erroneous additional s from Address on the project information page
+- removed extra the from notifcation of change task and add a transfer form
 
 ### Fixed
 

--- a/config/locales/conversion/tasks/complete_notification_of_change.en.yml
+++ b/config/locales/conversion/tasks/complete_notification_of_change.en.yml
@@ -32,7 +32,7 @@ en:
           title: Check the returned notification of change document
           hint:
             html:
-              <p>Compare the the notification of changes document to the section 251 spreadsheet.</p>
+              <p>Compare the notification of changes document to the section 251 spreadsheet.</p>
           guidance_link: What to check for
           guidance:
             html:

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -58,7 +58,7 @@ en:
           <p>You must describe how the project has progressed so far and highlight any issues or concerns.</p>
           <p>Include information about:</p>
           <ul>
-            <li>which version of the master funding agreement the the incoming trust uses</li>
+            <li>which version of the master funding agreement the incoming trust uses</li>
             <li>if the introduction and next steps email been sent to the trusts</li>
             <li>who the Schools Financial Support and Oversight lead is</li>
             <li>any finanical package that has been finalised and agreed</li>


### PR DESCRIPTION
## Changes

There were 2 cases of "the the" appearing in content. One in the notification of change tasks and another in the add a transfer form.

This work fixes those errors.

Before

![Screenshot 2023-08-03 at 4 29 11 pm](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/86c96eb8-c095-4561-aa6a-1d54bdcde544)

After

![Screenshot 2023-08-03 at 4 28 39 pm](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/88bca33a-56cc-43b5-8b8c-5a9e8d4974ed)


## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
