### PR TITLE
Move the "main contact" signifier

### DIFF
--- a/app/views/external_contacts/_contact_group.html.erb
+++ b/app/views/external_contacts/_contact_group.html.erb
@@ -32,8 +32,11 @@
             row.value { contact.phone }
           end
         end
+        if @project.main_contact_id == contact.id
+          summary_list.row do |row|
+            row.key { t("contact.details.main_contact") }
+            row.value { t("yes") }
+          end
+        end
       end %>
-    <% if @project.main_contact_id == contact.id %>
-      <p><%= t("contact.details.main_contact") %></p>
-    <% end %>
   <% end %>

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -17,7 +17,7 @@ en:
       phone: Phone
       edit_link: Change
       funding_agreement_letters: This person will receive the funding agreement letters.
-      main_contact: This person is the main contact.
+      main_contact: Project main contact
     new:
       title: Add contact
       save_contact_button: Add contact


### PR DESCRIPTION
Move the signifier showing this contact is the project's "main contact" into the summary table.

<img width="929" alt="Screenshot 2023-08-31 at 14 49 47" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/ca8b4973-fb09-47a8-bae1-7bbc38a6192b">


## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
