### PR TITLE
(Fix) Do not constrain the banner to a two-thirds section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Transfer projects can be assigned to users & teams
 - Show Transfers on the all completed projects page, projects added by you page
   and the completed projects by you page
+- Don't constrain the banners to a two-thirds section
 
 ## [Release 38][release-38]
 

--- a/app/views/conversions/shared/_project_summary.html.erb
+++ b/app/views/conversions/shared/_project_summary.html.erb
@@ -6,10 +6,10 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">URN <%= @project.urn %></span>
     <h1 class="govuk-heading-l"><%= @project.establishment.name %></h1>
-
-    <%= project_notification_banner(@project, current_user) %>
   </div>
 </div>
+
+<%= project_notification_banner(@project, current_user) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">

--- a/app/views/transfers/shared/_project_summary.html.erb
+++ b/app/views/transfers/shared/_project_summary.html.erb
@@ -6,10 +6,10 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">URN <%= @project.urn %></span>
     <h1 class="govuk-heading-l"><%= @project.establishment.name %></h1>
-
-    <%= project_notification_banner(@project, current_user) %>
   </div>
 </div>
+
+<%= project_notification_banner(@project, current_user) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">


### PR DESCRIPTION

## Changes

The banner is in its own two-thirds div, so don't encapsulate it in another one!

![Uploading image.png…]()


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
