### PR TITLE
Add "new projects this month" to Statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add jump links to task lists
 - Validate that a transfer's incoming trust is not the same as it's outgoing
   trust
+- Show a count of projects added this month on the statistics page
 
 ### Changed
 

--- a/app/models/statistics/project_statistics.rb
+++ b/app/models/statistics/project_statistics.rb
@@ -126,4 +126,15 @@ class Statistics::ProjectStatistics
     end
     hash
   end
+
+  def new_projects_this_month
+    transfers_count = Transfer::Project.where("created_at >= ?", Time.now.beginning_of_month).where("created_at <= ?", Time.now.end_of_month).count
+    conversions_count = Conversion::Project.where("created_at >= ?", Time.now.beginning_of_month).where("created_at <= ?", Time.now.end_of_month).count
+
+    OpenStruct.new(
+      total: transfers_count + conversions_count,
+      transfers: transfers_count,
+      conversions: conversions_count
+    )
+  end
 end

--- a/app/views/all/statistics/statistics/index.html.erb
+++ b/app/views/all/statistics/statistics/index.html.erb
@@ -23,6 +23,7 @@
         <%= render partial: "shared/side_navigation_item", locals: {name: "Conversion projects per region", path: "#conversionProjectsPerRegion"} %>
         <%= render partial: "shared/side_navigation_item", locals: {name: "Transfer projects per region", path: "#transferProjectsPerRegion"} %>
         <%= render partial: "shared/side_navigation_item", locals: {name: "6 month view of all project openers", path: "#sixMonthView"} %>
+        <%= render partial: "shared/side_navigation_item", locals: {name: "New projects this month", path: "#newProjects"} %>
         <%= render partial: "shared/side_navigation_item", locals: {name: "Users per team", path: "#usersPerTeam"} %>
       </ul>
     </nav>
@@ -217,6 +218,28 @@
               <td class="govuk-table__cell govuk-table__cell--numeric"><%= value[:transfers] %></td>
             </tr>
           <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters">
+        <h2 class="govuk-heading-l" id="newProjects">New projects this month (<%= Date.today.to_fs(:govuk_month) %>)</h2>
+        <table class="govuk-table" name="statistics_table" aria-label="Project statistics">
+          <tbody class="govuk-table__body">
+            <tr>
+              <th scope="row" class="govuk-table__cell">Total</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.new_projects_this_month.total %></td>
+            </tr>
+            <tr>
+              <th scope="row" class="govuk-table__cell">Conversions</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.new_projects_this_month.conversions %></td>
+            </tr>
+            <tr>
+              <th scope="row" class="govuk-table__cell">Transfers</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.new_projects_this_month.transfers %></td>
+            </tr>
           </tbody>
         </table>
       </div>

--- a/spec/models/statistics/project_statistics_spec.rb
+++ b/spec/models/statistics/project_statistics_spec.rb
@@ -246,4 +246,17 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
       end
     end
   end
+
+  describe "new projects this month" do
+    it "returns a count of projects created in the current month" do
+      create(:conversion_project, created_at: Time.now.beginning_of_month)
+      create(:conversion_project, created_at: Time.now.beginning_of_month + 1.day)
+      create(:transfer_project, created_at: Time.now.beginning_of_month + 1.week)
+      create(:transfer_project, created_at: Time.now.beginning_of_month - 1.month)
+
+      expect(subject.new_projects_this_month.total).to eq(3)
+      expect(subject.new_projects_this_month.transfers).to eq(1)
+      expect(subject.new_projects_this_month.conversions).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
This info is needed every month for reporting purposes. Count the total, conversions and transfrs for the current month.

<img width="807" alt="Screenshot 2023-08-29 at 13 51 35" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/f50c3807-65ba-4e1a-a387-bbc33ecc2e88">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
