### PR TITLE
Bubble errors up

### DIFF
--- a/script/check_accessibility
+++ b/script/check_accessibility
@@ -4,6 +4,9 @@
 #
 # Runs AXE tests, disbales Simplecov and then enables it so that coverage is not
 # measured for these
+#
+set -e
+
 echo "--> Accessibility"
 script/start_backing_services
 

--- a/script/lint_and_format
+++ b/script/lint_and_format
@@ -5,6 +5,8 @@
 # Runs all erblint, standardrb, prettier and eslint
 #
 # When AUTO_FIX is set, fixing will take place if available
+#
+set -e
 
 echo "--> Linting and formatting"
 

--- a/script/specs
+++ b/script/specs
@@ -3,5 +3,7 @@
 #
 # Shortcut to run just Rspec
 
+set -e
+
 # run specs and coverage
 script/specs_and_coverage "$@"

--- a/script/specs_and_coverage
+++ b/script/specs_and_coverage
@@ -3,6 +3,8 @@
 # script/specs_and_coverage:
 #
 # Runs Rspec along with Simplecov, unless a specific spec or set of specs is passed
+#
+set -e
 
 echo "--> Specs and coverage"
 script/start_backing_services

--- a/script/static_analysis
+++ b/script/static_analysis
@@ -3,6 +3,9 @@
 # script/static_analysis:
 #
 # Runs Brakeman
+#
+set -e
+
 echo "--> Static analysis"
 
 echo "==> Running Brakeman"


### PR DESCRIPTION
For scripts that check something and fail, we need to bubble the errors
up the script, `set -e` does that.