### PR TITLE
Add All conditions met? for Transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add a Deed of novation and variation task to Transfer projects
 - Add Articles of Association task to Transfer projects
 - Add commercial transfer agreement task to Transfer projects
+- Add All conditions met? task to Transfer projects
 
 ### Changed
 

--- a/app/controllers/your/projects_controller.rb
+++ b/app/controllers/your/projects_controller.rb
@@ -4,7 +4,7 @@ class Your::ProjectsController < ApplicationController
 
   def in_progress
     authorize Project, :index?
-    @pager, @projects = pagy(Project.assigned_to(current_user).in_progress.includes(:tasks_data).ordered_by_significant_date, items: 10)
+    @pager, @projects = pagy(Project.assigned_to(current_user).in_progress.ordered_by_significant_date, items: 10)
 
     AcademiesApiPreFetcherService.new.call!(@projects)
   end

--- a/app/forms/conversion/task/conditions_met_task_form.rb
+++ b/app/forms/conversion/task/conditions_met_task_form.rb
@@ -1,3 +1,15 @@
 class Conversion::Task::ConditionsMetTaskForm < BaseTaskForm
   attribute :confirm_all_conditions_met, :boolean
+
+  def initialize(tasks_data, user)
+    @tasks_data = tasks_data
+    @user = user
+    @project = @tasks_data.project
+    super(@tasks_data, @user)
+    self.confirm_all_conditions_met = @project.all_conditions_met
+  end
+
+  def save
+    @project.update(all_conditions_met: confirm_all_conditions_met)
+  end
 end

--- a/app/forms/transfer/task/conditions_met_task_form.rb
+++ b/app/forms/transfer/task/conditions_met_task_form.rb
@@ -1,0 +1,15 @@
+class Transfer::Task::ConditionsMetTaskForm < BaseTaskForm
+  attribute :confirm_all_conditions_met, :boolean
+
+  def initialize(tasks_data, user)
+    @tasks_data = tasks_data
+    @user = user
+    @project = @tasks_data.project
+    super(@tasks_data, @user)
+    self.confirm_all_conditions_met = @project.all_conditions_met
+  end
+
+  def save
+    @project.update!(all_conditions_met: confirm_all_conditions_met)
+  end
+end

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -26,10 +26,6 @@ class Conversion::Project < Project
     :voluntary
   end
 
-  def all_conditions_met?
-    tasks_data.conditions_met_confirm_all_conditions_met?
-  end
-
   def grant_payment_certificate_received?
     user = assigned_to
     tasks = Conversion::Task::ReceiveGrantPaymentCertificateTaskForm.new(tasks_data, user)

--- a/app/models/transfer/project.rb
+++ b/app/models/transfer/project.rb
@@ -19,11 +19,6 @@ class Transfer::Project < Project
     false
   end
 
-  def all_conditions_met?
-    # TODO: Replace with task value once task data is added
-    false
-  end
-
   private def outgoing_trust_exists
     outgoing_trust
   rescue Api::AcademiesApi::Client::NotFoundError

--- a/app/models/transfer/task_list.rb
+++ b/app/models/transfer/task_list.rb
@@ -16,6 +16,12 @@ class Transfer::TaskList < ::BaseTaskList
           Transfer::Task::ArticlesOfAssociationTaskForm,
           Transfer::Task::CommercialTransferAgreementTaskForm
         ]
+      },
+      {
+        identifier: :get_ready_for_opening,
+        tasks: [
+          Transfer::Task::ConditionsMetTaskForm
+        ]
       }
     ]
   end

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -22,7 +22,7 @@ class Export::Csv::ProjectPresenter
   end
 
   def all_conditions_met
-    if @project.tasks_data.conditions_met_confirm_all_conditions_met.nil?
+    if @project.all_conditions_met.nil?
       return I18n.t("export.csv.project.values.no")
     end
 

--- a/app/services/by_month_project_fetcher_service.rb
+++ b/app/services/by_month_project_fetcher_service.rb
@@ -4,7 +4,7 @@ class ByMonthProjectFetcherService
   end
 
   def confirmed(month, year)
