### PR TITLE
Allow a Project Contact to be selected as the main contact for an establishment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added the 'Deed of termination for the church supplemental agreement' task to
   transfers.
 - The application can now store the un-published GIAS establishment records.
+- Allow a contact to be marked as the "establishment main contact"
 
 ### Changed
 

--- a/app/controllers/external_contacts_controller.rb
+++ b/app/controllers/external_contacts_controller.rb
@@ -7,16 +7,14 @@ class ExternalContactsController < ApplicationController
 
   def new
     authorize @project, :new_contact?
-    @contact = Contact::Project.new(project: @project)
+    @contact = Contact::CreateProjectContactForm.new({}, @project)
   end
 
   def create
     authorize @project, :new_contact?
-    @contact = Contact::Project.new(project: @project, **contact_params)
+    @contact = Contact::CreateProjectContactForm.new(contact_params, @project)
 
-    if @contact.valid?
-      @contact.save
-
+    if @contact.save
       redirect_to project_contacts_path(@project), notice: I18n.t("contact.create.success")
     else
       render :new
@@ -24,20 +22,20 @@ class ExternalContactsController < ApplicationController
   end
 
   def edit
-    @contact = Contact.find(params[:id])
-    authorize @contact
+    @existing_contact = Contact.find(params[:id])
+    authorize @existing_contact
 
+    @contact = Contact::CreateProjectContactForm.new_from_contact({}, @project, @existing_contact)
     @users = User.all
   end
 
   def update
-    @contact = Contact.find(params[:id])
-    authorize @contact
+    @existing_contact = Contact.find(params[:id])
+    authorize @existing_contact
 
-    @contact.assign_attributes(contact_params)
+    @contact = Contact::CreateProjectContactForm.new(contact_params, @project, @existing_contact)
 
-    if @contact.valid?
-      @contact.save
+    if @contact.save
       redirect_to project_contacts_path(@project), notice: I18n.t("contact.update.success")
     else
       render :edit
@@ -59,6 +57,6 @@ class ExternalContactsController < ApplicationController
   end
 
   private def contact_params
-    params.require(:contact_project).permit(:name, :organisation_name, :title, :category, :email, :phone)
+    params.require(:contact_create_project_contact_form).permit(:name, :organisation_name, :title, :category, :email, :phone, :establishment_main_contact)
   end
 end

--- a/app/forms/contact/create_project_contact_form.rb
+++ b/app/forms/contact/create_project_contact_form.rb
@@ -1,0 +1,81 @@
+class Contact::CreateProjectContactForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
+  attribute :category
+  attribute :name
+  attribute :title
+  attribute :organisation_name
+  attribute :email
+  attribute :phone
+  attribute :establishment_main_contact
+  attribute :project_id
+  attr_accessor :category,
+    :name,
+    :title,
+    :organisation_name,
+    :email,
+    :phone,
+    :establishment_main_contact,
+    :project_id
+
+  validate :establishment_main_contact_for_school_only, if: -> { establishment_main_contact.eql?("1") }
+
+  def initialize(args = {}, project = nil, contact = nil)
+    @project = project
+    @contact = contact
+    super(args)
+  end
+
+  def self.new_from_contact(args = {}, project, contact)
+    @project = project
+    @contact = contact
+
+    new({category: contact.category,
+         name: contact.name,
+         title: contact.title,
+         organisation_name: contact.organisation_name,
+         email: contact.email,
+         phone: contact.phone,
+         establishment_main_contact: contact.establishment_main_contact},
+      @project,
+      @contact)
+  end
+
+  def save
+    @contact ||= Contact::Project.new
+    @contact.assign_attributes(category: category,
+      name: name,
+      title: title,
+      organisation_name: organisation_name,
+      email: email,
+      phone: phone,
+      project_id: @project.id)
+
+    if valid? && @contact.valid?
+      ActiveRecord::Base.transaction do
+        @contact.save
+        set_establishment_main_contact
+      end
+    else
+      errors.merge!(@contact.errors)
+      nil
+    end
+  end
+
+  private def establishment_main_contact_for_school_only
+    return true if category.eql?("school")
+    errors.add(:establishment_main_contact, :invalid)
+  end
+
+  private def set_establishment_main_contact
+    project = @project || Project.find(@contact.project_id)
+
+    if establishment_main_contact == "1"
+      project.update!(establishment_main_contact_id: @contact.id)
+    else
+      project.update!(establishment_main_contact_id: nil)
+    end
+  end
+end

--- a/app/models/contact/project.rb
+++ b/app/models/contact/project.rb
@@ -4,4 +4,10 @@ class Contact::Project < Contact
   end
 
   belongs_to :project, optional: true
