### PR TITLE
Move the site banner environment variable away from sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Update the "main contact" task content for Conversion and Transfer projects
+- Move the site banner environment variable away from sentry and replace with
+  our own definded environment variable.
 
 ### Fixed
 

--- a/app/helpers/environment_banner_helper.rb
+++ b/app/helpers/environment_banner_helper.rb
@@ -16,6 +16,6 @@ module EnvironmentBannerHelper
   end
 
   private def sentry_env
-    ENV.fetch("SENTRY_ENV", "local_development")
+    ENV.fetch("USER_ENV", "local_development")
   end
 end

--- a/spec/features/user_can_see_environment_banner_spec.rb
+++ b/spec/features/user_can_see_environment_banner_spec.rb
@@ -7,9 +7,9 @@ RSpec.feature "Environment banner" do
   end
 
   describe "environment banner" do
-    scenario "when the SETNRY_ENV is production cannot see the environment banner" do
+    scenario "when the USER_ENV is production cannot see the environment banner" do
       ClimateControl.modify(
-        SENTRY_ENV: "production"
+        USER_ENV: "production"
       ) do
         visit root_path
 
@@ -18,9 +18,9 @@ RSpec.feature "Environment banner" do
     end
   end
 
-  scenario "when the SENTRY_ENV is development can see the environment banner" do
+  scenario "when the USER_ENV is development can see the environment banner" do
     ClimateControl.modify(
-      SENTRY_ENV: "development"
+      USER_ENV: "development"
     ) do
       visit root_path
       within("#environment-banner") do

--- a/spec/helpers/environment_banner_helper_spec.rb
+++ b/spec/helpers/environment_banner_helper_spec.rb
@@ -4,26 +4,26 @@ RSpec.describe EnvironmentBannerHelper, type: :helper do
   describe "#environment_banner" do
     subject { helper.environment_banner }
 
-    context "when SENTRY_ENV is production" do
-      before { allow(ENV).to receive(:fetch).with("SENTRY_ENV", "local_development").and_return("production") }
+    context "when USER_ENV is production" do
+      before { allow(ENV).to receive(:fetch).with("USER_ENV", "local_development").and_return("production") }
 
       it { expect(subject).to be_nil }
     end
 
-    context "when SENTRY_ENV is development" do
-      before { allow(ENV).to receive(:fetch).with("SENTRY_ENV", "local_development").and_return("development") }
+    context "when USER_ENV is development" do
+      before { allow(ENV).to receive(:fetch).with("USER_ENV", "local_development").and_return("development") }
 
       it { expect(subject).to eql(environment_tag("turquoise", "DEVELOPMENT ENVIRONMENT")) }
     end
 
-    context "when SENTRY_ENV is local_development" do
-      before { allow(ENV).to receive(:fetch).with("SENTRY_ENV", "local_development").and_return("local_development") }
+    context "when USER_ENV is local_development" do
+      before { allow(ENV).to receive(:fetch).with("USER_ENV", "local_development").and_return("local_development") }
 
       it { expect(subject).to eql(environment_tag("purple", "LOCAL DEVELOPMENT ENVIRONMENT")) }
     end
 
-    context "when SENTRY_ENV is test" do
-      before { allow(ENV).to receive(:fetch).with("SENTRY_ENV", "local_development").and_return("test") }
+    context "when USER_ENV is test" do
+      before { allow(ENV).to receive(:fetch).with("USER_ENV", "local_development").and_return("test") }
 
       it { expect(subject).to eql(environment_tag("orange", "TEST ENVIRONMENT")) }
     end


### PR DESCRIPTION
## Changes

We used sentry for our application performance monitoring and erroring insights, but we are now required to use App Insights. This means that we will be dropping support for sentry and removing it from the service. This work is to remove all dependencies on sentry within the environment banner scope.

`USER_ENV` has replaced `SENTRY_ENV`. This will need adding to the environment variable set by terraform for `production`

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