-    projects = Project.includes(:tasks_data).confirmed.filtered_by_significant_date(month, year)
+    projects = Project.confirmed.filtered_by_significant_date(month, year)
 
     AcademiesApiPreFetcherService.new.call!(projects) if @pre_fetch_academies_api
     sort_by_conditions_met_and_name(projects)
@@ -19,9 +19,9 @@ class ByMonthProjectFetcherService
 
   def confirmed_openers_by_team(month, year, team)
     projects = if team.eql?("regional_casework_services")
-      Project.assigned_to_regional_caseworker_team.includes(:tasks_data).confirmed.filtered_by_significant_date(month, year)
+      Project.assigned_to_regional_caseworker_team.confirmed.filtered_by_significant_date(month, year)
     else
-      Project.not_assigned_to_regional_caseworker_team.by_region(team).includes(:tasks_data).confirmed.filtered_by_significant_date(month, year)
+      Project.not_assigned_to_regional_caseworker_team.by_region(team).confirmed.filtered_by_significant_date(month, year)
     end
 
     AcademiesApiPreFetcherService.new.call!(projects) if @pre_fetch_academies_api
@@ -30,9 +30,9 @@ class ByMonthProjectFetcherService
 
   def revised_openers_by_team(month, year, team)
     projects = if team.eql?("regional_casework_services")
-      Project.assigned_to_regional_caseworker_team.includes(:tasks_data).significant_date_revised_from(month, year)
+      Project.assigned_to_regional_caseworker_team.significant_date_revised_from(month, year)
     else
-      Project.not_assigned_to_regional_caseworker_team.by_region(team).includes(:tasks_data).significant_date_revised_from(month, year)
+      Project.not_assigned_to_regional_caseworker_team.by_region(team).significant_date_revised_from(month, year)
     end
 
     AcademiesApiPreFetcherService.new.call!(projects) if @pre_fetch_academies_api

--- a/app/views/transfers/tasks/conditions_met/edit.html.erb
+++ b/app/views/transfers/tasks/conditions_met/edit.html.erb
@@ -1,0 +1,36 @@
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-9">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @project.establishment.name %></span>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2"><%= t("transfer.task.conditions_met.title") %></h1>
+
+    <div class="app-task-hint">
+      <%= t("transfer.task.conditions_met.hint.html", date: @project.transfer_date.to_fs(:govuk)) %>
+    </div>
+
+    <%= govuk_details(summary_text: t("transfer.task.conditions_met.guidance_link")) do %>
+      <%= t("transfer.task.conditions_met.guidance.html") %>
+    <% end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :confirm_all_conditions_met)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/app/views/transfers/tasks/shared/_back_link.erb
+++ b/app/views/transfers/tasks/shared/_back_link.erb
@@ -1,0 +1,3 @@
+<nav aria-label="back link">
+  <%= govuk_back_link(href: project_tasks_path(project_id)) %>
+</nav>

--- a/config/locales/transfer/task_list.en.yml
+++ b/config/locales/transfer/task_list.en.yml
@@ -5,3 +5,5 @@ en:
         title: Project kick-off
       legal_documents:
         title: Clear and sign legal documents
+      get_ready_for_opening:
+        title: Get ready for opening

--- a/config/locales/transfer/tasks/conditions_met.en.yml
+++ b/config/locales/transfer/tasks/conditions_met.en.yml
@@ -1,0 +1,13 @@
+en:
+  transfer:
+    task:
+      conditions_met:
+        title: Confirm all conditions have been met
+        hint:
+        guidance_link: How to check all conditions have been met
+        guidance:
+        confirm_all_conditions_met:
+          title: Confirm all conditions are met
+          hint:
+          guidance_link: What to do if conditions are not met
+          guidance:

