### PR TITLE
Add basic GIAS Establishment model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add deeds of termination for MFA task to Transfer projects
 - Added the 'Deed of termination for the church supplemental agreement' task to
   transfers.
+- The application can now store the un-published GIAS establishment records.
 
 ### Changed
 

--- a/app/models/gias/establishment.rb
+++ b/app/models/gias/establishment.rb
@@ -1,0 +1,5 @@
+class Gias::Establishment < ApplicationRecord
+  self.table_name = :gias_establishments
+
+  validates :urn, presence: true
+end

--- a/db/migrate/20230907143938_add_gias_establishment.rb
+++ b/db/migrate/20230907143938_add_gias_establishment.rb
@@ -1,0 +1,32 @@
+class AddGiasEstablishment < ActiveRecord::Migration[7.0]
+  def change
+    create_table :gias_establishments, id: :uuid do |t|
+      t.integer :urn, index: {unique: true}
+      t.integer :ukprn, index: true
+      t.string :name, index: true
+      t.integer :establishment_number, index: true
+      t.string :local_authority_name
+      t.integer :local_authority_code, index: true
+      t.string :region_name
+      t.string :region_code
+      t.string :type_name
+      t.integer :type_code
+      t.integer :age_range_lower
+      t.integer :age_range_upper
+      t.string :phase_name
+      t.integer :phase_code
+      t.string :diocese_name
+      t.string :diocese_code
+      t.string :parliamentary_constituency_name
+      t.string :parliamentary_constituency_code
+      t.string :address_street
+      t.string :address_locality
+      t.string :address_additional
+      t.string :address_town
+      t.string :address_county
+      t.string :address_postcode
+      t.string :url
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_07_085358) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_07_143938) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -141,6 +141,41 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_07_085358) do
     t.boolean "complete_notification_of_change_check_document"
     t.boolean "complete_notification_of_change_send_document"
     t.string "sponsored_support_grant_type"
+  end
+
+  create_table "gias_establishments", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+    t.integer "urn"
+    t.integer "ukprn"
+    t.string "name"
+    t.integer "establishment_number"
+    t.string "local_authority_name"
+    t.integer "local_authority_code"
+    t.string "region_name"
+    t.string "region_code"
+    t.string "type_name"
+    t.integer "type_code"
+    t.integer "age_range_lower"
+    t.integer "age_range_upper"
+    t.string "phase_name"
+    t.integer "phase_code"
+    t.string "diocese_name"
+    t.string "diocese_code"
+    t.string "parliamentary_constituency_name"
+    t.string "parliamentary_constituency_code"
+    t.string "address_street"
+    t.string "address_locality"
+    t.string "address_additional"
+    t.string "address_town"
+    t.string "address_county"
+    t.string "address_postcode"
+    t.string "url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["establishment_number"], name: "index_gias_establishments_on_establishment_number"
+    t.index ["local_authority_code"], name: "index_gias_establishments_on_local_authority_code"
+    t.index ["name"], name: "index_gias_establishments_on_name"
+    t.index ["ukprn"], name: "index_gias_establishments_on_ukprn"
+    t.index ["urn"], name: "index_gias_establishments_on_urn", unique: true
   end
 
   create_table "local_authorities", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/factories/gias/establishment_factory.rb
+++ b/spec/factories/gias/establishment_factory.rb
@@ -1,0 +1,57 @@
+FactoryBot.define do
+  factory :gias_establishment, class: "Gias::Establishment" do
+    urn { 144731 }
+    ukprn { 10065250 }
+    name { "The Lanes Primary School" }
+    establishment_number { 2031 }
+    local_authority_name { "Nottinghamshire" }
+    local_authority_code { 891 }
+    region_name { "East Midlands" }
+    region_code { "E" }
+    type_name { "Community school" }
+    type_code { 1 }
+    age_range_lower { 5 }
+    age_range_upper { 11 }
+    phase_name { "Primary" }
+    phase_code { 2 }
+    diocese_name { nil }
+    diocese_code { nil }
+    parliamentary_constituency_name { "Broxtowe" }
+    parliamentary_constituency_code { "E07000172" }
+    address_street { "Cator Lane" }
+    address_locality { "Chilwell" }
+    address_additional { "Beeston" }
+    address_town { "Nottingham" }
+    address_county { "Nottinghamshire" }
+    address_postcode { "NG9 4BB" }
+    url { "www.thelanes.notts.sch.uk" }
+
+    trait :with_diocese do
+      urn { 142323 }
+      ukprn { 10080750 }
+      name { "Dagnall VA Church of England School" }
+      establishment_number { 2022 }
+      local_authority_name { "Buckinghamshire" }
+      local_authority_code { 825 }
+      region_name { "South East" }
+      region_code { "J" }
+      type_name { "Voluntary aided school" }
+      type_code { 2 }
+      age_range_lower { 4 }
+      age_range_upper { 11 }
+      phase_name { "Primary" }
+      phase_code { 2 }
+      diocese_name { "Diocese of St Albans" }
+      diocese_code { "CE32" }
+      parliamentary_constituency_name { "Buckingham" }
+      parliamentary_constituency_code { "E14000608" }
+      address_street { "Main Road South" }
+      address_locality { nil }
+      address_additional { "Berkhamsted" }
+      address_town { "Dagnall" }
+      address_county { "Buckinghamshire" }
+      address_postcode { "HP4 1QX" }
+      url { "www.dagnall.bucks.sch.uk" }
+    end
+  end
+end

--- a/spec/models/gias/establishment_spec.rb
+++ b/spec/models/gias/establishment_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Gias::Establishment do
+  describe "the basics" do
+    it "can create instances" do
+      establishment = create(:gias_establishment, urn: 123456, name: "A test establishment")
+
+      expect(establishment.urn).to eql 123456
+      expect(establishment.name).to eql "A test establishment"
+    end
+  end
+
+  describe "database constraints" do
+    it "ensures URN is unique" do
+      create(:gias_establishment, urn: 123456)
+
+      expect { create(:gias_establishment, urn: 123456) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:urn) }
+  end
+end


### PR DESCRIPTION
We want to model GIAS establishment so we can:

- have access to the unopen academy data
- allow searching
- improve performance
- break dependancies on the Academies API

This is a very simple start to that work that creates the table,
indexes, model and factory.

We don't validate any attribute other than `urn` because we do not own
the data (we'll be importing it later) so we need to remain flexible for
the moment and validate the data set first.

If a urn was missing, the record would be unusable for us, so we do
validate that attribute.

We try to balannce following the attribute names from the dataset, which
is the GIAS data from a signed in user with all fields selected, whilst
keeping thing approachable.

We store attriubute name and 'code' as these may be useful later, we
already model the 'GOR Region' codes on Project for example.

For the factory, we create a 'with_faith' trait as one of the main
indicators we use (showing diocese and marking some task as applicable).

Right now all of this is speculative, but takes us on a path we have
designed.

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Complete%20conversions%20transfers%20and%20changes/Academies-and-Free-Schools-SIP/Complete%20sprint%2031