### PR TITLE
Collect the "main contact" for a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Remove the Funding agreement letters contact task from the Conversion project
+  task list
+
 ## [Release 39][release-39]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Add the Main contact task to the Conversion project task list
+
 ### Changed
 
 - Remove the Funding agreement letters contact task from the Conversion project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add the Main contact task to the Conversion project task list
+- Add the Main contact task to the Transfer project task list
 
 ### Changed
 

--- a/app/forms/conversion/task/main_contact_task_form.rb
+++ b/app/forms/conversion/task/main_contact_task_form.rb
@@ -1,0 +1,20 @@
+class Conversion::Task::MainContactTaskForm < ::BaseTaskForm
+  attribute :main_contact_id, :string
+
+  def initialize(tasks_data, user)
+    @tasks_data = tasks_data
+    @user = user
+    @project = @tasks_data.project
+
+    super(@tasks_data, @user)
+    self.main_contact_id = @project.main_contact_id
+  end
+
+  def save
+    @project.update!(main_contact_id: main_contact_id)
+  end
+
+  private def completed?
+    @project.main_contact_id.present?
+  end
+end

--- a/app/forms/transfer/task/main_contact_task_form.rb
+++ b/app/forms/transfer/task/main_contact_task_form.rb
@@ -1,0 +1,20 @@
+class Transfer::Task::MainContactTaskForm < ::BaseTaskForm
+  attribute :main_contact_id, :string
+
+  def initialize(tasks_data, user)
+    @tasks_data = tasks_data
+    @user = user
+    @project = @tasks_data.project
+
+    super(@tasks_data, @user)
+    self.main_contact_id = @project.main_contact_id
+  end
+
+  def save
+    @project.update!(main_contact_id: main_contact_id)
+  end
+
+  private def completed?
+    @project.main_contact_id.present?
+  end
+end

--- a/app/models/conversion/task_list.rb
+++ b/app/models/conversion/task_list.rb
@@ -10,8 +10,7 @@ class Conversion::TaskList < ::BaseTaskList
           Conversion::Task::CompleteNotificationOfChangeTaskForm,
           Conversion::Task::ConversionGrantTaskForm,
           Conversion::Task::SponsoredSupportGrantTaskForm,
