### PR TITLE
Add Deeds of termination for CSA task to transfer task list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Show the main contact for a project in the project CSV exports
 - The all conditions met task for a transfer has updated content.
 - Add deeds of termination for MFA task to Transfer projects
+- Added the 'Deed of termination for the church supplemental agreement' task to
+  transfers.
 
 ### Changed
 

--- a/app/forms/transfer/task/deed_of_novation_and_variation_task_form.rb
+++ b/app/forms/transfer/task/deed_of_novation_and_variation_task_form.rb
@@ -1,9 +1,9 @@
-class Transfer::Task::DeedOfNovationAndVariationTaskForm < BaseOptionalTaskForm
+class Transfer::Task::DeedOfNovationAndVariationTaskForm < BaseTaskForm
   attribute :received, :boolean
   attribute :cleared, :boolean
   attribute :signed_outgoing_trust, :boolean
   attribute :signed_incoming_trust, :boolean
   attribute :saved, :boolean
   attribute :signed_secretary_state, :boolean
-  attribute :sent, :boolean
+  attribute :save_after_sign, :boolean
 end

--- a/app/forms/transfer/task/deed_termination_church_agreement_task_form.rb
+++ b/app/forms/transfer/task/deed_termination_church_agreement_task_form.rb
@@ -1,0 +1,10 @@
+class Transfer::Task::DeedTerminationChurchAgreementTaskForm < BaseOptionalTaskForm
+  attribute :received, :boolean
+  attribute :cleared, :boolean
+  attribute :signed_outgoing_trust, :boolean
+  attribute :signed_diocese, :boolean
+  attribute :saved, :boolean
+  attribute :signed_secretary_state, :boolean
+  attribute :saved_after_signing_by_secretary_state, :boolean
+  attribute :not_applicable, :boolean
+end

--- a/app/models/transfer/task_list.rb
+++ b/app/models/transfer/task_list.rb
@@ -21,7 +21,8 @@ class Transfer::TaskList < ::BaseTaskList
           Transfer::Task::LandConsentLetterTaskForm,
           Transfer::Task::FormMTaskForm,
           Transfer::Task::ChurchSupplementalAgreementTaskForm,
-          Transfer::Task::DeedOfTerminationForTheMasterFundingAgreementTaskForm
+          Transfer::Task::DeedOfTerminationForTheMasterFundingAgreementTaskForm,
+          Transfer::Task::DeedTerminationChurchAgreementTaskForm
         ]
       },
       {

--- a/app/views/transfers/tasks/deed_of_novation_and_variation/edit.html.erb
+++ b/app/views/transfers/tasks/deed_of_novation_and_variation/edit.html.erb
@@ -14,10 +14,6 @@
       <%= form.govuk_error_summary %>
 
       <div class="govuk-form-group">
-        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
-      </div>
-
-      <div class="govuk-form-group">
         <h2 class="govuk-heading-l"><%= t("transfer.task.deed_of_novation_and_variation.clear_section.title") %></h2>
         <div class="app-task-section__hint">
           <%= t("transfer.task.deed_of_novation_and_variation.clear_section.hint.html") %>
@@ -44,7 +40,7 @@
             ) %>
 
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed_secretary_state)) %>
-        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :save_after_sign)) %>
       </div>
 
       <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>

--- a/app/views/transfers/tasks/deed_termination_church_agreement/edit.html.erb
+++ b/app/views/transfers/tasks/deed_termination_church_agreement/edit.html.erb
@@ -1,0 +1,58 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.deed_termination_church_agreement.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
+      <div class="govuk-form-group">
+        <h2 class="govuk-heading-l"><%= t("transfer.task.deed_termination_church_agreement.clear_section.title") %></h2>
+
+        <%= govuk_details(
+              summary_text: t("transfer.task.deed_termination_church_agreement.clear_section.guidance_link"),
+              text: t("transfer.task.deed_termination_church_agreement.clear_section.guidance.html")
+            ) %>
+
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :received)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :cleared)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed_outgoing_trust)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed_diocese)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
+      </div>
+
+      <div class="govuk-form-group">
+        <h2 class="govuk-heading-l"><%= t("transfer.task.deed_termination_church_agreement.sign_section.title") %></h2>
+
+        <div class="app-task-section__hint">
+          <%= t("transfer.task.deed_termination_church_agreement.sign_section.hint.html") %>
+        </div>
+
+        <%= govuk_details(
+              summary_text: t("transfer.task.deed_termination_church_agreement.sign_section.guidance_link"),
+              text: t("transfer.task.deed_termination_church_agreement.sign_section.guidance.html")
+            ) %>
+
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed_secretary_state)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved_after_signing_by_secretary_state)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/app/views/transfers/tasks/stakeholder_kick_off/edit.html.erb
+++ b/app/views/transfers/tasks/stakeholder_kick_off/edit.html.erb
@@ -21,7 +21,7 @@
         <% if @project.transfer_date_provisional? %>
           <%= form.govuk_date_field :confirmed_transfer_date,
                 omit_day: true,
