### PR TITLE
Add All conditions met? task to Transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add "Outgoing trust" category to External contacts
 - Show user counts by team on the statistics page
+- Add All conditions met? task to Transfer projects
 
 ### Changed
 

--- a/app/forms/transfer/task/conditions_met_task_form.rb
+++ b/app/forms/transfer/task/conditions_met_task_form.rb
@@ -1,0 +1,3 @@
+class Transfer::Task::ConditionsMetTaskForm < BaseTaskForm
+  attribute :confirm_all_conditions_met, :boolean
+end

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -26,10 +26,6 @@ class Conversion::Project < Project
     :voluntary
   end
 
-  def all_conditions_met?
-    tasks_data.conditions_met_confirm_all_conditions_met?
-  end
-
   def grant_payment_certificate_received?
     user = assigned_to
     tasks = Conversion::Task::ReceiveGrantPaymentCertificateTaskForm.new(tasks_data, user)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -99,6 +99,10 @@ class Project < ApplicationRecord
     :not_applicable
   end
 
+  def all_conditions_met?
+    tasks_data.conditions_met_confirm_all_conditions_met?
+  end
+
   private def fetch_member_of_parliament
     Api::MembersApi::Client.new.member_for_constituency(establishment.parliamentary_constituency)
   end

--- a/app/models/transfer/project.rb
+++ b/app/models/transfer/project.rb
@@ -19,11 +19,6 @@ class Transfer::Project < Project
     false
   end
 
-  def all_conditions_met?
-    # TODO: Replace with task value once task data is added
-    false
-  end
-
   private def outgoing_trust_exists
     outgoing_trust
   rescue Api::AcademiesApi::Client::NotFoundError

--- a/app/models/transfer/task_list.rb
+++ b/app/models/transfer/task_list.rb
@@ -6,6 +6,12 @@ class Transfer::TaskList < ::BaseTaskList
         tasks: [
           Transfer::Task::StakeholderKickOffTaskForm
         ]
+      },
+      {
+        identifier: :get_ready_for_opening,
+        tasks: [
+          Transfer::Task::ConditionsMetTaskForm
+        ]
       }
     ]
   end

--- a/app/views/transfers/tasks/conditions_met/edit.html.erb
+++ b/app/views/transfers/tasks/conditions_met/edit.html.erb
@@ -1,0 +1,39 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "transfers/tasks/shared/back_link", locals: {project_id: @project.id} %>
+<% end %>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-9">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @project.establishment.name %></span>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2"><%= t("transfer.task.conditions_met.title") %></h1>
+
+    <div class="app-task-hint">
+      <% date = @project.transfer_date || @project.provisional_transfer_date %>
+      <%= t("transfer.task.conditions_met.hint.html", date: date.to_fs(:govuk)) %>
+    </div>
+
+    <%= govuk_details(summary_text: t("transfer.task.conditions_met.guidance_link")) do %>
+      <%= t("transfer.task.conditions_met.guidance.html") %>
+    <% end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :confirm_all_conditions_met)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/app/views/transfers/tasks/shared/_back_link.erb
+++ b/app/views/transfers/tasks/shared/_back_link.erb
@@ -1,0 +1,3 @@
+<nav aria-label="back link">
+  <%= govuk_back_link(href: project_tasks_path(project_id)) %>
+</nav>

--- a/config/locales/transfer/task_list.en.yml
+++ b/config/locales/transfer/task_list.en.yml
@@ -1,0 +1,7 @@
+en:
+  transfer:
+    task_list:
+      project_kick_off:
+        title: Project kick-off
+      get_ready_for_opening:
+        title: Get ready for opening

--- a/config/locales/transfer/tasks/conditions_met.en.yml
+++ b/config/locales/transfer/tasks/conditions_met.en.yml
@@ -1,0 +1,27 @@
+en:
+  transfer:
+    task:
+      conditions_met:
+        title: Confirm all conditions have been met
+        hint:
+          html:
+            "The deadline for meeting all conditions is in the email you got from the ADOP (Academies Delivery Operational Practice) team. All conditions must be met before the deadline or the school will not be able to convert on %{date}"
+        guidance_link: How to check all conditions have been met
+        guidance:
+          html:
+            <p>You need to check that:</p>
+            <ul>
+              <li>legal documents are cleared</li>
+              <li>legal documents are signed by the necessary people</li>
+              <li>the school have confirmed all of their actions are complete</li>
+            </ul>
+
+        confirm_all_conditions_met:
+          title: Confirm all conditions are met
+          hint:
+            html:
+              <p>This will change the transfer's status on the academy openers list. ADOP use that list to prepare funding agreement letters.</p>
+          guidance_link: What to do if conditions are not met
+          guidance:
+            html:
+              <p>You must agree a new transfer date with all stakeholders, then change transfer date recorded in this project.</p>

--- a/db/migrate/20230807105235_add_all_conditions_met_task_to_transfers.rb
+++ b/db/migrate/20230807105235_add_all_conditions_met_task_to_transfers.rb
@@ -1,0 +1,5 @@
+class AddAllConditionsMetTaskToTransfers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :transfer_tasks_data, :conditions_met_confirm_all_conditions_met, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_01_082723) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_07_105235) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -215,6 +215,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_01_082723) do
   create_table "transfer_tasks_data", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "conditions_met_confirm_all_conditions_met"
   end
 
   create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/models/transfer/project_spec.rb
+++ b/spec/models/transfer/project_spec.rb
@@ -40,9 +40,23 @@ RSpec.describe Transfer::Project do
     end
   end
 
-  describe "#all_conditions_met" do
-    it "returns false" do
-      expect(described_class.new.all_conditions_met?).to be false
+  describe "#all_conditions_met?" do
+    context "when the all conditions met task is completed" do
+      let(:tasks_data) { create(:transfer_tasks_data, conditions_met_confirm_all_conditions_met: true) }
+      let(:project) { build(:transfer_project, tasks_data: tasks_data) }
+
+      it "returns true" do
+        expect(project.all_conditions_met?).to eq(true)
+      end
+    end
+
+    context "when the all conditions met task has not been completed" do
+      let(:tasks_data) { create(:transfer_tasks_data, conditions_met_confirm_all_conditions_met: nil) }
+      let(:project) { build(:transfer_project, tasks_data: tasks_data) }
+
+      it "returns false" do
+        expect(project.all_conditions_met?).to eq(false)
+      end
     end
   end
 end


### PR DESCRIPTION


## Changes

This task is identical to the same task for Conversions, including the same content (with references to Conversions changed to Transfers).

There's no need for any migrations here as the Transfer and Conversion projects store their task data in different tables.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
