### PR TITLE
Grant type options

### DIFF
--- a/app/forms/conversion/task/sponsored_support_grant_task_form.rb
+++ b/app/forms/conversion/task/sponsored_support_grant_task_form.rb
@@ -5,4 +5,8 @@ class Conversion::Task::SponsoredSupportGrantTaskForm < BaseOptionalTaskForm
   attribute :send_information, :boolean
   attribute :inform_trust, :boolean
   attribute :type, :string
+
+  def type_options
+    Conversion::TasksData.sponsored_support_grant_types.values
+  end
 end

--- a/app/models/conversion/tasks_data.rb
+++ b/app/models/conversion/tasks_data.rb
@@ -6,4 +6,11 @@ class Conversion::TasksData < ActiveRecord::Base
   def self.policy_class
     TaskListPolicy
   end
+
+  enum :sponsored_support_grant_type,
+    {
+      fast_track: "fast_track",
+      intermediate: "intermediate",
+      full_sponsored: "full_sponsored"
+    }
 end

--- a/app/views/conversions/tasks/sponsored_support_grant/edit.html.erb
+++ b/app/views/conversions/tasks/sponsored_support_grant/edit.html.erb
@@ -13,7 +13,7 @@
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
       </div>
 
-      <div class="govuk-form-group">
+      <div class="govuk-form-group govuk-!-margin-bottom-9">
         <%= form.govuk_radio_buttons_fieldset(:type, legend: {size: "l", text: t("conversion.task.sponsored_support_grant.type_of_grant.radio_buttons.title")}) do %>
           <div class="app-task-section__hint">
             <%= t("conversion.task.sponsored_support_grant.type_of_grant.radio_buttons.hint.html") %>
@@ -22,10 +22,12 @@
                 summary_text: t("conversion.task.sponsored_support_grant.type_of_grant.radio_buttons.guidance_link"),
                 text: t("conversion.task.sponsored_support_grant.type_of_grant.radio_buttons.guidance.html")
               ) %>
-          <%= form.govuk_radio_button :type, "fast-track", label: {text: t("conversion.task.sponsored_support_grant.type_of_grant.radio_buttons.responses.fast_track")} %>
-          <%= form.govuk_radio_button :type, "intermediate", label: {text: t("conversion.task.sponsored_support_grant.type_of_grant.radio_buttons.responses.intermediate")} %>
-          <%= form.govuk_radio_button :type, "full-sponsored", label: {text: t("conversion.task.sponsored_support_grant.type_of_grant.radio_buttons.responses.full_sponsored")} %>
+        <% @task.type_options.each do |option| %>
+          <%= form.govuk_radio_button :type,
+                option,
+                label: {text: t("conversion.task.sponsored_support_grant.type_of_grant.radio_buttons.responses.#{option}")} %>
         <% end %>
+      <% end %>
       </div>
 
       <div class="govuk-form-group">

--- a/db/migrate/20230807091931_correct_support_grant_types.rb
+++ b/db/migrate/20230807091931_correct_support_grant_types.rb
@@ -1,0 +1,23 @@
+class CorrectSupportGrantTypes < ActiveRecord::Migration[7.0]
+  def up
+    Conversion::TasksData.all.each do |tasks_data|
+      case tasks_data.sponsored_support_grant_type
+      when "fast-track"
+        tasks_data.update_attribute(:sponsored_support_grant_type, "fast_track")
+      when "full-sponsored"
+        tasks_data.update_attribute(:sponsored_support_grant_type, "full_sponsored")
+      end
+    end
+  end
+
+  def down
+    Conversion::TasksData.all.each do |tasks_data|
+      case tasks_data.sponsored_support_grant_type
+      when "fast_track"
+        tasks_data.update_attribute(:sponsored_support_grant_type, "fast-track")
+      when "full_sponsored"
+        tasks_data.update_attribute(:sponsored_support_grant_type, "full-sponsored")
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_01_082723) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_07_091931) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -189,7 +189,7 @@ RSpec.feature "Users can complete conversion tasks" do
       choose "Fast track"
       click_on I18n.t("task_list.continue_button.text")
 
-      expect(project.reload.tasks_data.sponsored_support_grant_type).to eq "fast-track"
+      expect(project.reload.tasks_data.sponsored_support_grant_type).to eq "fast_track"
     end
 
     scenario "the response can be intermediate" do
@@ -203,7 +203,7 @@ RSpec.feature "Users can complete conversion tasks" do
       choose "Full sponsored"
       click_on I18n.t("task_list.continue_button.text")
 
-      expect(project.reload.tasks_data.sponsored_support_grant_type).to eq "full-sponsored"
+      expect(project.reload.tasks_data.sponsored_support_grant_type).to eq "full_sponsored"
     end
   end
 


### PR DESCRIPTION
For the sponsored support grant type we save the value with hyphens, this is a bit at odds with Rails conventions.

We also do not validate the strings stored, which leaves us open to potential injections.

Here we fix both by making the attribute an enum so only the three acceptable values can be stored and those values are underscored so things work as expected when pulling the values out.

https://trello.com/c/k1DjbrHd