### PR TITLE
Added named volume mount

### DIFF
--- a/docker-compose.checks.yml
+++ b/docker-compose.checks.yml
@@ -27,6 +27,8 @@ services:
       REDIS_URL: redis://test-redis:6379
     networks:
       - test-ci
+    volumes:
+      - test-ci:/srv/app/coverage
 
   test-db:
     image: mcr.microsoft.com/azure-sql-edge:latest
@@ -57,3 +59,7 @@ services:
 
 networks:
   test-ci:
+
+volumes:
+  test-ci:
+    name: test-ci-coverage-report


### PR DESCRIPTION
- Using a named volume mount allows us to persist the files between container runs and extract the files with an ephemeral container
- After the /bin/rspec test has finished and the container exits, you can manipulate the coverage report with other containers
- `docker run --rm -v test-ci-coverage-report:/source -v $PWD:/dest -w /source alpine cp -r . /dest/coverage/` can be used to download the coverage report onto the runner using a shim container