+
+  def establishment_main_contact
+    return false unless project_id
+    project = ::Project.find(project_id)
+    project&.establishment_main_contact_id.eql?(id)
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -13,6 +13,7 @@ class Project < ApplicationRecord
   has_many :contacts, dependent: :destroy, class_name: "Contact::Project"
   has_one :funding_agreement_contact, dependent: :destroy, class_name: "Contact::Project", required: false
   has_one :main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
+  has_one :establishment_main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
 
   validates :urn, presence: true
   validates :urn, urn: true

--- a/app/views/external_contacts/_contact_group.html.erb
+++ b/app/views/external_contacts/_contact_group.html.erb
@@ -38,5 +38,11 @@
             row.value { t("yes") }
           end
         end
+        if @project.establishment_main_contact_id == contact.id
+          summary_list.row do |row|
+            row.key { t("contact.details.establishment_main_contact") }
+            row.value { t("yes") }
+          end
+        end
       end %>
   <% end %>

--- a/app/views/external_contacts/edit.html.erb
+++ b/app/views/external_contacts/edit.html.erb
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for [@project, @contact], url: project_contact_path(@project) do |form| %>
+    <%= form_for @contact, url: project_contact_path(@project), method: :put do |form| %>
       <%= form.govuk_error_summary %>
 
       <%= form.govuk_collection_select :category,
@@ -23,9 +23,12 @@
       <%= form.govuk_text_field :organisation_name %>
       <%= form.govuk_email_field :email %>
       <%= form.govuk_phone_field :phone, width: 10 %>
+      <%= form.govuk_check_boxes_fieldset :establishment_main_contact, multiple: false, legend: {text: t("helpers.label.contact_project.establishment_main_contact"), size: "s"} do %>
+        <%= form.govuk_check_box :establishment_main_contact, 1, 0, multiple: false, link_errors: true, label: {text: t("yes")} %>
+      <% end %>
 
       <%= form.govuk_submit t("contact.edit.save_contact_button") do %>
-        <%= govuk_button_link_to "Delete", project_contact_delete_path(@project, @contact), warning: true %>
+        <%= govuk_button_link_to "Delete", project_contact_delete_path(@project, @existing_contact), warning: true %>
         <%= govuk_link_to "Cancel", project_contacts_path(@project) %>
       <% end %>
     <% end %>

--- a/app/views/external_contacts/new.html.erb
+++ b/app/views/external_contacts/new.html.erb
@@ -10,12 +10,12 @@
 
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for [@project, @contact], url: project_contacts_path(@project) do |form| %>
+    <%= form_for [@project, @contact], url: project_contacts_path(@project, @contact) do |form| %>
       <%= form.govuk_error_summary %>
 
       <%= form.govuk_select(:category) do %>
         <option selected="selected" value=""><%= t("contact.categories.choose") %></option>
-        <% Contact.categories.each do |name, category| %>
+        <% Contact.categories.each do |name, _category| %>
           <option value="<%= name %>"><%= name.humanize %></option>
         <% end %>
       <% end %>
@@ -25,6 +25,9 @@
       <%= form.govuk_text_field :organisation_name %>
       <%= form.govuk_email_field :email %>
       <%= form.govuk_phone_field :phone, width: 10 %>
+      <%= form.govuk_check_boxes_fieldset :establishment_main_contact, multiple: false, legend: {text: t("helpers.label.contact_project.establishment_main_contact"), size: "s"} do %>
+        <%= form.govuk_check_box :establishment_main_contact, 1, 0, multiple: false, link_errors: true, label: {text: t("yes")} %>
+      <% end %>
 
       <%= form.govuk_submit t("contact.new.save_contact_button") do %>
         <%= govuk_link_to "Cancel", project_contacts_path(@project) %>

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -18,6 +18,7 @@ en:
       edit_link: Change
       funding_agreement_letters: This person will receive the funding agreement letters.
       main_contact: Project main contact
+      establishment_main_contact: Is this the main contact for the school or academy?
     new:
       title: Add contact
       save_contact_button: Add contact
@@ -49,7 +50,18 @@ en:
         organisation_name: Organisation
         email: Email
         phone: Phone
+        establishment_main_contact: Is this the main contact for the school or academy?
+      contact_create_project_contact_form:
+        category: Contact for
+        title: Role
+        name: Name
+        organisation_name: Organisation
+        email: Email
+        phone: Phone
+        establishment_main_contact: Is this the main contact for the school or academy?
   errors:
     attributes:
       category:
         blank: Choose a category
+      establishment_main_contact:
+        invalid: You can only select a School contact as the school or academy's main contact

