### PR TITLE
Update the Brakeman ignore list

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,52 +1,7 @@
 {
   "ignored_warnings": [
-    {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "28a7229a2e3fba8df4385d5ae305857a7577122245c12e1cd3efc6f25aa952ef",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/controllers/task_lists_controller.rb",
-      "line": 10,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => task_template_path(Project.conversions.find(params[:project_id]).task_list.task(params[:task_id]).class.identifier), {})",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "TaskListsController",
-        "method": "edit"
-      },
-      "user_input": "params[:task_id]",
-      "confidence": "Weak",
-      "cwe_id": [
-        22
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "e98a8c32cbb7e9adae900f5eb57bb4efa419be6d645cc1cb07f7c14587102714",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/controllers/task_lists_controller.rb",
-      "line": 23,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => task_template_path(Project.conversions.find(params[:project_id]).task_list.task(params[:task_id]).class.identifier), {})",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "TaskListsController",
-        "method": "update"
-      },
-      "user_input": "params[:task_id]",
-      "confidence": "Weak",
-      "cwe_id": [
-        22
-      ],
-      "note": ""
-    }
+
   ],
-  "updated": "2023-05-09 16:31:36 +0100",
-  "brakeman_version": "5.3.1"
+  "updated": "2023-10-05 15:15:19 +0100",
+  "brakeman_version": "6.0.1"
 }

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -43,7 +43,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
 
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.75.0"
-  constraints = ">= 3.59.0"
+  constraints = ">= 3.52.0, >= 3.59.0"
   hashes = [
     "h1:EHfCeensfAl5wfELjpd5oK7I+Fn6UrCfNJQRxvdMyFc=",
     "h1:FUZ2LGjyYoFLqndfXJnF/SRDJh8Y+uEGevSL0u7WpfY=",
@@ -56,6 +56,18 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "h1:jdCddD1ADiQQB/rjC2aB7fFzOMZswHRPcVVC6YmL5K0=",
     "h1:kYGXRzbJpeHh95Dm7OQaqUnG/wy/GRlaZ3EzMJnUI/4=",
     "h1:p1Gx4LldGfKHDKHwZU71wS2tglVIyE0d0rxkXrkG0HA=",
+    "zh:0d881d7b499367400ced6e315e32a1948d823309c5677a16056367001a8785ce",
+    "zh:384acba136f1b347cac7831bb4e0396a370f6664e1c1242fce42a6fc55b9db8a",
+    "zh:409a01af5d873e4ac7e62cfd8c9a27638a719394ccf6a8de89ac4a1049275c20",
+    "zh:547eab553ea24cc9079fd80093c1611d036df089385bb4a38c5db21f6126e75e",
+    "zh:714a1fc3d1485deec10f4a49be556997f8ea0cc717db78fa0613f5bee728fcd7",
+    "zh:90d197c03a3bad2a8cfa7fc2396dc1601bf08be9368d399d58ec51654201c6fb",
+    "zh:9587b44249147b0e9d7619568cf46de126ec947ca5c56a1d740d8142b89919c2",
+    "zh:9d910ae66496833d4f85a4fe6b24649f74a1624f1502f63e9ff8201f29c0c1d1",
+    "zh:9f355767fc7f5ab769a60b46e42f9498f33ee95c3833b7d95c7f7c69fe101564",
+    "zh:d11d91da699d8c62f873cdea72bc26ab40cde4f18bc88ab6583ea836fee26ecd",
+    "zh:e0f9d50274f54acc2c5e300537d96a5aa03be650cfb66249a14ed45375014c77",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
 


### PR DESCRIPTION
As our code changes over time we update what we may have previously ignored in
Brakeman (static analysis).

We do this by running `bin/brakeman -I`.

[Task 141046](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/141046): Update Brakeman ignore entries
