### PR TITLE
Update school contact category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   task list
 - Change order of the legal tasks in the Transfer task list
 - The 'Team projects' section is now 'Your team projects'
+- The "School" contact type is now "School or academy"
 
 ## [Release 39][release-39]
 

--- a/app/forms/contact/create_project_contact_form.rb
+++ b/app/forms/contact/create_project_contact_form.rb
@@ -75,7 +75,7 @@ class Contact::CreateProjectContactForm
   end
 
   private def establishment_main_contact_for_school_only
-    return true if category.eql?("school")
+    return true if category.eql?("school_or_academy")
     errors.add(:establishment_main_contact, :invalid)
   end
 

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -7,7 +7,7 @@ class Contact < ApplicationRecord
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}, allow_blank: true
 
   enum category: {
-    school: 1,
+    school_or_academy: 1,
     incoming_trust: 2,
     outgoing_trust: 6,
     local_authority: 3,

--- a/config/locales/academies_api_en.yml
+++ b/config/locales/academies_api_en.yml
@@ -2,12 +2,12 @@ en:
   academies_api:
     get_establishment:
       errors:
-        not_found: Could not find establishment with URN %{urn}
-        other: There was an error connecting to the Academies API, could not fetch establishment for URN %{urn}
+        not_found: Could not find a school or academy with URN %{urn}
+        other: There was an error connecting to the Academies API, could not fetch a school or academy for URN %{urn}
     get_establishments:
       errors:
-        not_found: Could not find any establishments for the following URNs %{urns}
-        other: There was an error connecting to the Academies API, could not fetch establishments for URNs %{urns}
+        not_found: Could not find any schools or academies for the following URNs %{urns}
+        other: There was an error connecting to the Academies API, could not fetch schools or academies for URNs %{urns}
     get_trust:
       errors:
         not_found: Could not find trust for UKPRN %{ukprn}

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -7,7 +7,7 @@ en:
       add_contact_button: Add contact
       no_contacts_yet: There are not any contacts for this project yet.
       external_contacts_hint:
-        add_contacts: Add contacts for the school, trust, solicitor and local authority. If this is a faith school, add a contact for the diocese too.
+        add_contacts: Add contacts for the school or academy, trust, solicitor and local authority. If this is a faith school, add a contact for the diocese too.
         get_missing_contact_information: You might be able to get missing contact information from the person who prepared this project for, or presented at, the advisory board.
     details:
       name: Name
@@ -70,7 +70,7 @@ en:
       category:
         blank: Choose a category
       establishment_main_contact:
-        invalid: You can only select a School contact as the school or academy's main contact
+        invalid: You can only select a School or academy contact as the school or academy's main contact
       incoming_trust_main_contact:
         invalid: You can only select an Incoming trust contact as the incoming trust's main contact
       outgoing_trust_main_contact:

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -8,7 +8,7 @@ en:
       assigned_to_regional_delivery_officer:
         html:
           <h3 class="govuk-notification-banner__heading">Project created</h3>
-          <p class="govuk-body">You should add any contact details you have for the school, trust, solicitors, local authority and diocese (if applicable).</p>
+          <p class="govuk-body">You should add any contact details you have for the school or academy, trust, solicitors, local authority and diocese (if applicable).</p>
       assigned_to_regional_caseworker_team:
         title: Project created
         button: Add contacts
@@ -17,7 +17,7 @@ en:
           <h2 class="govuk-heading-l">Add contact details</h2>
           <p class="govuk-body">You must <a href="%{contacts_link}">add contact details</a> for the:</p>
           <ul class="govuk-list govuk-list--bullet">
-            <li>school</li>
+            <li>school or academy</li>
             <li>trust</li>
             <li>solicitors</li>
             <li>local authority</li>
@@ -55,7 +55,7 @@ en:
       conversion_create_project_form:
         urn: School URN (Unique Reference Number)
         incoming_trust_ukprn: Incoming trust UKPRN (UK Provider Reference Number)
-        establishment_sharepoint_link: School SharePoint link
+        establishment_sharepoint_link: School or academy SharePoint link
         incoming_trust_sharepoint_link: Incoming trust SharePoint link
       conversion_project:
         caseworker_id: Caseworker

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -77,7 +77,7 @@ en:
       title: Create academy URN for %{school_name} conversion
       body_html:
         <p>This is the URN for the academy that the school is converting to.</p>
-        <p>To add the academy URN you must have already created a new establishment in GIAS.</p>
+        <p>To add the academy URN you must have already created a new academy in GIAS.</p>
         <p>It can take up to 24 hours for changes to the academy URN to appear on the project information page.</p>
       edit:
         label: Enter academy URN
@@ -286,7 +286,7 @@ en:
         caseworker_id: Caseworker
         regional_delivery_officer_id: Regional delivery officer
         advisory_board_conditions: Advisory board conditions
-        establishment_sharepoint_link: School SharePoint link
+        establishment_sharepoint_link: School or academy SharePoint link
         trust_sharepoint_link: Trust SharePoint link
     legend:
       project:
@@ -303,14 +303,14 @@ en:
           <a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in new tab)</a>.
         caseworker_id: The caseworker responsible for this project
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
-        establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
+        establishment_sharepoint_link: Provide a link to the SharePoint folder for this school or academy. This is where you save all the relevant school documents.
         trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
         advisory_board_date: You can find this in the advisory board template.
   errors:
     attributes:
       urn:
         blank: Enter a school URN
