### PR TITLE
Update 'Your team projects' in progress table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Change order of the legal tasks in the Transfer task list
 - The 'Team projects' section is now 'Your team projects'
 - The "School" contact type is now "School or academy"
+- Amend the "Your team projects" in progress table view to show either a team
+  column or region column depending on whether the current user is a regional
+  delivery officer or a regional case worker
 
 ## [Release 39][release-39]
 

--- a/app/views/team/projects/_in_progress_table.html.erb
+++ b/app/views/team/projects/_in_progress_table.html.erb
@@ -1,0 +1,44 @@
+<% if projects.empty? %>
+  <%= govuk_inset_text(text: t("project.table.in_progress.empty")) %>
+<% else %>
+  <table class="govuk-table" name="projects_table" aria-label="Projects table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.local_authority_name") %></th>
+        <% if @current_user.is_regional_caseworker? %>
+          <th class="govuk-table__header" scope="col"><%= t("project.table.headers.region") %></th>
+        <% end %>
+        <% if @current_user.is_regional_delivery_officer? %>
+          <th class="govuk-table__header" scope="col"><%= t("project.table.headers.team") %></th>
+        <% end %>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% projects.each do |project| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__header govuk-table__cell">
+          <%= link_to project.establishment.name, project_path(project), class: "govuk-link govuk-link--no-visited-state" %>
+        </td>
+        <td class="govuk-table__cell"><%= project.urn %></td>
+        <td class="govuk-table__cell"><%= project.establishment.local_authority_name %></td>
+        <% if @current_user.is_regional_caseworker? %>
+          <td class="govuk-table__cell"><%= t("teams.#{project.region}") %></td>
+        <% end %>
+        <% if @current_user.is_regional_delivery_officer? %>
+          <td class="govuk-table__cell"><%= t("teams.#{project.team}") %></td>
+        <% end %>
+        <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
+        <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
+        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<%= govuk_pagination(pagy: pager) %>

--- a/app/views/team/projects/in_progress.html.erb
+++ b/app/views/team/projects/in_progress.html.erb
@@ -13,7 +13,7 @@
       <%= t("project.team.in_progress.title") %>
     </h1>
 
-    <%= render partial: "/projects/shared/in_progress_table", locals: {projects: @projects, pager: @pager} %>
+    <%= render partial: "/team/projects/in_progress_table", locals: {projects: @projects, pager: @pager} %>
 
   </div>
 </div>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -112,7 +112,7 @@ en:
       back_link: Return to project list
     summary:
       type:
-        title: Type
+        title: Project type
         conversion: Conversion
         transfer: Transfer
       incoming_trust:

--- a/spec/features/your_team_projects/users_can_view_their_team_projects_spec.rb
+++ b/spec/features/your_team_projects/users_can_view_their_team_projects_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.feature "Users can view their team's projects" do
+  before do
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  context "within the in progress tab" do
+    describe "when the current user is a regional delivery officer" do
+      let(:user) { create(:regional_delivery_officer_user, team: :london) }
+      scenario "they can see the column heading Team" do
+        create(:conversion_project, assigned_to: user, region: :london)
+
+        visit in_progress_team_projects_path
+
+        within("thead") do
+          expect(page).to have_content("Team")
+          expect(page).not_to have_content("Region")
+        end
+      end
+    end
+
+    describe "when the current user is a regional case worker" do
+      let(:user) { create(:regional_casework_services_user) }
+      scenario "they can see the column heading Region" do
+        create(:conversion_project, assigned_to: user, team: :regional_casework_services)
+
+        visit in_progress_team_projects_path
+
+        within("thead") do
+          expect(page).to have_content("Region")
+          expect(page).not_to have_content("Team")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes

`Regional case workers` need to be able to see an overview of all the regions projects and so this work is to ensure that if the current user is a `Regional case worker`, they will see what region each project belongs to. For all `Regional delivery officers`, they will only see the projects which are within their same team, and therefore will see a `Team` column in place of the `Region` column.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
