### PR TITLE
Release 38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release 38][release-38]
+
 ### Added
 
 - Add "Outgoing trust" category to External contacts
@@ -1213,7 +1215,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-37...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-38...HEAD
+[release-38]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-37...release-38
 [release-37]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-36...release-37
 [release-36]:


### PR DESCRIPTION
Added

- Add "Outgoing trust" category to External contacts
- Show user counts by team on the statistics page
- Add a Handover task to Transfer projects
- Add more actions to the Stakeholder kick-off task for Transfers
- Store the DateTime of a user's latest session (the last time they logged in)
- Show the time of the user's latest session in the User table, as "Last seen"
- Add master funding agreement task to Transfer projects
- Add a Deed of novation and variation task to Transfer projects
- Add Articles of Association task to Transfer projects
- Add commercial transfer agreement task to Transfer projects
- Add All conditions met? task to Transfer projects
- Add Supplmental funding agreement task to Transfer projects
- Add Deed of Variation task to Transfer projects

Changed

- removed erroneous additional s from Address on the project information page
- used details components to chunk up the guidance in the notification of change task to improve readability
- removed extra the from notifcation of change task and add a transfer form
- add simple side navigation to the statistics page
- the Director of Child Services contact information is now in the External contacts area, not the Local authority information area.
- updated grants team email address
- added C of E/cofe issue to accessibility statement
- do not send any mails to deactivated users
- Amended all table views to be able to display a conversion project as well as a transfer project
- Remove the View project column from the table views and make the school name link to the project view instead

Fixed

- The all projects in-progress table is sorted by the conversion or transfer date.


