### PR TITLE
Change grants team email address to their new one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - add simple side navigation to the statistics page
 - the Director of Child Services contact information is now in the External
   contacts area, not the Local authority information area.
+- updated grants team email address
 
 ### Fixed
 

--- a/config/locales/conversion/tasks/conversion_grant.en.yml
+++ b/config/locales/conversion/tasks/conversion_grant.en.yml
@@ -41,7 +41,7 @@ en:
           guidance:
             html:
               <p>You'll find the academy order, application to convert and grant claim form in the school's SharePoint folder.</p>
-              <p>You should send the documents to the Grant Payments team by email at <a href="mailto:cfugrantpayments.regionsgroup@education.gov.uk" target="_blank">cfugrantpayments.regionsgroup@education.gov.uk</a>.</p>
+              <p>You should send the documents to the Grant Payments team by email at <a href="mailto:grantpaymentandrecoveries.regionsgroup@education.gov.uk" target="_blank">grantpaymentandrecoveries.regionsgroup@education.gov.uk</a>.</p>
               <p>The subject line of the email must include the:</p>
               <ul>
                 <li>region the school is in</li>

--- a/config/locales/conversion/tasks/sponsored_support_grant.en.yml
+++ b/config/locales/conversion/tasks/sponsored_support_grant.en.yml
@@ -91,7 +91,7 @@ en:
               <p>You'll find the directive academy order and grant claim form in the
               school's SharePoint folder.</p>
               <p>You should send the documents to the Grant Payments team by email at
-              <a href="mailto:cfugrantpayments.regionsgroup@education.gov.uk" class="govuk-link" target="_blank">cfugrantpayments.regionsgroup@education.gov.uk</a>.</p>
+              <a href="mailto:grantpaymentandrecoveries.regionsgroup@education.gov.uk" class="govuk-link" target="_blank">grantpaymentandrecoveries.regionsgroup@education.gov.uk</a>.</p>
               <p>The subject line of the email must include the:</p>
               <ul class="govuk-list govuk-list--bullet">
               <li>region the school is in</li>


### PR DESCRIPTION
## Changes

RCS told us the email address for the grants team has changed. This work corrects email address we use to the new one.

It affects 2 tasks. `Process the conversion grant` and `Confirm and process the sponsored support grant`.

## Before

![Screenshot 2023-08-08 at 10 22 35 am](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/be0e8249-8e03-4f1e-bba4-e11cc63ea8a1)

![Screenshot 2023-08-08 at 10 22 59 am](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/3edf1aa0-9004-4706-8865-af1c0145216c)

## After

![Screenshot 2023-08-08 at 10 23 27 am](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/487157c0-b303-405a-a3e1-8fda72ada253)

![Screenshot 2023-08-08 at 10 23 45 am](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/e7660a46-cc26-4222-bb2a-b1baeca9841f)


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
