### PR TITLE
Add more actions to the Stakeholder Kick-off task for Transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add "Outgoing trust" category to External contacts
 - Show user counts by team on the statistics page
 - Add a Handover task to Transfer projects
+- Add more actions to the Stakeholder kick-off task for Transfers
 
 ### Changed
 

--- a/app/forms/transfer/task/stakeholder_kick_off_task_form.rb
+++ b/app/forms/transfer/task/stakeholder_kick_off_task_form.rb
@@ -1,6 +1,10 @@
 class Transfer::Task::StakeholderKickOffTaskForm < BaseTaskForm
   include TransferDatable
 
+  attribute :introductory_emails, :boolean
+  attribute :setup_meeting, :boolean
+  attribute :meeting, :boolean
+
   def initialize(tasks_data, user)
     @tasks_data = tasks_data
     @user = user
@@ -17,6 +21,12 @@ class Transfer::Task::StakeholderKickOffTaskForm < BaseTaskForm
         user: @user
       ).update!
     end
+
+    @tasks_data.assign_attributes(
+      stakeholder_kick_off_introductory_emails: introductory_emails,
+      stakeholder_kick_off_setup_meeting: setup_meeting,
+      stakeholder_kick_off_meeting: meeting
+    )
 
     @tasks_data.save!
   end

--- a/app/views/transfers/tasks/stakeholder_kick_off/edit.html.erb
+++ b/app/views/transfers/tasks/stakeholder_kick_off/edit.html.erb
@@ -9,6 +9,11 @@
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
       <%= form.govuk_error_summary %>
 
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :introductory_emails)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :setup_meeting)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :meeting)) %>
+
         <% if @project.transfer_date_provisional? %>
           <%= form.govuk_date_field :confirmed_transfer_date,
                 omit_day: true,
@@ -24,6 +29,7 @@
           <% end %>
 
         <% end %>
+      </div>
 
       <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
     <% end %>

--- a/config/locales/transfer/tasks/stakeholder_kick_off.en.yml
+++ b/config/locales/transfer/tasks/stakeholder_kick_off.en.yml
@@ -8,6 +8,41 @@ en:
             <p>This is where you make sure everyone involved in the transfer knows what they need to do, and when to do it, so the school can transfer on time.</p>
             <p>This is also a good opportunity to talk about common problems and how to avoid them.</p>
 
+        introductory_emails:
+          title: Send introductory emails
+          hint:
+            html: <p>Email the outgoing trust, the incoming trust and their solicitors. Email the diocese too if this is a faith school.</p>
+          guidance_link: What to include in introductory emails
+          guidance:
+            html:
+              <p>You can <a href="https://educationgovuk.sharepoint.com/:w:/r/sites/ServiceDeliveryDirectorate/_layouts/15/doc2.aspx?sourcedoc=%7BB09ACD14-DB17-4AEC-8E72-589553B85CB9%7D&file=TRANSFERS_Trust_Email_Template.docx&action=default&mobileredirect=true" target="_blank">choose an email template (opens in new tab)</a> to help you write your introductory emails. There are templates for the outgoing trust, incoming trust and their solicitors.</p>
+              <p>This will help you to:</p>
+              <ul>
+              <li>organise kick-off meetings</li>
+              <li>clarify roles and expectation</li>
+              <li>establish dates and deadlines</li>
+              <li>provide links to documents that need to be completed</li>
+              <li>agree ways of working</li>
+              </ul>
+              <p>You should aim to do this in the first week after you have been assigned the project.</p>
+              <p>Ideally the kick-off meeting should take place within the first two weeks.</p>
+        setup_meeting:
+          title: Send invites to the kick-off meeting or call
+          hint:
+            html: <p>Check who the outgoing and incoming trust would like to attend the kick-off meeting.</p>
+          guidance_link: How to arrange the kick-off meeting
+          guidance:
+            html:
+              <p>You should have included possible dates for the kick-off meeting in your introductory email.</p>
+              <p>Once the trusts have got back to you with a suitable date and list of attendees, send out invites to arrange the time, date and location of the meeting. It's likely to be a video call over Microsoft Teams.</p>
+              <p>Some trusts may prefer to have a one-to-one call with you, rather than a meeting involving all stakeholders.</p>
+        meeting:
+          title: Host the kick-off meeting or call
+          hint:
+            html:
+              <p>Make sure all attendees understand what they need to do, and when they need to do it.</p>
+              <p>You should discuss and record issues that might complicate or delay the project.</p>
+          guidance_link: What to talk about in the meeting
         confirmed_transfer_date:
           title: Enter the confirmed transfer date
           hint:

