### PR TITLE
Add Sonarcloud to checks workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -141,3 +141,15 @@ jobs:
         run: |
           docker compose -p complete-app -f docker-compose.checks.yml \
           run -e NO_COVERAGE=true --rm test bin/rspec --tag accessibility spec/accessibility
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=DFE-Digital_dfe-complete-conversions-transfers-and-changes
+sonar.organization=dfe-digital
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=dfe-complete-conversions-transfers-and-changes
+#sonar.projectVersion=1.0
+
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
We want to try and pass the coverage report to Sonarcloud and that will
require running it within our workflow.

This is the basic setup for that.

## Changes

_Add a summary of the changes in this pull request_

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
