### PR TITLE
Add transfer project statistics to statistics page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Every page now has a unique page title
+- Add transfer project statistics to statistics page
 
 ### Changed
 

--- a/app/models/statistics/project_statistics.rb
+++ b/app/models/statistics/project_statistics.rb
@@ -1,22 +1,39 @@
 class Statistics::ProjectStatistics
   def initialize
     @projects = Conversion::Project.all
+    @transfer_projects = Transfer::Project.all
   end
 
-  def total_number_of_projects
+  def total_number_of_conversion_projects
     @projects.count
   end
 
-  def total_number_of_in_progress_projects
+  def total_number_of_transfer_projects
+    @transfer_projects.count
+  end
+
+  def total_number_of_in_progress_conversion_projects
     @projects.in_progress.count
   end
 
-  def total_number_of_unassigned_projects
+  def total_number_of_in_progress_transfer_projects
+    @transfer_projects.in_progress.count
+  end
+
+  def total_number_of_unassigned_conversion_projects
     @projects.unassigned_to_user.count
   end
 
-  def total_number_of_completed_projects
+  def total_number_of_unassigned_transfer_projects
+    @transfer_projects.unassigned_to_user.count
+  end
+
+  def total_number_of_completed_conversion_projects
     @projects.completed.count
+  end
+
+  def total_number_of_completed_transfer_projects
+    @transfer_projects.completed.count
   end
 
   def total_projects_with_regional_casework_services

--- a/app/models/statistics/project_statistics.rb
+++ b/app/models/statistics/project_statistics.rb
@@ -36,20 +36,36 @@ class Statistics::ProjectStatistics
     @transfer_projects.completed.count
   end
 
-  def total_projects_with_regional_casework_services
+  def total_conversion_projects_with_regional_casework_services
     @projects.assigned_to_regional_caseworker_team.count
   end
 
-  def in_progress_projects_with_regional_casework_services
+  def total_transfer_projects_with_regional_casework_services
+    @transfer_projects.assigned_to_regional_caseworker_team.count
+  end
+
+  def in_progress_conversion_projects_with_regional_casework_services
     @projects.assigned_to_regional_caseworker_team.in_progress.count
   end
 
-  def completed_projects_with_regional_casework_services
+  def in_progress_transfer_projects_with_regional_casework_services
+    @transfer_projects.assigned_to_regional_caseworker_team.in_progress.count
+  end
+
+  def completed_conversion_projects_with_regional_casework_services
     @projects.assigned_to_regional_caseworker_team.completed.count
   end
 
-  def unassigned_projects_with_regional_casework_services
+  def completed_transfer_projects_with_regional_casework_services
+    @transfer_projects.assigned_to_regional_caseworker_team.completed.count
+  end
+
+  def unassigned_conversion_projects_with_regional_casework_services
     @projects.assigned_to_regional_caseworker_team.unassigned_to_user.count
+  end
+
+  def unassigned_transfer_projects_with_regional_casework_services
+    @transfer_projects.assigned_to_regional_caseworker_team.unassigned_to_user.count
   end
 
   def total_projects_not_with_regional_casework_services

--- a/app/models/statistics/project_statistics.rb
+++ b/app/models/statistics/project_statistics.rb
@@ -68,8 +68,12 @@ class Statistics::ProjectStatistics
     @transfer_projects.assigned_to_regional_caseworker_team.unassigned_to_user.count
   end
 
-  def total_projects_not_with_regional_casework_services
+  def total_conversion_projects_not_with_regional_casework_services
     @projects.not_assigned_to_regional_caseworker_team.count
+  end
+
+  def total_transfer_projects_not_with_regional_casework_services
+    @transfer_projects.not_assigned_to_regional_caseworker_team.count
   end
 
   def voluntary_projects_not_with_regional_casework_services
@@ -80,16 +84,28 @@ class Statistics::ProjectStatistics
     @projects.not_assigned_to_regional_caseworker_team.sponsored.count
   end
 
-  def in_progress_projects_not_with_regional_casework_services
+  def in_progress_conversion_projects_not_with_regional_casework_services
     @projects.not_assigned_to_regional_caseworker_team.in_progress.count
   end
 
-  def completed_projects_not_with_regional_casework_services
+  def in_progress_transfer_projects_not_with_regional_casework_services
+    @transfer_projects.not_assigned_to_regional_caseworker_team.in_progress.count
+  end
+
+  def completed_conversion_projects_not_with_regional_casework_services
     @projects.not_assigned_to_regional_caseworker_team.completed.count
   end
 
