### PR TITLE
Add main incoming trust contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   transfers.
 - The application can now store the un-published GIAS establishment records.
 - Allow a contact to be marked as the "establishment main contact"
+- Allow a contact to be marked as the "incoming trust main contact"
 
 ### Changed
 

--- a/app/controllers/external_contacts_controller.rb
+++ b/app/controllers/external_contacts_controller.rb
@@ -57,6 +57,6 @@ class ExternalContactsController < ApplicationController
   end
 
   private def contact_params
-    params.require(:contact_create_project_contact_form).permit(:name, :organisation_name, :title, :category, :email, :phone, :establishment_main_contact)
+    params.require(:contact_create_project_contact_form).permit(:name, :organisation_name, :title, :category, :email, :phone, :establishment_main_contact, :incoming_trust_main_contact)
   end
 end

--- a/app/forms/contact/create_project_contact_form.rb
+++ b/app/forms/contact/create_project_contact_form.rb
@@ -10,6 +10,7 @@ class Contact::CreateProjectContactForm
   attribute :email
   attribute :phone
   attribute :establishment_main_contact
+  attribute :incoming_trust_main_contact
   attribute :project_id
   attr_accessor :category,
     :name,
@@ -18,9 +19,11 @@ class Contact::CreateProjectContactForm
     :email,
     :phone,
     :establishment_main_contact,
+    :incoming_trust_main_contact,
     :project_id
 
   validate :establishment_main_contact_for_school_only, if: -> { establishment_main_contact.eql?("1") }
+  validate :incoming_trust_main_contact_for_incoming_trust_only, if: -> { incoming_trust_main_contact.eql?("1") }
 
   def initialize(args = {}, project = nil, contact = nil)
     @project = project
@@ -38,7 +41,8 @@ class Contact::CreateProjectContactForm
          organisation_name: contact.organisation_name,
          email: contact.email,
          phone: contact.phone,
-         establishment_main_contact: contact.establishment_main_contact},
+         establishment_main_contact: contact.establishment_main_contact,
+         incoming_trust_main_contact: contact.incoming_trust_main_contact},
       @project,
       @contact)
   end
@@ -57,6 +61,7 @@ class Contact::CreateProjectContactForm
       ActiveRecord::Base.transaction do
         @contact.save
         set_establishment_main_contact
+        set_incoming_trust_main_contact
       end
     else
       errors.merge!(@contact.errors)
@@ -69,6 +74,11 @@ class Contact::CreateProjectContactForm
     errors.add(:establishment_main_contact, :invalid)
   end
 
+  private def incoming_trust_main_contact_for_incoming_trust_only
+    return true if category.eql?("incoming_trust")
+    errors.add(:incoming_trust_main_contact, :invalid)
+  end
+
   private def set_establishment_main_contact
     project = @project || Project.find(@contact.project_id)
 
@@ -76,6 +86,16 @@ class Contact::CreateProjectContactForm
       project.update!(establishment_main_contact_id: @contact.id)
     else
       project.update!(establishment_main_contact_id: nil)
+    end
+  end
+
+  private def set_incoming_trust_main_contact
+    project = @project || Project.find(@contact.project_id)
+
+    if incoming_trust_main_contact == "1"
+      project.update!(incoming_trust_main_contact_id: @contact.id)
+    else
+      project.update!(incoming_trust_main_contact_id: nil)
     end
   end
 end

--- a/app/models/contact/project.rb
+++ b/app/models/contact/project.rb
@@ -10,4 +10,10 @@ class Contact::Project < Contact
     project = ::Project.find(project_id)
     project&.establishment_main_contact_id.eql?(id)
   end
+
+  def incoming_trust_main_contact
+    return false unless project_id
+    project = ::Project.find(project_id)
+    project&.incoming_trust_main_contact_id.eql?(id)
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -14,6 +14,7 @@ class Project < ApplicationRecord
   has_one :funding_agreement_contact, dependent: :destroy, class_name: "Contact::Project", required: false
   has_one :main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
   has_one :establishment_main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
