### PR TITLE
Improve the checks Dockerfile

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.checks
-          target: test
           build-args: RAILS_ENV=test
           push: false
           tags: complete-app:latest
@@ -47,7 +46,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.checks
-          target: test
           build-args: |
             RAILS_ENV=test
           push: false
@@ -76,7 +74,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.checks
-          target: test
           build-args: |
             RAILS_ENV=test
           push: false
@@ -105,7 +102,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.checks
-          target: test
           build-args: |
             RAILS_ENV=test
           push: false
@@ -135,7 +131,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.checks
-          target: test
           build-args: RAILS_ENV=test
           push: false
           load: true

--- a/Dockerfile.checks
+++ b/Dockerfile.checks
@@ -3,6 +3,15 @@
 # ------------------------------------------------------------------------------
 FROM ruby:3.1.2 AS base
 
+# setup env
+ENV APP_HOME /srv/app
+ENV DEPS_HOME /deps
+
+# RAILS_ENV defaults to production
+ARG RAILS_ENV
+ENV RAILS_ENV ${RAILS_ENV:-production}
+ENV NODE_ENV ${RAILS_ENV:-production}
+
 # Install basics
 #
 RUN apt-get update && apt-get install -y build-essential libpq-dev ca-certificates curl gnupg
@@ -26,8 +35,13 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesourc
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-# Install Node and Yarn
-RUN apt-get update && apt-get install -y nodejs yarn
+# Install system dependancies
+RUN \
+  if [ "${RAILS_ENV}" = "test" ]; then \
+    apt-get update && apt-get install -y nodejs yarn firefox-esr shellcheck; \
+  else \
+    apt-get update && apt-get install -y nodejs yarn; \
+  fi
 
 # Install FreeTDS
 # https://github.com/rails-sqlserver/tiny_tds#install
@@ -39,12 +53,19 @@ RUN ./configure --prefix=/usr/local --with-tdsver=7.3
 RUN make
 RUN make install
 
-ENV APP_HOME /srv/app
-ENV DEPS_HOME /deps
+# Intstall Geckodriver
+#
+# default Geckodriver version
+ARG gecko_driver_version=0.32.0
 
-ARG RAILS_ENV
-ENV RAILS_ENV ${RAILS_ENV:-production}
-ENV NODE_ENV ${RAILS_ENV:-production}
+RUN \
+  if [ "${RAILS_ENV}" = "test" ]; then \
+    wget https://github.com/mozilla/geckodriver/releases/download/v$gecko_driver_version/geckodriver-v$gecko_driver_version-linux64.tar.gz && \
+    tar -xvzf  geckodriver-v$gecko_driver_version-linux64.tar.gz && \
+    rm geckodriver-v$gecko_driver_version-linux64.tar.gz && \
+    chmod +x geckodriver && \
+    mv geckodriver* /usr/local/bin; \
+  fi
 
 # ------------------------------------------------------------------------------
 # Dependencies stage
@@ -113,6 +134,15 @@ COPY db ${APP_HOME}/db
 COPY app ${APP_HOME}/app
 # End
 
+# Copy specs
+COPY .eslintignore ${APP_HOME}/.eslintignore
+COPY .eslintrc.json ${APP_HOME}/.eslintrc.json
+COPY .prettierignore ${APP_HOME}/.prettierignore
+COPY .prettierrc ${APP_HOME}/.prettierrc
+COPY .rspec ${APP_HOME}/.rspec
+COPY spec ${APP_HOME}/spec
+# End
+
 # Create tmp/pids
 RUN mkdir -p tmp/pids
 
@@ -140,30 +170,3 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 3000
 
 CMD ["bundle", "exec", "rails", "server"]
-
-# ------------------------------------------------------------------------------
-# Test stage
-# ------------------------------------------------------------------------------
-FROM application AS test
-
-RUN \
-  apt-get update && \
-  apt-get install -y --fix-missing\
-  firefox-esr \
-  shellcheck
-
-ARG gecko_driver_version=0.32.0
-
-RUN wget https://github.com/mozilla/geckodriver/releases/download/v$gecko_driver_version/geckodriver-v$gecko_driver_version-linux64.tar.gz
-RUN tar -xvzf  geckodriver-v$gecko_driver_version-linux64.tar.gz
-RUN rm geckodriver-v$gecko_driver_version-linux64.tar.gz
-RUN chmod +x geckodriver
-RUN mv geckodriver* /usr/local/bin
-
-COPY .eslintignore ${APP_HOME}/.eslintignore
-COPY .eslintrc.json ${APP_HOME}/.eslintrc.json
-COPY .prettierignore ${APP_HOME}/.prettierignore
-COPY .prettierrc ${APP_HOME}/.prettierrc
-
-COPY .rspec ${APP_HOME}/.rspec
-COPY spec ${APP_HOME}/spec

--- a/docker-compose.checks.yml
+++ b/docker-compose.checks.yml
@@ -4,7 +4,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.checks
-      target: test
       cache_from:
         - type=gha
       args:


### PR DESCRIPTION
We've moved the installation of firefix and geckodriver into the base
stage but made the installation conditional based on the RAILS_ENV. This
is a common pattern in the Dockerfile.

The result is that we should see the install cached by Docker saving
lots of time in CI.

We can also drop the 'test' stage as all it now does is copies the test
files into the image - we can live with that overhead being in the
production build.

Now the entire build is controlled by the RAILS_ENV build argument.