-  def unassigned_projects_not_with_regional_casework_services
+  def completed_transfer_projects_not_with_regional_casework_services
+    @transfer_projects.not_assigned_to_regional_caseworker_team.completed.count
+  end
+
+  def unassigned_conversion_projects_not_with_regional_casework_services
     @projects.not_assigned_to_regional_caseworker_team.unassigned_to_user.count
+  end
+
+  def unassigned_transfer_projects_not_with_regional_casework_services
+    @transfer_projects.not_assigned_to_regional_caseworker_team.unassigned_to_user.count
   end
 
   def statistics_for_region(region)

--- a/app/models/statistics/project_statistics.rb
+++ b/app/models/statistics/project_statistics.rb
@@ -130,7 +130,7 @@ class Statistics::ProjectStatistics
     hash = {}
     (1..6).each do |i|
       date = Date.today + i.month
-      hash["#{Date::MONTHNAMES[date.month]} #{date.year}"] = Conversion::Project.confirmed.filtered_by_significant_date(date.month, date.year).count
+      hash["#{date.month}/#{date.year}"] = {conversions: Conversion::Project.confirmed.filtered_by_significant_date(date.month, date.year).count, transfers: Transfer::Project.confirmed.filtered_by_significant_date(date.month, date.year).count}
     end
     hash
   end

--- a/app/models/statistics/project_statistics.rb
+++ b/app/models/statistics/project_statistics.rb
@@ -108,12 +108,21 @@ class Statistics::ProjectStatistics
     @transfer_projects.not_assigned_to_regional_caseworker_team.unassigned_to_user.count
   end
 
-  def statistics_for_region(region)
+  def conversion_project_statistics_for_region(region)
     OpenStruct.new(
       total: @projects.by_region(region).count,
       in_progress: @projects.by_region(region).in_progress.count,
       completed: @projects.by_region(region).completed.count,
       unassigned: @projects.by_region(region).unassigned_to_user.count
+    )
+  end
+
+  def transfer_project_statistics_for_region(region)
+    OpenStruct.new(
+      total: @transfer_projects.by_region(region).count,
+      in_progress: @transfer_projects.by_region(region).in_progress.count,
+      completed: @transfer_projects.by_region(region).completed.count,
+      unassigned: @transfer_projects.by_region(region).unassigned_to_user.count
     )
   end
 

--- a/app/views/all/statistics/statistics/index.html.erb
+++ b/app/views/all/statistics/statistics/index.html.erb
@@ -36,25 +36,30 @@
           <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col">Detail</th>
-            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Total number</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Conversions</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Transfers</th>
           </tr>
           </thead>
           <tbody class="govuk-table__body">
           <tr class="govuk-table__row" id="in_progress">
             <th scope="row" class="govuk-table__cell">In progress projects</th>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_number_of_in_progress_projects %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_number_of_in_progress_conversion_projects %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_number_of_in_progress_transfer_projects %></td>
           </tr>
           <tr class="govuk-table__row" id="completed">
             <th scope="row" class="govuk-table__cell">Completed projects</th>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_number_of_completed_projects %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_number_of_completed_conversion_projects %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_number_of_completed_transfer_projects %></td>
           </tr>
           <tr class="govuk-table__row" id="unassigned">
             <th scope="row" class="govuk-table__cell">Unassigned projects</th>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_number_of_unassigned_projects %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_number_of_unassigned_conversion_projects %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_number_of_unassigned_transfer_projects %></td>
           </tr>
           <tr class="govuk-table__row" id="all_projects">
             <th scope="row" class="govuk-table__cell">All projects</th>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_number_of_projects %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_number_of_conversion_projects %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_number_of_transfer_projects %></td>
           </tr>
           </tbody>
         </table>

--- a/app/views/all/statistics/statistics/index.html.erb
+++ b/app/views/all/statistics/statistics/index.html.erb
@@ -20,7 +20,8 @@
         <%= render partial: "shared/side_navigation_item", locals: {name: "Overview of all projects", path: "#projectOverview"} %>
         <%= render partial: "shared/side_navigation_item", locals: {name: "Projects with Regional casework services", path: "#projectsRCS"} %>
         <%= render partial: "shared/side_navigation_item", locals: {name: "Projects not with Regional casework services", path: "#projectsNotRCS"} %>