-                form_group: {classes: "app-confirmed-conversion-date"},
+                form_group: {classes: "app-confirmed-transfer-date"},
                 legend: {text: t("transfer.task.stakeholder_kick_off.confirmed_transfer_date.title"), size: "s"} do %>
             <div class="govuk-hint"><%= t("transfer.task.stakeholder_kick_off.confirmed_transfer_date.hint.html") %></div>
           <% end %>

--- a/config/locales/transfer/tasks/deed_of_novation_and_variation.en.yml
+++ b/config/locales/transfer/tasks/deed_of_novation_and_variation.en.yml
@@ -38,9 +38,7 @@ en:
           title: Signed by incoming trust
         saved:
           title: Saved in academy SharePoint folder
-        sent:
-          title: Sent to team leader or deputy director
         signed_secretary_state:
           title: Signed on behalf of Secretary of State
-        not_applicable:
-          title: Not applicable
+        save_after_sign:
+          title: Saved in academy SharePoint folder

--- a/config/locales/transfer/tasks/deed_termination_church_agreement.en.yml
+++ b/config/locales/transfer/tasks/deed_termination_church_agreement.en.yml
@@ -1,0 +1,52 @@
+en:
+  transfer:
+    task:
+      deed_termination_church_agreement:
+        title: Deed of termination for the church supplemental agreement
+        hint:
+          html:
+            <p>Use a deed of termination to end an outgoing trust's church supplemental agreement.</p>
+            <p>Once the existing church supplemental agreement has been terminated, you will need to draft a new one for the incoming trust.</p>
+        guidance_link: Other ways to deal with a church supplemental agreement
+        guidance:
+          html:
+            <p>Solicitors may want to transfer a church supplemental agreement to the new trust with a deed of novation and variation instead.</p>
+            <p>This is not advised and is not our preferred option.</p>
+            <p>Only use a deed of novation and variation on a case-by-case basis.</p>
+
+        not_applicable:
+          title: Not applicable
+
+        clear_section:
+          title: Check and clear the deed of termination
+          guidance_link: Using a deed of termination to transfer a church supplemental agreement
+          guidance:
+            html:
+              <p>There is no model document for using a deed of termination to transfer a church supplemental agreement.</p>
+              <p>You must <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00116/SitePages/Commissioning%20Form.aspx" target="_blank">contact the policy team (opens in new tab)</a> if you need to use the deed of termination for transferring a church supplemental agreement.</p>
+        received:
+          title: Received
+        cleared:
+          title: Cleared by policy
+        signed_outgoing_trust:
+          title: Signed by outgoing trust
+        signed_diocese:
+          title: Signed by diocese
+        saved:
+          title: Saved in academy and outgoing trust SharePoint folder
+
+        sign_section:
+          title: Signed by the Secretary of State
+          hint:
+            html:
+              <p>This must be signed before the transfer date.</p>
+          guidance_link: How to sign the deed of termination
+          guidance:
+            html:
+              <p>The Secretary of State, or somebody with the authority to act on their behalf, must sign the deed of termination.</p>
+              <p>Each team may have a different process for signing and sealing documents. Follow your team's signing process.</p>
+              <p>Once you have the signed version of the document, save it as a PDF in SharePoint.</p>
+        signed_secretary_state:
+          title: Signed on behalf of Secretary of State
+        saved_after_signing_by_secretary_state:
+          title: Saved in academy SharePoint folder