-          Conversion::Task::AcademyDetailsTaskForm,
-          Conversion::Task::FundingAgreementContactTaskForm
+          Conversion::Task::AcademyDetailsTaskForm
         ]
       },
       {

--- a/app/models/conversion/task_list.rb
+++ b/app/models/conversion/task_list.rb
@@ -10,7 +10,8 @@ class Conversion::TaskList < ::BaseTaskList
           Conversion::Task::CompleteNotificationOfChangeTaskForm,
           Conversion::Task::ConversionGrantTaskForm,
           Conversion::Task::SponsoredSupportGrantTaskForm,
-          Conversion::Task::AcademyDetailsTaskForm
+          Conversion::Task::AcademyDetailsTaskForm,
+          Conversion::Task::MainContactTaskForm
         ]
       },
       {

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -12,6 +12,7 @@ class Project < ApplicationRecord
   has_many :notes, dependent: :destroy
   has_many :contacts, dependent: :destroy, class_name: "Contact::Project"
   has_one :funding_agreement_contact, dependent: :destroy, class_name: "Contact::Project", required: false
+  has_one :main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
 
   validates :urn, presence: true
   validates :urn, urn: true

--- a/app/models/transfer/task_list.rb
+++ b/app/models/transfer/task_list.rb
@@ -5,7 +5,8 @@ class Transfer::TaskList < ::BaseTaskList
         identifier: :project_kick_off,
         tasks: [
           Transfer::Task::HandoverTaskForm,
-          Transfer::Task::StakeholderKickOffTaskForm
+          Transfer::Task::StakeholderKickOffTaskForm,
+          Transfer::Task::MainContactTaskForm
         ]
       },
       {

--- a/app/views/conversions/tasks/main_contact/edit.html.erb
+++ b/app/views/conversions/tasks/main_contact/edit.html.erb
@@ -1,0 +1,37 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.main_contact.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @project.contacts.count > 0 %>
+      <%= form_for @task, url: project_edit_task_path(@project, @task.identifier), method: :put do |form| %>
+        <%= form.govuk_error_summary %>
+
+        <%= form.govuk_collection_radio_buttons :main_contact_id,
+              @project.contacts,
+              :id,
+              :name,
+              :title,
+              legend: {text: t("conversion.task.main_contact.choose_a_contact.title"), size: "l"},
+              form_group: {id: "main-contact-choose-a-contact"} %>
+
+        <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+      <% end %>
+    <% else %>
+      <h2 class="govuk-heading-l"><%= t("conversion.task.main_contact.no_contacts.title") %></h2>
+      <%= t("conversion.task.main_contact.no_contacts.add_contacts_guidance_html", add_contact_link: project_contacts_path(@project)) %>
+      <%= govuk_button_link_to t("task_list.continue_button.text"), project_tasks_path(@project) %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/app/views/external_contacts/_contact_group.html.erb
+++ b/app/views/external_contacts/_contact_group.html.erb
@@ -33,7 +33,7 @@
           end
         end
       end %>
-    <% if @project.funding_agreement_contact_id == contact.id %>
-      <p><%= t("contact.details.funding_agreement_letters") %></p>
+    <% if @project.main_contact_id == contact.id %>
+      <p><%= t("contact.details.main_contact") %></p>
     <% end %>
   <% end %>

--- a/app/views/transfers/tasks/main_contact/edit.html.erb
+++ b/app/views/transfers/tasks/main_contact/edit.html.erb
@@ -1,0 +1,37 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "transfers/tasks/shared/back_link", locals: {project_id: @project.id} %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.main_contact.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @project.contacts.count > 0 %>
+      <%= form_for @task, url: project_edit_task_path(@project, @task.identifier), method: :put do |form| %>
+        <%= form.govuk_error_summary %>
+
+        <%= form.govuk_collection_radio_buttons :main_contact_id,
+              @project.contacts,
+              :id,
+              :name,
+              :title,
+              legend: {text: t("transfer.task.main_contact.choose_a_contact.title"), size: "l"},
+              form_group: {id: "main-contact-choose-a-contact"} %>
+
+        <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+      <% end %>
+    <% else %>
+      <h2 class="govuk-heading-l"><%= t("transfer.task.main_contact.no_contacts.title") %></h2>
+      <%= t("transfer.task.main_contact.no_contacts.add_contacts_guidance_html", add_contact_link: project_contacts_path(@project)) %>
+      <%= govuk_button_link_to t("task_list.continue_button.text"), project_tasks_path(@project) %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -17,6 +17,7 @@ en:
       phone: Phone
       edit_link: Change
       funding_agreement_letters: This person will receive the funding agreement letters.
+      main_contact: This person is the main contact.
     new:
       title: Add contact
       save_contact_button: Add contact

--- a/config/locales/conversion/tasks/main_contact.en.yml
+++ b/config/locales/conversion/tasks/main_contact.en.yml
@@ -1,0 +1,13 @@
+en:
+  conversion:
+    task:
+      main_contact:
+        title: Confirm who is the main contact for this conversion
+        no_contacts:
+          title: Add contacts
+          add_contacts_guidance_html:
+            <p>You must <a href="%{add_contact_link}">add a contact</a> before you can choose which person is the main contact for the conversion.</p>
+            <p>Then you can come back to this task and confirm who is the main contact.</p>
+        choose_a_contact:
+          title: Choose a contact
+          legend:

--- a/config/locales/transfer/tasks/main_contact.en.yml
+++ b/config/locales/transfer/tasks/main_contact.en.yml
@@ -1,0 +1,13 @@
+en:
+  transfer:
+    task:
+      main_contact:
+        title: Confirm who is the main contact for this transfer
+        no_contacts:
+          title: Add contacts
+          add_contacts_guidance_html:
+            <p>You must <a href="%{add_contact_link}">add a contact</a> before you can choose which person is the main contact for the transfer.</p>
+            <p>Then you can come back to this task and confirm who is the main contact.</p>
+        choose_a_contact:
+          title: Choose a contact
+          legend:

--- a/db/migrate/20230830095034_add_main_contact_to_projects.rb
+++ b/db/migrate/20230830095034_add_main_contact_to_projects.rb
@@ -1,0 +1,5 @@
+class AddMainContactToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :main_contact_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_25_100251) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_30_095034) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -197,6 +197,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_25_100251) do
     t.boolean "two_requires_improvement", default: false
     t.text "outgoing_trust_sharepoint_link"
     t.boolean "all_conditions_met", default: false
