### PR TITLE
Shift priority for tfdocs

### DIFF
--- a/.github/workflows/continuous-integration-terraform.yml
+++ b/.github/workflows/continuous-integration-terraform.yml
@@ -27,6 +27,15 @@ jobs:
             exit 1
           fi
 
+      - name: Validate Terraform docs
+        uses: terraform-docs/gh-actions@v1.0.0
+        with:
+          working-dir: terraform
+          config-file: .terraform-docs.yml
+          output-file: README.md
+          output-method: inject
+          fail-on-diff: true
+
       - name: Remove azure backend
         run: rm ./terraform/backend.tf
 
@@ -47,16 +56,7 @@ jobs:
         with:
           entrypoint: terraform
           args: -chdir=terraform fmt -check=true -diff=true
-
-      - name: Validate Terraform docs
-        uses: terraform-docs/gh-actions@v1.0.0
-        with:
-          working-dir: terraform
-          config-file: .terraform-docs.yml
-          output-file: README.md
-          output-method: inject
-          fail-on-diff: true
-
+          
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@v3
         with:


### PR DESCRIPTION
- The 'validate terraform docs' step will fail if there is a diff in the source so this needs to happen before the 'remove azure backend' step.