--- a/db/migrate/20230906134022_add_deed_termination_church_agreement_task_attributes.rb
+++ b/db/migrate/20230906134022_add_deed_termination_church_agreement_task_attributes.rb
@@ -1,0 +1,12 @@
+class AddDeedTerminationChurchAgreementTaskAttributes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :transfer_tasks_data, :deed_termination_church_agreement_received, :boolean
+    add_column :transfer_tasks_data, :deed_termination_church_agreement_cleared, :boolean
+    add_column :transfer_tasks_data, :deed_termination_church_agreement_signed_outgoing_trust, :boolean
+    add_column :transfer_tasks_data, :deed_termination_church_agreement_signed_diocese, :boolean
+    add_column :transfer_tasks_data, :deed_termination_church_agreement_saved, :boolean
+    add_column :transfer_tasks_data, :deed_termination_church_agreement_signed_secretary_state, :boolean
+    add_column :transfer_tasks_data, :deed_termination_church_agreement_saved_after_signing_by_secretary_state, :boolean
+    add_column :transfer_tasks_data, :deed_termination_church_agreement_not_applicable, :boolean
+  end
+end

--- a/db/migrate/20230907085358_rename_task_action_on_deed_novation_variation.rb
+++ b/db/migrate/20230907085358_rename_task_action_on_deed_novation_variation.rb
@@ -1,0 +1,5 @@
+class RenameTaskActionOnDeedNovationVariation < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :transfer_tasks_data, :deed_of_novation_and_variation_sent, :deed_of_novation_and_variation_save_after_sign
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_06_104512) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_06_134022) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -281,6 +281,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_06_104512) do
     t.boolean "deed_of_termination_for_the_master_funding_agreement_signed_secretary_state"
     t.boolean "deed_of_termination_for_the_master_funding_agreement_saved_in_academy_sharepoint_folder"
     t.boolean "deed_of_termination_for_the_master_funding_agreement_not_applicable"
+    t.boolean "deed_termination_church_agreement_received"
+    t.boolean "deed_termination_church_agreement_cleared"
+    t.boolean "deed_termination_church_agreement_signed_outgoing_trust"
+    t.boolean "deed_termination_church_agreement_signed_diocese"
+    t.boolean "deed_termination_church_agreement_saved"
+    t.boolean "deed_termination_church_agreement_signed_secretary_state"
+    t.boolean "deed_termination_church_agreement_saved_after_signing_by_secretary_state"
+    t.boolean "deed_termination_church_agreement_not_applicable"
   end
 
   create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_06_134022) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_07_085358) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -235,7 +235,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_06_134022) do
     t.boolean "deed_of_novation_and_variation_signed_incoming_trust"
     t.boolean "deed_of_novation_and_variation_saved"
     t.boolean "deed_of_novation_and_variation_signed_secretary_state"
-    t.boolean "deed_of_novation_and_variation_sent"
+    t.boolean "deed_of_novation_and_variation_save_after_sign"
     t.boolean "articles_of_association_received"
     t.boolean "articles_of_association_cleared"
     t.boolean "articles_of_association_signed"

--- a/spec/features/transfers/tasks/users_can_compelte_main_contact_spec.rb
+++ b/spec/features/transfers/tasks/users_can_compelte_main_contact_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.feature "Users can complete the main contact task" do
+  let(:user) { create(:user, :regional_delivery_officer) }
+
+  before do
+    mock_all_academies_api_responses
+    sign_in_with_user(user)
+    visit project_tasks_path(project)
+  end
+
+  context "the main contact task" do
+    let(:project) { create(:transfer_project, assigned_to: user) }
+
+    context "when the project has contacts already" do
+      let!(:contact) { create(:project_contact, project: project) }
+
+      it "lets the user select an existing contact" do
+        visit project_tasks_path(project)
+        click_on "Confirm who is the main contact for this transfer"
+        choose contact.name
+        click_on I18n.t("task_list.continue_button.text")
+
+        expect(project.reload.main_contact_id).to eq contact.id
+      end
+    end
+
+    context "when the project has no contacts" do
+      it "directs the user to add contacts" do
+        visit project_tasks_path(project)
+        click_on "Confirm who is the main contact for this transfer"
+
+        expect(page).to have_content("Add contacts")
+        click_link "add a contact"
+        expect(page.current_path).to include("external-contacts")
+      end
+    end
+  end
+end