+  has_one :incoming_trust_main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
 
   validates :urn, presence: true
   validates :urn, urn: true

--- a/app/views/external_contacts/_contact_group.html.erb
+++ b/app/views/external_contacts/_contact_group.html.erb
@@ -44,5 +44,11 @@
             row.value { t("yes") }
           end
         end
+        if @project.incoming_trust_main_contact_id == contact.id
+          summary_list.row do |row|
+            row.key { t("contact.details.incoming_trust_main_contact") }
+            row.value { t("yes") }
+          end
+        end
       end %>
   <% end %>

--- a/app/views/external_contacts/edit.html.erb
+++ b/app/views/external_contacts/edit.html.erb
@@ -26,6 +26,9 @@
       <%= form.govuk_check_boxes_fieldset :establishment_main_contact, multiple: false, legend: {text: t("helpers.label.contact_project.establishment_main_contact"), size: "s"} do %>
         <%= form.govuk_check_box :establishment_main_contact, 1, 0, multiple: false, link_errors: true, label: {text: t("yes")} %>
       <% end %>
+      <%= form.govuk_check_boxes_fieldset :incoming_trust_main_contact, multiple: false, legend: {text: t("helpers.label.contact_project.incoming_trust_main_contact"), size: "s"} do %>
+        <%= form.govuk_check_box :incoming_trust_main_contact, 1, 0, multiple: false, link_errors: true, label: {text: t("yes")} %>
+      <% end %>
 
       <%= form.govuk_submit t("contact.edit.save_contact_button") do %>
         <%= govuk_button_link_to "Delete", project_contact_delete_path(@project, @existing_contact), warning: true %>

--- a/app/views/external_contacts/new.html.erb
+++ b/app/views/external_contacts/new.html.erb
@@ -28,6 +28,9 @@
       <%= form.govuk_check_boxes_fieldset :establishment_main_contact, multiple: false, legend: {text: t("helpers.label.contact_project.establishment_main_contact"), size: "s"} do %>
         <%= form.govuk_check_box :establishment_main_contact, 1, 0, multiple: false, link_errors: true, label: {text: t("yes")} %>
       <% end %>
+      <%= form.govuk_check_boxes_fieldset :incoming_trust_main_contact, multiple: false, legend: {text: t("helpers.label.contact_project.incoming_trust_main_contact"), size: "s"} do %>
+        <%= form.govuk_check_box :incoming_trust_main_contact, 1, 0, multiple: false, link_errors: true, label: {text: t("yes")} %>
+      <% end %>
 
       <%= form.govuk_submit t("contact.new.save_contact_button") do %>
         <%= govuk_link_to "Cancel", project_contacts_path(@project) %>

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -19,6 +19,7 @@ en:
       funding_agreement_letters: This person will receive the funding agreement letters.
       main_contact: Project main contact
       establishment_main_contact: Is this the main contact for the school or academy?
+      incoming_trust_main_contact: Is this the main contact for the incoming trust?
     new:
       title: Add contact
       save_contact_button: Add contact
@@ -51,6 +52,7 @@ en:
         email: Email
         phone: Phone
         establishment_main_contact: Is this the main contact for the school or academy?
+        incoming_trust_main_contact: Is this the main contact for the incoming trust?
       contact_create_project_contact_form:
         category: Contact for
         title: Role
@@ -59,9 +61,12 @@ en:
         email: Email
         phone: Phone
         establishment_main_contact: Is this the main contact for the school or academy?
+        incoming_trust_main_contact: Is this the main contact for the incoming trust?
   errors:
     attributes:
       category:
         blank: Choose a category
       establishment_main_contact:
         invalid: You can only select a School contact as the school or academy's main contact
+      incoming_trust_main_contact:
+        invalid: You can only select an Incoming trust contact as the incoming trust's main contact

--- a/db/migrate/20230907113049_add_incoming_trust_main_contact_id_to_projects.rb
+++ b/db/migrate/20230907113049_add_incoming_trust_main_contact_id_to_projects.rb
@@ -1,0 +1,5 @@
+class AddIncomingTrustMainContactIdToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :incoming_trust_main_contact_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -234,6 +234,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_07_143938) do
     t.boolean "all_conditions_met", default: false
     t.uuid "main_contact_id"
     t.uuid "establishment_main_contact_id"