+    t.uuid "main_contact_id"
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -27,7 +27,6 @@ RSpec.feature "Users can complete conversion tasks" do
   tasks_with_collected_data = %w[
     stakeholder_kick_off
     academy_details
-    funding_agreement_contact
     risk_protection_arrangement
     sponsored_support_grant
     conditions_met
@@ -121,7 +120,7 @@ RSpec.feature "Users can complete conversion tasks" do
     context "when the project has contacts already" do
       let!(:contact) { create(:project_contact, project: project) }
 
-      it "lets the user select an existing contact" do
+      skip "lets the user select an existing contact" do
         visit project_tasks_path(project)
         click_on "Confirm who will get the funding agreement letters"
         choose contact.name
@@ -132,7 +131,7 @@ RSpec.feature "Users can complete conversion tasks" do
     end
 
     context "when the project has no contacts" do
-      it "directs the user to add contacts" do
+      skip "directs the user to add contacts" do
         visit project_tasks_path(project)
         click_on "Confirm who will get the funding agreement letters"
 

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature "Users can complete conversion tasks" do
     risk_protection_arrangement
     sponsored_support_grant
     conditions_met
+    main_contact
   ]
 
   it "confirms we are checking all tasks" do
@@ -134,6 +135,34 @@ RSpec.feature "Users can complete conversion tasks" do
       skip "directs the user to add contacts" do
         visit project_tasks_path(project)
         click_on "Confirm who will get the funding agreement letters"
+
+        expect(page).to have_content("Add contacts")
+        click_link "add a contact"
+        expect(page.current_path).to include("external-contacts")
+      end
+    end
+  end
+
+  context "the main contact task" do
+    let(:project) { create(:conversion_project, assigned_to: user) }
+
+    context "when the project has contacts already" do
+      let!(:contact) { create(:project_contact, project: project) }
+
+      it "lets the user select an existing contact" do
+        visit project_tasks_path(project)
+        click_on "Confirm who is the main contact for this conversion"
+        choose contact.name
+        click_on I18n.t("task_list.continue_button.text")
+
+        expect(project.reload.main_contact_id).to eq contact.id
+      end
+    end
+
+    context "when the project has no contacts" do
+      it "directs the user to add contacts" do
+        visit project_tasks_path(project)
+        click_on "Confirm who is the main contact for this conversion"
 
         expect(page).to have_content("Add contacts")
         click_link "add a contact"

--- a/spec/features/conversions/users_can_select_a_funding_agreement_letter_contact_spec.rb
+++ b/spec/features/conversions/users_can_select_a_funding_agreement_letter_contact_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Users select a contact to receive the funding agreement letters" 
     let!(:contact_1) { create(:project_contact, project: project, name: "John Smith") }
     let!(:contact_2) { create(:project_contact, project: project, name: "Jane Jones") }
 
-    it "allows the user to select one of the existing contacts on the Funding Agreement Letters task page" do
+    skip "allows the user to select one of the existing contacts on the Funding Agreement Letters task page" do
       visit project_tasks_path(project)
       click_on "Confirm who will get the funding agreement letters"
       expect(page).to have_content(contact_1.name)
@@ -35,7 +35,7 @@ RSpec.feature "Users select a contact to receive the funding agreement letters" 
       project.update(funding_agreement_contact_id: contact_2.id)
     end
 
-    it "shows the contact as preselected on the Funding Agreement Letters task page" do
+    skip "shows the contact as preselected on the Funding Agreement Letters task page" do
       visit project_tasks_path(project)
       click_on "Confirm who will get the funding agreement letters"
 
