### PR TITLE
Show the Director of child services in the External contacts area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   task to improve readability
 - removed extra the from notifcation of change task and add a transfer form
 - add simple side navigation to the statistics page
+- the Director of Child Services contact information is now in the External
+  contacts area, not the Local authority information area.
 
 ### Fixed
 

--- a/app/views/conversions/external_contacts/index.html.erb
+++ b/app/views/conversions/external_contacts/index.html.erb
@@ -15,7 +15,7 @@
       </p>
     </div>
 
-    <% if @grouped_contacts.empty? %>
+    <% if @grouped_contacts.empty? && !@project.director_of_child_services %>
       <%= govuk_inset_text(text: t("contact.index.no_contacts_yet")) %>
     <% end %>
 
@@ -27,6 +27,28 @@
       <% if @grouped_contacts[category].present? %>
         <%= render partial: "contact_group", locals: {category: category, contacts: @grouped_contacts[category]} %>
       <% end %>
+    <% end %>
+
+    <% if @project.director_of_child_services %>
+      <h3 class="govuk-heading-m"><%= t("project_information.show.director_of_child_services.title") %></h3>
+      <%= govuk_summary_list(actions: false) do |summary_list|
+            summary_list.row do |row|
+              row.key { t("project_information.show.director_of_child_services.rows.title") }
+              row.value { @project.director_of_child_services.title }
+            end
+            summary_list.row do |row|
+              row.key { t("project_information.show.director_of_child_services.rows.name") }
+              row.value { @project.director_of_child_services.name }
+            end
+            summary_list.row do |row|
+              row.key { t("project_information.show.director_of_child_services.rows.email") }
+              row.value { @project.director_of_child_services.email }
+            end
+            summary_list.row do |row|
+              row.key { t("project_information.show.director_of_child_services.rows.phone") }
+              row.value { @project.director_of_child_services.phone }
+            end
+          end %>
     <% end %>
 
   </div>

--- a/app/views/conversions/project_information/_local_authority_details.html.erb
+++ b/app/views/conversions/project_information/_local_authority_details.html.erb
@@ -12,26 +12,4 @@
           end
         end
       end %>
-
-  <% if project.director_of_child_services %>
-    <h2 class="govuk-heading-l"><%= t("project_information.show.director_of_child_services.title") %></h2>
-    <%= govuk_summary_list(actions: false) do |summary_list|
-          summary_list.row do |row|
-            row.key { t("project_information.show.director_of_child_services.rows.title") }
-            row.value { project.director_of_child_services.title }
-          end
-          summary_list.row do |row|
-            row.key { t("project_information.show.director_of_child_services.rows.name") }
-            row.value { project.director_of_child_services.name }
-          end
-          summary_list.row do |row|
-            row.key { t("project_information.show.director_of_child_services.rows.email") }
-            row.value { project.director_of_child_services.email }
-          end
-          summary_list.row do |row|
-            row.key { t("project_information.show.director_of_child_services.rows.phone") }
-            row.value { project.director_of_child_services.phone }
-          end
-        end %>
-  <% end %>
 </div>

--- a/app/views/conversions/project_information/_side_navigation.html.erb
+++ b/app/views/conversions/project_information/_side_navigation.html.erb
@@ -5,7 +5,7 @@
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.advisory_board_details.title"), path: "#advisoryBoardDetails"} %>
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.school_details.title"), path: "#schoolDetails"} %>
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.academy_details.title"), path: "#academyDetails"} %>
-    <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.trust_details.title"), path: "#trustDetails"} %>
+    <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.incoming_trust_details.title"), path: "#incomingTrustDetails"} %>
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.local_authority_details.title"), path: "#localAuthorityDetails"} %>
     <%= render partial: "shared/side_navigation_item", locals: {name: t("project_information.show.diocese_details.title"), path: "#dioceseDetails"} %>
   </ul>

--- a/spec/features/project_information/users_can_view_local_authority_details_spec.rb
+++ b/spec/features/project_information/users_can_view_local_authority_details_spec.rb
@@ -50,21 +50,4 @@ RSpec.feature "Users can view local authority details" do
       end
     end
   end
-
-  context "when the local authority has a director of child services" do
-    before do
-      mock_successful_api_responses(urn: any_args, ukprn: any_args)
-      create(:director_of_child_services, local_authority: local_authority)
-      allow_any_instance_of(Api::AcademiesApi::Establishment).to receive(:local_authority).and_return(local_authority)
-      sign_in_with_user(user)
-      visit project_information_path(project)
-    end
-
-    scenario "they can view the director of child services" do
-      director = local_authority.director_of_child_services
-      within("#localAuthorityDetails") do
-        expect(page).to have_content(director.name)
-      end
-    end
-  end
 end

--- a/spec/requests/contacts_controller_spec.rb
+++ b/spec/requests/contacts_controller_spec.rb
@@ -26,6 +26,20 @@ RSpec.describe ExternalContactsController, type: :request do
     it "returns a successful response" do
       expect(subject).to have_http_status :success
     end
+
+    context "when the project has a director of child services" do
+      let(:local_authority) { create(:local_authority) }
+
+      before do
+        create(:director_of_child_services, local_authority: local_authority)
+        allow_any_instance_of(Api::AcademiesApi::Establishment).to receive(:local_authority).and_return(local_authority)
+      end
+
+      it "includes the director of child services in the response" do
+        director = local_authority.director_of_child_services
+        expect(subject.body).to include(director.name)
+      end
+    end
   end
 
   describe "#new" do


### PR DESCRIPTION
## Changes

Move the Director of Child Services contact information into the External contacts area.

<img width="873" alt="Screenshot 2023-08-04 at 09 04 15" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/73d543e3-e66c-4777-b28d-cc29bf80286f">

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
