### PR TITLE
Refactor and fix Contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   order of some of the information, remove some fields, add 50px spacing between
   each block.
 
+### Fixed
+
+- the director of child services is now shown on the external contacts view as
+  long as one is available, it is centrall managed and cannot be edited.
+
 ## [Release 39][release-39]
 
 ### Added

--- a/app/controllers/external_contacts_controller.rb
+++ b/app/controllers/external_contacts_controller.rb
@@ -7,12 +7,12 @@ class ExternalContactsController < ApplicationController
 
   def new
     authorize @project, :new_contact?
-    @contact = Contact::CreateProjectContactForm.new({}, @project)
+    @contact = Contact::CreateProjectContactForm.new(contact: Contact::Project.new, project: @project)
   end
 
   def create
     authorize @project, :new_contact?
-    @contact = Contact::CreateProjectContactForm.new(contact_params, @project)
+    @contact = Contact::CreateProjectContactForm.new(contact: Contact::Project.new, project: @project, args: contact_params)
 
     if @contact.save
       redirect_to project_contacts_path(@project), notice: I18n.t("contact.create.success")
@@ -25,15 +25,14 @@ class ExternalContactsController < ApplicationController
     @existing_contact = Contact.find(params[:id])
     authorize @existing_contact
 
-    @contact = Contact::CreateProjectContactForm.new_from_contact({}, @project, @existing_contact)
-    @users = User.all
+    @contact = Contact::CreateProjectContactForm.new(contact: @existing_contact, project: @project)
   end
 
   def update
     @existing_contact = Contact.find(params[:id])
     authorize @existing_contact
 
-    @contact = Contact::CreateProjectContactForm.new(contact_params, @project, @existing_contact)
+    @contact = Contact::CreateProjectContactForm.new(contact: @existing_contact, project: @project, args: contact_params)
 
     if @contact.save
       redirect_to project_contacts_path(@project), notice: I18n.t("contact.update.success")
@@ -57,6 +56,6 @@ class ExternalContactsController < ApplicationController
   end
 
   private def contact_params
-    params.require(:contact_create_project_contact_form).permit(:name, :organisation_name, :title, :category, :email, :phone, :establishment_main_contact, :incoming_trust_main_contact, :outgoing_trust_main_contact)
+    params.require(:contact_create_project_contact_form).permit(:name, :organisation_name, :title, :category, :email, :phone, :primary_contact_for_category)
   end
 end

--- a/app/controllers/external_contacts_controller.rb
+++ b/app/controllers/external_contacts_controller.rb
@@ -2,7 +2,7 @@ class ExternalContactsController < ApplicationController
   include Projectable
 
   def index
-    @grouped_contacts = @project.contacts.by_name.group_by(&:category).with_indifferent_access
+    @grouped_contacts = ContactsFetcherService.new.all_project_contacts(@project)
   end
 
   def new

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -17,4 +17,8 @@ class Contact < ApplicationRecord
   }
 
   scope :by_name, -> { order(:name) }
+
+  def editable?
+    true
+  end
 end

--- a/app/models/contact/director_of_child_services.rb
+++ b/app/models/contact/director_of_child_services.rb
@@ -10,4 +10,8 @@ class Contact::DirectorOfChildServices < Contact
   def organisation_name
     local_authority.name
   end
+
+  def editable?
+    false
+  end
 end

--- a/app/models/contact/project.rb
+++ b/app/models/contact/project.rb
@@ -3,23 +3,17 @@ class Contact::Project < Contact
     ContactPolicy
   end
 
-  belongs_to :project, optional: true
+  belongs_to :project, class_name: "::Project"
 
   def establishment_main_contact
-    return false unless project_id
-    project = ::Project.find(project_id)
-    project&.establishment_main_contact_id.eql?(id)
+    project.establishment_main_contact_id == id
   end
 
   def incoming_trust_main_contact
-    return false unless project_id
-    project = ::Project.find(project_id)
-    project&.incoming_trust_main_contact_id.eql?(id)
+    project.incoming_trust_main_contact_id == id
   end
 
   def outgoing_trust_main_contact
-    return false unless project_id
-    project = ::Project.find(project_id)
-    project&.outgoing_trust_main_contact_id.eql?(id)
+    project.outgoing_trust_main_contact_id == id
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -11,7 +11,7 @@ class Project < ApplicationRecord
   delegate :director_of_child_services, to: :local_authority
 
   has_many :notes, dependent: :destroy
-  has_many :contacts, dependent: :destroy, class_name: "Contact::Project"
+  has_many :contacts, class_name: "Contact::Project", inverse_of: :project, dependent: :destroy
 
   has_one :funding_agreement_contact, dependent: :destroy, class_name: "Contact::Project", required: false
   has_one :main_contact, dependent: :destroy, class_name: "Contact::Project", required: false

--- a/app/services/contacts_fetcher_service.rb
+++ b/app/services/contacts_fetcher_service.rb
@@ -1,0 +1,13 @@
+class ContactsFetcherService
+  def all_project_contacts(project)
+    project_contacts = project.contacts
+    all_contacts = project_contacts.to_a
+
+    director_of_child_services = project.director_of_child_services
+    all_contacts << director_of_child_services unless director_of_child_services.nil?
+
+    return {} unless all_contacts.any?
+
+    all_contacts.sort_by(&:name).group_by(&:category)
+  end
+end

--- a/app/views/conversions/external_contacts/index.html.erb
+++ b/app/views/conversions/external_contacts/index.html.erb
@@ -15,41 +15,19 @@
       </p>
     </div>
 
