### PR TITLE
Allow RCS and RDO users to add a new transfer project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add the "Add new transfer" button for users who can add new projects
+
 ### Changed
 
 - Update the "main contact" task content for Conversion and Transfer projects

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,6 +61,11 @@ class User < ApplicationRecord
     end
   end
 
+  # Override the db column temporarily while we test adding Transfers
+  def add_new_project
+    is_regional_caseworker? || is_regional_delivery_officer?
+  end
+
   def team_options
     User.teams.keys.map { |team| OpenStruct.new(id: team, name: I18n.t("user.teams.#{team}")) }
   end

--- a/app/views/projects/shared/_new_projects.html.erb
+++ b/app/views/projects/shared/_new_projects.html.erb
@@ -4,5 +4,9 @@
           conversions_new_path,
           class: "govuk-button",
           data: {module: "govuk-button"} %>
+    <%= link_to t("transfer_project.new.title"),
+          transfers_new_path,
+          class: "govuk-button",
+          data: {module: "govuk-button"} %>
   </div>
 <% end %>

--- a/spec/features/home_page/regional_casework_services_user_spec.rb
+++ b/spec/features/home_page/regional_casework_services_user_spec.rb
@@ -12,9 +12,9 @@ RSpec.feature "The home page for a regional casework services user" do
     expect(page.current_path).to eql in_progress_your_projects_path
   end
 
-  scenario "does not show the added by you primary navigation" do
+  scenario "shows the added by you primary navigation" do
     visit root_path
 
-    expect(page).not_to have_link "Added by you"
+    expect(page).to have_link "Added by you"
   end
 end

--- a/spec/requests/conversions/projects_controller_spec.rb
+++ b/spec/requests/conversions/projects_controller_spec.rb
@@ -109,12 +109,9 @@ RSpec.describe Conversions::ProjectsController do
         sign_in_with(caseworker)
       end
 
-      it "does not create the project and shows an error message" do
+      it "creates the project" do
         perform_request
-        expect(response).not_to render_template(:edit)
-        expect(response).to redirect_to(root_path)
-        follow_redirect!
-        expect(flash.alert).to eq I18n.t("unauthorised_action.message")
+        expect(response).to redirect_to project_path(Project.last)
       end
     end
   end

--- a/spec/requests/project_management_spec.rb
+++ b/spec/requests/project_management_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe "Project management" do
         expect(response).to render_template(:new)
       end
 
-      it "shows the new project button" do
+      it "shows the new project buttons" do
         get in_progress_your_projects_path
         expect(response.body).to include(I18n.t("conversion_project.new.title"))
+        expect(response.body).to include(I18n.t("transfer_project.new.title"))
       end
     end
 
@@ -28,9 +29,10 @@ RSpec.describe "Project management" do
         expect(response).to render_template(:new)
       end
 
-      it "shows the new project button" do
+      it "shows the new project buttons" do
         get in_progress_your_projects_path
         expect(response.body).to include(I18n.t("conversion_project.new.title"))
+        expect(response.body).to include(I18n.t("transfer_project.new.title"))
       end
     end
 
@@ -45,9 +47,10 @@ RSpec.describe "Project management" do
         expect(flash.alert).to eq I18n.t("unauthorised_action.message")
       end
 
-      it "does not show the new project button" do
+      it "does not show the new project buttons" do
         get in_progress_your_projects_path
         expect(response.body).not_to include(I18n.t("conversion_project.new.title"))
+        expect(response.body).not_to include(I18n.t("transfer_project.new.title"))
       end
     end
   end

--- a/spec/requests/project_management_spec.rb
+++ b/spec/requests/project_management_spec.rb
@@ -23,17 +23,14 @@ RSpec.describe "Project management" do
     context "when a user is a caseworker" do
       let(:user) { create(:user, :caseworker) }
 
-      it "redirects to the root path and displays a not authorized message" do
+      it "allows the action and renders the new template" do
         get conversions_new_path
-        expect(response).not_to render_template(:new)
-        expect(response).to redirect_to(root_path)
-        follow_redirect!
-        expect(flash.alert).to eq I18n.t("unauthorised_action.message")
+        expect(response).to render_template(:new)
       end
 
-      it "does not show the new project button" do
+      it "shows the new project button" do
         get in_progress_your_projects_path
-        expect(response.body).not_to include(I18n.t("conversion_project.new.title"))
+        expect(response.body).to include(I18n.t("conversion_project.new.title"))
       end
     end
 


### PR DESCRIPTION
## Changes

We want to temporarily grant RCS users the ability to add new projects
(specifically Transfer projects, but all projects for convenience).

To do this, we have overridden the `add_new_project` column in the db with
a method. The db column is still set to `false` on creation of an RCS user,
but the overriding method returns true.

Once that is done, add the "Add new transfer" button for users who can `add_new_project`.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
