### PR TITLE
(Fix) Show missing transfers on index pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Transfer projects can be assigned to users & teams
+- Show Transfers on the all completed projects page, projects added by you page
+  and the completed projects by you page
 
 ## [Release 38][release-38]
 

--- a/app/controllers/all/completed/projects_controller.rb
+++ b/app/controllers/all/completed/projects_controller.rb
@@ -4,7 +4,7 @@ class All::Completed::ProjectsController < ApplicationController
 
   def index
     authorize Project, :index?
-    @pager, @projects = pagy(Conversion::Project.completed)
+    @pager, @projects = pagy(Project.completed)
 
     AcademiesApiPreFetcherService.new.call!(@projects)
   end

--- a/app/controllers/team/users/projects_controller.rb
+++ b/app/controllers/team/users/projects_controller.rb
@@ -9,7 +9,7 @@ class Team::Users::ProjectsController < ApplicationController
     authorize Project, :index?
 
     @user = User.find(user_id)
-    @pager, @projects = pagy(Conversion::Project.assigned_to(@user).in_progress.by_conversion_date)
+    @pager, @projects = pagy(Project.assigned_to(@user).in_progress.ordered_by_significant_date)
 
     AcademiesApiPreFetcherService.new.call!(@projects)
   end

--- a/app/controllers/your/projects_controller.rb
+++ b/app/controllers/your/projects_controller.rb
@@ -11,14 +11,14 @@ class Your::ProjectsController < ApplicationController
 
   def added_by
     authorize Project, :index?
-    @pager, @projects = pagy(Conversion::Project.added_by(current_user).not_completed.by_conversion_date.includes(:assigned_to))
+    @pager, @projects = pagy(Project.added_by(current_user).not_completed.ordered_by_significant_date.includes(:assigned_to))
 
     AcademiesApiPreFetcherService.new.call!(@projects)
   end
 
   def completed
     authorize Project, :index?
-    @pager, @projects = pagy(Conversion::Project.assigned_to(current_user).completed)
+    @pager, @projects = pagy(Project.assigned_to(current_user).completed)
 
     AcademiesApiPreFetcherService.new.call!(@projects)
   end


### PR DESCRIPTION


## Changes

Transfers were not being included in the following pages, despite the views being updated to support them:

- All completed projects
- Team projects in progress
- Projects added by you
- Your completed projects

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