-    <% if @grouped_contacts.empty? && !@project.director_of_child_services %>
-      <%= govuk_inset_text(text: t("contact.index.no_contacts_yet")) %>
-    <% end %>
-
     <div class="govuk-!-margin-bottom-5">
       <%= govuk_button_link_to t("contact.index.add_contact_button"), new_project_contact_path(@project) %>
     </div>
 
-    <% Contact.categories.keys.each do |category| %>
-      <% if @grouped_contacts[category].present? %>
-        <%= render partial: "contact_group", locals: {category: category, contacts: @grouped_contacts[category]} %>
+    <% if @grouped_contacts.empty? %>
+      <%= govuk_inset_text(text: t("contact.index.no_contacts_yet")) %>
+    <% else %>
+
+      <% Contact.categories.keys.each do |category| %>
+        <% if @grouped_contacts[category].present? %>
+          <%= render partial: "contact_group", locals: {category: category, contacts: @grouped_contacts[category]} %>
+        <% end %>
       <% end %>
     <% end %>
-
-    <% if @project.director_of_child_services %>
-      <h3 class="govuk-heading-m"><%= t("project_information.show.director_of_child_services.title") %></h3>
-      <%= govuk_summary_list(actions: false) do |summary_list|
-            summary_list.row do |row|
-              row.key { t("project_information.show.director_of_child_services.rows.title") }
-              row.value { @project.director_of_child_services.title }
-            end
-            summary_list.row do |row|
-              row.key { t("project_information.show.director_of_child_services.rows.name") }
-              row.value { @project.director_of_child_services.name }
-            end
-            summary_list.row do |row|
-              row.key { t("project_information.show.director_of_child_services.rows.email") }
-              row.value { @project.director_of_child_services.email }
-            end
-            summary_list.row do |row|
-              row.key { t("project_information.show.director_of_child_services.rows.phone") }
-              row.value { @project.director_of_child_services.phone }
-            end
-          end %>
-    <% end %>
-
   </div>
 </div>

--- a/app/views/external_contacts/_contact_group.html.erb
+++ b/app/views/external_contacts/_contact_group.html.erb
@@ -6,11 +6,13 @@
         summary_list.row do |row|
           row.key { t("contact.details.title") }
           row.value { contact.title }
-          row.action(
-            text: t("contact.details.edit_link"),
-            href: edit_project_contact_path(@project, contact),
-            visually_hidden_text: contact.name
-          )
+          if contact.editable?
+            row.action(
+              text: t("contact.details.edit_link"),
+              href: edit_project_contact_path(@project, contact),
+              visually_hidden_text: contact.name
+            )
+          end
         end
         summary_list.row do |row|
           row.key { t("contact.details.name") }

--- a/app/views/external_contacts/_contact_group.html.erb
+++ b/app/views/external_contacts/_contact_group.html.erb
@@ -40,22 +40,24 @@
             row.value { t("yes") }
           end
         end
-        if contact.establishment_main_contact
-          summary_list.row do |row|
-            row.key { t("contact.details.establishment_main_contact") }
-            row.value { t("yes") }
+        if contact.is_a?(Contact::Project)
+          if contact.establishment_main_contact
+            summary_list.row do |row|
+              row.key { t("contact.details.establishment_main_contact") }
+              row.value { t("yes") }
+            end
           end
-        end
-        if contact.incoming_trust_main_contact
-          summary_list.row do |row|
-            row.key { t("contact.details.incoming_trust_main_contact") }
-            row.value { t("yes") }
+          if contact.incoming_trust_main_contact
+            summary_list.row do |row|
+              row.key { t("contact.details.incoming_trust_main_contact") }
+              row.value { t("yes") }
+            end
           end
-        end
-        if contact.outgoing_trust_main_contact
-          summary_list.row do |row|
-            row.key { t("contact.details.outgoing_trust_main_contact") }
-            row.value { t("yes") }
+          if contact.outgoing_trust_main_contact
+            summary_list.row do |row|
+              row.key { t("contact.details.outgoing_trust_main_contact") }
+              row.value { t("yes") }
+            end
           end
         end
       end %>

--- a/app/views/external_contacts/_contact_group.html.erb
+++ b/app/views/external_contacts/_contact_group.html.erb
@@ -40,19 +40,19 @@
             row.value { t("yes") }
           end
         end
-        if @project.establishment_main_contact_id == contact.id
+        if contact.establishment_main_contact
           summary_list.row do |row|
             row.key { t("contact.details.establishment_main_contact") }
             row.value { t("yes") }
           end
         end
-        if @project.incoming_trust_main_contact_id == contact.id
+        if contact.incoming_trust_main_contact
           summary_list.row do |row|
             row.key { t("contact.details.incoming_trust_main_contact") }
             row.value { t("yes") }
           end
         end
-        if @project.outgoing_trust_main_contact_id == contact.id
+        if contact.outgoing_trust_main_contact
           summary_list.row do |row|
             row.key { t("contact.details.outgoing_trust_main_contact") }
             row.value { t("yes") }

--- a/app/views/external_contacts/edit.html.erb
+++ b/app/views/external_contacts/edit.html.erb
@@ -18,20 +18,15 @@
             :to_s,
             ->(category_name) { category_name.humanize } %>
 
+      <%= form.govuk_check_boxes_fieldset :primary_contact_for_category, multiple: false, legend: nil, hint: nil do %>
+        <%= form.govuk_check_box :primary_contact_for_category, 1, 0, multiple: false, link_errors: true, label: {text: t("helpers.label.contact_create_project_contact_form.primary_contact_for_category")}, hint: {text: t("helpers.hint.contact_create_project_contact_form.primary_contact_for_category")} %>
+      <% end %>
+
       <%= form.govuk_text_field :title, width: 20 %>
       <%= form.govuk_text_field :name %>
       <%= form.govuk_text_field :organisation_name %>
       <%= form.govuk_email_field :email %>
       <%= form.govuk_phone_field :phone, width: 10 %>
