### PR TITLE
Release 40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [Release 40][release-40]
+
+### Added
+
 - Add the Main contact task to the Conversion project task list
 - Add the Main contact task to the Transfer project task list
 - Show the main contact for a project in the project CSV exports
@@ -1299,7 +1307,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-39...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-40...HEAD
+[release-40]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-39...release-40
 [release-39]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-38...release-39
 [release-38]:


### PR DESCRIPTION
### Added

- Add the Main contact task to the Conversion project task list
- Add the Main contact task to the Transfer project task list
- Show the main contact for a project in the project CSV exports
- The all conditions met task for a transfer has updated content.
- Add deeds of termination for MFA task to Transfer projects
- Added the 'Deed of termination for the church supplemental agreement' task to
  transfers.
- The application can now store the un-published GIAS establishment records.
- Allow a contact to be marked as the "establishment main contact"
- Allow a contact to be marked as the "incoming trust main contact"
- Allow a contact to be marked as the "outgoing trust main contact"
- Add missing navigation to the individual (show) export pages
- Add Closure or transfer declaration task to transfers
- Add "Confirm incoming trust has completed all actions" task to transfers
- Add "Redact and send documents" task to transfers
- Add "Request new URN and record" task to transfers

### Changed

- Remove the Funding agreement letters contact task from the Conversion project
  task list
- Change order of the legal tasks in the Transfer task list
- The 'Team projects' section is now 'Your team projects'
- The "School" contact type is now "School or academy"
- Amend the "Your team projects" in progress table view to show either a team
  column or region column depending on whether the current user is a regional
  delivery officer or a regional case worker
- Rework the project summary to contain more concise information.
- Rework the Project information (now called "About the project") tab. Change
  order of some of the information, remove some fields, add 50px spacing between
  each block.
- Update the Your team projects Completed table

### Fixed

- the director of child services is now shown on the external contacts view as
  long as one is available, it is centrall managed and cannot be edited.