-        <%= render partial: "shared/side_navigation_item", locals: {name: "Projects per region", path: "#projectsPerRegion"} %>
+        <%= render partial: "shared/side_navigation_item", locals: {name: "Conversion projects per region", path: "#conversionProjectsPerRegion"} %>
+        <%= render partial: "shared/side_navigation_item", locals: {name: "Transfer projects per region", path: "#transferProjectsPerRegion"} %>
         <%= render partial: "shared/side_navigation_item", locals: {name: "6 month view of all project openers", path: "#sixMonthView"} %>
         <%= render partial: "shared/side_navigation_item", locals: {name: "Users per team", path: "#usersPerTeam"} %>
       </ul>
@@ -141,20 +142,49 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <h2 class="govuk-heading-l" id="projectsPerRegion">Projects per region</h2>
-        <table class="govuk-table" name="not_with_regional_casework_services_statistics_table" aria-label="Not with Regional casework services statistics">
+        <h2 class="govuk-heading-l" id="conversionProjectsPerRegion">Conversion projects per region</h2>
+        <table class="govuk-table" name="not_with_regional_casework_services_statistics_table" aria-label="Conversion projects per region statistics">
           <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col">Region</th>
             <th class="govuk-table__header govuk-table__header--numeric" scope="col">In-progress projects</th>
             <th class="govuk-table__header govuk-table__header--numeric" scope="col">Completed projects</th>
-            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Unassigned</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Unassigned projects</th>
             <th class="govuk-table__header govuk-table__header--numeric" scope="col">All projects</th>
           </tr>
           </thead>
           <tbody class="govuk-table__body">
           <% Project.regions.keys.each do |region| %>
-            <% statistics = @project_statistics.statistics_for_region(region) %>
+            <% statistics = @project_statistics.conversion_project_statistics_for_region(region) %>
+            <tr class="govuk-table__row" id="<%= region.dasherize %>">
+              <th scope="row" class="govuk-table__cell"><%= t("project.region.#{region}") %></th>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= statistics.in_progress %></td>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= statistics.completed %></td>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= statistics.unassigned %></td>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= statistics.total %></td>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <h2 class="govuk-heading-l" id="transferProjectsPerRegion">Transfer projects per region</h2>
+        <table class="govuk-table" name="not_with_regional_casework_services_statistics_table" aria-label="Transfer projects per region statistics">
+          <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col">Region</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">In-progress projects</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Completed projects</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Unassigned projects</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">All projects</th>
+          </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+          <% Project.regions.keys.each do |region| %>
+            <% statistics = @project_statistics.conversion_project_statistics_for_region(region) %>
             <tr class="govuk-table__row" id="<%= region.dasherize %>">
               <th scope="row" class="govuk-table__cell"><%= t("project.region.#{region}") %></th>
               <td class="govuk-table__cell govuk-table__cell--numeric"><%= statistics.in_progress %></td>

--- a/app/views/all/statistics/statistics/index.html.erb
+++ b/app/views/all/statistics/statistics/index.html.erb
@@ -205,14 +205,16 @@
           <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col">Project opener date</th>
-            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Total number</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Conversions</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Transfers</th>
           </tr>
           </thead>
           <tbody class="govuk-table__body">
           <% @project_statistics.opener_date_and_project_total.each do |key, value| %>
-            <tr class="govuk-table__row" id="<%= key.tr(" ", "_") %>">
-              <th scope="row" class="govuk-table__cell"><%= key %></th>
-              <td class="govuk-table__cell govuk-table__cell--numeric"><%= value %></td>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__cell"><%= Date.strptime(key, "%m/%Y").to_formatted_s(:govuk_month) %></th>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= value[:conversions] %></td>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= value[:transfers] %></td>
             </tr>
           <% end %>
           </tbody>

--- a/app/views/all/statistics/statistics/index.html.erb
+++ b/app/views/all/statistics/statistics/index.html.erb
@@ -110,24 +110,29 @@
           <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col">Detail</th>
