### PR TITLE
Validate that a transfers incoming trust is not the same as its outgoing trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add Form M task to Transfer projects
 - Add Church Supplemental Agreement task to Transfer projects
 - Add jump links to task lists
+- Validate that a transfer's incoming trust is not the same as it's outgoing
+  trust
 
 ### Changed
 
@@ -27,7 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The links on the By region table have been moved to the region name column.
 - The links on the By user table have been moved to the user name column.
 - The links on the By trust table have been moved to the trust name column.
-- The links on the By local authority table have been moved to the local  
+- The links on the By local authority table have been moved to the local
   authority name column.
 - The links on the Team By user table have been moved to the user name column.
 - Rework the columns on the By month > Confirmed table data

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -11,6 +11,8 @@ class Transfer::CreateProjectForm < CreateProjectForm
 
   validates :outgoing_trust_sharepoint_link, presence: true, sharepoint_url: true
 
+  validate :check_incoming_trust_and_outgoing_trust
+
   def initialize(params = {})
     @attributes_with_invalid_values = []
     super(params)
@@ -51,5 +53,9 @@ class Transfer::CreateProjectForm < CreateProjectForm
     nil
   rescue TypeError, Date::Error, NegativeValueError
     @attributes_with_invalid_values << :provisional_transfer_date
+  end
+
+  def check_incoming_trust_and_outgoing_trust
+    errors.add(:incoming_trust_ukprn, I18n.t("errors.attributes.incoming_trust_ukprn.ukprns_must_not_match")) if incoming_trust_ukprn == outgoing_trust_ukprn
   end
 end

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -319,6 +319,7 @@ en:
         no_trust_found: There's no trust with that UKPRN. Check the number you entered is correct.
         not_a_number: UKPRN can only contain numbers. No letters or special characters.
         must_be_correct_format: UKPRN must be 8 digits long and start with a 1. For example, 12345678.
+        ukprns_must_not_match: Incoming trust must not be the same as the outgoing trust.
       outgoing_trust_ukprn:
         blank: Enter a UKPRN
         no_trust_found: There's no trust with that UKPRN. Check the number you entered is correct.

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -91,6 +91,16 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
         expect(form).to be_invalid
       end
     end
+
+    describe "#check_incoming_trust_and_outgoing_trust" do
+      it "throws an error when the incoming trust and outgoing trust are the same" do
+        form = build(:create_transfer_project_form, incoming_trust_ukprn: 10061021)
+        form.outgoing_trust_ukprn = 10061021
+
+        expect(form).to be_invalid
+        expect(form.errors.messages[:incoming_trust_ukprn]).to include I18n.t("errors.attributes.incoming_trust_ukprn.ukprns_must_not_match")
+      end
+    end
   end
 
   describe "urn" do


### PR DESCRIPTION
## Changes

A transfers incoming trust should not be the same as its outgoing trust.
This work sets a validation to check that these UKPRNs do not match, and if they do to throw an error

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
