### PR TITLE
Add a full stop after conversion date in all conditions met hint text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   a transfer project
 - Remove the View project column from the table views and make the school name
   link to the project view instead
+- added missing full stop to all conditions met task
 
 ### Fixed
 

--- a/config/locales/conversion/tasks/conditions_met.en.yml
+++ b/config/locales/conversion/tasks/conditions_met.en.yml
@@ -5,7 +5,7 @@ en:
         title: Confirm all conditions have been met
         hint:
           html:
-            "The deadline for meeting all conditions is in the email you got from the ADOP (Academies Delivery Operational Practice) team. All conditions must be met before the deadline or the school will not be able to convert on %{date}"
+            "The deadline for meeting all conditions is in the email you got from the ADOP (Academies Delivery Operational Practice) team. All conditions must be met before the deadline or the school will not be able to convert on %{date}."
         guidance_link: How to check all conditions have been met
         guidance:
           html:


### PR DESCRIPTION
## Changes

## Before

<img width="770" alt="Screenshot 2023-08-15 at 3 57 38 pm" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/738f3158-5e2d-4e05-bc83-2a0985f746d8">

## After

<img width="770" alt="Screenshot 2023-08-15 at 3 56 47 pm" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/4a1d6cb2-9fb2-4267-9ada-82385eba891f">

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
