### PR TITLE
Add page titles to task edit views and the task generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add transfer project statistics to statistics page
 - Add Transfer project counts to Team > By user view
 - Add Land consent letter task to Transfer projects
+- Add page titles to Transfer and Conversion project task pages
 
 ### Changed
 

--- a/app/views/conversions/tasks/academy_details/edit.html.erb
+++ b/app/views/conversions/tasks/academy_details/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.academy_details.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/articles_of_association/edit.html.erb
+++ b/app/views/conversions/tasks/articles_of_association/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.articles_of_association.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/check_accuracy_of_higher_needs/edit.html.erb
+++ b/app/views/conversions/tasks/check_accuracy_of_higher_needs/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.check_accuracy_of_higher_needs.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/church_supplemental_agreement/edit.html.erb
+++ b/app/views/conversions/tasks/church_supplemental_agreement/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.church_supplemental_agreement.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/commercial_transfer_agreement/edit.html.erb
+++ b/app/views/conversions/tasks/commercial_transfer_agreement/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.commercial_transfer_agreement.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/complete_notification_of_change/edit.html.erb
+++ b/app/views/conversions/tasks/complete_notification_of_change/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.complete_notification_of_change.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/conditions_met/edit.html.erb
+++ b/app/views/conversions/tasks/conditions_met/edit.html.erb
@@ -2,6 +2,10 @@
   <%= page_title(t("conversion.task.conditions_met.title")) %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.conditions_met.title")) %>
+<% end %>
+
 <div class="govuk-grid-row govuk-!-margin-bottom-9">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l"><%= @project.establishment.name %></span>

--- a/app/views/conversions/tasks/conversion_grant/edit.html.erb
+++ b/app/views/conversions/tasks/conversion_grant/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.conversion_grant.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/deed_of_variation/edit.html.erb
+++ b/app/views/conversions/tasks/deed_of_variation/edit.html.erb
@@ -4,6 +4,10 @@
 <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.deed_of_variation.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/direction_to_transfer/edit.html.erb
+++ b/app/views/conversions/tasks/direction_to_transfer/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.direction_to_transfer.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/funding_agreement_contact/edit.html.erb
+++ b/app/views/conversions/tasks/funding_agreement_contact/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.funding_agreement_contact.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @project.contacts.count > 0 %>

