### PR TITLE
Basic search service

### DIFF
--- a/app/services/project_search_service.rb
+++ b/app/services/project_search_service.rb
@@ -1,0 +1,30 @@
+class ProjectSearchService
+  def search(query)
+    if urn_pattern(query)
+      return search_by_urn(query)
+    end
+
+    if ukprn_pattern(query)
+      return search_by_ukprn(query)
+    end
+
+    []
+  end
+
+  def search_by_urn(urn)
+    Project.where("urn = ?", urn)
+  end
+
+  def search_by_ukprn(ukprn)
+    Project.where("incoming_trust_ukprn = ?", ukprn)
+      .or(Project.where("outgoing_trust_ukprn = ?", ukprn))
+  end
+
+  private def urn_pattern(query)
+    query.match?(/^\d{6}$/)
+  end
+
+  private def ukprn_pattern(query)
+    query.match?(/\d{8}$/)
+  end
+end

--- a/db/migrate/20230914082600_add_ukprn_indexes.rb
+++ b/db/migrate/20230914082600_add_ukprn_indexes.rb
@@ -1,0 +1,6 @@
+class AddUkprnIndexes < ActiveRecord::Migration[7.0]
+  def change
+    add_index :projects, :incoming_trust_ukprn
+    add_index :projects, :outgoing_trust_ukprn
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_07_143938) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_14_082600) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -237,6 +237,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_07_143938) do
     t.uuid "incoming_trust_main_contact_id"
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
+    t.index ["incoming_trust_ukprn"], name: "index_projects_on_incoming_trust_ukprn"
+    t.index ["outgoing_trust_ukprn"], name: "index_projects_on_outgoing_trust_ukprn"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"
     t.index ["team_leader_id"], name: "index_projects_on_team_leader_id"
     t.index ["urn"], name: "index_projects_on_urn"

--- a/doc/decisions/0020-keep-search-simple.md
+++ b/doc/decisions/0020-keep-search-simple.md
@@ -1,0 +1,27 @@
+# 20. Keep search simple
+
+Date: 2023-09-14
+
+## Status
+
+Accepted
+
+## Context
+
+Search is a valuable feature for any user which we would like to offer. There
+are many ways to approach this from the very simple to incredibly complicated.
+
+## Decision
+
+We will keep our approach simple in both the needs it will be able to meet and
+it's implementation, to deliver as much value for the least effort and technical
+overhead.
+
+## Consequences
+
+We will only be able to offer search on data we hold in our database tables,
+right now, those neatly align to the needs we've already identified with our
+users once we can access GIAS data without the Academies API.
+
+We may reach the point where our simple approach can no longer meet new needs of
+users and we may have to change the approach.

--- a/spec/services/project_search_service_spec.rb
+++ b/spec/services/project_search_service_spec.rb
@@ -1,0 +1,120 @@
+require "rails_helper"
+
+RSpec.describe ProjectSearchService do
+  before do
+    mock_all_academies_api_responses
+  end
+
+  describe "#search" do
+    context "when passed a URN i.e. a 6 digit number" do
+      it "returns the match by URN" do
+        matching_project = create(:conversion_project, urn: 100000)
+        not_matching_project = create(:conversion_project, urn: 123456)
+
+        service = described_class.new
+        result = service.search("100000")
+
+        expect(result.count).to eql 1
+        expect(result).to include(matching_project)
+        expect(result).not_to include(not_matching_project)
+      end
+    end
+
+    context "when passed a UKPRN i.e. an 8 digit number" do
+      it "returns the match by UKPRN" do
+        matching_incoming_project = create(:conversion_project, incoming_trust_ukprn: 10000000)
+        matching_outgoing_project = create(:transfer_project, outgoing_trust_ukprn: 10000000)
+
+        not_matching_incoming_project = create(:conversion_project, incoming_trust_ukprn: 12345678)
+        not_matching_outgoing_project = create(:transfer_project, outgoing_trust_ukprn: 12345678)
+
+        service = described_class.new
+        result = service.search("10000000")
+
+        expect(result.count).to eql 2
+
+        expect(result).to include(matching_incoming_project)
+        expect(result).to include(matching_outgoing_project)
+
+        expect(result).not_to include(not_matching_incoming_project)
+        expect(result).not_to include(not_matching_outgoing_project)
+      end
+    end
+
+    context "when passed a string" do
+      it "returns an empty result" do
+        service = described_class.new
+        result = service.search("School name search not implemented")
+
+        expect(result.count).to be_zero
+      end
+    end
+  end
+
+  describe "#search_by_urn" do
+    context "when a match is found" do
+      it "returns an array with the matches" do
+        matching_project = create(:conversion_project, urn: 100000)
+        another_matching_project = create(:transfer_project, urn: 100000)
+        not_matching_project = create(:conversion_project, urn: 123456)
+
+        service = described_class.new
+        result = service.search_by_urn("100000")
+
+        expect(result.count).to eql 2
+
+        expect(result).to include(matching_project)
+        expect(result).to include(another_matching_project)
+
+        expect(result).not_to include(not_matching_project)
+      end
+    end
+
+    context "when a match is not found" do
+      it "returns an empty result" do
+        create(:conversion_project, urn: 100000)
+        create(:transfer_project, urn: 100000)
+
+        service = described_class.new
+        result = service.search_by_urn("123456")
+
+        expect(result.count).to be_zero
+      end
+    end
+  end
+
+  describe "#search_by_ukprn" do
+    context "when a match is found" do
+      it "returns an array with the matches" do
+        matching_incoming_project = create(:conversion_project, incoming_trust_ukprn: 10000000)
+        matching_outgoing_project = create(:transfer_project, outgoing_trust_ukprn: 10000000)
+
+        not_matching_incoming_project = create(:conversion_project, incoming_trust_ukprn: 12345678)
+        not_matching_outgoing_project = create(:transfer_project, outgoing_trust_ukprn: 12345678)
+
+        service = described_class.new
+        result = service.search_by_ukprn("10000000")
+
+        expect(result.count).to eql 2
+
+        expect(result).to include(matching_incoming_project)
+        expect(result).to include(matching_outgoing_project)
+
+        expect(result).not_to include(not_matching_incoming_project)
+        expect(result).not_to include(not_matching_outgoing_project)
+      end
+    end
+
+    context "when a match is not found" do
+      it "returns an empty result" do
+        create(:conversion_project, incoming_trust_ukprn: 10000000)
+        create(:transfer_project, outgoing_trust_ukprn: 10000000)
+
+        service = described_class.new
+        result = service.search_by_ukprn("12345678")
+
+        expect(result.count).to be_zero
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to offer search to users. This work begins to lay the foundation on which we can build a valuable search.

We add a ProjectSearchService that takes a query, infers the best search to use and performs the search, returning matching projects.

Right now, we can only search on distinct identifiers, URN and UKPRN, but once we have completed the GIAS Establishement and Establishment group work, we'll be able to offer support for much more.

For now we know that searching by the identifiers is valuable and so laying a strong foundation is a great start, we won't offer this to users until we can offer a more complete search, so there is no UI here.

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Complete%20conversions%20transfers%20and%20changes/Academies-and-Free-Schools-SIP/Post%20Advisory%20Board/Sprint%2032?team=Complete%20conversions%20transfers%20and%20changes&workitem=138982