-      <%= form.govuk_check_boxes_fieldset :establishment_main_contact, multiple: false, legend: {text: t("helpers.label.contact_project.establishment_main_contact"), size: "s"} do %>
-        <%= form.govuk_check_box :establishment_main_contact, 1, 0, multiple: false, link_errors: true, label: {text: t("yes")} %>
-      <% end %>
-      <%= form.govuk_check_boxes_fieldset :incoming_trust_main_contact, multiple: false, legend: {text: t("helpers.label.contact_project.incoming_trust_main_contact"), size: "s"} do %>
-        <%= form.govuk_check_box :incoming_trust_main_contact, 1, 0, multiple: false, link_errors: true, label: {text: t("yes")} %>
-      <% end %>
-      <%= form.govuk_check_boxes_fieldset :outgoing_trust_main_contact, multiple: false, legend: {text: t("helpers.label.contact_project.outgoing_trust_main_contact"), size: "s"} do %>
-        <%= form.govuk_check_box :outgoing_trust_main_contact, 1, 0, multiple: false, link_errors: true, label: {text: t("yes")} %>
-      <% end %>
 
       <%= form.govuk_submit t("contact.edit.save_contact_button") do %>
         <%= govuk_button_link_to "Delete", project_contact_delete_path(@project, @existing_contact), warning: true %>

--- a/app/views/external_contacts/new.html.erb
+++ b/app/views/external_contacts/new.html.erb
@@ -20,20 +20,15 @@
         <% end %>
       <% end %>
 
+      <%= form.govuk_check_boxes_fieldset :primary_contact_for_category, multiple: false, legend: nil, hint: nil do %>
+        <%= form.govuk_check_box :primary_contact_for_category, 1, 0, multiple: false, link_errors: true, label: {text: t("helpers.label.contact_create_project_contact_form.primary_contact_for_category")}, hint: {text: t("helpers.hint.contact_create_project_contact_form.primary_contact_for_category")} %>
+      <% end %>
+
       <%= form.govuk_text_field :title, width: 20 %>
       <%= form.govuk_text_field :name %>
       <%= form.govuk_text_field :organisation_name %>
       <%= form.govuk_email_field :email %>
       <%= form.govuk_phone_field :phone, width: 10 %>
-      <%= form.govuk_check_boxes_fieldset :establishment_main_contact, multiple: false, legend: {text: t("helpers.label.contact_project.establishment_main_contact"), size: "s"} do %>
-        <%= form.govuk_check_box :establishment_main_contact, 1, 0, multiple: false, link_errors: true, label: {text: t("yes")} %>
-      <% end %>
-      <%= form.govuk_check_boxes_fieldset :incoming_trust_main_contact, multiple: false, legend: {text: t("helpers.label.contact_project.incoming_trust_main_contact"), size: "s"} do %>
-        <%= form.govuk_check_box :incoming_trust_main_contact, 1, 0, multiple: false, link_errors: true, label: {text: t("yes")} %>
-      <% end %>
-      <%= form.govuk_check_boxes_fieldset :outgoing_trust_main_contact, multiple: false, legend: {text: t("helpers.label.contact_project.outgoing_trust_main_contact"), size: "s"} do %>
-        <%= form.govuk_check_box :outgoing_trust_main_contact, 1, 0, multiple: false, link_errors: true, label: {text: t("yes")} %>
-      <% end %>
 
       <%= form.govuk_submit t("contact.new.save_contact_button") do %>
         <%= govuk_link_to "Cancel", project_contacts_path(@project) %>

--- a/app/views/transfers/external_contacts/index.html.erb
+++ b/app/views/transfers/external_contacts/index.html.erb
@@ -6,13 +6,13 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l"><%= t("contact.index.external_contacts") %></h2>
 
-    <% if @grouped_contacts.empty? %>
-      <%= govuk_inset_text(text: t("contact.index.no_contacts_yet")) %>
-    <% end %>
-
     <div class="govuk-!-margin-bottom-5">
       <%= govuk_button_link_to t("contact.index.add_contact_button"), new_project_contact_path(@project) %>
     </div>
+
+    <% if @grouped_contacts.empty? %>
+      <%= govuk_inset_text(text: t("contact.index.no_contacts_yet")) %>
+    <% end %>
 
     <% Contact.categories.keys.each do |category| %>
       <% if @grouped_contacts[category].present? %>

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -18,9 +18,9 @@ en:
       edit_link: Change
       funding_agreement_letters: This person will receive the funding agreement letters.
       main_contact: Project main contact
-      establishment_main_contact: Is this the main contact for the school or academy?
-      incoming_trust_main_contact: Is this the main contact for the incoming trust?
-      outgoing_trust_main_contact: Is this the main contact for the outgoing trust?
+      establishment_main_contact: Primary contact for school or academy?
+      incoming_trust_main_contact: Primary contact for incoming trust?
+      outgoing_trust_main_contact: Primary contact for outgoing trust?
     new:
       title: Add contact
       save_contact_button: Add contact
@@ -52,9 +52,6 @@ en:
         organisation_name: Organisation
         email: Email
         phone: Phone
-        establishment_main_contact: Is this the main contact for the school or academy?
-        incoming_trust_main_contact: Is this the main contact for the incoming trust?
-        outgoing_trust_main_contact: Is this the main contact for the outgoing trust?
       contact_create_project_contact_form:
         category: Contact for
         title: Role
@@ -62,16 +59,14 @@ en:
         organisation_name: Organisation
         email: Email
         phone: Phone
