### PR TITLE
Add navigation to export page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow a contact to be marked as the "establishment main contact"
 - Allow a contact to be marked as the "incoming trust main contact"
 - Allow a contact to be marked as the "outgoing trust main contact"
+- Add missing navigation to the individual (show) export pages
 
 ### Changed
 

--- a/app/views/all/export/education_and_skills_funding_agency/projects/show.html.erb
+++ b/app/views/all/export/education_and_skills_funding_agency/projects/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
 <% content_for :page_title do %>
   <%= page_title(t("export.education_and_skills_funding_agency.show.title", date: @month.to_fs(:govuk_month))) %>
 <% end %>

--- a/app/views/all/export/funding_agreement_letters/projects/show.html.erb
+++ b/app/views/all/export/funding_agreement_letters/projects/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
 <% content_for :page_title do %>
   <%= page_title(t("export.funding_agreement_letters.show.title", date: @month.to_fs(:govuk_month))) %>
 <% end %>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -175,6 +175,7 @@ en:
         date: Date
         confirmed: Confirmed
         revised: Revised
+        export: Export
         team: Team
       body:
         type_name:


### PR DESCRIPTION
## Changes

The navigation was missing from the individual (per month) export pages. 

<img width="1149" alt="Screenshot 2023-09-14 at 16 36 49" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/1fb73be3-d8b9-46c7-b861-a224a977fd42">

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