--- a/spec/features/transfers/tasks/users_can_compelte_stakeholder_kick_off_spec.rb
+++ b/spec/features/transfers/tasks/users_can_compelte_stakeholder_kick_off_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.feature "Users can complete the stakeholder kick off task" do
+  let(:user) { create(:user, :regional_delivery_officer) }
+
+  before do
+    mock_all_academies_api_responses
+    sign_in_with_user(user)
+    visit project_tasks_path(project)
+  end
+
+  describe "the stakeholder kick-off task" do
+    context "when the project transfer date is provisional" do
+      let(:project) { create(:transfer_project, assigned_to: user, transfer_date_provisional: true) }
+
+      scenario "they can set the confirmed date" do
+        visit project_tasks_path(project)
+
+        click_on "External stakeholder kick-off"
+        page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
+        within(".app-confirmed-transfer-date") do
+          completion_date = Date.today + 1.year
+          fill_in "Month", with: completion_date.month
+          fill_in "Year", with: completion_date.year
+        end
+        click_on I18n.t("task_list.continue_button.text")
+        table_row = page.find("li.app-task-list__item", text: "External stakeholder kick-off")
+        expect(table_row).to have_content("Completed")
+      end
+    end
+
+    context "when the project transfer date is confirmed" do
+      let(:project) { create(:transfer_project, assigned_to: user, transfer_date_provisional: false) }
+
+      scenario "they can continue to submit the task form" do
+        visit project_tasks_path(project)
+
+        click_on "External stakeholder kick-off"
+        page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
+        click_on I18n.t("task_list.continue_button.text")
+        table_row = page.find("li.app-task-list__item", text: "External stakeholder kick-off")
+        expect(table_row).to have_content("Completed")
+      end
+    end
+  end
+end

--- a/spec/features/transfers/tasks/users_can_complete_all_conditions_met_spec.rb
+++ b/spec/features/transfers/tasks/users_can_complete_all_conditions_met_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.feature "Users can complete the all conditions met task" do
+  let(:user) { create(:user, :regional_delivery_officer) }
+  let(:project) { create(:transfer_project, assigned_to: user) }
+
+  before do
+    mock_all_academies_api_responses
+    sign_in_with_user(user)
+    visit project_tasks_path(project)
+  end
+
+  describe "the confirm all conditions met task" do
+    scenario "they can confirm all conditions have been met" do
+      visit project_tasks_path(project)
+      click_on "Confirm all conditions have been met"
+      page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
+      click_on I18n.t("task_list.continue_button.text")
+
+      expect(project.reload.all_conditions_met).to be true
+    end
+  end
+end

--- a/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
+++ b/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Users can complete conversion tasks" do
+RSpec.feature "Users can complete transfer tasks" do
   let(:user) { create(:user, :regional_delivery_officer) }
   let(:project) { create(:transfer_project, assigned_to: user) }
 
@@ -10,14 +10,83 @@ RSpec.feature "Users can complete conversion tasks" do
     visit project_tasks_path(project)
   end
 
-  describe "the confirm all conditions met task" do
-    scenario "they can confirm all conditions have been met" do
-      visit project_tasks_path(project)
-      click_on "Confirm all conditions have been met"
-      page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
-      click_on I18n.t("task_list.continue_button.text")
+  mandatory_tasks = %w[
+    deed_of_novation_and_variation
+    commercial_transfer_agreement
+    form_m
+    rpa_policy
+    supplemental_funding_agreement
+  ]
 
