### PR TITLE
Every page has a unique page title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Every page now has a unique page title
+
 ## [Release 38][release-38]
 
 ### Added

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,4 +36,8 @@ module ApplicationHelper
     return false unless cookies[:ACCEPT_OPTIONAL_COOKIES] == "true"
     true
   end
+
+  def page_title(title)
+    "#{title} - #{I18n.t("service_name")}"
+  end
 end

--- a/app/views/all/completed/projects/index.html.erb
+++ b/app/views/all/completed/projects/index.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.all.completed.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/all/export/education_and_skills_funding_agency/projects/show.html.erb
+++ b/app/views/all/export/education_and_skills_funding_agency/projects/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("export.education_and_skills_funding_agency.show.title", date: @month.to_fs(:govuk_month))) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_back_link(href: all_export_education_and_skills_funding_agency_projects_path) %>

--- a/app/views/all/export/funding_agreement_letters/projects/show.html.erb
+++ b/app/views/all/export/funding_agreement_letters/projects/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("export.funding_agreement_letters.show.title", date: @month.to_fs(:govuk_month))) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_back_link(href: all_export_funding_agreement_letters_projects_path) %>

--- a/app/views/all/in_progress/projects/index.html.erb
+++ b/app/views/all/in_progress/projects/index.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.all.in_progress.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/all/local_authorities/projects/index.html.erb
+++ b/app/views/all/local_authorities/projects/index.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.all.by_local_authority.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/all/local_authorities/projects/show.html.erb
+++ b/app/views/all/local_authorities/projects/show.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.all.trust_ukprn.title", trust: @local_authority.name)) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/all/opening/projects/confirmed.html.erb
+++ b/app/views/all/opening/projects/confirmed.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.openers.title", date: @date)) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/all/opening/projects/revised.html.erb
+++ b/app/views/all/opening/projects/revised.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.revised_conversion_date.title", date: @date)) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/all/regions/projects/index.html.erb
+++ b/app/views/all/regions/projects/index.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.all.by_region.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/all/regions/projects/show.html.erb
+++ b/app/views/all/regions/projects/show.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.all.by_region.title_with_region", region: t("project.region.#{@region}"))) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/all/statistics/statistics/index.html.erb
+++ b/app/views/all/statistics/statistics/index.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title("Statistics") %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">Statistics</h1>

--- a/app/views/all/trusts/projects/index.html.erb
+++ b/app/views/all/trusts/projects/index.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.all.by_trust.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/all/trusts/projects/show.html.erb
+++ b/app/views/all/trusts/projects/show.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.all.trust_ukprn.title", trust: @trust.name)) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/all/users/projects/index.html.erb
+++ b/app/views/all/users/projects/index.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.all.by_user.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/all/users/projects/show.html.erb
+++ b/app/views/all/users/projects/show.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.all.by_user.projects.title", name: @user.full_name)) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/conversions/academy_urn/confirm.html.erb
+++ b/app/views/conversions/academy_urn/confirm.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("project.academy_urn.confirm.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/conversions/academy_urn/edit.html.erb
+++ b/app/views/conversions/academy_urn/edit.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("project.academy_urn.title", school_name: @project.establishment.name)) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/conversions/academy_urn/not_found.html.erb
+++ b/app/views/conversions/academy_urn/not_found.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("project.academy_urn.not_found.title", academy_urn: @academy_urn)) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/conversions/date_histories/new.html.erb
+++ b/app/views/conversions/date_histories/new.html.erb
@@ -1,3 +1,12 @@
+<% content_for :page_title do %>
+  <%= page_title(t(
+        "conversion_new_date_history_form.title",
+        school_name: @project.establishment.name,
+        urn: @project.urn, conversion_date:
+                     @project.conversion_date.to_formatted_s(:govuk)
+      )) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @form, url: project_change_date_path(@project) do |form| %>

--- a/app/views/conversions/index.html.erb
+++ b/app/views/conversions/index.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("project.index.conversions.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/conversions/projects/new.html.erb
+++ b/app/views/conversions/projects/new.html.erb
@@ -2,6 +2,10 @@
   <% render partial: "shared/back_link", locals: {href: root_path} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion_project.voluntary.new.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @project, url: conversions_path do |form| %>

--- a/app/views/conversions/shared/_project_summary.html.erb
+++ b/app/views/conversions/shared/_project_summary.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(@project.establishment.name) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">URN <%= @project.urn %></span>

--- a/app/views/conversions/tasks/conditions_met/edit.html.erb
+++ b/app/views/conversions/tasks/conditions_met/edit.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.conditions_met.title")) %>
+<% end %>
+
 <div class="govuk-grid-row govuk-!-margin-bottom-9">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l"><%= @project.establishment.name %></span>

--- a/app/views/cookies/edit.html.erb
+++ b/app/views/cookies/edit.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title("Cookies") %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Cookies</h1>

--- a/app/views/external_contacts/confirm_destroy.html.erb
+++ b/app/views/external_contacts/confirm_destroy.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("contact.confirm_destroy.title", contact_name: @contact.name)) %>
+<% end %>
+
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for [@project, @contact], url: project_contact_path(@project, @contact), method: :delete do |form| %>

