### PR TITLE
(Fix) Correct error message for "role" field on contacts

### DIFF
--- a/config/locales/note.en.yml
+++ b/config/locales/note.en.yml
@@ -43,4 +43,4 @@ en:
             email:
               invalid: Enter an email address in the correct format, like name@example.com
             title:
-              blank: Enter a title
+              blank: Enter a role


### PR DESCRIPTION
This should be "role" not "title"