-            <th class="govuk-table__header" scope="col">Total number</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Conversions</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Transfers</th>
           </tr>
           </thead>
           <tr class="govuk-table__row" id="in_progress">
             <th scope="row" class="govuk-table__cell">In progress projects</th>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.in_progress_projects_not_with_regional_casework_services %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.in_progress_conversion_projects_not_with_regional_casework_services %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.in_progress_transfer_projects_not_with_regional_casework_services %></td>
           </tr>
           <tr class="govuk-table__row" id="completed">
             <th scope="row" class="govuk-table__cell">Completed projects</th>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.completed_projects_not_with_regional_casework_services %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.completed_conversion_projects_not_with_regional_casework_services %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.completed_transfer_projects_not_with_regional_casework_services %></td>
           </tr>
           <tr class="govuk-table__row" id="unassigned">
             <th scope="row" class="govuk-table__cell">Unassigned projects</th>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.unassigned_projects_not_with_regional_casework_services %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.unassigned_conversion_projects_not_with_regional_casework_services %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.unassigned_transfer_projects_not_with_regional_casework_services %></td>
           </tr>
           <tr class="govuk-table__row" id="all_projects">
             <th scope="row" class="govuk-table__cell">All projects not with Regional casework services</th>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_projects_not_with_regional_casework_services %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_conversion_projects_not_with_regional_casework_services %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_transfer_projects_not_with_regional_casework_services %></td>
           </tr>
           </tbody>
         </table>

--- a/app/views/all/statistics/statistics/index.html.erb
+++ b/app/views/all/statistics/statistics/index.html.erb
@@ -73,25 +73,30 @@
           <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col">Detail</th>
-            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Total number</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Conversions</th>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Transfers</th>
           </tr>
           </thead>
           <tbody class="govuk-table__body" id="voluntary_projects">
           <tr class="govuk-table__row" id="in_progress">
             <th scope="row" class="govuk-table__cell">In progress projects</th>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.in_progress_projects_with_regional_casework_services %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.in_progress_conversion_projects_with_regional_casework_services %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.in_progress_transfer_projects_with_regional_casework_services %></td>
           </tr>
           <tr class="govuk-table__row" id="completed">
             <th scope="row" class="govuk-table__cell">Completed projects</th>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.completed_projects_with_regional_casework_services %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.completed_conversion_projects_with_regional_casework_services %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.completed_transfer_projects_with_regional_casework_services %></td>
           </tr>
           <tr class="govuk-table__row" id="unassigned">
             <th scope="row" class="govuk-table__cell">Unassigned projects</th>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.unassigned_projects_with_regional_casework_services %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.unassigned_conversion_projects_with_regional_casework_services %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.unassigned_transfer_projects_with_regional_casework_services %></td>
           </tr>
           <tr class="govuk-table__row" id="all_projects">
             <th scope="row" class="govuk-table__cell">All projects with Regional casework services</th>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_projects_with_regional_casework_services %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_conversion_projects_with_regional_casework_services %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_transfer_projects_with_regional_casework_services %></td>
           </tr>
           </tbody>
         </table>

--- a/spec/models/statistics/project_statistics_spec.rb
+++ b/spec/models/statistics/project_statistics_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
   end
 
   describe "projects per region" do
-    it "returns the statistics for the region" do
+    before do
       create(:conversion_project, region: :london, completed_at: nil)
       create(:conversion_project, region: :london, completed_at: Date.today + 2.years)
       create(:conversion_project, region: :south_east)
@@ -210,12 +210,34 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
       create(:conversion_project, region: :london, completed_at: nil, directive_academy_order: true)
       create(:conversion_project, region: :london, assigned_to: nil)
 
-      statistics = subject.statistics_for_region(:london)
+      create(:transfer_project, region: :london, completed_at: nil)
+      create(:transfer_project, region: :london, completed_at: Date.today + 2.years)
+      create(:transfer_project, region: :west_midlands)
+      create(:transfer_project, region: :london, completed_at: Date.today + 2.years, directive_academy_order: true)
+      create(:transfer_project, region: :london, completed_at: nil, directive_academy_order: true)
+      create(:transfer_project, region: :london, assigned_to: nil)
+    end
 