-        establishment_main_contact: Is this the main contact for the school or academy?
-        incoming_trust_main_contact: Is this the main contact for the incoming trust?
-        outgoing_trust_main_contact: Is this the main contact for the outgoing trust?
+        primary_contact_for_category: Primary contact
+    hint:
+      contact_create_project_contact_form:
+        primary_contact_for_category: The primary contact for this category, this is not the overall contact for the project itself.
+
   errors:
     attributes:
       category:
         blank: Choose a category
-      establishment_main_contact:
-        invalid: You can only select a School or academy contact as the school or academy's main contact
-      incoming_trust_main_contact:
-        invalid: You can only select an Incoming trust contact as the incoming trust's main contact
-      outgoing_trust_main_contact:
-        invalid: You can only select an Outgoing trust contact as the outgoing trust's main contact
+      primary_contact_for_category:
+        category: Only the incoming trust, outgoing trust and school or academy categories can have a primary contact

--- a/spec/features/users_can_manage_contacts_spec.rb
+++ b/spec/features/users_can_manage_contacts_spec.rb
@@ -120,7 +120,7 @@ RSpec.feature "Users can manage contacts" do
     fill_in "Organisation", with: "Trust Name"
     fill_in "Role", with: "Chief of Knowledge"
     fill_in "Email", with: "some@example.com"
-    check "contact_create_project_contact_form[establishment_main_contact]"
+    check "contact_create_project_contact_form[primary_contact_for_category]"
 
     click_button("Add contact")
 
@@ -132,7 +132,7 @@ RSpec.feature "Users can manage contacts" do
     contact = create(:project_contact, project: project, category: "school_or_academy")
 
     visit edit_project_contact_path(project, contact)
-    check "contact_create_project_contact_form[establishment_main_contact]"
+    check "contact_create_project_contact_form[primary_contact_for_category]"
 
     click_button("Save contact")
 
@@ -150,7 +150,7 @@ RSpec.feature "Users can manage contacts" do
     fill_in "Organisation", with: "Trust Name"
     fill_in "Role", with: "Chief of Knowledge"
     fill_in "Email", with: "some@example.com"
-    check "contact_create_project_contact_form[incoming_trust_main_contact]"
+    check "contact_create_project_contact_form[primary_contact_for_category]"
 
     click_button("Add contact")
 
@@ -168,7 +168,7 @@ RSpec.feature "Users can manage contacts" do
     fill_in "Organisation", with: "Trust Name"
     fill_in "Role", with: "Chief of Knowledge"
     fill_in "Email", with: "some@example.com"
-    check "contact_create_project_contact_form[outgoing_trust_main_contact]"
+    check "contact_create_project_contact_form[primary_contact_for_category]"
 
     click_button("Add contact")
 

--- a/spec/forms/contact/contact_project_form_spec.rb
+++ b/spec/forms/contact/contact_project_form_spec.rb
@@ -1,270 +1,255 @@
 require "rails_helper"
 
 RSpec.describe Contact::CreateProjectContactForm do
-  let(:project) { create(:conversion_project) }
+  let(:project) { create(:conversion_project, establishment_main_contact: nil, incoming_trust_main_contact: nil, outgoing_trust_main_contact: nil) }
 
   before do
     mock_successful_api_response_to_create_any_project
   end
 
-  describe "establishment_main_contact" do
-    context "a new contact" do
-      context "when the establishment_main_contact box is NOT checked" do
-        it "is valid" do
-          contact_form = Contact::CreateProjectContactForm.new({}, project)
-          contact_form.establishment_main_contact = "0"
-          expect(contact_form).to be_valid
-        end
-      end
+  describe "new contact" do
+    it "can add them" do
+      contact = Contact::Project.new
+      contact_form = Contact::CreateProjectContactForm.new(contact: contact, project: project)
+      contact_form.name = "Adifferent Name"
+      contact_form.email = "a.name@domain.com"
+      contact_form.category = "school_or_academy"
+      contact_form.title = "Role"
 
-      context "when the establishment_main_contact box is checked" do
-        context "when the contact category is school_or_academy" do
+      contact_form.save
+
+      expect(Contact::Project.count).to eql 1
+
+      expect(contact.name).to eql("Adifferent Name")
+      expect(contact.email).to eql("a.name@domain.com")
+    end
+  end
+
+  describe "existing contact" do
+    it "can update them" do
+      contact = create(:project_contact, project: project, category: "school_or_academy")
+      contact_form = Contact::CreateProjectContactForm.new(contact: contact, project: project)
+      contact_form.name = "Adifferent Name"
+      contact_form.email = "a.name@domain.com"
+
+      contact_form.save
+
+      expect(contact.reload.name).to eql("Adifferent Name")
+      expect(contact.reload.email).to eql("a.name@domain.com")
+    end
+  end
+
+  describe "the primary contact" do
+    context "when adding a new contact" do
+      let(:contact_form) { Contact::CreateProjectContactForm.new(contact: Contact::Project.new, project: project) }
+
+      context "when the primary contact box is checked" do
+        before { contact_form.primary_contact_for_category = false }
+
+        context "and the cateogry is school or academy" do
           it "is valid" do
-            contact_form = Contact::CreateProjectContactForm.new({}, project)
-            contact_form.establishment_main_contact = "1"
             contact_form.category = "school_or_academy"
+
             expect(contact_form).to be_valid
           end
 
-          it "marks the contact as the establishment main contact on the project" do
-            contact_form = Contact::CreateProjectContactForm.new({}, project)
-            contact_form.establishment_main_contact = "1"
+          it "sets the contact as the establishment main contact" do
+            contact_form.primary_contact_for_category = true
             contact_form.category = "school_or_academy"
             contact_form.name = "New Contact"
             contact_form.title = "Financial Controller"
             contact_form.organisation_name = "School"
