### PR TITLE
Change Ruby image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------
 # Base stage
 # ------------------------------------------------------------------------------
-FROM ruby:3.1.4 AS base
+FROM ruby:3.1.4-bullseye AS base
 
 # setup env
 ENV APP_HOME /srv/app
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y build-essential libpq-dev ca-certificat
 #
 ENV NODE_MAJOR=18
 
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN mkdir -p /etc/apt/keyrings/ && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
 | tee /etc/apt/sources.list.d/nodesource.list


### PR DESCRIPTION
We base our application container off the official Ruby one.

We recently updated to Ruby 3.1.4, we then started to see issues as soon
as this was deployed. They issue seems to relate to Sidekiq and Redis
and shows up as a 500.

```
E, [2023-09-28T12:34:45.186167 #1] ERROR -- :
[4c75378d-4fda-41d7-869a-aa79da7b9159] [ActiveJob] Failed enqueuing
ActionMailer::MailDeliveryJob to Sidekiq(default):
OpenSSL::SSL::SSLError (SSL_read: unsupported method)
```

The issue is very itermittent, we can validate that most email jobs get
sent because we can see them in the Notify API:

https://www.notifications.service.gov.uk/services/32d75f94-b459-4e65-b753-3f9d55c8c9b7/api

We have a working hypothesis that release 40 was the change point and
that included the change to ruby 3.1.4 which by default (`ruby:3.1.4`)
is built against OpenSSL 3.x for the container image.

Our first step to solving this is the try the `ruby:3.1.4-bullseye`
images, which looks to be built against OpenSSL 1.x:

https://hub.docker.com/layers/library/ruby/3.1.4-bullseye/images/sha256-05c433d108a01a11d9f2d5412568f1f5cf79ff0aec51c89ae3296b4078e23bab?context=explore