-      expect(project.reload.all_conditions_met).to be true
+  optional_tasks = %w[
+    handover
+    deed_of_variation
+    articles_of_association
+    land_consent_letter
+    church_supplemental_agreement
+    deed_termination_church_agreement
+    master_funding_agreement
+    deed_of_termination_for_the_master_funding_agreement
+  ]
+
+  tasks_with_collected_data = %w[
+    stakeholder_kick_off
+    conditions_met
+    main_contact
+  ]
+
+  it "confirms that all tasks are tested here" do
+    number_of_tasks = Transfer::TaskList.new(project, user).all_tasks.count
+    number_of_tested_tasks = mandatory_tasks.count + optional_tasks.count + tasks_with_collected_data.count
+    expect(number_of_tested_tasks).to eq number_of_tasks
+  end
+
+  describe "required tasks" do
+    mandatory_tasks.each do |task|
+      scenario "complete the actions on the mandatory #{I18n.t("transfer.task.#{task}.title")} task" do
+        click_on I18n.t("transfer.task.#{task}.title")
+        click_all_action_checkboxes(page)
+
+        click_on I18n.t("task_list.continue_button.text")
+        table_row = page.find("li.app-task-list__item", text: I18n.t("transfer.task.#{task}.title"))
+
+        expect(table_row).to have_content("Completed")
+      end
     end
+  end
+
+  describe "optional tasks" do
+    optional_tasks.each do |task|
+      scenario "mark an optional task #{I18n.t("transfer.task.#{task}.title")} as not applicable" do
+        click_on I18n.t("transfer.task.#{task}.title")
+        click_not_applicable(page)
+
+        click_on I18n.t("task_list.continue_button.text")
+        table_row = page.find("li.app-task-list__item", text: I18n.t("transfer.task.#{task}.title"))
+
+        expect(table_row).to have_content("Not applicable")
+      end
+    end
+
+    optional_tasks.each do |task|
+      scenario "complete the actions on the optional task #{I18n.t("transfer.task.#{task}.title")}" do
+        click_on I18n.t("transfer.task.#{task}.title")
+        click_all_action_checkboxes(page)
+        click_not_applicable(page)
+
+        click_on I18n.t("task_list.continue_button.text")
+        table_row = page.find("li.app-task-list__item", text: I18n.t("transfer.task.#{task}.title"))
+
+        expect(table_row).to have_content("Completed")
+      end
+    end
+  end
+
+  def click_all_action_checkboxes(page)
+    page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
+  end
+
+  def click_not_applicable(page)
+    page.find(".govuk-checkboxes__label", text: "Not applicable").click
   end
 end

--- a/spec/models/transfer/task_list_spec.rb
+++ b/spec/models/transfer/task_list_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe Transfer::TaskList do
+  let(:user) { create(:user) }
+
+  describe ".identifiers" do
+    it "returns all the identifiers for the tasks in the list" do
+      transfer_task_list_identifiers = [
+        :handover,
+        :stakeholder_kick_off,
+        :main_contact,
+        :master_funding_agreement,
+        :deed_of_novation_and_variation,
+        :articles_of_association,
+        :commercial_transfer_agreement,
+        :deed_of_variation,
+        :supplemental_funding_agreement,
+        :land_consent_letter,
+        :form_m,
+        :church_supplemental_agreement,
+        :deed_of_termination_for_the_master_funding_agreement,
+        :deed_termination_church_agreement,
+        :conditions_met,
+        :rpa_policy
+      ]
+
+      expect(described_class.identifiers).to eql transfer_task_list_identifiers
+    end
+  end
+
+  describe "#sections" do
+    it "returns an array of the sections in the task list" do
+      mock_successful_api_response_to_create_any_project
+      project = create(:transfer_project)
+      task_list = described_class.new(project, user)
+
+      expect(task_list.sections.count).to eql 3
+    end
+  end
+
+  describe "#tasks" do
+    it "returns an array of all the tasks in the task list" do
+      mock_successful_api_response_to_create_any_project
+      project = create(:transfer_project)
+      task_list = described_class.new(project, user)
+
+      expect(task_list.tasks.count).to eql 16
+      expect(task_list.tasks.first).to be_a Transfer::Task::HandoverTaskForm
+      expect(task_list.tasks.last).to be_a Transfer::Task::RpaPolicyTaskForm
+    end
+  end
+end


### PR DESCRIPTION
Adding in this task to the transfers task list.

Took some time to put in some coverage around the transfers task list based on what we have for conversions, just with a few tweaks - the test revealed some issues that we have taken care of here.

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Complete%20conversions%20transfers%20and%20changes/Academies-and-Free-Schools-SIP/Complete%20sprint%2031?team=Complete%20conversions%20transfers%20and%20changes&workitem=138920

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/568b6137-b3d3-4529-b8ff-9b08c27def4d)
