### PR TITLE
Fix script name for lint_and_format

### DIFF
--- a/doc/developer-scripts.md
+++ b/doc/developer-scripts.md
@@ -35,7 +35,7 @@ As any subset of specs will not reach the required coverage.
 
 You want to only check formatting
 
-`script/linting_and_formatting`
+`script/lint_and_format`
 
 ### Auto fixing option
 


### PR DESCRIPTION
## Changes

This is just a small fix to the script name for `lint_and_format`. It was originally down wrong as `linting_and_formatting`

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