--- a/app/views/conversions/tasks/handover/edit.html.erb
+++ b/app/views/conversions/tasks/handover/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.handover.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/land_questionnaire/edit.html.erb
+++ b/app/views/conversions/tasks/land_questionnaire/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.land_questionnaire.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/land_registry/edit.html.erb
+++ b/app/views/conversions/tasks/land_registry/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.land_registry.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/master_funding_agreement/edit.html.erb
+++ b/app/views/conversions/tasks/master_funding_agreement/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.master_funding_agreement.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/one_hundred_and_twenty_five_year_lease/edit.html.erb
+++ b/app/views/conversions/tasks/one_hundred_and_twenty_five_year_lease/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.one_hundred_and_twenty_five_year_lease.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/receive_grant_payment_certificate/edit.html.erb
+++ b/app/views/conversions/tasks/receive_grant_payment_certificate/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.receive_grant_payment_certificate.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/redact_and_send/edit.html.erb
+++ b/app/views/conversions/tasks/redact_and_send/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.redact_and_send.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/risk_protection_arrangement/edit.html.erb
+++ b/app/views/conversions/tasks/risk_protection_arrangement/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.risk_protection_arrangement.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/school_completed/edit.html.erb
+++ b/app/views/conversions/tasks/school_completed/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.school_completed.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/share_information/edit.html.erb
+++ b/app/views/conversions/tasks/share_information/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.share_information.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/single_worksheet/edit.html.erb
+++ b/app/views/conversions/tasks/single_worksheet/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.single_worksheet.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/sponsored_support_grant/edit.html.erb
+++ b/app/views/conversions/tasks/sponsored_support_grant/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.sponsored_support_grant.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/stakeholder_kick_off/edit.html.erb
+++ b/app/views/conversions/tasks/stakeholder_kick_off/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.stakeholder_kick_off.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/subleases/edit.html.erb
+++ b/app/views/conversions/tasks/subleases/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.subleases.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/supplemental_funding_agreement/edit.html.erb
+++ b/app/views/conversions/tasks/supplemental_funding_agreement/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.supplemental_funding_agreement.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/tenancy_at_will/edit.html.erb
+++ b/app/views/conversions/tasks/tenancy_at_will/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.tenancy_at_will.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/trust_modification_order/edit.html.erb
+++ b/app/views/conversions/tasks/trust_modification_order/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.trust_modification_order.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/conversions/tasks/update_esfa/edit.html.erb
+++ b/app/views/conversions/tasks/update_esfa/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.update_esfa.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/transfers/tasks/articles_of_association/edit.html.erb
+++ b/app/views/transfers/tasks/articles_of_association/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.articles_of_association.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/transfers/tasks/commercial_transfer_agreement/edit.html.erb
+++ b/app/views/transfers/tasks/commercial_transfer_agreement/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.commercial_transfer_agreement.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/transfers/tasks/deed_of_novation_and_variation/edit.html.erb
+++ b/app/views/transfers/tasks/deed_of_novation_and_variation/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.deed_of_novation_and_variation.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/transfers/tasks/deed_of_variation/edit.html.erb
+++ b/app/views/transfers/tasks/deed_of_variation/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.deed_of_variation.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/transfers/tasks/handover/edit.html.erb
+++ b/app/views/transfers/tasks/handover/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.handover.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/transfers/tasks/master_funding_agreement/edit.html.erb
+++ b/app/views/transfers/tasks/master_funding_agreement/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.master_funding_agreement.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/transfers/tasks/stakeholder_kick_off/edit.html.erb
+++ b/app/views/transfers/tasks/stakeholder_kick_off/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.stakeholder_kick_off.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/app/views/transfers/tasks/supplemental_funding_agreement/edit.html.erb
+++ b/app/views/transfers/tasks/supplemental_funding_agreement/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.supplemental_funding_agreement.title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/lib/generators/conversion/task_generator.rb
+++ b/lib/generators/conversion/task_generator.rb
@@ -10,6 +10,7 @@ class Conversion::TaskGenerator < Rails::Generators::NamedBase
   def gsub_files
     gsub_file "app/forms/conversion/task/#{file_name}_task_form.rb", "TaskName", "#{class_name}TaskForm"
     gsub_file "config/locales/conversion/tasks/#{file_name}.en.yml", "task_name:", "#{file_name}:"
+    gsub_file "app/views/conversions/tasks/#{file_name}/edit.html.erb", "task_title", "conversion.task.#{file_name}.title"
   end
 
   def generate_migration

--- a/lib/generators/conversion/templates/edit.html.erb
+++ b/lib/generators/conversion/templates/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("task_title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>

--- a/lib/generators/transfer/task_generator.rb
+++ b/lib/generators/transfer/task_generator.rb
@@ -10,6 +10,7 @@ class Transfer::TaskGenerator < Rails::Generators::NamedBase
   def gsub_files
     gsub_file "app/forms/transfer/task/#{file_name}_task_form.rb", "TaskName", "#{class_name}TaskForm"
     gsub_file "config/locales/transfer/tasks/#{file_name}.en.yml", "task_name:", "#{file_name}:"
+    gsub_file "app/views/transfers/tasks/#{file_name}/edit.html.erb", "task_title", "transfer.task.#{file_name}.title"
   end
 
   def generate_migration

--- a/lib/generators/transfer/templates/edit.html.erb
+++ b/lib/generators/transfer/templates/edit.html.erb
@@ -4,6 +4,10 @@
   <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
 <% end %>
 
+<% content_for :page_title do %>
+  <%= page_title(t("task_title")) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>


### PR DESCRIPTION
## Changes

When we added unique page titles to all pages, we actually managed to miss out the Conversion and Transfer task pages. 

Add the page title blocks to all of the Task edit pages.

Add the empty page title block to the task generators.

## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