-        no_establishment_found: There's no school with that URN. Check the number you entered is correct.
+        no_establishment_found: There's no school or academy with that URN. Check the number you entered is correct.
         not_a_number: School URN can only contain numbers. No letters or special characters.
         wrong_length: URN must be 6 digits long. For example, 123456.
         duplicate: There is already an in-progress project with this URN

--- a/config/locales/project_information.en.yml
+++ b/config/locales/project_information.en.yml
@@ -9,7 +9,7 @@ en:
           regional_delivery_officer: Regional delivery officer
           assigned_to: Assigned to
           unassigned: Not yet assigned
-          establishment_sharepoint_link: School SharePoint folder
+          establishment_sharepoint_link: School or academy SharePoint folder
           trust_sharepoint_link: Trust SharePoint folder
           directive_academy_order:
             title: Has a directive academy order been issued?

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -51,8 +51,8 @@ en:
           <p>A UKPRN is an 8-digit number that always starts with a 1.</p>
           <p><a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the outgoing trust's UKPRN (opens in new tab).</a>.</p>
         provisional_transfer_date: You can find this in the advisory board template.
-        advisory_board_conditions: Enter details of conditions that must be met before the school can transfer.
-        establishment_sharepoint_link: Provide a link to the SharePoint folder for this school. This is where you save all the relevant school documents.
+        advisory_board_conditions: Enter details of conditions that must be met before the school or academy can transfer.
+        establishment_sharepoint_link: Provide a link to the SharePoint folder for this school or academy. This is where you save all the relevant school documents.
         incoming_trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
         handover_note_body_html:
           <p>You must describe how the project has progressed so far and highlight any issues or concerns.</p>

--- a/spec/features/conversions/users_can_create_conversion_projects_spec.rb
+++ b/spec/features/conversions/users_can_create_conversion_projects_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Users can create new conversion projects" do
       fill_in "Year", with: completion_date.year
     end
 
-    fill_in "School SharePoint link", with: "https://educationgovuk-my.sharepoint.com/school-folder"
+    fill_in "School or academy SharePoint link", with: "https://educationgovuk-my.sharepoint.com/school-folder"
     fill_in "Incoming trust SharePoint link", with: "https://educationgovuk-my.sharepoint.com/trust-folder"
 
     within("#advisory-board-date") do

--- a/spec/features/users_can_manage_contacts_spec.rb
+++ b/spec/features/users_can_manage_contacts_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Users can manage contacts" do
 
   scenario "the contact groups are in the order users might expect to use them" do
     create(:project_contact, category: :other, project: project)
-    create(:project_contact, category: :school, project: project)
+    create(:project_contact, category: :school_or_academy, project: project)
     create(:project_contact, category: :incoming_trust, project: project)
     create(:project_contact, category: :outgoing_trust, project: project)
     create(:project_contact, category: :solicitor, project: project)