--- a/db/migrate/20230831160511_add_establishment_contact_id_to_projects.rb
+++ b/db/migrate/20230831160511_add_establishment_contact_id_to_projects.rb
@@ -1,0 +1,5 @@
+class AddEstablishmentContactIdToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :establishment_main_contact_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -233,6 +233,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_07_143938) do
     t.text "outgoing_trust_sharepoint_link"
     t.boolean "all_conditions_met", default: false
     t.uuid "main_contact_id"
+    t.uuid "establishment_main_contact_id"
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"

--- a/spec/features/users_can_manage_contacts_spec.rb
+++ b/spec/features/users_can_manage_contacts_spec.rb
@@ -108,6 +108,38 @@ RSpec.feature "Users can manage contacts" do
     expect(page).to have_content(I18n.t("contact.details.main_contact"))
   end
 
+  scenario "they can create a new contact and set it as the establishment main contact" do
+    visit project_contacts_path(project)
+
+    click_link "Add contact"
+
+    expect(page).to have_select("Contact for", selected: "Choose category")
+
+    select "School", from: "Contact for"
+    fill_in "Name", with: "Some One"
+    fill_in "Organisation", with: "Trust Name"
+    fill_in "Role", with: "Chief of Knowledge"
+    fill_in "Email", with: "some@example.com"
+    check "contact_create_project_contact_form[establishment_main_contact]"
+
+    click_button("Add contact")
+
+    expect(page).to have_content("School contacts")
+    expect(page).to have_content(I18n.t("contact.details.establishment_main_contact"))
+  end
+
+  scenario "they can edit a contact and set it to be the establishment main contact" do
+    contact = create(:project_contact, project: project, category: "school")
+
+    visit edit_project_contact_path(project, contact)
+    check "contact_create_project_contact_form[establishment_main_contact]"
+
+    click_button("Save contact")
+
+    expect(project.reload.establishment_main_contact_id).to eq(contact.id)
+    expect(page).to have_content(I18n.t("contact.details.establishment_main_contact"))
+  end
+
   private def expect_page_to_have_contact(name:, title:, organisation_name: nil, email: nil, phone: nil)
     expect(page).to have_content(name)
     expect(page).to have_content(organisation_name) if organisation_name

--- a/spec/forms/contact/contact_project_form_spec.rb
+++ b/spec/forms/contact/contact_project_form_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+RSpec.describe Contact::CreateProjectContactForm do
+  let(:project) { create(:conversion_project) }
+
+  before do
+    mock_successful_api_response_to_create_any_project
+  end
+
+  context "a new contact" do
+    context "when the establishment_main_contact box is NOT checked" do
+      it "is valid" do
+        contact_form = Contact::CreateProjectContactForm.new({}, project)
+        contact_form.establishment_main_contact = "0"
+        expect(contact_form).to be_valid
+      end
+    end
+
+    context "when the establishment_main_contact box is checked" do
+      context "when the contact category is school" do
+        it "is valid" do
+          contact_form = Contact::CreateProjectContactForm.new({}, project)
+          contact_form.establishment_main_contact = "1"
+          contact_form.category = "school"
+          expect(contact_form).to be_valid
+        end
+
+        it "marks the contact as the establishment main contact on the project" do
+          contact_form = Contact::CreateProjectContactForm.new({}, project)
+          contact_form.establishment_main_contact = "1"
+          contact_form.category = "school"
+          contact_form.name = "New Contact"
+          contact_form.title = "Financial Controller"
+          contact_form.organisation_name = "School"
+          contact_form.save
+          contact = Contact::Project.last
+          expect(project.reload.establishment_main_contact).to eq(contact)
+        end
+      end
+
+      context "when the contact category is NOT school" do
+        it "is not valid" do
+          contact_form = Contact::CreateProjectContactForm.new({}, project)
+          contact_form.establishment_main_contact = "1"
+          contact_form.category = "incoming_trust"
+          expect(contact_form).to_not be_valid
+        end
+      end
+    end
+
+    context "when something fails in the transaction" do
+      before do
+        allow_any_instance_of(Contact::Project).to receive(:save).and_return(ActiveRecord::ActiveRecordError)
+      end
+
+      it "does not create the contact" do
+        contact_form = Contact::CreateProjectContactForm.new({}, project)
+        contact_form.category = "school"
+        contact_form.name = "New Contact"
+        contact_form.title = "Financial Controller"
+        contact_form.organisation_name = "School"
+        contact_form.save
+
+        expect(Contact::Project.count).to eq(0)
+      end
+    end
+  end
+
+  context "editing a contact" do
+    let(:contact) { create(:project_contact, project: project) }
+
+    context "when the establishment_main_contact box is NOT checked" do
+      it "is valid" do
+        contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
+        contact_form.establishment_main_contact = "0"
+        expect(contact_form).to be_valid
+      end
+
+      it "updates the existing contact" do
+        contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
+        contact_form.establishment_main_contact = "0"
+        contact_form.name = "New Name"
+        contact_form.save
+        expect(contact.reload.name).to eq("New Name")
+      end
+    end
+
+    context "when the establishment_main_contact box is checked" do
+      context "when the contact category is school" do
+        let(:contact) { create(:project_contact, project: project, category: "school") }
+
+        it "is valid" do
+          contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
+          contact_form.establishment_main_contact = "1"
+          expect(contact_form).to be_valid
+        end
+
+        it "updates the existing contact" do
+          contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
+          contact_form.establishment_main_contact = "1"
+          contact_form.name = "New Name"
+          contact_form.save
+          expect(contact.reload.name).to eq("New Name")
+        end
+      end
+
+      context "when the contact category is NOT school" do
+        let(:contact) { create(:project_contact, project: project, category: "solicitor") }
+
+        it "is not valid" do
+          contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
+          contact_form.establishment_main_contact = "1"
+          expect(contact_form).to_not be_valid
+        end
+      end
+    end
+  end
+end