+
             contact_form.save
             contact = Contact::Project.last
+
             expect(project.reload.establishment_main_contact).to eq(contact)
+            expect(project.establishment_main_contact.name).to eql("New Contact")
           end
         end
 
-        context "when the contact category is NOT school_or_academy" do
-          it "is not valid" do
-            contact_form = Contact::CreateProjectContactForm.new({}, project)
-            contact_form.establishment_main_contact = "1"
-            contact_form.category = "incoming_trust"
-            expect(contact_form).to_not be_valid
-          end
-        end
-      end
-    end
-
-    context "when something fails in the transaction" do
-      before do
-        allow_any_instance_of(Contact::Project).to receive(:save).and_return(ActiveRecord::ActiveRecordError)
-      end
-
-      it "does not create the contact" do
-        contact_form = Contact::CreateProjectContactForm.new({}, project)
-        contact_form.category = "school_or_academy"
-        contact_form.name = "New Contact"
-        contact_form.title = "Financial Controller"
-        contact_form.organisation_name = "School"
-        contact_form.save
-
-        expect(Contact::Project.count).to eq(0)
-      end
-    end
-
-    context "editing a contact" do
-      let(:contact) { create(:project_contact, project: project) }
-
-      context "when the establishment_main_contact box is NOT checked" do
-        it "is valid" do
-          contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
-          contact_form.establishment_main_contact = "0"
-          expect(contact_form).to be_valid
-        end
-
-        it "updates the existing contact" do
-          contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
-          contact_form.establishment_main_contact = "0"
-          contact_form.name = "New Name"
-          contact_form.save
-          expect(contact.reload.name).to eq("New Name")
-        end
-      end
-
-      context "when the establishment_main_contact box is checked" do
-        context "when the contact category is school_or_academy" do
-          let(:contact) { create(:project_contact, project: project, category: "school_or_academy") }
-
+        context "and the category is incoming trust" do
           it "is valid" do
-            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
-            contact_form.establishment_main_contact = "1"
+            contact_form.category = "incoming_trust"
+
             expect(contact_form).to be_valid
           end
 
-          it "updates the existing contact" do
-            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
-            contact_form.establishment_main_contact = "1"
-            contact_form.name = "New Name"
-            contact_form.save
-            expect(contact.reload.name).to eq("New Name")
-          end
-        end
-
-        context "when the contact category is NOT school_or_academy" do
-          let(:contact) { create(:project_contact, project: project, category: "solicitor") }
-
-          it "is not valid" do
-            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
-            contact_form.establishment_main_contact = "1"
-            expect(contact_form).to_not be_valid
-          end
-        end
-      end
-    end
-  end
-
-  describe "incoming_trust_main_contact" do
-    context "a new contact" do
-      context "when the incoming_trust_main_contact is checked" do
-        context "when the contact category is incoming_trust" do
-          it "is valid" do
-            contact_form = Contact::CreateProjectContactForm.new({}, project)
-            contact_form.incoming_trust_main_contact = "1"
-            contact_form.category = "incoming_trust"
-            expect(contact_form).to be_valid
-          end
-
-          it "marks the contact as the incoming_trust_main_contact on the project" do
-            contact_form = Contact::CreateProjectContactForm.new({}, project)
-            contact_form.incoming_trust_main_contact = "1"
+          it "sets the contact as the incoming trust main contact" do
+            contact_form.primary_contact_for_category = true
             contact_form.category = "incoming_trust"
             contact_form.name = "New Contact"
             contact_form.title = "Financial Controller"
-            contact_form.organisation_name = "Trust"
+            contact_form.organisation_name = "School"
+
             contact_form.save
             contact = Contact::Project.last
+
             expect(project.reload.incoming_trust_main_contact).to eq(contact)
           end
         end
 
-        context "when the contact category is NOT incoming_trust" do
-          it "is not valid" do
-            contact_form = Contact::CreateProjectContactForm.new({}, project)
-            contact_form.incoming_trust_main_contact = "1"
-            contact_form.category = "school_or_academy"
-            expect(contact_form).to_not be_valid
+        context "and the category is outgoing trust" do
+          it "is valid" do
+            contact_form.category = "outgoing_trust"
+
+            expect(contact_form).to be_valid
           end
+
+          it "sets the contact as the outgoing trust main contact" do
+            contact_form.primary_contact_for_category = true
+            contact_form.category = "outgoing_trust"
+            contact_form.name = "New Contact"
+            contact_form.title = "Financial Controller"
+            contact_form.organisation_name = "School"
+
+            contact_form.save
+            contact = Contact::Project.last
+
+            expect(project.reload.outgoing_trust_main_contact).to eq(contact)
+          end
+        end
+
+        context "and the category is local authority" do
+          it "is invalid" do
+            contact_form.primary_contact_for_category = true
+            contact_form.category = "local_authority"
+
+            expect(contact_form).to be_invalid
+          end
+        end
+
+        context "and the category is diocese" do
+          it "is invalid" do
+            contact_form.primary_contact_for_category = true
+            contact_form.category = "diocese"
+
+            expect(contact_form).to be_invalid
+          end
+        end
+
+        context "and the category is solicitor" do
+          it "is invalid" do
+            contact_form.primary_contact_for_category = true
+            contact_form.category = "solicitor"
+
+            expect(contact_form).to be_invalid
+          end
+        end
+
+        context "and the category is other" do
+          it "is invalid" do
+            contact_form.primary_contact_for_category = true
+            contact_form.category = "other"
+
+            expect(contact_form).to be_invalid
+          end
+        end
+      end
+
+      context "when something fails in the transaction" do
+        it "does not create the contact" do
+          contact = Contact::Project.new
+
+          allow(project).to receive(:save!).and_raise(ActiveRecord::RecordInvalid)
+
+          contact_form = Contact::CreateProjectContactForm.new(contact: contact, project: project)
+          contact_form.category = "school_or_academy"
+          contact_form.name = "New Contact"
+          contact_form.title = "Financial Controller"
+          contact_form.organisation_name = "School"
+
+          expect { contact_form.save }.to raise_error(ActiveRecord::RecordInvalid)
+          expect(Contact::Project.count).to be_zero
         end
       end
     end
 