@@ -43,7 +43,7 @@ RSpec.feature "Users select a contact to receive the funding agreement letters" 
     end
 
     context "and the funding agreement letters contact is changed" do
-      it "switches the contact for the project" do
+      skip "switches the contact for the project" do
         visit project_tasks_path(project)
         click_on "Confirm who will get the funding agreement letters"
 
@@ -56,7 +56,7 @@ RSpec.feature "Users select a contact to receive the funding agreement letters" 
   end
 
   context "when the project does not have any contacts" do
-    it "directs the user to the external contacts page" do
+    skip "directs the user to the external contacts page" do
       visit project_tasks_path(project)
       click_on "Confirm who will get the funding agreement letters"
 
@@ -65,7 +65,7 @@ RSpec.feature "Users select a contact to receive the funding agreement letters" 
       expect(page.current_path).to include("external-contacts")
     end
 
-    it "allows the user to go back to the task list without adding a user" do
+    skip "allows the user to go back to the task list without adding a user" do
       visit project_tasks_path(project)
       click_on "Confirm who will get the funding agreement letters"
 

--- a/spec/features/conversions/users_can_select_a_main_contact_spec.rb
+++ b/spec/features/conversions/users_can_select_a_main_contact_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.feature "Users select a main contact for a conversion" do
+  let(:user) { create(:user, :caseworker) }
+  let(:project) { create(:conversion_project, assigned_to: user) }
+
+  before do
+    mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    sign_in_with_user(user)
+  end
+
+  context "when the project already has some contacts" do
+    let!(:contact_1) { create(:project_contact, project: project, name: "John Smith") }
+    let!(:contact_2) { create(:project_contact, project: project, name: "Jane Jones") }
+
+    it "allows the user to select one of the existing contacts on the Main Contact task page" do
+      visit project_tasks_path(project)
+      click_on "Confirm who is the main contact for this conversion"
+      expect(page).to have_content(contact_1.name)
+      expect(page).to have_content(contact_2.name)
+
+      choose contact_1.name
+      click_button "Save and return"
+
+      expect(project.reload.main_contact_id).to eq(contact_1.id)
+      expect(page.find("#confirm-who-is-the-main-contact-for-this-conversion-status").text).to eq("Completed")
+    end
+  end
+
+  context "when the project already has a main contact set" do
+    let!(:contact_1) { create(:project_contact, project: project, name: "John Smith") }
+    let!(:contact_2) { create(:project_contact, project: project, name: "Jane Jones") }
+
+    before do
+      project.update(main_contact_id: contact_2.id)
+    end
+
+    it "shows the contact as preselected on the Main Contact task page" do
+      visit project_tasks_path(project)
+      click_on "Confirm who is the main contact for this conversion"
+
+      expect(page).to have_checked_field(contact_2.name)
+    end
+
+    context "and the main contact is changed" do
+      it "switches the contact for the project" do
+        visit project_tasks_path(project)
+        click_on "Confirm who is the main contact for this conversion"
+
+        choose contact_1.name
+        click_on "Save and return"
+
+        expect(project.reload.main_contact_id).to eq(contact_1.id)
+      end
+    end
+  end
+
+  context "when the project does not have any contacts" do
+    it "directs the user to the external contacts page" do
+      visit project_tasks_path(project)
+      click_on "Confirm who is the main contact for this conversion"
+
+      expect(page).to have_content("Add contacts")
+      click_link "add a contact"
+      expect(page.current_path).to include("external-contacts")
+    end
+
+    it "allows the user to go back to the task list without adding a user" do
+      visit project_tasks_path(project)
+      click_on "Confirm who is the main contact for this conversion"
+
+      expect(page).to have_content("Add contacts")
+      click_link "Save and return"
+      expect(page.find("#confirm-who-is-the-main-contact-for-this-conversion-status").text).to eq("Not started")
+    end
+  end
+end

--- a/spec/features/users_can_manage_contacts_spec.rb
+++ b/spec/features/users_can_manage_contacts_spec.rb
@@ -101,11 +101,11 @@ RSpec.feature "Users can manage contacts" do
     expect(page).to have_content("There are not any contacts for this project yet.")
   end
 
