### PR TITLE
Add outgoing trust main contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The application can now store the un-published GIAS establishment records.
 - Allow a contact to be marked as the "establishment main contact"
 - Allow a contact to be marked as the "incoming trust main contact"
+- Allow a contact to be marked as the "outgoing trust main contact"
 
 ### Changed
 

--- a/app/controllers/external_contacts_controller.rb
+++ b/app/controllers/external_contacts_controller.rb
@@ -57,6 +57,6 @@ class ExternalContactsController < ApplicationController
   end
 
   private def contact_params
-    params.require(:contact_create_project_contact_form).permit(:name, :organisation_name, :title, :category, :email, :phone, :establishment_main_contact, :incoming_trust_main_contact)
+    params.require(:contact_create_project_contact_form).permit(:name, :organisation_name, :title, :category, :email, :phone, :establishment_main_contact, :incoming_trust_main_contact, :outgoing_trust_main_contact)
   end
 end

--- a/app/forms/contact/create_project_contact_form.rb
+++ b/app/forms/contact/create_project_contact_form.rb
@@ -11,6 +11,7 @@ class Contact::CreateProjectContactForm
   attribute :phone
   attribute :establishment_main_contact
   attribute :incoming_trust_main_contact
+  attribute :outgoing_trust_main_contact
   attribute :project_id
   attr_accessor :category,
     :name,
@@ -20,10 +21,12 @@ class Contact::CreateProjectContactForm
     :phone,
     :establishment_main_contact,
     :incoming_trust_main_contact,
+    :outgoing_trust_main_contact,
     :project_id
 
   validate :establishment_main_contact_for_school_only, if: -> { establishment_main_contact.eql?("1") }
   validate :incoming_trust_main_contact_for_incoming_trust_only, if: -> { incoming_trust_main_contact.eql?("1") }
+  validate :outgoing_trust_main_contact_for_outgoing_trust_only, if: -> { outgoing_trust_main_contact.eql?("1") }
 
   def initialize(args = {}, project = nil, contact = nil)
     @project = project
@@ -42,7 +45,8 @@ class Contact::CreateProjectContactForm
          email: contact.email,
          phone: contact.phone,
          establishment_main_contact: contact.establishment_main_contact,
-         incoming_trust_main_contact: contact.incoming_trust_main_contact},
+         incoming_trust_main_contact: contact.incoming_trust_main_contact,
+         outgoing_trust_main_contact: contact.outgoing_trust_main_contact},
       @project,
       @contact)
   end
@@ -62,6 +66,7 @@ class Contact::CreateProjectContactForm
         @contact.save
         set_establishment_main_contact
         set_incoming_trust_main_contact
+        set_outgoing_trust_main_contact
       end
     else
       errors.merge!(@contact.errors)
@@ -77,6 +82,11 @@ class Contact::CreateProjectContactForm
   private def incoming_trust_main_contact_for_incoming_trust_only
     return true if category.eql?("incoming_trust")
     errors.add(:incoming_trust_main_contact, :invalid)
+  end
+
+  private def outgoing_trust_main_contact_for_outgoing_trust_only
+    return true if category.eql?("outgoing_trust")
+    errors.add(:outgoing_trust_main_contact, :invalid)
   end
 
   private def set_establishment_main_contact
@@ -96,6 +106,16 @@ class Contact::CreateProjectContactForm
       project.update!(incoming_trust_main_contact_id: @contact.id)
     else
       project.update!(incoming_trust_main_contact_id: nil)
+    end
+  end
+
+  private def set_outgoing_trust_main_contact
+    project = @project || Project.find(@contact.project_id)
+
+    if outgoing_trust_main_contact == "1"
+      project.update!(outgoing_trust_main_contact_id: @contact.id)
+    else
+      project.update!(outgoing_trust_main_contact_id: nil)
     end
   end
 end

--- a/app/models/contact/project.rb
+++ b/app/models/contact/project.rb
@@ -16,4 +16,10 @@ class Contact::Project < Contact
     project = ::Project.find(project_id)
     project&.incoming_trust_main_contact_id.eql?(id)
   end
+
+  def outgoing_trust_main_contact
+    return false unless project_id
+    project = ::Project.find(project_id)
+    project&.outgoing_trust_main_contact_id.eql?(id)
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,6 +15,7 @@ class Project < ApplicationRecord
   has_one :main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
   has_one :establishment_main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
   has_one :incoming_trust_main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
+  has_one :outgoing_trust_main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
 
   validates :urn, presence: true
   validates :urn, urn: true

--- a/app/views/external_contacts/_contact_group.html.erb
+++ b/app/views/external_contacts/_contact_group.html.erb
@@ -50,5 +50,11 @@
             row.value { t("yes") }
           end
         end
+        if @project.outgoing_trust_main_contact_id == contact.id
+          summary_list.row do |row|
+            row.key { t("contact.details.outgoing_trust_main_contact") }
+            row.value { t("yes") }
+          end
+        end
       end %>
   <% end %>