-    context "editing a contact" do
-      context "when the incoming_trust_main_contact is checked" do
-        context "when the contact category is incoming_trust" do
-          let(:contact) { create(:project_contact, project: project, category: "incoming_trust") }
+    context "when editing a contact" do
+      context "and the category is one that does support a primary contact" do
+        let(:contact) { create(:project_contact, project: project, category: "school_or_academy") }
 
-          it "is valid" do
-            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
-            contact_form.incoming_trust_main_contact = "1"
-            expect(contact_form).to be_valid
-          end
-        end
+        it "updates the contact details" do
+          contact_form = Contact::CreateProjectContactForm.new(contact: contact, project: project)
+          contact_form.name = "Adifferent Name"
+          contact_form.email = "a.name@domain.com"
 
-        context "when the contact category is NOT incoming_trust" do
-          let(:contact) { create(:project_contact, project: project, category: "solicitor") }
+          contact_form.save
 
-          it "is not valid" do
-            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
-            contact_form.incoming_trust_main_contact = "1"
-            expect(contact_form).to_not be_valid
-          end
+          expect(contact.reload.name).to eql("Adifferent Name")
+          expect(contact.reload.email).to eql("a.name@domain.com")
         end
       end
 
-      context "when the incoming_trust_main_contact box is NOT checked" do
-        context "when the contact was previously marked as the incoming_trust_main_contact" do
+      context "when the category is one that does not support a primary contact" do
+        let(:contact) { create(:project_contact, project: project, category: "other") }
+
+        it "is invalid" do
+          contact_form = Contact::CreateProjectContactForm.new(contact: contact, project: project)
+          contact_form.primary_contact_for_category = true
+
+          expect(contact_form).to be_invalid
+        end
+      end
+
+      context "when the existing contact is not the primary contact" do
+        let(:contact) { create(:project_contact, project: project, category: "school_or_academy") }
+
+        it "can be set" do
+          contact_form = Contact::CreateProjectContactForm.new(contact: contact, project: project)
+          contact_form.primary_contact_for_category = true
+
+          expect(project.establishment_main_contact_id).to be_nil
+
+          contact_form.save
+
+          expect(project.establishment_main_contact_id).to eql(contact.id)
+        end
+      end
+
+      context "when the exisiting contact is the primary contact" do
+        context "and the contact is for the school or academy category" do
+          let(:contact) { create(:project_contact, project: project, category: "school_or_academy") }
+
+          it "can be unset" do
+            project.update!(establishment_main_contact_id: contact.id)
+            contact_form = Contact::CreateProjectContactForm.new(contact: contact, project: project)
+            contact_form.primary_contact_for_category = false
+
+            expect(project.establishment_main_contact_id).to eql(contact.id)
+
+            contact_form.save
+
+            expect(project.establishment_main_contact_id).to be_nil
+          end
+        end
+
+        context "and the contact is for the incoming trust category" do
           let(:contact) { create(:project_contact, project: project, category: "incoming_trust") }
 
-          before do
+          it "can be unset" do
             project.update!(incoming_trust_main_contact_id: contact.id)
-          end
+            contact_form = Contact::CreateProjectContactForm.new(contact: contact, project: project)
+            contact_form.primary_contact_for_category = false
 
-          it "removes the incoming_trust_main_contact from the project" do
-            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
-            contact_form.incoming_trust_main_contact = "0"
+            expect(project.incoming_trust_main_contact_id).to eql(contact.id)
+
             contact_form.save
 
             expect(project.incoming_trust_main_contact_id).to be_nil
           end
         end
-      end
-    end
-  end
 
-  describe "outgoing_trust_main_contact" do
-    context "a new contact" do
-      context "when the outgoing_trust_main_contact is checked" do
-        context "when the contact category is outgoing_trust" do
-          it "is valid" do
-            contact_form = Contact::CreateProjectContactForm.new({}, project)
-            contact_form.outgoing_trust_main_contact = "1"
-            contact_form.category = "outgoing_trust"
-            expect(contact_form).to be_valid
-          end
-
-          it "marks the contact as the outgoing_trust_main_contact on the project" do
-            contact_form = Contact::CreateProjectContactForm.new({}, project)
-            contact_form.outgoing_trust_main_contact = "1"
-            contact_form.category = "outgoing_trust"
-            contact_form.name = "New Contact"
-            contact_form.title = "Financial Controller"
-            contact_form.organisation_name = "Trust"
-            contact_form.save
-            contact = Contact::Project.last
-            expect(project.reload.outgoing_trust_main_contact).to eq(contact)
-          end
-        end
-
-        context "when the contact category is NOT outgoing_trust" do
-          it "is not valid" do
-            contact_form = Contact::CreateProjectContactForm.new({}, project)
-            contact_form.outgoing_trust_main_contact = "1"
-            contact_form.category = "school_or_academy"
-            expect(contact_form).to_not be_valid
-          end
-        end
-      end
-    end
-
-    context "editing a contact" do
-      context "when the outgoing_trust_main_contact is checked" do
-        context "when the contact category is outgoing_trust" do
+        context "and the contact is for the outgoing trust category" do
           let(:contact) { create(:project_contact, project: project, category: "outgoing_trust") }
 
