### PR TITLE
Store when a user last created a session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Show user counts by team on the statistics page
 - Add a Handover task to Transfer projects
 - Add more actions to the Stakeholder kick-off task for Transfers
+- Store the DateTime of a user's latest session (the last time they logged in)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add a Handover task to Transfer projects
 - Add more actions to the Stakeholder kick-off task for Transfers
 - Store the DateTime of a user's latest session (the last time they logged in)
+- Show the time of the user's latest session in the User table, as "Last seen"
 
 ### Changed
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -38,6 +38,7 @@ class SessionsController < ApplicationController
   private def create_session
     assign_active_directory_user_id
     assign_active_directory_user_group_ids
+    update_latest_session_for_user
     session[:user_id] = registered_user.id
   end
 
@@ -49,6 +50,10 @@ class SessionsController < ApplicationController
 
   private def assign_active_directory_user_group_ids
     registered_user.update_attribute(:active_directory_user_group_ids, active_directory_user_group_ids)
+  end
+
+  private def update_latest_session_for_user
+    registered_user.update(latest_session: DateTime.now)
   end
 
   private def authenticated_user_info

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -1,0 +1,7 @@
+module UserHelper
+  def last_seen_datetime(user)
+    return "N/A" unless user.active
+    return "N/A" if user.latest_session.nil?
+    user.latest_session.to_formatted_s(:govuk_date_time)
+  end
+end

--- a/app/views/users/_users_table.html.erb
+++ b/app/views/users/_users_table.html.erb
@@ -6,6 +6,7 @@
       <th class="govuk-table__header" scope="col"><%= t("user.table.headers.email") %></th>
       <th class="govuk-table__header" scope="col"><%= t("user.table.headers.team") %></th>
       <th class="govuk-table__header" scope="col"><%= t("user.table.headers.team_lead") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("user.table.headers.last_seen") %></th>
       <th class="govuk-table__header" scope="col"><%= t("user.table.headers.edit_user") %></th>
     </tr>
   </thead>
@@ -16,9 +17,10 @@
       <td class="govuk-table__cell"><%= account.email %></td>
       <td class="govuk-table__cell"><%= account.team.nil? ? "No team" : t("user.teams.#{account.team}") %></td>
       <td class="govuk-table__cell"><%= t("user.table.body.team_lead.#{account.manage_team}") %></td>
-        <td class="govuk-table__cell">
-          <%= link_to t("user.table.body.edit_user_html", user: account.full_name), edit_user_path(account) %>
-        </td>
+      <td class="govuk-table__cell"><%= last_seen_datetime(account) %></td>
+      <td class="govuk-table__cell">
+        <%= link_to t("user.table.body.edit_user_html", user: account.full_name), edit_user_path(account) %>
+      </td>
     </tr>
   <% end %>
   </tbody>

--- a/config/locales/user.en.yml
+++ b/config/locales/user.en.yml
@@ -43,6 +43,7 @@ en:
         team: Team
         team_lead: Team lead
         edit_user: Edit user
+        last_seen: Last seen
       body:
         team_lead:
           "true": "Yes"

--- a/db/migrate/20230804140435_add_last_session_column_to_users.rb
+++ b/db/migrate/20230804140435_add_last_session_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastSessionColumnToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :latest_session, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -240,6 +240,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_07_151713) do
     t.datetime "deactivated_at"
     t.boolean "manage_conversion_urns", default: false
     t.boolean "manage_local_authorities", default: false
+    t.datetime "latest_session"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/features/users/users_can_manage_user_accounts_spec.rb
+++ b/spec/features/users/users_can_manage_user_accounts_spec.rb
@@ -111,7 +111,7 @@ RSpec.feature "Users can manage user accounts" do
     end
   end
 
-  context "then the users team is nil becuase it is a legacy account" do
+  context "then the users team is nil because it is a legacy account" do
     scenario "no team is shown" do
       other_user = User.new(
         first_name: "First",
@@ -128,6 +128,23 @@ RSpec.feature "Users can manage user accounts" do
       within("tbody") do
         expect(page).to have_content("No team")
       end
+    end
+  end
+
+  scenario "the user's last session datetime is shown" do
+    date = DateTime.new(2023, 0o1, 0o1, 10, 30, 0o0, 0)
+    _other_user = create(:user, :caseworker, latest_session: date)
+
+    sign_in_with_user(user)
+
+    visit users_path
+
+    within("thead") do
+      expect(page).to have_content("Last seen")
+    end
+
+    within("tbody") do
+      expect(page).to have_content(date.to_formatted_s(:govuk_date_time))
     end
   end
 end

--- a/spec/helpers/user_helper_spec.rb
+++ b/spec/helpers/user_helper_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe UserHelper, type: :helper do
+  describe "#last_seen_datetime" do
+    context "with an active user" do
+      it "shows the formatted latest_session date" do
+        user = create(:user, latest_session: DateTime.new(2023, 1, 1, 10, 30, 0, 0))
+        expect(helper.last_seen_datetime(user)).to eq("1 January 2023 10:30")
+      end
+    end
+
+    context "with an inactive user" do
+      it "shows not applicable" do
+        user = create(:user, latest_session: DateTime.new(2023, 1, 1, 10, 30, 0, 0), deactivated_at: DateTime.now)
+        expect(helper.last_seen_datetime(user)).to eq("N/A")
+      end
+    end
+
+    context "with an active user who has never logged in" do
+      it "shows not applicable" do
+        user = create(:user, latest_session: nil)
+        expect(helper.last_seen_datetime(user)).to eq("N/A")
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe User do
     it { is_expected.to have_db_column(:active_directory_user_group_ids).of_type :string }
     it { is_expected.to have_db_column(:team).of_type :string }
     it { is_expected.to have_db_column(:deactivated_at).of_type :datetime }
+    it { is_expected.to have_db_column(:latest_session).of_type :datetime }
   end
 
   describe "scopes" do

--- a/spec/requests/sign_in_spec.rb
+++ b/spec/requests/sign_in_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe "Sign in" do
     expect(user.reload.active_directory_user_group_ids).to eql(test_group_ids)
   end
 
+  it "updates the latest_session column on the user" do
+    freeze_time
+    mock_successful_authentication(user.email)
+
+    get "/auth/azure_activedirectory_v2/callback"
+    expect(user.reload.latest_session).to eq(DateTime.now)
+  end
+
   context "when the users is not known by the application" do
     before { mock_successful_authentication("user@education.gov.uk") }
 


### PR DESCRIPTION


## Changes

When a user logs in (creates a session), store a DateTime in the `latest_session` column on the user. This value will update each time a user creates a session.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
