### PR TITLE
(Fix) Supply a default page title if none is set

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template ">
   <head>
     <meta charset="utf-8">
-    <title><%= yield :page_title %></title>
+    <title><%= content_for?(:page_title) ? yield(:page_title) : t("service_name") %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="theme-color" content="#0b0c0c">
 


### PR DESCRIPTION
I really wanted to add a test for this but I can't figure out how to mock out `content_for?` in a feature spec!
