### PR TITLE
Remove script from workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,7 +55,8 @@ jobs:
       -
         name: Run linters and formaters
         run: |
-          docker run --rm complete-app:latest script/lint_and_format
+          docker run --rm complete-app:latest sh -c "bin/standardrb -f simple && bin/erblint --lint-all \
+          && yarn run lint:format && yarn run lint:js"
 
   static-analysis:
     name: Static analysis


### PR DESCRIPTION
The workflows depending on the scripts feels a bit off, whilst it keeps
things in one place, the link is not obvious and as the lint and format
script is the only one we can use in the ci environment, it feels better
to keep the workflows consistent by not running scripts.