### PR TITLE
(Fix) Validate outgoing trust exists on Transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Fix an error that meant outgoing trust UKPRNs were not being properly
+  validated for Transfers. We were not checking the outgoing trust actually
+  existed.
+
 ## [Release 42][release-42]
 
 ### Added

--- a/app/forms/create_project_form.rb
+++ b/app/forms/create_project_form.rb
@@ -29,7 +29,7 @@ class CreateProjectForm
   validates :handover_note_body, presence: true, if: -> { assigned_to_regional_caseworker_team.eql?(true) }
 
   validate :establishment_exists, if: -> { urn.present? }
-  validate :trust_exists, if: -> { incoming_trust_ukprn.present? }
+  validate :incoming_trust_exists, if: -> { incoming_trust_ukprn.present? }
 
   validate :multiparameter_date_attributes_values
 
@@ -62,7 +62,7 @@ class CreateProjectForm
     errors.add(:urn, :no_establishment_found)
   end
 
-  private def trust_exists
+  private def incoming_trust_exists
     result = Api::AcademiesApi::Client.new.get_trust(incoming_trust_ukprn)
     raise result.error if result.error.present?
   rescue Api::AcademiesApi::Client::NotFoundError

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
     context "when no trust with that UKPRN exists in the API" do
       it "is invalid" do
         form = build(:create_transfer_project_form)
-        mock_trust_not_found(ukprn: form.incoming_trust_ukprn)
+        mock_trust_not_found(ukprn: form.outgoing_trust_ukprn)
 
         expect(form).to be_invalid
       end


### PR DESCRIPTION
When we put Transfer projects live, we were getting uncaught exceptions from a user trying to create a Transfer. After some investigation we discovered they were trying to add a UKPRN for a trust that doesn't exist, to the outgoing trust UKPRN field.

After some investigation we discovered that the outgoing trust UKPRN field was not being validated in the same way as the incoming trust. We were checking it was an integer, but not that the trust existed. There was a typo in the create transfer form spec which masked this error.

Add proper validations for both the incoming & outgoing trust UKPRNs, for both Conversions and Transfers.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