--- a/db/migrate/20230809083044_add_all_conditions_met_to_project.rb
+++ b/db/migrate/20230809083044_add_all_conditions_met_to_project.rb
@@ -1,0 +1,31 @@
+class AddAllConditionsMetToProject < ActiveRecord::Migration[7.0]
+  def up
+    add_column :projects, :all_conditions_met, :boolean, default: false
+
+    if update_all_projects
+      remove_column :conversion_tasks_data, :conditions_met_confirm_all_conditions_met, :boolean
+    end
+  end
+
+  def down
+    add_column :conversion_tasks_data, :conditions_met_confirm_all_conditions_met, :boolean
+
+    if revert_all_projects
+      remove_column :projects, :all_conditions_met, :boolean
+    end
+  end
+
+  def update_all_projects
+    Conversion::Project.all.each do |project|
+      all_conditions_met = project&.tasks_data&.conditions_met_confirm_all_conditions_met || false
+      project.update_attribute(:all_conditions_met, all_conditions_met)
+    end
+  end
+
+  def revert_all_projects
+    Conversion::Project.all.each do |project|
+      all_conditions_met = project.all_conditions_met || false
+      project.update_attribute(:all_conditions_met, all_conditions_met)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -90,7 +90,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_09_135448) do
     t.boolean "single_worksheet_send"
     t.boolean "school_completed_emailed"
     t.boolean "school_completed_saved"
-    t.boolean "conditions_met_confirm_all_conditions_met"
     t.boolean "redact_and_send_redact"
     t.boolean "redact_and_send_save_redaction"
     t.boolean "redact_and_send_send_redaction"
@@ -197,6 +196,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_09_135448) do
     t.string "team"
     t.boolean "two_requires_improvement", default: false
     t.text "outgoing_trust_sharepoint_link"
+    t.boolean "all_conditions_met", default: false
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"

--- a/spec/accessibility/projects_spec.rb
+++ b/spec/accessibility/projects_spec.rb
@@ -35,14 +35,14 @@ RSpec.feature "Test projects accessibility", driver: :headless_firefox, accessib
   scenario "project completed page" do
     tasks_data = create(:conversion_tasks_data,
       receive_grant_payment_certificate_check_and_save: true,
-      receive_grant_payment_certificate_update_kim: true,
-      conditions_met_confirm_all_conditions_met: true)
+      receive_grant_payment_certificate_update_kim: true)
     project = create(:conversion_project,
       regional_delivery_officer: user,
       assigned_to: user,
       tasks_data: tasks_data,
       conversion_date: 1.month.ago.at_beginning_of_month,
-      conversion_date_provisional: false)
+      conversion_date_provisional: false,
+      all_conditions_met: true)
     visit project_path(project)
 
     click_on I18n.t("project.complete.submit_button")

--- a/spec/factories/conversion/project_factory.rb
+++ b/spec/factories/conversion/project_factory.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     regional_delivery_officer { association :user, :regional_delivery_officer }
     tasks_data { association :conversion_tasks_data }
     team { Project.teams["london"] }
+    all_conditions_met { nil }
 
     trait :with_conditions do
       advisory_board_conditions { "The following must be met:\n 1. Must be red\n2. Must be blue\n" }

--- a/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
+++ b/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
@@ -12,14 +12,14 @@ RSpec.feature "Users can complete a conversion project" do
     let(:tasks_data) {
       create(:conversion_tasks_data,
         receive_grant_payment_certificate_check_and_save: true,
-        receive_grant_payment_certificate_update_kim: true,
-        conditions_met_confirm_all_conditions_met: true)
+        receive_grant_payment_certificate_update_kim: true)
     }
     let(:project) {
       create(:conversion_project,
         assigned_to: user,
         conversion_date: 2.months.ago.at_beginning_of_month,
         conversion_date_provisional: false,
+        all_conditions_met: true,
         tasks_data: tasks_data)
     }
 

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -13,7 +13,6 @@ RSpec.feature "Users can complete conversion tasks" do
   mandatory_tasks = %w[
     check_accuracy_of_higher_needs
     commercial_transfer_agreement
-    conditions_met
     land_questionnaire land_registry
     receive_grant_payment_certificate redact_and_send
     school_completed share_information single_worksheet
@@ -31,6 +30,7 @@ RSpec.feature "Users can complete conversion tasks" do
     funding_agreement_contact
     risk_protection_arrangement
     sponsored_support_grant
+    conditions_met
   ]
 
   it "confirms we are checking all tasks" do
