### PR TITLE
Add Articles of Association task to Transfer projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Show the time of the user's latest session in the User table, as "Last seen"
 - Add master funding agreement task to Transfer projects
 - Add a Deed of novation and variation task to Transfer projects
+- Add Articles of Association task to Transfer projects
 
 ### Changed
 

--- a/app/forms/transfer/task/articles_of_association_task_form.rb
+++ b/app/forms/transfer/task/articles_of_association_task_form.rb
@@ -1,0 +1,6 @@
+class Transfer::Task::ArticlesOfAssociationTaskForm < BaseOptionalTaskForm
+  attribute :received, :boolean
+  attribute :cleared, :boolean
+  attribute :signed, :boolean
+  attribute :saved, :boolean
+end

--- a/app/models/transfer/task_list.rb
+++ b/app/models/transfer/task_list.rb
@@ -12,7 +12,8 @@ class Transfer::TaskList < ::BaseTaskList
         identifier: :legal_documents,
         tasks: [
           Transfer::Task::MasterFundingAgreementTaskForm,
-          Transfer::Task::DeedOfNovationAndVariationTaskForm
+          Transfer::Task::DeedOfNovationAndVariationTaskForm,
+          Transfer::Task::ArticlesOfAssociationTaskForm
         ]
       }
     ]

--- a/app/views/transfers/tasks/articles_of_association/edit.html.erb
+++ b/app/views/transfers/tasks/articles_of_association/edit.html.erb
@@ -1,0 +1,40 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
+      <div class="govuk-form-group">
+        <h2 class="govuk-heading-l"><%= t("transfer.task.articles_of_association.clear_section.title") %></h2>
+        <div class="app-task-section__hint">
+          <%= t("transfer.task.articles_of_association.clear_section.hint.html") %>
+        </div>
+
+        <%= govuk_details(
+              summary_text: t("transfer.task.articles_of_association.clear_section.guidance_link"),
+              text: t("transfer.task.articles_of_association.clear_section.guidance.html")
+            ) %>
+
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :received)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :cleared)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/config/locales/transfer/task_list.en.yml
+++ b/config/locales/transfer/task_list.en.yml
@@ -1,0 +1,7 @@
+en:
+  transfer:
+    task_list:
+      project_kick_off:
+        title: Project kick-off
+      legal_documents:
+        title: Clear and sign legal documents

--- a/config/locales/transfer/tasks/articles_of_association.en.yml
+++ b/config/locales/transfer/tasks/articles_of_association.en.yml
@@ -1,0 +1,34 @@
+en:
+  transfer:
+    task:
+      articles_of_association:
+        title: Articles of association
+        hint:
+          html:
+            <p>You must update the articles of association if any of the following statements are true:</p>
+            <ul>
+            <li>the trust currently uses a version from February 2016 or earlier</li>
+            <li>a different type of academy is joining the trust (for example, a Church of England academy joining a trust containing only community academies)</li>
+            <li>it is a condition of the advisory board's decision</li>
+            </ul>
+            <p>You do not always need to update the articles but it is strongly advised, even when not required.</p>
+        clear_section:
+          title: Check and clear the articles of association
+          hint:
+            html: <p>You can use the <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Academy-Governance-(includes-clearing-Articles-of-Association).aspx" target="_blank">academy governance guidance (opens in new tab)</a> to help you check and clear the articles of association.</p>
+          guidance_link: Help checking for changes
+          guidance:
+            html:
+              <p>Changes that personalise the model documents to a school or trust, and remove or add optional clauses, are expected. The wording of clauses should not change.</p>
+              <p>You'll need to <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Commissioning%20Form.aspx" target="_blank">contact the policy team (opens in new tab)</a> about changes to clause text.</p>
+
+        received:
+          title: Received
+        cleared:
+          title: Cleared
+        signed:
+          title: Signed by school or trust
+        saved:
+          title: Saved in the school's SharePoint folder
+        not_applicable:
+          title: Not applicable

--- a/db/migrate/20230809134700_add_transfer_articles_of_association_task_attributes.rb
+++ b/db/migrate/20230809134700_add_transfer_articles_of_association_task_attributes.rb
@@ -1,0 +1,9 @@
+class AddTransferArticlesOfAssociationTaskAttributes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :transfer_tasks_data, :articles_of_association_received, :boolean
+    add_column :transfer_tasks_data, :articles_of_association_cleared, :boolean
+    add_column :transfer_tasks_data, :articles_of_association_signed, :boolean
+    add_column :transfer_tasks_data, :articles_of_association_saved, :boolean
+    add_column :transfer_tasks_data, :articles_of_association_not_applicable, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -235,6 +235,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_09_134700) do
     t.boolean "deed_of_novation_and_variation_saved"
     t.boolean "deed_of_novation_and_variation_signed_secretary_state"
     t.boolean "deed_of_novation_and_variation_sent"
+    t.boolean "articles_of_association_received"
+    t.boolean "articles_of_association_cleared"
+    t.boolean "articles_of_association_signed"
+    t.boolean "articles_of_association_saved"
+    t.boolean "articles_of_association_not_applicable"
   end
 
   create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|


### PR DESCRIPTION


## Changes

This task is much like the same one for Conversion projects except with slightly different wording.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
