### PR TITLE
Bring the flash messages inline with GOV.uk styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Every page now has a unique page title
 
+### Changed
+
+- Bring the flash banners in line with GOV.uk styles
+
 ## [Release 38][release-38]
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,8 @@ gem "mail-notify"
 
 gem "high_voltage"
 
+gem "nokogiri"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -457,6 +457,7 @@ DEPENDENCIES
   govuk_markdown
   high_voltage
   mail-notify
+  nokogiri
   omniauth
   omniauth-azure-activedirectory-v2
   omniauth-rails_csrf_protection

--- a/app/components/notification_banner.html.erb
+++ b/app/components/notification_banner.html.erb
@@ -1,26 +1,28 @@
 <% if @flashes.present? %>
   <% @flashes.each do |type, msg| %>
     <% if type == "notice" %>
-    <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-      <div class="govuk-notification-banner__header">
-        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-          Success
-        </h2>
-      </div>
-    <% else %>
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-      <div class="govuk-notification-banner__header">
-        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-          Important
-        </h2>
-      </div>
-    <% end %>
-      <div class="govuk-notification-banner__content">
-        <div class="flash <%= type %>">
-          <%= msg.html_safe %>
+      <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Success
+          </h2>
+        </div>
+        <div class="govuk-notification-banner__content flash">
+          <%= notification_banner_html(msg) %>
         </div>
       </div>
-    </div>
+    <% else %>
+      <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Important
+          </h2>
+        </div>
+        <div class="govuk-notification-banner__content flash">
+          <%= notification_banner_html(msg) %>
+        </div>
+      </div>
+    <% end %>
   <% end %>
 <% end %>
 
@@ -31,10 +33,8 @@
           Important
         </h2>
       </div>
-      <div class="govuk-notification-banner__content">
-        <div class="flash">
-          <%= @message.html_safe %>
-        </div>
+      <div class="govuk-notification-banner__content flash">
+        <%= notification_banner_html(@message) %>
       </div>
     </div>
 <% end %>

--- a/app/components/notification_banner.rb
+++ b/app/components/notification_banner.rb
@@ -1,4 +1,6 @@
 class NotificationBanner < ViewComponent::Base
+  delegate :notification_banner_html, to: :helpers
+
   def initialize(flashes: nil, message: nil)
     @flashes = flashes
     @message = message

--- a/app/helpers/notification_helper.rb
+++ b/app/helpers/notification_helper.rb
@@ -1,0 +1,12 @@
+require "nokogiri"
+
+module NotificationHelper
+  def notification_banner_html(message)
+    parsed_message = Nokogiri.parse(message)
+    if parsed_message.children.count > 0
+      message.html_safe
+    else
+      content_tag(:h3, message.html_safe, class: "govuk-notification-banner__heading").html_safe
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,7 +49,9 @@
     <div class="govuk-width-container ">
       <%= yield :pre_content_nav %>
       <main class="govuk-main-wrapper app-content" id="main-content" role="main">
-        <%= render(NotificationBanner.new(flashes: flash)) %>
+        <div class="govuk-grid-column-two-thirds">
+          <%= render(NotificationBanner.new(flashes: flash)) %>
+        </div>
 
         <%= yield %>
       </main>

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -11,7 +11,7 @@ en:
       create:
         assigned_to_regional_delivery_officer:
           html:
-            <h2>Project created</h2>
+            <h3 class="govuk-notification-banner__heading">Project created</h3>
             <p class="govuk-body">You should add any contact details you have for the school, trust, solicitors, local authority and diocese (if applicable).</p>
         assigned_to_regional_caseworker_team:
           title: Project created

--- a/spec/helpers/notification_helper_spec.rb
+++ b/spec/helpers/notification_helper_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe NotificationHelper, type: :helper do
+  describe "#notification_banner_html" do
+    context "when the banner message does NOT contain html" do
+      it "outputs the message in an h3 tag" do
+        expect(helper.notification_banner_html("This is a single line message")).to eq '<h3 class="govuk-notification-banner__heading">This is a single line message</h3>'
+      end
+    end
+
+    context "when the banner message contains html" do
+      it "outputs the message as-is (with its html)" do
+        message = '<h3 class="govuk-notification-banner__heading">This is a multi line message</h3><p class="govuk-body">With a second line</p>'
+        expect(helper.notification_banner_html(message)).to eq '<h3 class="govuk-notification-banner__heading">This is a multi line message</h3><p class="govuk-body">With a second line</p>'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes

The flash banner should be in its own two-thirds layout.

The banner should be styled as per the GOV.uk guidelines. The main message
must be an h3, and any other text in a paragraph.

We have added a helper to parse the flash messages correctly. If a message only
has one line (no HTML), the helper encapsulates the message in an h3 tag. If
a message contains HTML, we output the HTML in its entirety. 

We determine if a message has HTML by parsing it with Nokogiri and counting
the number of node children. A non-zero number means there is HTML present.

We will have to
ensure any HTML added to flash messages via local files has the correct HTML
format.

We only currently have one multi-line flash message, and the HTML for this has
been updated in the locale file.

https://design-system.service.gov.uk/components/notification-banner/

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
