### PR TITLE
Add jump to section to both task lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add RPA Policy task to Transfer projects
 - Add Form M task to Transfer projects
 - Add Church Supplemental Agreement task to Transfer projects
+- Add jump links to task lists
 
 ### Changed
 

--- a/app/views/shared/_side_navigation_item.html.erb
+++ b/app/views/shared/_side_navigation_item.html.erb
@@ -1,3 +1,3 @@
 <li>
-  <%= link_to(name, path, class: govuk_link_classes) %>
+  <%= link_to(name, path, class: "govuk-link govuk-link--no-visited-state") %>
 </li>

--- a/app/views/shared/projects/_task_list.html.erb
+++ b/app/views/shared/projects/_task_list.html.erb
@@ -1,16 +1,27 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full-width">
     <h2 class="govuk-heading-l"><%= t("project.show.title") %></h2>
 
-    <ol class="app-task-list">
-      <% @task_list.sections.each do |section| %>
-        <li>
-          <h3 class="app-task-list__section">
-            <%= t("#{section.locales_path}.title") %>
-          </h3>
-          <ul class="app-task-list__items">
-            <% section.tasks.each do |task| %>
-              <li class="app-task-list__item">
+    <div class="govuk-grid-column-one-quarter">
+      <nav>
+        <h2 class="govuk-heading-m"><%= t("project_information.show.side_navigation.title") %></h2>
+        <ul class="list-style-none govuk-!-padding-0">
+          <% @task_list.sections.each do |section| %>
+            <%= render partial: "shared/side_navigation_item", locals: {name: t("#{section.locales_path}.title"), path: "##{section.identifier}"} %>
+          <% end %>
+        </ul>
+      </nav>
+    </div>
+    <div class="govuk-grid-column-three-quarters">
+      <ol class="app-task-list">
+        <% @task_list.sections.each do |section| %>
+          <li>
+            <h3 class="app-task-list__section" id="<%= section.identifier %>">
+              <%= t("#{section.locales_path}.title") %>
+            </h3>
+            <ul class="app-task-list__items">
+              <% section.tasks.each do |task| %>
+                <li class="app-task-list__item">
                 <span class="app-task-list__task-name">
                   <%= govuk_link_to(
                         t("#{task.locales_path}.title"),
@@ -18,12 +29,13 @@
                         aria: {describedby: task_id(task)}
                       ) %>
                 </span>
-                <%= task_status_tag(task, task_id(task)) %>
-              </li>
-            <% end %>
-          </ul>
-        </li>
-      <% end %>
-    </ol>
+                  <%= task_status_tag(task, task_id(task)) %>
+                </li>
+              <% end %>
+            </ul>
+          </li>
+        <% end %>
+      </ol>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Changes

Add jump links to the task sections for both Transfer and Conversion task lists.

<img width="1395" alt="Screenshot 2023-08-25 at 10 46 24" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/2e5265c8-fd94-4dd4-ab2b-e208eb650712">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