+    t.uuid "incoming_trust_main_contact_id"
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"

--- a/spec/features/users_can_manage_contacts_spec.rb
+++ b/spec/features/users_can_manage_contacts_spec.rb
@@ -140,6 +140,24 @@ RSpec.feature "Users can manage contacts" do
     expect(page).to have_content(I18n.t("contact.details.establishment_main_contact"))
   end
 
+  scenario "they can create a new contact and set it as the incoming trust main contact" do
+    visit project_contacts_path(project)
+
+    click_link "Add contact"
+
+    select "Incoming trust", from: "Contact for"
+    fill_in "Name", with: "Some One"
+    fill_in "Organisation", with: "Trust Name"
+    fill_in "Role", with: "Chief of Knowledge"
+    fill_in "Email", with: "some@example.com"
+    check "contact_create_project_contact_form[incoming_trust_main_contact]"
+
+    click_button("Add contact")
+
+    expect(page).to have_content("Incoming trust contacts")
+    expect(page).to have_content(I18n.t("contact.details.incoming_trust_main_contact"))
+  end
+
   private def expect_page_to_have_contact(name:, title:, organisation_name: nil, email: nil, phone: nil)
     expect(page).to have_content(name)
     expect(page).to have_content(organisation_name) if organisation_name

--- a/spec/forms/contact/contact_project_form_spec.rb
+++ b/spec/forms/contact/contact_project_form_spec.rb
@@ -7,43 +7,45 @@ RSpec.describe Contact::CreateProjectContactForm do
     mock_successful_api_response_to_create_any_project
   end
 
-  context "a new contact" do
-    context "when the establishment_main_contact box is NOT checked" do
-      it "is valid" do
-        contact_form = Contact::CreateProjectContactForm.new({}, project)
-        contact_form.establishment_main_contact = "0"
-        expect(contact_form).to be_valid
-      end
-    end
-
-    context "when the establishment_main_contact box is checked" do
-      context "when the contact category is school" do
+  describe "establishment_main_contact" do
+    context "a new contact" do
+      context "when the establishment_main_contact box is NOT checked" do
         it "is valid" do
           contact_form = Contact::CreateProjectContactForm.new({}, project)
-          contact_form.establishment_main_contact = "1"
-          contact_form.category = "school"
+          contact_form.establishment_main_contact = "0"
           expect(contact_form).to be_valid
-        end
-
-        it "marks the contact as the establishment main contact on the project" do
-          contact_form = Contact::CreateProjectContactForm.new({}, project)
-          contact_form.establishment_main_contact = "1"
-          contact_form.category = "school"
-          contact_form.name = "New Contact"
-          contact_form.title = "Financial Controller"
-          contact_form.organisation_name = "School"
-          contact_form.save
-          contact = Contact::Project.last
-          expect(project.reload.establishment_main_contact).to eq(contact)
         end
       end
 
-      context "when the contact category is NOT school" do
-        it "is not valid" do
-          contact_form = Contact::CreateProjectContactForm.new({}, project)
-          contact_form.establishment_main_contact = "1"
-          contact_form.category = "incoming_trust"
-          expect(contact_form).to_not be_valid
+      context "when the establishment_main_contact box is checked" do
+        context "when the contact category is school" do
+          it "is valid" do
+            contact_form = Contact::CreateProjectContactForm.new({}, project)
+            contact_form.establishment_main_contact = "1"
+            contact_form.category = "school"
+            expect(contact_form).to be_valid
+          end
+
+          it "marks the contact as the establishment main contact on the project" do
+            contact_form = Contact::CreateProjectContactForm.new({}, project)
+            contact_form.establishment_main_contact = "1"
+            contact_form.category = "school"
+            contact_form.name = "New Contact"
+            contact_form.title = "Financial Controller"
+            contact_form.organisation_name = "School"
+            contact_form.save
+            contact = Contact::Project.last
+            expect(project.reload.establishment_main_contact).to eq(contact)
+          end
+        end
+
+        context "when the contact category is NOT school" do
+          it "is not valid" do
+            contact_form = Contact::CreateProjectContactForm.new({}, project)
+            contact_form.establishment_main_contact = "1"
+            contact_form.category = "incoming_trust"
+            expect(contact_form).to_not be_valid
+          end
         end
       end
     end
