### PR TITLE
Import GIAS establishments data job

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,7 @@
+class ApplicationJob < ActiveJob::Base
+  # Automatically retry jobs that encountered a deadlock
+  # retry_on ActiveRecord::Deadlocked
+
+  # Most jobs are safe to ignore if the underlying records are no longer available
+  # discard_on ActiveJob::DeserializationError
+end

--- a/app/jobs/import/gias_establishment_import_job.rb
+++ b/app/jobs/import/gias_establishment_import_job.rb
@@ -6,5 +6,10 @@ class Import::GiasEstablishmentImportJob < ApplicationJob
     result = importer.import!
 
     GiasEstablishmentImportMailer.import_notification(user, result).deliver_later
+    delete_file(file_path)
+  end
+
+  private def delete_file(file_path)
+    File.delete(file_path)
   end
 end

--- a/app/jobs/import/gias_establishment_import_job.rb
+++ b/app/jobs/import/gias_establishment_import_job.rb
@@ -1,0 +1,10 @@
+class Import::GiasEstablishmentImportJob < ApplicationJob
+  queue_as :default
+
+  def perform(file_path, user)
+    importer = Import::GiasEstablishmentCsvImporterService.new(file_path)
+    result = importer.import!
+
+    GiasEstablishmentImportMailer.import_notification(user, result).deliver_later
+  end
+end

--- a/app/mailers/gias_establishment_import_mailer.rb
+++ b/app/mailers/gias_establishment_import_mailer.rb
@@ -1,0 +1,11 @@
+class GiasEstablishmentImportMailer < ApplicationMailer
+  def import_notification(user, result)
+    template_mail(
+      "316ef413-5e53-48e4-8a78-2aeaa9b98114",
+      to: user.email,
+      personalisation: {
+        result: result
+      }
+    )
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,4 +58,5 @@ Rails.application.configure do
   config.assets.css_compressor = nil
 
   config.action_mailer.default_url_options = {host: "https://example.com"}
+  config.active_job.queue_adapter = :test
 end

--- a/spec/jobs/import/gias_establishment_import_job_spec.rb
+++ b/spec/jobs/import/gias_establishment_import_job_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe Import::GiasEstablishmentImportJob, type: :job do
+  describe "#perform" do
+    let(:user) { create(:user, :service_support) }
+    let(:importer) { double(Import::GiasEstablishmentCsvImporterService, import!: true) }
+    subject { described_class }
+
+    before do
+      allow(Import::GiasEstablishmentCsvImporterService).to receive(:new).and_return(importer)
+    end
+
+    context "when the import succeeds" do
+      let(:file_path) { "gias_establishment_data_good.csv" }
+
+      it "queues the job" do
+        subject.perform_later(file_path, user)
+        expect(Import::GiasEstablishmentImportJob).to have_been_enqueued.exactly(:once)
+      end
+
+      it "calls the importer service" do
+        subject.perform_now(file_path, user)
+        expect(importer).to have_received(:import!)
+      end
+
+      it "sends an email to the user with the import report" do
+        mock_mailer = double(GiasEstablishmentImportMailer, deliver_later: true)
+        expect(GiasEstablishmentImportMailer).to receive(:import_notification).and_return(mock_mailer)
+
+        subject.perform_now(file_path, user)
+
+        expect(mock_mailer).to have_received(:deliver_later).exactly(1).time
+      end
+    end
+  end
+end

--- a/spec/jobs/import/gias_establishment_import_job_spec.rb
+++ b/spec/jobs/import/gias_establishment_import_job_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Import::GiasEstablishmentImportJob, type: :job do
 
     before do
       allow(Import::GiasEstablishmentCsvImporterService).to receive(:new).and_return(importer)
+      allow(File).to receive(:delete).and_return(true)
     end
 
     context "when the import succeeds" do
@@ -30,6 +31,14 @@ RSpec.describe Import::GiasEstablishmentImportJob, type: :job do
         subject.perform_now(file_path, user)
 
         expect(mock_mailer).to have_received(:deliver_later).exactly(1).time
+      end
+
+      it "deletes the file afterwards" do
+        mock_mailer = double(GiasEstablishmentImportMailer, deliver_later: true)
+        expect(GiasEstablishmentImportMailer).to receive(:import_notification).and_return(mock_mailer)
+
+        subject.perform_now(file_path, user)
+        expect(File).to have_received(:delete).with(file_path)
       end
     end
   end

--- a/spec/mailers/gias_establishment_import_mailer_spec.rb
+++ b/spec/mailers/gias_establishment_import_mailer_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe GiasEstablishmentImportMailer do
+  describe "#import_notification" do
+    let(:user) { create(:user, :service_support) }
+    let(:template_id) { "316ef413-5e53-48e4-8a78-2aeaa9b98114" }
+    let(:result) do
+      {result: {total_csv_rows: 10,
+                new_records: 1,
+                changed_records: 2,
+                changes: 0,
+                time: Time.now,
+                errors: []}}
+    end
+    let(:expected_personalisation) { {result: result} }
+
+    subject(:send_mail) { described_class.import_notification(user, result).deliver_now }
+
+    it "sends an email with the correct personalisation" do
+      expect_any_instance_of(Mail::Notify::Mailer)
+        .to receive(:template_mail)
+        .with(template_id, {to: user.email, personalisation: expected_personalisation})
+
+      send_mail
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -111,4 +111,10 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  # clean out the queue after each spec
+  config.after(:each) do
+    ActiveJob::Base.queue_adapter.enqueued_jobs = []
+    ActiveJob::Base.queue_adapter.performed_jobs = []
+  end
 end


### PR DESCRIPTION
## Changes

Add a job to run the GIAS Establishment Importer from a provided file. The job then sends an email to the requesting user with the output of the importer. 

The email has not been "contentified" - it just sends the raw output. We can iterate on this.

A requirement of this ticket was to run the job at 4am (or a provided time). However, we need to do this from the controller which calls the job. When we call the job, we should call it with (e.g.)

`Import::GiasEstablishmentImportJob.set(wait_until: <DateTime>).perform_later(file_path, user)`

Finally, when the job has been run & the email has been sent, the uploaded file is deleted.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