-      expect(statistics.total).to eql(5)
-      expect(statistics.in_progress).to eql(2)
-      expect(statistics.completed).to eql(2)
-      expect(statistics.unassigned).to eql(1)
+    describe "#conversion_project_statistics_for_region" do
+      it "returns the conversion project statistics for the region" do
+        statistics = subject.conversion_project_statistics_for_region(:london)
+
+        expect(statistics.total).to eql(5)
+        expect(statistics.in_progress).to eql(2)
+        expect(statistics.completed).to eql(2)
+        expect(statistics.unassigned).to eql(1)
+      end
+    end
+
+    describe "#transfer_project_statistics_for_region" do
+      it "returns the transfer project statistics for the region" do
+        statistics = subject.transfer_project_statistics_for_region(:london)
+
+        expect(statistics.total).to eql(5)
+        expect(statistics.in_progress).to eql(2)
+        expect(statistics.completed).to eql(2)
+        expect(statistics.unassigned).to eql(1)
+      end
     end
   end
 

--- a/spec/models/statistics/project_statistics_spec.rb
+++ b/spec/models/statistics/project_statistics_spec.rb
@@ -132,11 +132,23 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
       create(:conversion_project, team: "london", completed_at: nil, directive_academy_order: true)
       create(:conversion_project, team: "london", completed_at: Date.today + 2.years, directive_academy_order: true)
       create(:conversion_project, team: "london", assigned_to: nil)
+
+      create(:transfer_project, team: "london", completed_at: nil)
+      create(:transfer_project, team: "london", completed_at: Date.today + 2.years)
+      create(:transfer_project, team: "london", completed_at: nil, directive_academy_order: true)
+      create(:transfer_project, team: "london", completed_at: Date.today + 2.years, directive_academy_order: true)
+      create(:transfer_project, team: "london", assigned_to: nil)
     end
 
-    describe "#total_projects_not_with_regional_casework_services" do
-      it "returns the total number of projects not with regional casework services" do
-        expect(subject.total_projects_not_with_regional_casework_services).to eql(5)
+    describe "#total_conversion_projects_not_with_regional_casework_services" do
+      it "returns the total number of conversion projects not with regional casework services" do
+        expect(subject.total_conversion_projects_not_with_regional_casework_services).to eql(5)
+      end
+    end
+
+    describe "#total_transfer_projects_not_with_regional_casework_services" do
+      it "returns the total number of transfer projects not with regional casework services" do
+        expect(subject.total_transfer_projects_not_with_regional_casework_services).to eql(5)
       end
     end
 
@@ -152,21 +164,39 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
       end
     end
 
-    describe "#in_progress_projects_not_with_regional_casework_services" do
-      it "returns the total number of in-progress projects not with regional casework services" do
-        expect(subject.in_progress_projects_not_with_regional_casework_services).to eql(2)
+    describe "#in_progress_conversion_projects_not_with_regional_casework_services" do
+      it "returns the total number of in-progress conversion projects not with regional casework services" do
+        expect(subject.in_progress_conversion_projects_not_with_regional_casework_services).to eql(2)
       end
     end
 
-    describe "#completed_projects_not_with_regional_casework_services" do
-      it "returns the total number of completed projects not with regional casework services" do
-        expect(subject.completed_projects_not_with_regional_casework_services).to eql(2)
+    describe "#in_progress_transfer_projects_not_with_regional_casework_services" do
+      it "returns the total number of in-progress transfer projects not with regional casework services" do
+        expect(subject.in_progress_transfer_projects_not_with_regional_casework_services).to eql(2)
       end
     end
 
-    describe "#unassigned_projects_not_with_regional_casework_services" do
-      it "returns the total number of unassigned  projects not within regional casework services" do
-        expect(subject.unassigned_projects_not_with_regional_casework_services).to eql(1)
+    describe "#completed_conversion_projects_not_with_regional_casework_services" do
+      it "returns the total number of completed conversion projects not with regional casework services" do
+        expect(subject.completed_conversion_projects_not_with_regional_casework_services).to eql(2)
+      end
+    end
+
+    describe "#completed_transfer_projects_not_with_regional_casework_services" do
+      it "returns the total number of completed transfer projects not with regional casework services" do
+        expect(subject.completed_transfer_projects_not_with_regional_casework_services).to eql(2)
+      end
+    end
+
+    describe "#unassigned_conversion_projects_not_with_regional_casework_services" do
+      it "returns the total number of unassigned conversion projects not within regional casework services" do
+        expect(subject.unassigned_conversion_projects_not_with_regional_casework_services).to eql(1)
+      end
+    end
+
+    describe "#unassigned_transfer_projects_not_with_regional_casework_services" do
+      it "returns the total number of unassigned transfer projects not within regional casework services" do
+        expect(subject.unassigned_transfer_projects_not_with_regional_casework_services).to eql(1)
       end
     end
   end

