### PR TITLE
Import GIAS data upload page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,6 @@ REDIS_URL=REDIS_URL
 GOV_NOTIFY_API_KEY=GOV_NOTIFY_API_KEY
 
 MEMBERS_API_HOST=https://members-api.parliament.uk
+
+# Hour in 24h time, e.g. 4 for 4am, 16 for 4pm
+GIAS_IMPORT_TIME: 4

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,8 @@ tmp/
 
 # Ignore Rspec persisted failure list
 /spec/examples.txt
+
+!/spec/fixtures/files/*.csv
+
+# Upload temp storage
+/storage/uploads/gias/establishments/*.csv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Allow service support users to upload GIAS data for asynchronous ingestion
+
 ## [Release 43][release-43]
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,7 @@ COPY config.ru ${APP_HOME}/config.ru
 COPY Rakefile ${APP_HOME}/Rakefile
 COPY script ${APP_HOME}/script
 COPY public ${APP_HOME}/public
+COPY storage ${APP_HOME}/storage
 COPY vendor ${APP_HOME}/vendor
 COPY bin ${APP_HOME}/bin
 COPY config ${APP_HOME}/config

--- a/app/controllers/service_support/upload/gias/establishments_controller.rb
+++ b/app/controllers/service_support/upload/gias/establishments_controller.rb
@@ -1,0 +1,24 @@
+class ServiceSupport::Upload::Gias::EstablishmentsController < ApplicationController
+  def new
+    authorize :import
+    @upload_form = ServiceSupport::Upload::Gias::UploadEstablishmentsForm.new(nil, current_user)
+  end
+
+  def upload
+    authorize :import
+
+    uploaded_file = upload_params[:uploaded_file]
+    @upload_form = ServiceSupport::Upload::Gias::UploadEstablishmentsForm.new(uploaded_file, current_user)
+    if @upload_form.valid?
+      @upload_form.save
+      time = ENV.fetch("GIAS_IMPORT_TIME", 4)
+      redirect_to service_support_upload_gias_establishments_new_path, notice: I18n.t("service_support.import.gias_establishments.success", time: "#{sprintf("%02d", time)}00")
+    else
+      render :new
+    end
+  end
+
+  private def upload_params
+    params.fetch(:service_support_upload_gias_upload_establishments_form, {}).permit(:uploaded_file)
+  end
+end

--- a/app/forms/service_support/upload/gias/upload_establishments_form.rb
+++ b/app/forms/service_support/upload/gias/upload_establishments_form.rb
@@ -1,0 +1,60 @@
+class ServiceSupport::Upload::Gias::UploadEstablishmentsForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :uploaded_file
+  attribute :user
+
+  validate :file_present
+  validate :file_type
+  validate :file_size
+  validate :file_headers
+
+  IMPORT_TIME = ENV.fetch("GIAS_IMPORT_TIME", 4)
+
+  def initialize(uploaded_file, user)
+    @uploaded_file = uploaded_file
+    @user = user
+    super({uploaded_file: uploaded_file, user: user})
+  end
+
+  def save
+    FileUtils.copy_file(@uploaded_file.path, file_path)
+
+    Import::GiasEstablishmentImportJob.set(wait_until: Date.tomorrow.in_time_zone.change(hour: IMPORT_TIME)).perform_later(file_path.to_s, @user)
+  end
+
+  def file_path
+    Rails.root.join("storage", "uploads", "gias", "establishments", "gias_establishments_#{DateTime.now.strftime("%Y-%m-%d-%H:%M:%s")}.csv")
+  end
+
+  private def file_present
+    if @uploaded_file.nil?
+      errors.add(:uploaded_file, message: I18n.t("errors.upload.attributes.uploaded_file.no_file"))
+    end
+  end
+
+  private def file_headers
+    return unless @uploaded_file.present?
+
+    unless Import::GiasEstablishmentCsvImporterService.new(@uploaded_file.path).required_columns_present?
+      errors.add(:uploaded_file, message: I18n.t("errors.upload.attributes.uploaded_file.file_headers"))
+    end
+  end
+
+  private def file_size
+    return unless @uploaded_file.present?
+    file_size = File.size(@uploaded_file.tempfile)
+    return true if file_size.between?(1, 150000000)
+
+    errors.add(:uploaded_file, message: I18n.t("errors.upload.attributes.uploaded_file.file_size")) if file_size > 150000000
+    errors.add(:uploaded_file, message: I18n.t("errors.upload.attributes.uploaded_file.empty_file")) if file_size == 0
+  end
+
+  private def file_type
+    return unless @uploaded_file.present?
+    return if @uploaded_file.content_type.include?("text/csv")
+
+    errors.add(:uploaded_file, message: I18n.t("errors.upload.attributes.uploaded_file.file_type"))
+  end
+end

--- a/app/mailers/gias_establishment_import_mailer.rb
+++ b/app/mailers/gias_establishment_import_mailer.rb
@@ -4,8 +4,18 @@ class GiasEstablishmentImportMailer < ApplicationMailer
       "316ef413-5e53-48e4-8a78-2aeaa9b98114",
       to: user.email,
       personalisation: {
-        result: result
+        result: format_result(result)
       }
     )
+  end
+
+  private def format_result(result)
+    <<~TEXT
+      Total CSV rows: #{result[:result][:total_csv_rows]}
+      New records: #{result[:result][:new_records]}
+      Changed records: #{result[:result][:changed_records]}
+      Time: #{result[:result][:time].strftime("%Y-%m-%d %H:%M")}
+      Errors: #{result[:result][:errors].count}
+    TEXT
   end
 end

--- a/app/policies/import_policy.rb
+++ b/app/policies/import_policy.rb
@@ -1,0 +1,15 @@
+class ImportPolicy
+  attr_reader :user
+
+  def initialize(user, _record)
+    @user = user
+  end
+
+  def new?
+    @user.service_support_team?
+  end
+
+  def upload?
+    @user.service_support_team?
+  end
+end

--- a/app/views/service_support/upload/gias/establishments/new.html.erb
+++ b/app/views/service_support/upload/gias/establishments/new.html.erb
@@ -1,0 +1,25 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/service_support_primary_navigation" %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("service_support.import.gias_establishments.page_title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t("service_support.import.gias_establishments.page_title") %></h1>
+
+    <%= form_with model: @upload_form, url: service_support_upload_gias_establishments_upload_path do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_file_field :uploaded_file,
+              label: {text: I18n.t("service_support.import.gias_establishments.upload_form.label")},
+              hint: {text: I18n.t("service_support.import.gias_establishments.upload_form.hint")} %>
+      </div>
+
+      <%= form.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,3 +157,4 @@ en:
       service_support:
         conversion_urns: Conversion URNs
         local_authorities: Local authorities
+        users: Users

--- a/config/locales/service_support.en.yml
+++ b/config/locales/service_support.en.yml
@@ -12,3 +12,12 @@ en:
         title: URNs added
       local_authorities:
         title: Local authorities
+  errors:
+    upload:
+      attributes:
+        uploaded_file:
+          file_size: Please upload a file smaller than 150Mb
+          empty_file: The file you have supplied is empty
+          no_file: Please upload a file
+          file_type: We can only accept CSV files
+          file_headers: The uploaded file does not contain the expected columns

--- a/config/locales/service_support.en.yml
+++ b/config/locales/service_support.en.yml
@@ -2,6 +2,13 @@ en:
   service_support:
     conversion_urns:
       title: Conversion URNs
+    import:
+      gias_establishments:
+        page_title: Upload GIAS establishments data
+        success: Your file was successfully uploaded and will be ingested at %{time}. You will receive an email with the results of the ingestion.
+        upload_form:
+          label: GIAS Establishments data
+          hint: This file must be the unmodified CSV file downloaded from Get Information About Schools
     sub_navigation:
       without_urn: URNs to create
       with_urn: URNs added

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -200,6 +200,15 @@ Rails.application.routes.draw do
     resources :local_authorities, path: "local-authorities", concerns: :has_destroy_confirmation
   end
 
+  namespace :service_support, path: "service-support" do
+    namespace :upload do
+      namespace :gias do
+        get "establishments/new", to: "establishments#new"
+        post "establishments/upload", to: "establishments#upload"
+      end
+    end
+  end
+
   scope :projects do
     namespace :transfers do
       get "new", to: "projects#new"

--- a/spec/features/service_support/users_can_upload_gias_establishments_data_spec.rb
+++ b/spec/features/service_support/users_can_upload_gias_establishments_data_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.feature "Service support users can upload GIAS data" do
+  let(:user) { create(:user, :service_support) }
+
+  before do
+    sign_in_with_user(user)
+  end
+
+  scenario "a service support user can successfully upload GIAS data for ingestion" do
+    visit service_support_upload_gias_establishments_new_path
+
+    attach_file(I18n.t("service_support.import.gias_establishments.upload_form.label"), Rails.root + "spec/fixtures/files/gias_establishment_data_good.csv")
+    click_on "Continue"
+    expect(page).to have_content(I18n.t("service_support.import.gias_establishments.success", time: "0400"))
+  end
+
+  scenario "a service support user sees an error message after uploading an invalid file" do
+    visit service_support_upload_gias_establishments_new_path
+
+    attach_file(I18n.t("service_support.import.gias_establishments.upload_form.label"), Rails.root + "spec/fixtures/files/gias_establishment_data_bad.csv")
+    click_on "Continue"
+    expect(page).to have_content(I18n.t("errors.upload.attributes.uploaded_file.file_headers"))
+  end
+
+  scenario "a service support user sees an error message after submitting the form without attaching a file" do
+    visit service_support_upload_gias_establishments_new_path
+
+    click_on "Continue"
+    expect(page).to have_content(I18n.t("errors.upload.attributes.uploaded_file.no_file"))
+  end
+end

--- a/spec/fixtures/files/text_file.txt
+++ b/spec/fixtures/files/text_file.txt
@@ -1,0 +1,1 @@
+A text file for testing.

--- a/spec/forms/service_support/upload/gias/upload_establishments_form_spec.rb
+++ b/spec/forms/service_support/upload/gias/upload_establishments_form_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+RSpec.describe ServiceSupport::Upload::Gias::UploadEstablishmentsForm do
+  let(:uploaded_file) { fixture_file_upload("gias_establishment_data_good.csv", "text/csv") }
+  let(:user) { create(:service_support_user) }
+  let(:file_path) { Rails.root.join("spec", "fixtures", "files", "gias_establishments_#{DateTime.now.strftime("%Y-%m-%d-%H:%M:%s")}.csv") }
+
+  before do
+    freeze_time
+  end
+
+  after do
+    File.delete(file_path) if File.exist?(file_path)
+  end
+
+  it "generates a unique filename" do
+    expected_file_path = Rails.root.join("storage", "uploads", "gias", "establishments", "gias_establishments_#{DateTime.now.strftime("%Y-%m-%d-%H:%M:%s")}.csv")
+    form = described_class.new(uploaded_file, user)
+    expect(form.file_path).to eq(expected_file_path)
+  end
+
+  it "uploads the file with the correct filename on save" do
+    allow_any_instance_of(ServiceSupport::Upload::Gias::UploadEstablishmentsForm).to receive(:file_path).and_return(file_path)
+
+    described_class.new(uploaded_file, user).save
+    expect(File.exist?(file_path)).to be true
+  end
+
+  describe "validations" do
+    context "when the file is empty" do
+      let(:uploaded_file) { fixture_file_upload("gias_establishment_data_empty.csv", "text/csv") }
+
+      it "is invalid" do
+        form = described_class.new(uploaded_file, user)
+        expect(form).to_not be_valid
+      end
+
+      it "does not save the file" do
+        described_class.new(uploaded_file, user)
+        expect(File.exist?(file_path)).to be false
+      end
+    end
+
+    context "when no file is uploaded" do
+      let(:uploaded_file) { nil }
+
+      it "is invalid" do
+        form = described_class.new(uploaded_file, user)
+        expect(form).to_not be_valid
+      end
+    end
+
+    context "when the file is greater than 150Mb" do
+      let(:uploaded_file) { fixture_file_upload("gias_establishment_data_good.csv", "text/csv") }
+
+      before do
+        allow(File).to receive(:size).and_return(200000000)
+      end
+
+      it "is invalid" do
+        form = described_class.new(uploaded_file, user)
+        expect(form).to_not be_valid
+      end
+    end
+
+    context "when the file is not CSV" do
+      let(:uploaded_file) { fixture_file_upload("text_file.txt", "text/plain") }
+
+      it "is invalid" do
+        form = described_class.new(uploaded_file, user)
+        expect(form).to_not be_valid
+      end
+    end
+
+    context "when the file does not contain the required columns" do
+      let(:uploaded_file) { fixture_file_upload("gias_establishment_data_bad.csv", "text/csv") }
+
+      it "is invalid" do
+        form = described_class.new(uploaded_file, user)
+        expect(form).to_not be_valid
+      end
+    end
+  end
+
+  context "when the form is valid" do
+    let(:importer) { double(Import::GiasEstablishmentImportJob, perform_later: true) }
+
+    before do
+      allow_any_instance_of(ServiceSupport::Upload::Gias::UploadEstablishmentsForm).to receive(:file_path).and_return(file_path)
+      allow(Import::GiasEstablishmentImportJob).to receive(:set).and_return(importer)
+    end
+
+    it "calls Import::GiasEstablishmentImportJob" do
+      form = described_class.new(uploaded_file, user)
+      expect(form).to be_valid
+      form.save
+      expect(Import::GiasEstablishmentImportJob).to have_received(:set).with(wait_until: Date.tomorrow.in_time_zone.change(hour: 4))
+      expect(importer).to have_received(:perform_later).with(file_path.to_s, user)
+    end
+  end
+end

--- a/spec/mailers/gias_establishment_import_mailer_spec.rb
+++ b/spec/mailers/gias_establishment_import_mailer_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe GiasEstablishmentImportMailer do
                 new_records: 1,
                 changed_records: 2,
                 changes: 0,
-                time: Time.now,
+                time: DateTime.now,
                 errors: []}}
     end
-    let(:expected_personalisation) { {result: result} }
+    let(:expected_personalisation) { {result: "Total CSV rows: 10\nNew records: 1\nChanged records: 2\nTime: #{DateTime.now.strftime("%Y-%m-%d %H:%M")}\nErrors: 0\n"} }
 
     subject(:send_mail) { described_class.import_notification(user, result).deliver_now }
 

--- a/spec/policies/import_policy_spec.rb
+++ b/spec/policies/import_policy_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe ImportPolicy do
+  let(:esfa_user) { build(:user, team: :education_and_skills_funding_agency) }
+  let(:aopu_user) { build(:user, team: :academies_operational_practice_unit) }
+  let(:rdo_user) { build(:regional_delivery_officer_user) }
+  let(:rcs_user) { build(:regional_casework_services_user) }
+  let(:service_support_user) { build(:service_support_user) }
+
+  permissions :new?, :upload? do
+    it "grants access if the user is in the service support team" do
+      expect(described_class).not_to permit(esfa_user)
+      expect(described_class).not_to permit(aopu_user)
+      expect(described_class).not_to permit(rdo_user)
+      expect(described_class).not_to permit(rcs_user)
+      expect(described_class).to permit(service_support_user)
+    end
+  end
+end

--- a/spec/requests/service_support/upload/gias/establishments_controller_spec.rb
+++ b/spec/requests/service_support/upload/gias/establishments_controller_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe ServiceSupport::Upload::Gias::EstablishmentsController, type: :request do
+  let(:user) { create(:service_support_user) }
+
+  before do
+    sign_in_with(user)
+  end
+
+  describe "#new" do
+    it "allows a service support user to see the upload form" do
+      get "/service-support/upload/gias/establishments/new"
+      expect(response).to have_http_status(:success)
+    end
+
+    context "with a non service support user" do
+      let(:user) { create(:user) }
+
+      it "does not allow the user to see the upload form" do
+        get "/service-support/upload/gias/establishments/new"
+        expect(response).not_to render_template(:new)
+        expect(response).to redirect_to(root_path)
+        follow_redirect!
+        expect(flash.alert).to eq I18n.t("unauthorised_action.message")
+      end
+    end
+  end
+
+  describe "#upload" do
+    context "with a non service support user" do
+      let(:user) { create(:user) }
+
+      it "does not allow the user to upload" do
+        params = {service_support_upload_gias_upload_establishments_form: {uploaded_file: fixture_file_upload("gias_establishment_data_good.csv", "text/csv")}}
+        post "/service-support/upload/gias/establishments/upload", params: params
+
+        expect(response).to redirect_to(root_path)
+        follow_redirect!
+        expect(flash.alert).to eq I18n.t("unauthorised_action.message")
+      end
+    end
+
+    context "when the upload is successful" do
+      before do
+        allow_any_instance_of(ServiceSupport::Upload::Gias::UploadEstablishmentsForm).to receive(:save).and_return(true)
+      end
+
+      it "shows a success message" do
+        params = {service_support_upload_gias_upload_establishments_form: {uploaded_file: fixture_file_upload("gias_establishment_data_good.csv", "text/csv")}}
+        post "/service-support/upload/gias/establishments/upload", params: params
+
+        expect(response).to redirect_to(service_support_upload_gias_establishments_new_path)
+        follow_redirect!
+        expect(response.body).to include(I18n.t("service_support.import.gias_establishments.success", time: "0400"))
+      end
+    end
+
+    context "when the upload fails" do
+      it "shows a success message" do
+        params = {service_support_upload_gias_upload_establishments_form: {uploaded_file: fixture_file_upload("gias_establishment_data_empty.csv", "text/csv")}}
+        post "/service-support/upload/gias/establishments/upload", params: params
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(I18n.t("errors.upload.attributes.uploaded_file.empty_file"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Ticket [Task 140090](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/140090): Upload GIAS establishment data via application

Add a very basic upload page to allow service support users to upload GIAS data. This needs content designing!

The page will show validation errors if the uploaded file is not CSV, or is empty, has the wrong headers, or is too large (> 150Mb)

On successful upload, the user will see a success message and the file will be scheduled for ingestion at 4am the next day. This time can be overridden via the `GIAS_IMPORT_TIME` environment variable.

If the ingestion fails later on, the user will receive an email with the errors; they will not be shown on this page.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