@@ -38,7 +38,7 @@ RSpec.feature "Users can manage contacts" do
     order_categories = page.find_all("h3.govuk-heading-m")
 
     %i[
-      school
+      school_or_academy
       incoming_trust
       outgoing_trust
       local_authority
@@ -115,7 +115,7 @@ RSpec.feature "Users can manage contacts" do
 
     expect(page).to have_select("Contact for", selected: "Choose category")
 
-    select "School", from: "Contact for"
+    select "School or academy", from: "Contact for"
     fill_in "Name", with: "Some One"
     fill_in "Organisation", with: "Trust Name"
     fill_in "Role", with: "Chief of Knowledge"
@@ -124,12 +124,12 @@ RSpec.feature "Users can manage contacts" do
 
     click_button("Add contact")
 
-    expect(page).to have_content("School contacts")
+    expect(page).to have_content("School or academy contacts")
     expect(page).to have_content(I18n.t("contact.details.establishment_main_contact"))
   end
 
   scenario "they can edit a contact and set it to be the establishment main contact" do
-    contact = create(:project_contact, project: project, category: "school")
+    contact = create(:project_contact, project: project, category: "school_or_academy")
 
     visit edit_project_contact_path(project, contact)
     check "contact_create_project_contact_form[establishment_main_contact]"

--- a/spec/forms/contact/contact_project_form_spec.rb
+++ b/spec/forms/contact/contact_project_form_spec.rb
@@ -18,18 +18,18 @@ RSpec.describe Contact::CreateProjectContactForm do
       end
 
       context "when the establishment_main_contact box is checked" do
-        context "when the contact category is school" do
+        context "when the contact category is school_or_academy" do
           it "is valid" do
             contact_form = Contact::CreateProjectContactForm.new({}, project)
             contact_form.establishment_main_contact = "1"
-            contact_form.category = "school"
+            contact_form.category = "school_or_academy"
             expect(contact_form).to be_valid
           end
 
           it "marks the contact as the establishment main contact on the project" do
             contact_form = Contact::CreateProjectContactForm.new({}, project)
             contact_form.establishment_main_contact = "1"
-            contact_form.category = "school"
+            contact_form.category = "school_or_academy"
             contact_form.name = "New Contact"
             contact_form.title = "Financial Controller"
             contact_form.organisation_name = "School"
@@ -39,7 +39,7 @@ RSpec.describe Contact::CreateProjectContactForm do
           end
         end
 
-        context "when the contact category is NOT school" do
+        context "when the contact category is NOT school_or_academy" do
           it "is not valid" do
             contact_form = Contact::CreateProjectContactForm.new({}, project)
             contact_form.establishment_main_contact = "1"
@@ -57,7 +57,7 @@ RSpec.describe Contact::CreateProjectContactForm do
 
       it "does not create the contact" do
         contact_form = Contact::CreateProjectContactForm.new({}, project)
-        contact_form.category = "school"
+        contact_form.category = "school_or_academy"
         contact_form.name = "New Contact"
         contact_form.title = "Financial Controller"
         contact_form.organisation_name = "School"
@@ -87,8 +87,8 @@ RSpec.describe Contact::CreateProjectContactForm do
       end
 
       context "when the establishment_main_contact box is checked" do
-        context "when the contact category is school" do
-          let(:contact) { create(:project_contact, project: project, category: "school") }
+        context "when the contact category is school_or_academy" do
+          let(:contact) { create(:project_contact, project: project, category: "school_or_academy") }
 
           it "is valid" do
             contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
@@ -105,7 +105,7 @@ RSpec.describe Contact::CreateProjectContactForm do
           end
         end
 
-        context "when the contact category is NOT school" do
+        context "when the contact category is NOT school_or_academy" do
           let(:contact) { create(:project_contact, project: project, category: "solicitor") }
 
           it "is not valid" do
@@ -146,7 +146,7 @@ RSpec.describe Contact::CreateProjectContactForm do
           it "is not valid" do
             contact_form = Contact::CreateProjectContactForm.new({}, project)
             contact_form.incoming_trust_main_contact = "1"
-            contact_form.category = "school"
+            contact_form.category = "school_or_academy"
             expect(contact_form).to_not be_valid
           end
         end
@@ -224,7 +224,7 @@ RSpec.describe Contact::CreateProjectContactForm do
           it "is not valid" do
             contact_form = Contact::CreateProjectContactForm.new({}, project)
             contact_form.outgoing_trust_main_contact = "1"
-            contact_form.category = "school"
+            contact_form.category = "school_or_academy"
             expect(contact_form).to_not be_valid
           end
         end

--- a/spec/requests/contacts_controller_spec.rb
+++ b/spec/requests/contacts_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe ExternalContactsController, type: :request do
     let(:new_contact_title) { "Headteacher" }
 
     subject(:perform_request) do
-      post project_contacts_path(project_id), params: {contact_create_project_contact_form: {name: new_contact_name, title: new_contact_title, category: "school"}}
+      post project_contacts_path(project_id), params: {contact_create_project_contact_form: {name: new_contact_name, title: new_contact_title, category: "school_or_academy"}}
       response
     end
 


### PR DESCRIPTION
## Changes

Change the "Contact" category from "School" to "School or academy". Transfer projects will happen to academies, so change the wording slightly to reflect a "School" contact could actually belong to a school or academy.

Also remove any references to "Establishments" in the text. These are schools or academies.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