--- a/spec/models/statistics/project_statistics_spec.rb
+++ b/spec/models/statistics/project_statistics_spec.rb
@@ -9,29 +9,56 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
       create_list(:conversion_project, 2, assigned_to: nil)
       create(:conversion_project)
       create(:conversion_project, completed_at: Date.today)
+      create_list(:transfer_project, 2, assigned_to: nil)
+      create(:transfer_project)
+      create(:transfer_project, completed_at: Date.today)
     end
 
-    describe "#total_number_of_projects" do
-      it "returns the total number of all projects" do
-        expect(subject.total_number_of_projects).to eql(4)
+    describe "#total_number_of_conversion_projects" do
+      it "returns the total number of all conversion projects" do
+        expect(subject.total_number_of_conversion_projects).to eql(4)
       end
     end
 
-    describe "#total_number_of_in_progress_projects" do
-      it "returns the total number of all in-progress projects" do
-        expect(subject.total_number_of_in_progress_projects).to eql(1)
+    describe "#total_number_of_transfer_projects" do
+      it "returns the total number of all transfer projects" do
+        expect(subject.total_number_of_transfer_projects).to eql(4)
       end
     end
 
-    describe "#total_number_of_unassigned_projects" do
-      it "returns the total number of all unassigned projects" do
-        expect(subject.total_number_of_unassigned_projects).to eql(2)
+    describe "#total_number_of_in_progress_conversion_projects" do
+      it "returns the total number of all in-progress conversion projects" do
+        expect(subject.total_number_of_in_progress_conversion_projects).to eql(1)
       end
     end
 
-    describe "#total_number_of_completed_projects" do
-      it "returns the total number of all completed projects" do
-        expect(subject.total_number_of_completed_projects).to eql(1)
+    describe "#total_number_of_in_progress_transfer_projects" do
+      it "returns the total number of all in-progress transfer projects" do
+        expect(subject.total_number_of_in_progress_transfer_projects).to eql(1)
+      end
+    end
+
+    describe "#total_number_of_unassigned_conversion_projects" do
+      it "returns the total number of all unassigned conversion projects" do
+        expect(subject.total_number_of_unassigned_conversion_projects).to eql(2)
+      end
+    end
+
+    describe "#total_number_of_unassigned_transfer_projects" do
+      it "returns the total number of all unassigned transfer projects" do
+        expect(subject.total_number_of_unassigned_transfer_projects).to eql(2)
+      end
+    end
+
+    describe "#total_number_of_completed_conversion_projects" do
+      it "returns the total number of all completed onversion projects" do
+        expect(subject.total_number_of_completed_conversion_projects).to eql(1)
+      end
+    end
+
+    describe "#total_number_of_completed_transfer_projects" do
+      it "returns the total number of all completed transfer projects" do
+        expect(subject.total_number_of_completed_transfer_projects).to eql(1)
       end
     end
   end

--- a/spec/models/statistics/project_statistics_spec.rb
+++ b/spec/models/statistics/project_statistics_spec.rb
@@ -69,29 +69,58 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
       create(:conversion_project, team: :regional_casework_services, completed_at: Date.today + 2.years)
       create(:conversion_project, team: :regional_casework_services, assigned_to: nil)
       create(:conversion_project, team: :north_west, assigned_to: nil)
+
+      create(:transfer_project, team: :regional_casework_services, completed_at: nil)
+      create(:transfer_project, team: :regional_casework_services, completed_at: Date.today + 2.years)
+      create(:transfer_project, team: :regional_casework_services, assigned_to: nil)
+      create(:transfer_project, team: :north_west, assigned_to: nil)
     end
 
-    describe "#total_projects_with_regional_casework_services" do
-      it "returns the total number of all projects within regional casework services" do
-        expect(subject.total_projects_with_regional_casework_services).to eql(3)
+    describe "#total_conversion_projects_with_regional_casework_services" do
+      it "returns the total number of all conversion projects within regional casework services" do
+        expect(subject.total_conversion_projects_with_regional_casework_services).to eql(3)
       end
     end
 
-    describe "#in_progress_projects_with_regional_casework_services" do
-      it "returns the total number of in-progress projects within regional casework services" do
-        expect(subject.in_progress_projects_with_regional_casework_services).to eql(1)
+    describe "#total_transfer_projects_with_regional_casework_services" do
+      it "returns the total number of all transfer projects within regional casework services" do
+        expect(subject.total_transfer_projects_with_regional_casework_services).to eql(3)
       end
     end
 
