### PR TITLE
Release 39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release 39][release-39]
+
 ### Added
 
 - Every page now has a unique page title
@@ -1257,7 +1259,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-38...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-39...HEAD
+[release-39]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-38...release-39
 [release-38]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-37...release-38
 [release-37]:


### PR DESCRIPTION
Added

- Every page now has a unique page title
- Add transfer project statistics to statistics page
- Add Transfer project counts to Team > By user view
- Add Land consent letter task to Transfer projects
- Add page titles to Transfer and Conversion project task pages
- Add RPA Policy task to Transfer projects
- Add Form M task to Transfer projects
- Add Church Supplemental Agreement task to Transfer projects
- Add jump links to task lists
- Validate that a transfer's incoming trust is not the same as it's outgoing trust
- Show a count of projects added this month on the statistics page

Changed

- Bring the flash banners in line with GOV.uk styles
- corrected content in action on all conditions met conversion task
- All `opening` URLs are now `by-month`, i.e. `/projects/all/by-month` and `/projects/team/by-month`
- The links on the By region table have been moved to the region name column.
- The links on the By user table have been moved to the user name column.
- The links on the By trust table have been moved to the trust name column.
- The links on the By local authority table have been moved to the local authority name column.
- The links on the Team By user table have been moved to the user name column.
- Rework the columns on the By month > Confirmed table data
- content changes to the sponsored grant task

Fixed

- Transfer projects can be assigned to users & teams
- Show Transfers on the all completed projects page, projects added by you page and the completed projects by you page
- Don't constrain the banners to a two-thirds section
- Show the correct values for `all_conditions_met?` in the project CSV export
