### PR TITLE
(Fix) Move the "complete project" content into alignment with task list

### DIFF
--- a/app/views/conversions/tasks/index.html.erb
+++ b/app/views/conversions/tasks/index.html.erb
@@ -3,5 +3,3 @@
 <%= render partial: "shared/projects/sub_navigation" %>
 
 <%= render partial: "shared/projects/task_list" %>
-
-<%= render "projects/show/complete" if policy(@project).update? %>

--- a/app/views/projects/show/_complete.html.erb
+++ b/app/views/projects/show/_complete.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-grid-row govuk-body">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <%= form_with url: project_complete_path(@project), method: :put do |form| %>

--- a/app/views/shared/projects/_task_list.html.erb
+++ b/app/views/shared/projects/_task_list.html.erb
@@ -13,29 +13,34 @@
       </nav>
     </div>
     <div class="govuk-grid-column-three-quarters">
-      <ol class="app-task-list">
-        <% @task_list.sections.each do |section| %>
-          <li>
-            <h3 class="app-task-list__section" id="<%= section.identifier %>">
-              <%= t("#{section.locales_path}.title") %>
-            </h3>
-            <ul class="app-task-list__items">
-              <% section.tasks.each do |task| %>
-                <li class="app-task-list__item">
-                <span class="app-task-list__task-name">
-                  <%= govuk_link_to(
-                        t("#{task.locales_path}.title"),
-                        project_edit_task_path(@project, task.identifier),
-                        aria: {describedby: task_id(task)}
-                      ) %>
-                </span>
-                  <%= task_status_tag(task, task_id(task)) %>
-                </li>
-              <% end %>
-            </ul>
-          </li>
-        <% end %>
-      </ol>
+      <div class="govuk-grid-row">
+        <ol class="app-task-list">
+          <% @task_list.sections.each do |section| %>
+            <li>
+              <h3 class="app-task-list__section" id="<%= section.identifier %>">
+                <%= t("#{section.locales_path}.title") %>
+              </h3>
+              <ul class="app-task-list__items">
+                <% section.tasks.each do |task| %>
+                  <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <%= govuk_link_to(
+                          t("#{task.locales_path}.title"),
+                          project_edit_task_path(@project, task.identifier),
+                          aria: {describedby: task_id(task)}
+                        ) %>
+                  </span>
+                    <%= task_status_tag(task, task_id(task)) %>
+                  </li>
+                <% end %>
+              </ul>
+            </li>
+          <% end %>
+        </ol>
+      </div>
+      <div class="govuk-grid-row">
+        <%= render "projects/show/complete" if policy(@project).update? %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/transfers/tasks/index.html.erb
+++ b/app/views/transfers/tasks/index.html.erb
@@ -3,5 +3,3 @@
 <%= render partial: "/shared/projects/sub_navigation" %>
 
 <%= render partial: "shared/projects/task_list" %>
-
-<%= render "projects/show/complete" if policy(@project).update? %>


### PR DESCRIPTION
## Changes

After adding the jump links to the task list, the "Complete project" button and info was out of alignment with the task list. Put it back into alignment.

<img width="874" alt="Screenshot 2023-08-29 at 12 35 53" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/04d74d96-bf84-4b72-a566-1fa66823fb9e">


## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