-          it "is valid" do
-            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
-            contact_form.outgoing_trust_main_contact = "1"
-            expect(contact_form).to be_valid
-          end
-        end
-
-        context "when the contact category is NOT outgoing_trust" do
-          let(:contact) { create(:project_contact, project: project, category: "solicitor") }
-
-          it "is not valid" do
-            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
-            contact_form.outgoing_trust_main_contact = "1"
-            expect(contact_form).to_not be_valid
-          end
-        end
-      end
-
-      context "when the outgoing_trust_main_contact box is NOT checked" do
-        context "when the contact was previously marked as the outgoing_trust_main_contact" do
-          let(:contact) { create(:project_contact, project: project, category: "outgoing_trust") }
-
-          before do
+          it "can be unset" do
             project.update!(outgoing_trust_main_contact_id: contact.id)
-          end
+            contact_form = Contact::CreateProjectContactForm.new(contact: contact, project: project)
+            contact_form.primary_contact_for_category = false
 
-          it "removes the outgoing_trust_main_contact from the project" do
-            contact_form = Contact::CreateProjectContactForm.new_from_contact(project, contact)
-            contact_form.outgoing_trust_main_contact = "0"
+            expect(project.outgoing_trust_main_contact_id).to eql(contact.id)
+
             contact_form.save
 
             expect(project.outgoing_trust_main_contact_id).to be_nil

--- a/spec/models/contact/director_of_child_services_spec.rb
+++ b/spec/models/contact/director_of_child_services_spec.rb
@@ -27,4 +27,13 @@ RSpec.describe Contact::DirectorOfChildServices, type: :model do
       expect(described_class.policy_class).to eql(LocalAuthorityPolicy)
     end
   end
+
+  describe "#editable" do
+    it "always returns false" do
+      local_authority = create(:local_authority)
+      director = create(:director_of_child_services, local_authority: local_authority)
+
+      expect(director.editable?).to be false
+    end
+  end
 end

--- a/spec/models/contact/project_spec.rb
+++ b/spec/models/contact/project_spec.rb
@@ -1,44 +1,7 @@
 require "rails_helper"
-
-RSpec.describe Contact::Project, type: :model do
-  describe "Columns" do
-    it { is_expected.to have_db_column(:name).of_type :string }
-    it { is_expected.to have_db_column(:title).of_type :string }
-    it { is_expected.to have_db_column(:email).of_type :string }
-    it { is_expected.to have_db_column(:phone).of_type :string }
-    it { is_expected.to have_db_column(:organisation_name).of_type :string }
-    it { is_expected.to have_db_column(:type).of_type :string }
-  end
-
+RSpec.describe Contact::Project do
   describe "Relationships" do
-    it { is_expected.to belong_to(:project).optional }
-  end
-
-  describe "Validations" do
-    it { should validate_presence_of(:category) }
-    it { should validate_presence_of(:name) }
-    it { should validate_presence_of(:title) }
-
-    describe "#email" do
-      it { is_expected.to allow_value("test@example.com").for(:email) }
-      it { is_expected.to_not allow_value("notavalidemail").for(:email) }
-    end
-  end
-
-  describe "scopes" do
-    describe "by_name" do
-      it "orders by name" do
-        mock_successful_api_responses(urn: any_args, ukprn: any_args)
-        project = create(:conversion_project)
-        first_solicitor_contact = create(:project_contact, category: :solicitor, name: "B solicitor", project: project)
-        second_solicitor_contact = create(:project_contact, category: :solicitor, name: "A solicitor", project: project)
-
-        ordered_contacts = project.contacts.by_name
-
-        expect(ordered_contacts.first).to eq second_solicitor_contact
-        expect(ordered_contacts.last).to eq first_solicitor_contact
-      end
-    end
+    it { is_expected.to belong_to(:project) }
   end
 
   describe "#establishment_main_contact" do

--- a/spec/models/contact/project_spec.rb
+++ b/spec/models/contact/project_spec.rb
@@ -24,11 +24,6 @@ RSpec.describe Contact::Project do
 
       expect(contact.establishment_main_contact).to be false
     end
-
-    it "returns false if the contact does not have a project" do
-      contact = create(:project_contact, project_id: nil)
-      expect(contact.establishment_main_contact).to be false
-    end
   end
 
   describe "#incoming_trust_main_contact" do
@@ -51,11 +46,6 @@ RSpec.describe Contact::Project do
 
       expect(contact.incoming_trust_main_contact).to be false
     end
-
-    it "returns false if the contact does not have a project" do
-      contact = create(:project_contact, project_id: nil)
-      expect(contact.incoming_trust_main_contact).to be false
-    end
   end
 
   describe "#outgoing_trust_main_contact" do
@@ -76,11 +66,6 @@ RSpec.describe Contact::Project do
       project = create(:conversion_project, outgoing_trust_main_contact_id: SecureRandom.uuid)
       contact = create(:project_contact, project: project)
 
-      expect(contact.outgoing_trust_main_contact).to be false
-    end
-
-    it "returns false if the contact does not have a project" do
-      contact = create(:project_contact, project_id: nil)
       expect(contact.outgoing_trust_main_contact).to be false
     end
   end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+RSpec.describe Contact do