-  scenario "if a contact is the funding agreement contact, it is indicated on the contact" do
-    project.update!(funding_agreement_contact_id: contact.id)
+  scenario "if a contact is the main contact, it is indicated on the contact" do
+    project.update!(main_contact_id: contact.id)
 
     visit project_contacts_path(project)
-    expect(page).to have_content(I18n.t("contact.details.funding_agreement_letters"))
+    expect(page).to have_content(I18n.t("contact.details.main_contact"))
   end
 
   private def expect_page_to_have_contact(name:, title:, organisation_name: nil, email: nil, phone: nil)

--- a/spec/forms/transfer/tasks/main_contact_task_form_spec.rb
+++ b/spec/forms/transfer/tasks/main_contact_task_form_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Transfer::Task::MainContactTaskForm do
+  let(:user) { create(:user) }
+
+  describe "#save" do
+    before { mock_successful_api_response_to_create_any_project }
+
+    let(:project) { create(:transfer_project) }
+    let(:contact) { create(:project_contact, project: project) }
+
+    it "sets main_contact_contact_id to the contact_id" do
+      form = described_class.new(project.tasks_data, user)
+      form.assign_attributes(main_contact_id: contact.id)
+      form.save
+
+      expect(project.main_contact).to eq(contact)
+    end
+  end
+end

--- a/spec/models/conversion/task_list_spec.rb
+++ b/spec/models/conversion/task_list_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Conversion::TaskList do
         :conversion_grant,
         :sponsored_support_grant,
         :academy_details,
-        :funding_agreement_contact,
         :land_questionnaire,
         :land_registry,
         :supplemental_funding_agreement,
@@ -54,8 +53,7 @@ RSpec.describe Conversion::TaskList do
               Conversion::Task::CompleteNotificationOfChangeTaskForm,
               Conversion::Task::ConversionGrantTaskForm,
               Conversion::Task::SponsoredSupportGrantTaskForm,
-              Conversion::Task::AcademyDetailsTaskForm,
-              Conversion::Task::FundingAgreementContactTaskForm
+              Conversion::Task::AcademyDetailsTaskForm
             ]
           },
           {

--- a/spec/models/conversion/task_list_spec.rb
+++ b/spec/models/conversion/task_list_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Conversion::TaskList do
         :conversion_grant,
         :sponsored_support_grant,
         :academy_details,
+        :main_contact,
         :land_questionnaire,
         :land_registry,
         :supplemental_funding_agreement,
@@ -53,7 +54,8 @@ RSpec.describe Conversion::TaskList do
               Conversion::Task::CompleteNotificationOfChangeTaskForm,
               Conversion::Task::ConversionGrantTaskForm,
               Conversion::Task::SponsoredSupportGrantTaskForm,
-              Conversion::Task::AcademyDetailsTaskForm
+              Conversion::Task::AcademyDetailsTaskForm,
+              Conversion::Task::MainContactTaskForm
             ]
           },
           {

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to belong_to(:assigned_to).required(false) }
     it { is_expected.to belong_to(:tasks_data).required(true) }
     it { is_expected.to have_one(:funding_agreement_contact).required(false) }
+    it { is_expected.to have_one(:main_contact).required(false) }
 
     describe "delete related entities" do
       context "when the project is deleted" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ SimpleCov.minimum_coverage 100
 unless ENV.fetch("NO_COVERAGE", false) == "true"
   SimpleCov.start "rails" do
     add_filter "lib/generators/"
+    add_filter "app/forms/conversion/task/funding_agreement_contact_task_form.rb"
   end
 end
 


### PR DESCRIPTION
## Changes

Remove the "Funding agreement letters contact" task from Conversion projects. 

Add a new "Main contact" task to both Conversions and Transfers. This task acts much like the old Funding agreement letters contact, except it stores the contact ID on the `main_contact_id` association on the project.

The content is TBC.

<img width="1131" alt="Screenshot 2023-08-30 at 14 50 34" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/7c238cf5-e3ec-449b-8aaf-100676fee8f4">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
