### PR TITLE
Add Zap to ci

### DIFF
--- a/.github/workflows/zap.yml
+++ b/.github/workflows/zap.yml
@@ -1,0 +1,33 @@
+name: Zap
+
+on:
+  pull_request:
+
+jobs:
+  specs:
+    name: Zap
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build and cache
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile.checks
+          build-args: |
+            RAILS_ENV=test
+          push: false
+          load: true
+          tags: complete-app:latest
+          cache-from: type=gha
+      -
+        name: Run Zap
+        run: |
+          docker compose -p complete-app -f docker-compose.zap.yml \
+          run --rm zap zap-full-scan.py -t http://application

--- a/docker-compose.zap.yml
+++ b/docker-compose.zap.yml
@@ -1,0 +1,65 @@
+version: "3.8"
+services:
+  application:
+    build:
+      context: .
+      dockerfile: Dockerfile.checks
+      cache_from:
+        - type=gha
+      args:
+        RAILS_ENV: "test"
+    command: bin/rails server
+    ports:
+      - "3000:3000"
+    depends_on:
+      test-db-health:
+        condition: service_healthy
+      test-redis:
+        condition: service_started
+    env_file:
+       - .env.test
+    environment:
+      DATABASE_URL: sqlserver://sa:strongPassword&@test-db:1433/sip_test
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
+      SECRET_KEY_BASE: secret
+      CI: "true"
+      SENTRY_ENV: test
+      REDIS_URL: redis://test-redis:6379
+    networks:
+      - test-ci
+  zap:
+    image: ghcr.io/zaproxy/zaproxy:stable
+    depends_on:
+      application:
+        condition: service_started
+    command: zap-full-scan.py -t http://application
+
+  test-db:
+    image: mcr.microsoft.com/azure-sql-edge:latest
+    environment:
+      ACCEPT_EULA: Y
+      MSSQL_SA_PASSWORD: strongPassword&
+    networks:
+      - test-ci
+
+  test-db-health:
+    image: mcr.microsoft.com/mssql-tools:latest
+    command: /bin/bash -c "touch /var/log/sqlcmd.log && tail -f /var/log/sqlcmd.log"
+    healthcheck:
+      test: /opt/mssql-tools/bin/sqlcmd -S test-db -U sa -P 'strongPassword&' -o /var/log/sqlcmd.log
+      interval: "2s"
+      retries: 10
+    depends_on:
+      - test-db
+    networks:
+      - test-ci
+
+  test-redis:
+    image: redis:6
+    ports:
+      - 6379:6379
+    networks:
+      - test-ci
+
+networks:
+  test-ci:


### PR DESCRIPTION
Zap is a autmotated security testing tool:

https://www.zaproxy.org/

We add a docker-compose file to support running zap and the applicaiton,
then a workflow to execute them.

## Changes

_Add a summary of the changes in this pull request_

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [ ] Update the `CHANGELOG.md` if needed.