--- a/app/views/external_contacts/edit.html.erb
+++ b/app/views/external_contacts/edit.html.erb
@@ -29,6 +29,9 @@
       <%= form.govuk_check_boxes_fieldset :incoming_trust_main_contact, multiple: false, legend: {text: t("helpers.label.contact_project.incoming_trust_main_contact"), size: "s"} do %>
         <%= form.govuk_check_box :incoming_trust_main_contact, 1, 0, multiple: false, link_errors: true, label: {text: t("yes")} %>
       <% end %>
+      <%= form.govuk_check_boxes_fieldset :outgoing_trust_main_contact, multiple: false, legend: {text: t("helpers.label.contact_project.outgoing_trust_main_contact"), size: "s"} do %>
+        <%= form.govuk_check_box :outgoing_trust_main_contact, 1, 0, multiple: false, link_errors: true, label: {text: t("yes")} %>
+      <% end %>
 
       <%= form.govuk_submit t("contact.edit.save_contact_button") do %>
         <%= govuk_button_link_to "Delete", project_contact_delete_path(@project, @existing_contact), warning: true %>

--- a/app/views/external_contacts/new.html.erb
+++ b/app/views/external_contacts/new.html.erb
@@ -31,6 +31,9 @@
       <%= form.govuk_check_boxes_fieldset :incoming_trust_main_contact, multiple: false, legend: {text: t("helpers.label.contact_project.incoming_trust_main_contact"), size: "s"} do %>
         <%= form.govuk_check_box :incoming_trust_main_contact, 1, 0, multiple: false, link_errors: true, label: {text: t("yes")} %>
       <% end %>
+      <%= form.govuk_check_boxes_fieldset :outgoing_trust_main_contact, multiple: false, legend: {text: t("helpers.label.contact_project.outgoing_trust_main_contact"), size: "s"} do %>
+        <%= form.govuk_check_box :outgoing_trust_main_contact, 1, 0, multiple: false, link_errors: true, label: {text: t("yes")} %>
+      <% end %>
 
       <%= form.govuk_submit t("contact.new.save_contact_button") do %>
         <%= govuk_link_to "Cancel", project_contacts_path(@project) %>

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -20,6 +20,7 @@ en:
       main_contact: Project main contact
       establishment_main_contact: Is this the main contact for the school or academy?
       incoming_trust_main_contact: Is this the main contact for the incoming trust?
+      outgoing_trust_main_contact: Is this the main contact for the outgoing trust?
     new:
       title: Add contact
       save_contact_button: Add contact
@@ -53,6 +54,7 @@ en:
         phone: Phone
         establishment_main_contact: Is this the main contact for the school or academy?
         incoming_trust_main_contact: Is this the main contact for the incoming trust?
+        outgoing_trust_main_contact: Is this the main contact for the outgoing trust?
       contact_create_project_contact_form:
         category: Contact for
         title: Role
@@ -62,6 +64,7 @@ en:
         phone: Phone
         establishment_main_contact: Is this the main contact for the school or academy?
         incoming_trust_main_contact: Is this the main contact for the incoming trust?
+        outgoing_trust_main_contact: Is this the main contact for the outgoing trust?
   errors:
     attributes:
       category:
@@ -70,3 +73,5 @@ en:
         invalid: You can only select a School contact as the school or academy's main contact
       incoming_trust_main_contact:
         invalid: You can only select an Incoming trust contact as the incoming trust's main contact
+      outgoing_trust_main_contact:
+        invalid: You can only select an Outgoing trust contact as the outgoing trust's main contact

--- a/db/migrate/20230914102113_add_outgoing_trust_main_contact_id_to_projects.rb
+++ b/db/migrate/20230914102113_add_outgoing_trust_main_contact_id_to_projects.rb
@@ -1,0 +1,5 @@
+class AddOutgoingTrustMainContactIdToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :outgoing_trust_main_contact_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_14_082600) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_14_102113) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -235,6 +235,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_14_082600) do
     t.uuid "main_contact_id"
     t.uuid "establishment_main_contact_id"
     t.uuid "incoming_trust_main_contact_id"
+    t.uuid "outgoing_trust_main_contact_id"
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["incoming_trust_ukprn"], name: "index_projects_on_incoming_trust_ukprn"

--- a/spec/features/users_can_manage_contacts_spec.rb
+++ b/spec/features/users_can_manage_contacts_spec.rb
@@ -158,6 +158,24 @@ RSpec.feature "Users can manage contacts" do
     expect(page).to have_content(I18n.t("contact.details.incoming_trust_main_contact"))
   end
 
+  scenario "they can create a new contact and set it as the outgoing trust main contact" do
+    visit project_contacts_path(project)
+
+    click_link "Add contact"
+
+    select "Outgoing trust", from: "Contact for"
+    fill_in "Name", with: "Some One"
+    fill_in "Organisation", with: "Trust Name"
+    fill_in "Role", with: "Chief of Knowledge"
+    fill_in "Email", with: "some@example.com"
+    check "contact_create_project_contact_form[outgoing_trust_main_contact]"
+
+    click_button("Add contact")
+
+    expect(page).to have_content("Outgoing trust contacts")
+    expect(page).to have_content(I18n.t("contact.details.outgoing_trust_main_contact"))
+  end
+
   private def expect_page_to_have_contact(name:, title:, organisation_name: nil, email: nil, phone: nil)
     expect(page).to have_content(name)
     expect(page).to have_content(organisation_name) if organisation_name