-    describe "#completed_projects_with_regional_casework_services" do
-      it "returns the total number of completed projects within regional casework services" do
-        expect(subject.completed_projects_with_regional_casework_services).to eql(1)
+    describe "#in_progress_conversion_projects_with_regional_casework_services" do
+      it "returns the total number of in-progress conversion projects within regional casework services" do
+        expect(subject.in_progress_conversion_projects_with_regional_casework_services).to eql(1)
       end
     end
 
-    describe "#unassigned_projects_with_regional_casework_services" do
-      it "returns the total number of unassigned projects within regional casework services" do
-        expect(subject.unassigned_projects_with_regional_casework_services).to eql(1)
+    describe "#in_progress_transfer_projects_with_regional_casework_services" do
+      it "returns the total number of in-progress transfer projects within regional casework services" do
+        expect(subject.in_progress_transfer_projects_with_regional_casework_services).to eql(1)
+      end
+    end
+
+    describe "#completed_conversion_projects_with_regional_casework_services" do
+      it "returns the total number of completed conversion projects within regional casework services" do
+        expect(subject.completed_conversion_projects_with_regional_casework_services).to eql(1)
+      end
+    end
+
+    describe "#completed_transfer_projects_with_regional_casework_services" do
+      it "returns the total number of completed transfer projects within regional casework services" do
+        expect(subject.completed_transfer_projects_with_regional_casework_services).to eql(1)
+      end
+    end
+
+    describe "#unassigned_conversion_projects_with_regional_casework_services" do
+      it "returns the total number of unassigned conversion projects within regional casework services" do
+        expect(subject.unassigned_conversion_projects_with_regional_casework_services).to eql(1)
+      end
+    end
+
+    describe "#unassigned_transfer_projects_with_regional_casework_services" do
+      it "returns the total number of unassigned transfer projects within regional casework services" do
+        expect(subject.unassigned_transfer_projects_with_regional_casework_services).to eql(1)
       end
     end
   end

--- a/spec/models/statistics/project_statistics_spec.rb
+++ b/spec/models/statistics/project_statistics_spec.rb
@@ -243,16 +243,24 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
 
   describe "Projects opening in the next 6 months" do
     describe "#opener_date_and_project_total" do
-      let!(:project_1) { create(:conversion_project, conversion_date: Date.today.at_beginning_of_month + 1.month, conversion_date_provisional: false) }
-      let!(:project_2) { create(:conversion_project, conversion_date: Date.today.at_beginning_of_month + 3.month, conversion_date_provisional: false) }
+      let!(:project_1) { create(:conversion_project, conversion_date: Date.new(2023, 2, 1), conversion_date_provisional: false) }
+      let!(:project_2) { create(:conversion_project, conversion_date: Date.new(2023, 5, 1), conversion_date_provisional: false) }
+      let!(:project_3) { create(:transfer_project, transfer_date: Date.new(2023, 3, 1), transfer_date_provisional: false) }
+      let!(:project_4) { create(:transfer_project, transfer_date: Date.new(2023, 6, 1), transfer_date_provisional: false) }
 
       it "returns the table of openers for the next 6 months" do
-        (1..6).each do |i|
-          date = Date.today + i.month
-          within("##{Date::MONTHNAMES[date.month]}_#{date.year}") do
-            expect(page).to have_content(Project.confirmed.filtered_by_significant_date(date.month, date.year).count)
-          end
-        end
+        travel_to Time.zone.local(2023, 0o1, 0o1, 0o1, 0o1, 44)
+
+        statistics = subject.opener_date_and_project_total
+
+        expect(statistics).to eql(
+          "2/2023" => {conversions: 1, transfers: 0},
+          "3/2023" => {conversions: 0, transfers: 1},
+          "4/2023" => {conversions: 0, transfers: 0},
+          "5/2023" => {conversions: 1, transfers: 0},
+          "6/2023" => {conversions: 0, transfers: 1},
+          "7/2023" => {conversions: 0, transfers: 0}
+        )
       end
     end
   end


### PR DESCRIPTION
## Changes

Now that we have transfer projects within the service, we want to be able to differentiate between Conversion projects and Transfer projects within our statistics page.


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