--- a/app/views/external_contacts/edit.html.erb
+++ b/app/views/external_contacts/edit.html.erb
@@ -2,6 +2,10 @@
   <% render partial: "shared/back_link", locals: {href: project_contacts_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("contact.edit.title")) %>
+<% end %>
+
 <h1 class="govuk-heading-l"><%= t("contact.edit.title") %></h1>
 
 <div class="govuk-grid-row govuk-body">

--- a/app/views/external_contacts/new.html.erb
+++ b/app/views/external_contacts/new.html.erb
@@ -2,6 +2,10 @@
   <% render partial: "shared/back_link", locals: {href: project_contacts_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("contact.new.title")) %>
+<% end %>
+
 <h1 class="govuk-heading-l"><%= t("contact.new.title") %></h1>
 
 <div class="govuk-grid-row govuk-body">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template ">
   <head>
     <meta charset="utf-8">
-    <title><%= t("service_name") %></title>
+    <title><%= yield :page_title %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="theme-color" content="#0b0c0c">
 

--- a/app/views/local_authorities/confirm_destroy.html.erb
+++ b/app/views/local_authorities/confirm_destroy.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/service_support_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("local_authority.destroy.title", local_authority: @local_authority.name)) %>
+<% end %>
+
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @local_authority, url: local_authority_path(@local_authority), method: :delete do |form| %>

--- a/app/views/local_authorities/edit.html.erb
+++ b/app/views/local_authorities/edit.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/service_support_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("local_authority.edit.change_details", local_authority: @local_authority.name)) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">