@@ -204,6 +204,19 @@ RSpec.feature "Users can complete conversion tasks" do
       click_on I18n.t("task_list.continue_button.text")
 
       expect(project.reload.tasks_data.sponsored_support_grant_type).to eq "full_sponsored"
+    end
+  end
+
+  describe "the confirm all conditions met task" do
+    let(:project) { create(:conversion_project, assigned_to: user) }
+
+    scenario "they can confirm all conditions have been met" do
+      visit project_tasks_path(project)
+      click_on "Confirm all conditions have been met"
+      page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
+      click_on I18n.t("task_list.continue_button.text")
+
+      expect(project.reload.all_conditions_met).to be true
     end
   end
 

--- a/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
+++ b/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.feature "Users can complete conversion tasks" do
+  let(:user) { create(:user, :regional_delivery_officer) }
+  let(:project) { create(:transfer_project, assigned_to: user) }
+
+  before do
+    mock_all_academies_api_responses
+    sign_in_with_user(user)
+    visit project_tasks_path(project)
+  end
+
+  describe "the confirm all conditions met task" do
+    scenario "they can confirm all conditions have been met" do
+      visit project_tasks_path(project)
+      click_on "Confirm all conditions have been met"
+      page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
+      click_on I18n.t("task_list.continue_button.text")
+
+      expect(project.reload.all_conditions_met).to be true
+    end
+  end
+end

--- a/spec/features/users_can_view_a_table_of_project_openers_spec.rb
+++ b/spec/features/users_can_view_a_table_of_project_openers_spec.rb
@@ -11,8 +11,7 @@ RSpec.feature "Users can view project openers in table form" do
   context "All conditions met tag" do
     context "when a project has all conditions met" do
       it "shows the correct value" do
-        tasks_data = create(:conversion_tasks_data, conditions_met_confirm_all_conditions_met: true)
-        _project = create(:conversion_project, tasks_data: tasks_data, conversion_date: Date.new(2023, 1, 1), conversion_date_provisional: false)
+        _project = create(:conversion_project, conversion_date: Date.new(2023, 1, 1), conversion_date_provisional: false, all_conditions_met: true)
 
         visit "/projects/all/opening/confirmed/1/2023"
         expect(page).to have_content("Yes")
@@ -21,8 +20,7 @@ RSpec.feature "Users can view project openers in table form" do
 
     context "when a project does not have all conditions met" do
       it "shows the correct value" do
-        tasks_data = create(:conversion_tasks_data, conditions_met_confirm_all_conditions_met: nil)
-        _project = create(:conversion_project, tasks_data: tasks_data, conversion_date: Date.new(2023, 1, 1), conversion_date_provisional: false)
+        _project = create(:conversion_project, conversion_date: Date.new(2023, 1, 1), conversion_date_provisional: false, all_conditions_met: nil)
 
         visit "/projects/all/opening/confirmed/1/2023"
         expect(page).to have_content("Not yet")

--- a/spec/helpers/project_helper_spec.rb
+++ b/spec/helpers/project_helper_spec.rb
@@ -155,8 +155,7 @@ RSpec.describe ProjectHelper, type: :helper do
 
   describe "#all_conditions_met_value" do
     context "when all_conditions_met is true" do
-      let(:tasks_data) { create(:conversion_tasks_data, conditions_met_confirm_all_conditions_met: true) }
-      let(:project) { build(:conversion_project, tasks_data: tasks_data) }
+      let(:project) { build(:conversion_project, all_conditions_met: true) }
 
       it "returns a turquoise tag with 'yes' text" do
         expect(helper.all_conditions_met_value(project)).to eql "Yes"
@@ -164,8 +163,7 @@ RSpec.describe ProjectHelper, type: :helper do
     end
 
     context "when all_conditions_met is false" do
