### PR TITLE
Setup a maintenance page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add the "Add new transfer" button for users who can add new projects
+- setup a maintenance page
 
 ### Changed
 

--- a/app/views/pages/maintenance.html.erb
+++ b/app/views/pages/maintenance.html.erb
@@ -1,0 +1,10 @@
+<% content_for :page_title do %>
+  <%= page_title("Maintenance page") %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
+    <p class="govuk-body">We expect the service to be available later, please try again. If you have an urgent issue, contact <a href="mailto:regionalservices.rg@education.gov.uk">support</a></p>
+  </div>
+</div>


### PR DESCRIPTION
## Changes

This is a temporary static page that will be used when the service is being intentionally switched off to users for maintenance work. 
As the service won't actually be down, we are able to use HighVoltage for this. This reflects the other static pages we have within the service.

There is no navigation to this page from the service, but is accessed via `/maintenance` route.

<img width="1281" alt="Screenshot 2023-10-04 at 15 28 22" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/59832893/320cc570-d7ea-4565-8071-8b520f9aa339">


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