--- a/spec/forms/contact/contact_project_form_spec.rb
+++ b/spec/forms/contact/contact_project_form_spec.rb
@@ -195,4 +195,82 @@ RSpec.describe Contact::CreateProjectContactForm do
       end
     end
   end
+
+  describe "outgoing_trust_main_contact" do
+    context "a new contact" do
+      context "when the outgoing_trust_main_contact is checked" do
+        context "when the contact category is outgoing_trust" do
+          it "is valid" do
+            contact_form = Contact::CreateProjectContactForm.new({}, project)
+            contact_form.outgoing_trust_main_contact = "1"
+            contact_form.category = "outgoing_trust"
+            expect(contact_form).to be_valid
+          end
+
+          it "marks the contact as the outgoing_trust_main_contact on the project" do
+            contact_form = Contact::CreateProjectContactForm.new({}, project)
+            contact_form.outgoing_trust_main_contact = "1"
+            contact_form.category = "outgoing_trust"
+            contact_form.name = "New Contact"
+            contact_form.title = "Financial Controller"
+            contact_form.organisation_name = "Trust"
+            contact_form.save
+            contact = Contact::Project.last
+            expect(project.reload.outgoing_trust_main_contact).to eq(contact)
+          end
+        end
+
+        context "when the contact category is NOT outgoing_trust" do
+          it "is not valid" do
+            contact_form = Contact::CreateProjectContactForm.new({}, project)
+            contact_form.outgoing_trust_main_contact = "1"
+            contact_form.category = "school"
+            expect(contact_form).to_not be_valid
+          end
+        end
+      end
+    end
+
+    context "editing a contact" do
+      context "when the outgoing_trust_main_contact is checked" do
+        context "when the contact category is outgoing_trust" do
+          let(:contact) { create(:project_contact, project: project, category: "outgoing_trust") }
+
+          it "is valid" do
+            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
+            contact_form.outgoing_trust_main_contact = "1"
+            expect(contact_form).to be_valid
+          end
+        end
+
+        context "when the contact category is NOT outgoing_trust" do
+          let(:contact) { create(:project_contact, project: project, category: "solicitor") }
+
+          it "is not valid" do
+            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
+            contact_form.outgoing_trust_main_contact = "1"
+            expect(contact_form).to_not be_valid
+          end
+        end
+      end
+
+      context "when the outgoing_trust_main_contact box is NOT checked" do
+        context "when the contact was previously marked as the outgoing_trust_main_contact" do
+          let(:contact) { create(:project_contact, project: project, category: "outgoing_trust") }
+
+          before do
+            project.update!(outgoing_trust_main_contact_id: contact.id)
+          end
+
+          it "removes the outgoing_trust_main_contact from the project" do
+            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
+            contact_form.outgoing_trust_main_contact = "0"
+            contact_form.save
+
+            expect(project.outgoing_trust_main_contact_id).to be_nil
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/models/contact/project_contact_spec.rb
+++ b/spec/models/contact/project_contact_spec.rb
@@ -94,4 +94,31 @@ RSpec.describe Contact::Project, type: :model do
       expect(contact.incoming_trust_main_contact).to be false
     end
   end
+
+  describe "#outgoing_trust_main_contact" do
+    before do
+      mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    end
+
+    it "returns true if the contact is the outgoing_trust_main_contact for its project" do
+      project = create(:conversion_project)
+      contact = create(:project_contact, project: project)
+      project.outgoing_trust_main_contact_id = contact.id
+      project.save
+
+      expect(contact.reload.outgoing_trust_main_contact).to be true
+    end
+
+    it "returns false if the contact is NOT the outgoing_trust_main_contact for its project" do
+      project = create(:conversion_project, outgoing_trust_main_contact_id: SecureRandom.uuid)
+      contact = create(:project_contact, project: project)
+
+      expect(contact.outgoing_trust_main_contact).to be false
+    end
+
+    it "returns false if the contact does not have a project" do
+      contact = create(:project_contact, project_id: nil)
+      expect(contact.outgoing_trust_main_contact).to be false
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_one(:main_contact).required(false) }
     it { is_expected.to have_one(:establishment_main_contact).required(false) }
     it { is_expected.to have_one(:incoming_trust_main_contact).required(false) }
+    it { is_expected.to have_one(:outgoing_trust_main_contact).required(false) }
 
     describe "delete related entities" do
       context "when the project is deleted" do


### PR DESCRIPTION
## Changes

Add the ability to mark a contact as the main contact for an outgoing trust. This is pretty much identical to https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/1066

<img width="648" alt="Screenshot 2023-09-14 at 14 44 56" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/4dc665e0-561c-4ce9-935d-98a6c9fd253f">

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