--- a/app/views/local_authorities/index.html.erb
+++ b/app/views/local_authorities/index.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/service_support_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("service_support.section.local_authorities.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/local_authorities/new.html.erb
+++ b/app/views/local_authorities/new.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/service_support_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("local_authority.new.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">

--- a/app/views/local_authorities/show.html.erb
+++ b/app/views/local_authorities/show.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/service_support_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(@local_authority.name) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/member_of_parliament/multiple_results_error.html.erb
+++ b/app/views/member_of_parliament/multiple_results_error.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("pages.members_api_multiple_results_error.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t("pages.members_api_multiple_results_error.title") %></h1>

--- a/app/views/notes/confirm_destroy.html.erb
+++ b/app/views/notes/confirm_destroy.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("note.confirm_destroy.title")) %>
+<% end %>
+
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for [@project, @note], url: project_note_path(@project, @note), method: :delete do |form| %>

--- a/app/views/pages/academies_api_client_timeout.html.erb
+++ b/app/views/pages/academies_api_client_timeout.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("pages.academies_api_client_timeout.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t("pages.academies_api_client_timeout.title") %></h1>

--- a/app/views/pages/academies_api_client_unauthorised.html.erb
+++ b/app/views/pages/academies_api_client_unauthorised.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("pages.academies_api_client_unauthorised.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t("pages.academies_api_client_unauthorised.title") %></h1>

--- a/app/views/pages/accessibility.erb
+++ b/app/views/pages/accessibility.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title("Accessibility statement") %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Accessibility statement</h1>
@@ -21,7 +25,7 @@
       easier to use if you have a disability.
     <h2 class="govuk-heading-l">How accessible this website is</h2>
     <p class="govuk-body">This website is partially compliant with the
-      Web Content Accessibility Guidelines version 2.1 AA standard, due 
+      Web Content Accessibility Guidelines version 2.1 AA standard, due
       to the following non-compliance:</p>
     <ul>
         <li>

--- a/app/views/pages/internal_server_error.html.erb
+++ b/app/views/pages/internal_server_error.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("pages.internal_server_error.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t("pages.internal_server_error.title") %></h1>

--- a/app/views/pages/members_api_client_error.html.erb
+++ b/app/views/pages/members_api_client_error.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("pages.members_api_client_error.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t("pages.members_api_client_error.title") %></h1>

--- a/app/views/pages/page_not_found.html.erb
+++ b/app/views/pages/page_not_found.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("pages.page_not_found.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t("pages.page_not_found.title") %></h1>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title("Privacy notice") %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Privacy Notice: <%= t("service_name") %></h1>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("project.index.all.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/projects/unassigned.html.erb
+++ b/app/views/projects/unassigned.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("project.index.unassigned.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/service_support/projects/with_academy_urn.html.erb
+++ b/app/views/service_support/projects/with_academy_urn.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/service_support_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("service_support.conversion_urns.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/service_support/projects/without_academy_urn.html.erb
+++ b/app/views/service_support/projects/without_academy_urn.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/service_support_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("service_support.conversion_urns.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title("Sign in") %>
+<% end %>
+
 <h1 class="govuk-heading-xl">
   Sign in
 </h1>

--- a/app/views/team/opening/projects/confirmed.html.erb
+++ b/app/views/team/opening/projects/confirmed.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/team_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.openers.title", date: @date)) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/team/opening/projects/revised.html.erb
+++ b/app/views/team/opening/projects/revised.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/team_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.revised_conversion_date.title", date: @date)) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/team/projects/completed.html.erb
+++ b/app/views/team/projects/completed.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/team_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.team.completed.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/team/projects/handed_over.html.erb
+++ b/app/views/team/projects/handed_over.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/team_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.team.handed_over.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/team/projects/in_progress.html.erb
+++ b/app/views/team/projects/in_progress.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/team_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.team.in_progress.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/team/projects/unassigned.html.erb
+++ b/app/views/team/projects/unassigned.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/team_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.team.unassigned.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/team/users/projects/index.html.erb
+++ b/app/views/team/users/projects/index.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/team_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.team.users.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/team/users/projects/show.html.erb
+++ b/app/views/team/users/projects/show.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/team_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.user.show.title", user: @user.full_name)) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/transfers/date_histories/new.html.erb
+++ b/app/views/transfers/date_histories/new.html.erb
@@ -1,3 +1,10 @@
+<% content_for :page_title do %>
+  <%= page_title(t("transfer_new_date_history_form.title",
+        school_name: @project.establishment.name,
+        urn: @project.urn, transfer_date:
+                     @project.transfer_date.to_formatted_s(:govuk))) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @form, url: project_change_date_path(@project) do |form| %>

--- a/app/views/transfers/projects/new.html.erb
+++ b/app/views/transfers/projects/new.html.erb
@@ -2,6 +2,10 @@
   <% render partial: "shared/back_link", locals: {href: root_path} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("transfer_project.new.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @project, url: transfers_path do |form| %>

--- a/app/views/transfers/shared/_project_summary.html.erb
+++ b/app/views/transfers/shared/_project_summary.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(@project.establishment.name) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">URN <%= @project.urn %></span>

--- a/app/views/transfers/tasks/conditions_met/edit.html.erb
+++ b/app/views/transfers/tasks/conditions_met/edit.html.erb
@@ -2,6 +2,10 @@
   <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.conditions_met.title")) %>
+<% end %>
+
 <div class="govuk-grid-row govuk-!-margin-bottom-9">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l"><%= @project.establishment.name %></span>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("user.edit.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t("user.edit.title") %></h1>

--- a/app/views/users/index_active.html.erb
+++ b/app/views/users/index_active.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/service_support_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("user.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/users/index_inactive.html.erb
+++ b/app/views/users/index_inactive.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/service_support_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("user.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("user.add.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t("user.add.title") %></h1>

--- a/app/views/users/set_team.html.erb
+++ b/app/views/users/set_team.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("user.set_team.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t("user.set_team.title") %></h1>

--- a/app/views/your/projects/added_by.html.erb
+++ b/app/views/your/projects/added_by.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/your_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.user.added_by.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
  <div class="govuk-grid-column-full">
 

--- a/app/views/your/projects/by_user.html.erb
+++ b/app/views/your/projects/by_user.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title(t("project.user.by_user.title", user: @user.full_name)) %>
+<% end %>
+
 <div class="govuk-grid-row">
  <div class="govuk-grid-column-full">
 

--- a/app/views/your/projects/completed.html.erb
+++ b/app/views/your/projects/completed.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/your_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.user.completed.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/app/views/your/projects/in_progress.html.erb
+++ b/app/views/your/projects/in_progress.html.erb
@@ -2,6 +2,10 @@
   <%= render partial: "shared/navigation/your_projects_primary_navigation" %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("project.user.in_progress.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render partial: "projects/shared/new_projects" if policy(:project).new? %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   describe "#page_title" do
     it "returns the supplied title concatenated with the service name" do
-      expect(helper.page_title("A page")).to eq("A page - #{t('service_name')}")
+      expect(helper.page_title("A page")).to eq("A page - #{t("service_name")}")
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -145,4 +145,10 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#page_title" do
+    it "returns the supplied title concatenated with the service name" do
+      expect(helper.page_title("A page")).to eq("A page - #{t('service_name')}")
+    end
+  end
 end


### PR DESCRIPTION
## Changes

The new page titles consist of the `h1` content already on the page, plus the
service name. 

We use a new `#page_title` helper to build the page title string, formed from
the passed-in string and the service name.

The page title is passed into a yielding block in the application base HTML
template.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
