### PR TITLE
Change Team projects to Your team projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove the Funding agreement letters contact task from the Conversion project
   task list
 - Change order of the legal tasks in the Transfer task list
+- The 'Team projects' section is now 'Your team projects'
 
 ## [Release 39][release-39]
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,7 +129,7 @@ en:
   navigation:
     header:
       your_projects: Your projects
-      team_projects: Team projects
+      team_projects: Your team projects
       all_projects: All projects
       service_support: Service support
     primary:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,7 +146,7 @@ Rails.application.routes.draw do
     end
   end
 
-  #  Team projects
+  #  Your team projects
   constraints(id: VALID_UUID_REGEX) do
     resources :projects, only: %i[index] do
       collection do

--- a/spec/features/projects/users_can_view_a_list_of_regional_casework_services_projects_spec.rb
+++ b/spec/features/projects/users_can_view_a_list_of_regional_casework_services_projects_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Viewing regional casework services projects" do
       scenario "the Team projects link leads to the unassigned page" do
         visit root_path
 
-        click_on "Team projects"
+        click_on "Your team projects"
 
         expect(page.find("h1")).to have_content("Unassigned")
       end
@@ -57,7 +57,7 @@ RSpec.feature "Viewing regional casework services projects" do
       scenario "the Team projects link leads to the in-progress page" do
         visit root_path
 
-        click_on "Team projects"
+        click_on "Your team projects"
 
         expect(page.find("h1")).to have_content("In progress")
       end
@@ -75,7 +75,7 @@ RSpec.feature "Viewing regional casework services projects" do
       scenario "the Team projects link leads to the in-progress page" do
         visit root_path
 
-        click_on "Team projects"
+        click_on "Your team projects"
 
         expect(page.find("h1")).to have_content("In progress")
       end


### PR DESCRIPTION
We decided that updating the path was not necessary.

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Complete%20conversions%20transfers%20and%20changes/Academies-and-Free-Schools-SIP/Post%20Advisory%20Board/Sprint%2032?team=Complete%20conversions%20transfers%20and%20changes&workitem=138923