### PR TITLE
Update build workflow to use cache

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -59,6 +59,10 @@ jobs:
           password: ${{ secrets.AZURE_ACR_SECRET }}
           registry: ${{ secrets.AZURE_ACR_URL }}
 
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push docker image
         uses: docker/build-push-action@v5
         with:
@@ -71,6 +75,7 @@ jobs:
             ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:sha-${{ needs.set-env.outputs.checked-out-sha }}
             ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:latest
           push: true
+          cache-from: type=gha
 
   deploy-image:
     name: Deploy '${{ needs.set-env.outputs.branch }}' to ${{ needs.set-env.outputs.environment }}


### PR DESCRIPTION
We've proven the value of using the Github action cache to speed up
builds, here we add it to the deploy workflow.