--- a/spec/models/contact/project_contact_spec.rb
+++ b/spec/models/contact/project_contact_spec.rb
@@ -40,4 +40,31 @@ RSpec.describe Contact::Project, type: :model do
       end
     end
   end
+
+  describe "#establishment_main_contact" do
+    before do
+      mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    end
+
+    it "returns true if the contact is the establishment_main_contact for its project" do
+      project = create(:conversion_project)
+      contact = create(:project_contact, project: project)
+      project.establishment_main_contact_id = contact.id
+      project.save
+
+      expect(contact.reload.establishment_main_contact).to be true
+    end
+
+    it "returns false if the contact is NOT the establishment_main_contact for its project" do
+      project = create(:conversion_project, establishment_main_contact_id: SecureRandom.uuid)
+      contact = create(:project_contact, project: project)
+
+      expect(contact.establishment_main_contact).to be false
+    end
+
+    it "returns false if the contact does not have a project" do
+      contact = create(:project_contact, project_id: nil)
+      expect(contact.establishment_main_contact).to be false
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to belong_to(:tasks_data).required(true) }
     it { is_expected.to have_one(:funding_agreement_contact).required(false) }
     it { is_expected.to have_one(:main_contact).required(false) }
+    it { is_expected.to have_one(:establishment_main_contact).required(false) }
 
     describe "delete related entities" do
       context "when the project is deleted" do

--- a/spec/requests/contacts_controller_spec.rb
+++ b/spec/requests/contacts_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe ExternalContactsController, type: :request do
     let(:new_contact_title) { "Headteacher" }
 
     subject(:perform_request) do
-      post project_contacts_path(project_id), params: {contact_project: {name: new_contact_name, title: new_contact_title}}
+      post project_contacts_path(project_id), params: {contact_create_project_contact_form: {name: new_contact_name, title: new_contact_title, category: "school"}}
       response
     end
 
@@ -139,7 +139,7 @@ RSpec.describe ExternalContactsController, type: :request do
     let(:new_contact_title) { "Headteacher" }
 
     subject(:perform_request) do
-      put project_contact_path(project_id, contact_id), params: {contact_project: {name: new_contact_name, title: new_contact_title}}
+      put project_contact_path(project_id, contact_id), params: {contact_create_project_contact_form: {name: new_contact_name, title: new_contact_title, category: "other"}}
       response
     end
 


### PR DESCRIPTION
## Changes

We want to be able to designate a Project Contact as the "main contact" for an establishment (school).

Users can now mark a contact as the "establishment main contact" when they create or edit an external contact.

ONLY "School" contacts can be establishment main contacts, not any other category of contact.

There can only be one establishment main contact per Project.

If a contact is the establishment main contact, this is shown on the External contacts list page.

### Mark contact as establishment main contact

<img width="682" alt="Screenshot 2023-09-07 at 08 40 08" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/375e4628-a347-45be-8a93-bd079c57725c">

### Validation

<img width="738" alt="Screenshot 2023-09-07 at 08 40 19" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/a69937cc-c93b-4312-accc-c400aed68ea3">

### Show that contact is establishment main contact

<img width="880" alt="Screenshot 2023-09-07 at 08 39 53" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/664596b6-b7c4-4b1c-b062-84b13ee7fd35">


## Checklist

- [x] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