-      let(:tasks_data) { create(:conversion_tasks_data, conditions_met_confirm_all_conditions_met: nil) }
-      let(:project) { build(:conversion_project, tasks_data: tasks_data) }
+      let(:project) { build(:conversion_project, all_conditions_met: nil) }
 
       it "returns a blue tag with 'not started' text" do
         expect(helper.all_conditions_met_value(project)).to eql "Not yet"

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -164,26 +164,6 @@ RSpec.describe Conversion::Project do
     end
   end
 
-  describe "#all_conditions_met?" do
-    context "when the all conditions met task is completed" do
-      let(:tasks_data) { create(:conversion_tasks_data, conditions_met_confirm_all_conditions_met: true) }
-      let(:project) { build(:conversion_project, tasks_data: tasks_data) }
-
-      it "returns true" do
-        expect(project.all_conditions_met?).to eq(true)
-      end
-    end
-
-    context "when the all conditions met task has not been completed" do
-      let(:tasks_data) { create(:conversion_tasks_data, conditions_met_confirm_all_conditions_met: nil) }
-      let(:project) { build(:conversion_project, tasks_data: tasks_data) }
-
-      it "returns false" do
-        expect(project.all_conditions_met?).to eq(false)
-      end
-    end
-  end
-
   describe "#grant_payment_certificate_received?" do
     let(:user) { create(:user) }
     let(:project) { build(:conversion_project, tasks_data: tasks_data) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_db_column(:region).of_type :string }
     it { is_expected.to have_db_column(:academy_urn).of_type :integer }
     it { is_expected.to have_db_column(:team).of_type :string }
+    it { is_expected.to have_db_column(:all_conditions_met).of_type :boolean }
   end
 
   describe "Relationships" do
@@ -578,6 +579,24 @@ RSpec.describe Project, type: :model do
 
     it "has the expected enum values" do
       expect(Project.teams.count).to eq(10)
+    end
+  end
+
+  describe "#all_conditions_met?" do
+    context "when the all conditions met task is completed" do
+      let(:project) { build(:conversion_project, all_conditions_met: true) }
+
+      it "returns true" do
+        expect(project.all_conditions_met?).to eq(true)
+      end
+    end
+
+    context "when the all conditions met task has not been completed" do
+      let(:project) { build(:conversion_project, all_conditions_met: nil) }
+
+      it "returns false" do
+        expect(project.all_conditions_met?).to eq(false)
+      end
     end
   end
 

--- a/spec/models/transfer/project_spec.rb
+++ b/spec/models/transfer/project_spec.rb
@@ -39,10 +39,4 @@ RSpec.describe Transfer::Project do
       end
     end
   end
-
-  describe "#all_conditions_met" do
-    it "returns false" do
-      expect(described_class.new.all_conditions_met?).to be false
-    end
-  end
 end

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -113,8 +113,7 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents all conditions met" do
-    tasks_data = double(Conversion::TasksData, conditions_met_confirm_all_conditions_met: true)
-    project = double(Conversion::Project, tasks_data: tasks_data)
+    project = double(Conversion::Project, all_conditions_met: true)
 
     presenter = described_class.new(project)
 
@@ -122,8 +121,7 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents all conditions met when it has not been met" do
-    tasks_data = double(Conversion::TasksData, conditions_met_confirm_all_conditions_met: nil)
-    project = double(Conversion::Project, tasks_data: tasks_data)
+    project = double(Conversion::Project, all_conditions_met: nil)
 
     presenter = described_class.new(project)
 


### PR DESCRIPTION
## Changes

Previously, the `all_conditions_met?` value for a Conversion::Project was determined by its
TasksData, on the `conditions_met_confirm_all_conditions_met` task.

Move this value up to be a native attribute on Project. This reduces a lot of
eager loading and makes the Project model simpler, although it does mean that
the "Conditions met" task becomes another "special case" task.

The All conditions met? task for Transfers is identical to the same task for Conversions, including the same
content (with references to Conversions changed to Transfers).

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