+  describe "Columns" do
+    it { is_expected.to have_db_column(:name).of_type :string }
+    it { is_expected.to have_db_column(:title).of_type :string }
+    it { is_expected.to have_db_column(:email).of_type :string }
+    it { is_expected.to have_db_column(:phone).of_type :string }
+    it { is_expected.to have_db_column(:organisation_name).of_type :string }
+    it { is_expected.to have_db_column(:type).of_type :string }
+  end
+
+  describe "Validations" do
+    it { should validate_presence_of(:category) }
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:title) }
+
+    describe "#email" do
+      it { is_expected.to allow_value("test@example.com").for(:email) }
+      it { is_expected.to_not allow_value("notavalidemail").for(:email) }
+    end
+  end
+
+  describe "scopes" do
+    describe "by_name" do
+      it "orders by name" do
+        mock_successful_api_responses(urn: any_args, ukprn: any_args)
+        project = create(:conversion_project)
+        first_solicitor_contact = create(:project_contact, category: :solicitor, name: "B solicitor", project: project)
+        second_solicitor_contact = create(:project_contact, category: :solicitor, name: "A solicitor", project: project)
+
+        ordered_contacts = project.contacts.by_name
+
+        expect(ordered_contacts.first).to eq second_solicitor_contact
+        expect(ordered_contacts.last).to eq first_solicitor_contact
+      end
+    end
+  end
+
+  describe "#editable?" do
+    it "always returns true" do
+      mock_all_academies_api_responses
+      project = create(:conversion_project)
+      contact = create(:project_contact, project: project)
+
+      expect(contact.editable?).to be true
+    end
+  end
+end

--- a/spec/requests/contacts_controller_spec.rb
+++ b/spec/requests/contacts_controller_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe ExternalContactsController, type: :request do
     let(:new_contact_title) { "Headteacher" }
 
     subject(:perform_request) do
-      put project_contact_path(project_id, contact_id), params: {contact_create_project_contact_form: {name: new_contact_name, title: new_contact_title, category: "other"}}
+      put project_contact_path(project_id, contact_id), params: {contact_create_project_contact_form: {name: new_contact_name, title: new_contact_title, category: "school_or_academy"}}
       response
     end
 

--- a/spec/requests/contacts_controller_spec.rb
+++ b/spec/requests/contacts_controller_spec.rb
@@ -28,16 +28,14 @@ RSpec.describe ExternalContactsController, type: :request do
     end
 
     context "when the project has a director of child services" do
-      let(:local_authority) { create(:local_authority) }
-
-      before do
-        create(:director_of_child_services, local_authority: local_authority)
-        allow_any_instance_of(Api::AcademiesApi::Establishment).to receive(:local_authority).and_return(local_authority)
-      end
-
       it "includes the director of child services in the response" do
-        director = local_authority.director_of_child_services
-        expect(subject.body).to include(director.name)
+        project = create(:conversion_project)
+        director_of_child_services_contact = create(:director_of_child_services)
+        allow_any_instance_of(Project).to receive(:director_of_child_services).and_return(director_of_child_services_contact)
+
+        get project_contacts_path(project)
+
+        expect(response.body).to include(director_of_child_services_contact.name)
       end
     end
   end

--- a/spec/services/contacts_fetcher_service_spec.rb
+++ b/spec/services/contacts_fetcher_service_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe ContactsFetcherService do
+  before { mock_all_academies_api_responses }
+
+  describe "#all_project_contacts" do
+    it "returns the contacts for a given project" do
+      project = create(:transfer_project)
+      project_contact = create(:project_contact, project: project, category: "school_or_academy")
+      director_of_child_services_contact = create(:director_of_child_services)
+      allow(project).to receive(:director_of_child_services).and_return(director_of_child_services_contact)
+
+      service = described_class.new
+      result = service.all_project_contacts(project)
+
+      expect(result.count).to eql(2)
+      expect(result["school_or_academy"]).to include(project_contact)
+      expect(result["local_authority"]).to include(director_of_child_services_contact)
+    end
+
+    context "when there are no contacts" do
+      context "and there is a director of child services" do
+        it "returns the director of child services contact" do
+          project = create(:transfer_project)
+          director_of_child_services = create(:director_of_child_services)
+          allow(project).to receive(:director_of_child_services).and_return(director_of_child_services)
+
+          service = described_class.new
+          result = service.all_project_contacts(project)
+
+          expect(result.values.flatten.count).to eql(1)
+          expect(result.values.flatten.first).to be(director_of_child_services)
+        end
+      end
+
+      context "and there is not a director of child services" do
+        it "returns empty" do
+          project = create(:transfer_project)
+          allow(project).to receive(:director_of_child_services).and_return(nil)
+
+          service = described_class.new
+          result = service.all_project_contacts(project)
+
+          expect(result).to be_empty
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This work started out as 'I wonder why calling the `project` association on a `Contact` results in nil?...' to what you see here!

There is a fair bit so jump in:

The project association was caused by a naming collision between `Contact::Project` and `Project` - ideally we would rename the `Contact::Project` class - but the scope of felt a bit big (at the time!).

Whilst working on this we found a bug on the 'main contact' behaviour that meant any time the main contact for a category was updated, all of the other main contact states were dropped - this would have meant a sort of data loss if we deployed it.  We fixed that and simplified the approach, we don't think this is the final solution to this area, but it does let us deploy the feature. We've changed most of the language around this to 'primary contact for category' to avoid confusion with the 'main contact' for the project - as mentioned, this is be not means perfect -just a step forwards.

We also refactored how the director of child services is fetched, adding a service to do the fetching and so simplifying the way the view works - this fixes another issue where the director of child services is not showing up on transfer project and we no longer have to think about it.

I feel like:

- Contacts are pretty important and complex
- There is a lot more we can do if we have the capacity
- this is enough for now

