### PR TITLE
Reorder tasks in the Transfer task list "Get ready for transfer" section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Allow service support users to upload GIAS data for asynchronous ingestion
 
+### Changed
+
+- Reorder tasks in the "Get ready to transfer" section in the Transfer task
+  list.
+
 ## [Release 43][release-43]
 
 ### Fixed

--- a/app/models/transfer/task_list.rb
+++ b/app/models/transfer/task_list.rb
@@ -30,9 +30,9 @@ class Transfer::TaskList < ::BaseTaskList
       {
         identifier: :get_ready_for_opening,
         tasks: [
-          Transfer::Task::ConditionsMetTaskForm,
+          Transfer::Task::RpaPolicyTaskForm,
           Transfer::Task::ConfirmIncomingTrustHasCompletedAllActionsTaskForm,
-          Transfer::Task::RpaPolicyTaskForm
+          Transfer::Task::ConditionsMetTaskForm
         ]
       },
       {

--- a/spec/models/transfer/task_list_spec.rb
+++ b/spec/models/transfer/task_list_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe Transfer::TaskList do
         :deed_termination_church_agreement,
         :commercial_transfer_agreement,
         :closure_or_transfer_declaration,
-        :conditions_met,
-        :confirm_incoming_trust_has_completed_all_actions,
         :rpa_policy,
+        :confirm_incoming_trust_has_completed_all_actions,
+        :conditions_met,
         :redact_and_send_documents
       ]
 


### PR DESCRIPTION
## Changes

[Task 142894](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/142894): Change order of "get ready to transfer" tasks

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
