### PR TITLE
(Fix) Correct navigation namespace in By month section

### DIFF
--- a/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
@@ -10,7 +10,7 @@
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.in_progress"), path: all_in_progress_projects_path, namespace: "/projects/all/in-progress"} %>
 
-          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_month"), path: confirmed_all_by_month_projects_path, namespace: "/projects/all/opening"} %>
+          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_month"), path: confirmed_all_by_month_projects_path, namespace: "/projects/all/by-month"} %>
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_region"), path: all_regions_projects_path, namespace: "/projects/all/regions"} %>
 

--- a/app/views/shared/navigation/_team_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_team_projects_primary_navigation.html.erb
@@ -11,7 +11,7 @@
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.in_progress"), path: in_progress_team_projects_path, namespace: "/projects/team/in-progress"} %>
 
-          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.by_month"), path: confirmed_team_by_month_projects_path, namespace: "/projects/team/opening"} %>
+          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.by_month"), path: confirmed_team_by_month_projects_path, namespace: "/projects/team/by-month"} %>
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.by_user"), path: team_users_projects_path, namespace: "/projects/team/user"} %>
 


### PR DESCRIPTION
This namepsace should be "by-month". This means the currect navigation link remains selected in the By month section.


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