@@ -64,53 +66,131 @@ RSpec.describe Contact::CreateProjectContactForm do
         expect(Contact::Project.count).to eq(0)
       end
     end
-  end
 
-  context "editing a contact" do
-    let(:contact) { create(:project_contact, project: project) }
+    context "editing a contact" do
+      let(:contact) { create(:project_contact, project: project) }
 
-    context "when the establishment_main_contact box is NOT checked" do
-      it "is valid" do
-        contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
-        contact_form.establishment_main_contact = "0"
-        expect(contact_form).to be_valid
-      end
-
-      it "updates the existing contact" do
-        contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
-        contact_form.establishment_main_contact = "0"
-        contact_form.name = "New Name"
-        contact_form.save
-        expect(contact.reload.name).to eq("New Name")
-      end
-    end
-
-    context "when the establishment_main_contact box is checked" do
-      context "when the contact category is school" do
-        let(:contact) { create(:project_contact, project: project, category: "school") }
-
+      context "when the establishment_main_contact box is NOT checked" do
         it "is valid" do
           contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
-          contact_form.establishment_main_contact = "1"
+          contact_form.establishment_main_contact = "0"
           expect(contact_form).to be_valid
         end
 
         it "updates the existing contact" do
           contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
-          contact_form.establishment_main_contact = "1"
+          contact_form.establishment_main_contact = "0"
           contact_form.name = "New Name"
           contact_form.save
           expect(contact.reload.name).to eq("New Name")
         end
       end
 
-      context "when the contact category is NOT school" do
-        let(:contact) { create(:project_contact, project: project, category: "solicitor") }
+      context "when the establishment_main_contact box is checked" do
+        context "when the contact category is school" do
+          let(:contact) { create(:project_contact, project: project, category: "school") }
 
-        it "is not valid" do
-          contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
-          contact_form.establishment_main_contact = "1"
-          expect(contact_form).to_not be_valid
+          it "is valid" do
+            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
+            contact_form.establishment_main_contact = "1"
+            expect(contact_form).to be_valid
+          end
+
+          it "updates the existing contact" do
+            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
+            contact_form.establishment_main_contact = "1"
+            contact_form.name = "New Name"
+            contact_form.save
+            expect(contact.reload.name).to eq("New Name")
+          end
+        end
+
+        context "when the contact category is NOT school" do
+          let(:contact) { create(:project_contact, project: project, category: "solicitor") }
+
+          it "is not valid" do
+            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
+            contact_form.establishment_main_contact = "1"
+            expect(contact_form).to_not be_valid
+          end
+        end
+      end
+    end
+  end
+
+  describe "incoming_trust_main_contact" do
+    context "a new contact" do
+      context "when the incoming_trust_main_contact is checked" do
+        context "when the contact category is incoming_trust" do
+          it "is valid" do
+            contact_form = Contact::CreateProjectContactForm.new({}, project)
+            contact_form.incoming_trust_main_contact = "1"
+            contact_form.category = "incoming_trust"
+            expect(contact_form).to be_valid
+          end
+
+          it "marks the contact as the incoming_trust_main_contact on the project" do
+            contact_form = Contact::CreateProjectContactForm.new({}, project)
+            contact_form.incoming_trust_main_contact = "1"
+            contact_form.category = "incoming_trust"
+            contact_form.name = "New Contact"
+            contact_form.title = "Financial Controller"
+            contact_form.organisation_name = "Trust"
+            contact_form.save
+            contact = Contact::Project.last
+            expect(project.reload.incoming_trust_main_contact).to eq(contact)
+          end
+        end
+
+        context "when the contact category is NOT incoming_trust" do
+          it "is not valid" do
+            contact_form = Contact::CreateProjectContactForm.new({}, project)
+            contact_form.incoming_trust_main_contact = "1"
+            contact_form.category = "school"
+            expect(contact_form).to_not be_valid
+          end
+        end
+      end
+    end
+
+    context "editing a contact" do
+      context "when the incoming_trust_main_contact is checked" do
+        context "when the contact category is incoming_trust" do
+          let(:contact) { create(:project_contact, project: project, category: "incoming_trust") }
+
+          it "is valid" do
+            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
+            contact_form.incoming_trust_main_contact = "1"
+            expect(contact_form).to be_valid
+          end
+        end
+
+        context "when the contact category is NOT incoming_trust" do
+          let(:contact) { create(:project_contact, project: project, category: "solicitor") }
+
+          it "is not valid" do
+            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
+            contact_form.incoming_trust_main_contact = "1"
+            expect(contact_form).to_not be_valid
+          end
+        end
+      end
+
+      context "when the incoming_trust_main_contact box is NOT checked" do
+        context "when the contact was previously marked as the incoming_trust_main_contact" do
+          let(:contact) { create(:project_contact, project: project, category: "incoming_trust") }
+
+          before do
+            project.update!(incoming_trust_main_contact_id: contact.id)
+          end
+
+          it "removes the incoming_trust_main_contact from the project" do
+            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
+            contact_form.incoming_trust_main_contact = "0"
+            contact_form.save
+
+            expect(project.incoming_trust_main_contact_id).to be_nil
+          end
         end
       end
     end