--- a/db/migrate/20230807151713_add_stakeholder_kickoff_attributes_to_transfers.rb
+++ b/db/migrate/20230807151713_add_stakeholder_kickoff_attributes_to_transfers.rb
@@ -1,0 +1,7 @@
+class AddStakeholderKickoffAttributesToTransfers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :transfer_tasks_data, :stakeholder_kick_off_introductory_emails, :boolean
+    add_column :transfer_tasks_data, :stakeholder_kick_off_setup_meeting, :boolean
+    add_column :transfer_tasks_data, :stakeholder_kick_off_meeting, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_07_114533) do
- create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+ActiveRecord::Schema[7.0].define(version: 2023_08_07_151713) do
+  create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
     t.string "title", null: false
@@ -219,6 +219,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_07_114533) do
     t.boolean "handover_notes"
     t.boolean "handover_meeting"
     t.boolean "handover_not_applicable"
+    t.boolean "stakeholder_kick_off_introductory_emails"
+    t.boolean "stakeholder_kick_off_setup_meeting"
+    t.boolean "stakeholder_kick_off_meeting"
   end
 
   create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/forms/transfer/tasks/stakeholder_kick_off_task_form_spec.rb
+++ b/spec/forms/transfer/tasks/stakeholder_kick_off_task_form_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Transfer::Task::StakeholderKickOffTaskForm do
     let(:task_form) { described_class.new(tasks_data, user) }
 
     context "when the form is valid" do
-      context "and the confirmed conversion date is submitted" do
+      context "and the confirmed transfer date is submitted" do
         let(:project) { create(:transfer_project, transfer_date_provisional: true) }
 
         it "creates a new date history" do
@@ -141,16 +141,46 @@ RSpec.describe Transfer::Task::StakeholderKickOffTaskForm do
     let(:tasks_data) { project.tasks_data }
     let(:task_form) { described_class.new(tasks_data, user) }
 
-    context "when the transfer date is not confirmed" do
-      it "returns :in_progress" do
+    context "when the task has no completed actions" do
+      it "returns :not_started" do
         expect(task_form.status).to eql :not_started
       end
     end
 
-    context "when the transfer date is confirmed" do
+    context "when the task has some completed actions" do
+      it "returns :in_progress" do
+        task_form.introductory_emails = true
+
+        expect(task_form.status).to eql :in_progress
+      end
+    end
+
+    context "when the tasks are all complete but the transfer date is not confirmed" do
+      it "returns :in_progress" do
+        task_form.introductory_emails = true
+        task_form.setup_meeting = true
+        task_form.meeting = true
+
+        expect(task_form.status).to eql :in_progress
+      end
+    end
+
+    context "when only the transfer date is confirmed" do
+      let(:project) { create(:transfer_project, transfer_date_provisional: false) }
+
+      it "returns :in_progress" do
+        expect(task_form.status).to eql :in_progress
+      end
+    end
+
+    context "when the task has all completed actions and confirmed the transfer date" do
       let(:project) { create(:transfer_project, transfer_date_provisional: false) }
 
       it "returns :completed" do
+        task_form.introductory_emails = true
+        task_form.setup_meeting = true
+        task_form.meeting = true
+
         expect(task_form.status).to eql :completed
       end
     end


### PR DESCRIPTION

## Changes

Add the remaining actions to this task. This is much like the Stakeholder Kick- off task for Conversions with slightly different wording.

<img width="922" alt="Screenshot 2023-08-08 at 15 18 27" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/e381849f-bdaf-402a-83c3-7a5e49c24a07">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