--- a/spec/models/contact/project_contact_spec.rb
+++ b/spec/models/contact/project_contact_spec.rb
@@ -67,4 +67,31 @@ RSpec.describe Contact::Project, type: :model do
       expect(contact.establishment_main_contact).to be false
     end
   end
+
+  describe "#incoming_trust_main_contact" do
+    before do
+      mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    end
+
+    it "returns true if the contact is the incoming_trust_main_contact for its project" do
+      project = create(:conversion_project)
+      contact = create(:project_contact, project: project)
+      project.incoming_trust_main_contact_id = contact.id
+      project.save
+
+      expect(contact.reload.incoming_trust_main_contact).to be true
+    end
+
+    it "returns false if the contact is NOT the incoming_trust_main_contact for its project" do
+      project = create(:conversion_project, incoming_trust_main_contact_id: SecureRandom.uuid)
+      contact = create(:project_contact, project: project)
+
+      expect(contact.incoming_trust_main_contact).to be false
+    end
+
+    it "returns false if the contact does not have a project" do
+      contact = create(:project_contact, project_id: nil)
+      expect(contact.incoming_trust_main_contact).to be false
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_one(:funding_agreement_contact).required(false) }
     it { is_expected.to have_one(:main_contact).required(false) }
     it { is_expected.to have_one(:establishment_main_contact).required(false) }
+    it { is_expected.to have_one(:incoming_trust_main_contact).required(false) }
 
     describe "delete related entities" do
       context "when the project is deleted" do


### PR DESCRIPTION
## Changes

Allow users to select an external contact as the main contact for an incoming trust. This can be done on create and update.

<img width="718" alt="Screenshot 2023-09-12 at 11 57 10" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/4434c6d9-032c-420f-abbf-175f287e0562">

The contact must be an Incoming trust contact - trying to select any other contact type as the incoming trust main contact will result in a validation error.

<img width="686" alt="Screenshot 2023-09-12 at 11 59 00" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/80c40e11-1428-44fa-b52f-e3c7efa1d4c3">


The contact will be marked as the incoming trust main contact on the External contacts list pagel

<img width="966" alt="Screenshot 2023-09-12 at 11 58 51" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/d5a190b8-266e-4893-b66c-144c95a3f423">

## Checklist

- [ ] Attach this pull request to the appropriate card in Trello.
- [x] Update the `CHANGELOG.md` if needed.
