### PR TITLE
Allow sharepoint folder links to be changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   conversion page about SFSO lead's name
 - New contacts are imported from the GIAS Establishment data if the required
   fields are present.
+- Allow sharepoint links for conversion and transfer projects to be updated and
+  changed
 
 ### Changed
 

--- a/app/controllers/conversions/projects_controller.rb
+++ b/app/controllers/conversions/projects_controller.rb
@@ -22,6 +22,33 @@ class Conversions::ProjectsController < ProjectsController
     end
   end
 
+  def edit
+    authorize project
+    @project_form = Conversion::EditProjectSharepointLinkForm.new(project: project)
+  end
+
+  def update
+    authorize project
+    @project_form = Conversion::EditProjectSharepointLinkForm.new(project: project, args: sharepoint_link_params)
+
+    if @project_form.save
+      redirect_to project_information_path(project), notice: I18n.t("project.update.success")
+    else
+      render :edit
+    end
+  end
+
+  private def project
+    @project ||= Project.find(params[:id])
+  end
+
+  private def sharepoint_link_params
+    params.require(:conversion_edit_project_sharepoint_link_form).permit(
+      :establishment_sharepoint_link,
+      :incoming_trust_sharepoint_link
+    )
+  end
+
   private def project_params
     params.require(:conversion_create_project_form).permit(
       :urn,

--- a/app/controllers/transfers/projects_controller.rb
+++ b/app/controllers/transfers/projects_controller.rb
@@ -17,6 +17,34 @@ class Transfers::ProjectsController < ApplicationController
     end
   end
 
+  def edit
+    authorize project
+    @project_form = Transfer::EditProjectSharepointLinkForm.new(project: project)
+  end
+
+  def update
+    authorize project
+    @project_form = Transfer::EditProjectSharepointLinkForm.new(project: project, args: sharepoint_link_params)
+
+    if @project_form.save
+      redirect_to project_information_path(project), notice: I18n.t("project.update.success")
+    else
+      render :edit
+    end
+  end
+
+  private def project
+    @project ||= Project.find(params[:id])
+  end
+
+  private def sharepoint_link_params
+    params.require(:transfer_edit_project_sharepoint_link_form).permit(
+      :establishment_sharepoint_link,
+      :incoming_trust_sharepoint_link,
+      :outgoing_trust_sharepoint_link
+    )
+  end
+
   private def project_params
     params.require(:transfer_create_project_form).permit(
       :urn,

--- a/app/forms/conversion/edit_project_sharepoint_link_form.rb
+++ b/app/forms/conversion/edit_project_sharepoint_link_form.rb
@@ -1,0 +1,33 @@
+class Conversion::EditProjectSharepointLinkForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
+  attribute :establishment_sharepoint_link
+  attribute :incoming_trust_sharepoint_link
+
+  validates :establishment_sharepoint_link, presence: true, sharepoint_url: true
+  validates :incoming_trust_sharepoint_link, presence: true, sharepoint_url: true
+
+  def initialize(project:, args: {})
+    @project = project
+    super(args)
+
+    if args.empty?
+      assign_attributes(
+        establishment_sharepoint_link: @project.establishment_sharepoint_link,
+        incoming_trust_sharepoint_link: @project.incoming_trust_sharepoint_link
+      )
+    end
+  end
+
+  def save
+    @project.assign_attributes(
+      establishment_sharepoint_link: establishment_sharepoint_link,
+      incoming_trust_sharepoint_link: incoming_trust_sharepoint_link
+    )
+    if valid?
+      @project.save
+    end
+  end
+end

--- a/app/forms/transfer/edit_project_sharepoint_link_form.rb
+++ b/app/forms/transfer/edit_project_sharepoint_link_form.rb
@@ -1,0 +1,37 @@
+class Transfer::EditProjectSharepointLinkForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
+  attribute :establishment_sharepoint_link
+  attribute :incoming_trust_sharepoint_link
+  attribute :outgoing_trust_sharepoint_link
+
+  validates :establishment_sharepoint_link, presence: true, sharepoint_url: true
+  validates :incoming_trust_sharepoint_link, presence: true, sharepoint_url: true
+  validates :outgoing_trust_sharepoint_link, presence: true, sharepoint_url: true
+
+  def initialize(project:, args: {})
+    @project = project
+    super(args)
+
+    if args.empty?
+      assign_attributes(
+        establishment_sharepoint_link: @project.establishment_sharepoint_link,
+        incoming_trust_sharepoint_link: @project.incoming_trust_sharepoint_link,
+        outgoing_trust_sharepoint_link: @project.outgoing_trust_sharepoint_link
+      )
+    end
+  end
+
+  def save
+    @project.assign_attributes(
+      establishment_sharepoint_link: establishment_sharepoint_link,
+      incoming_trust_sharepoint_link: incoming_trust_sharepoint_link,
+      outgoing_trust_sharepoint_link: outgoing_trust_sharepoint_link
+    )
+    if valid?
+      @project.save
+    end
+  end
+end

--- a/app/views/conversions/project_information/_school_details.html.erb
+++ b/app/views/conversions/project_information/_school_details.html.erb
@@ -1,6 +1,6 @@
 <div id="schoolDetails" class="project-information-block">
   <h3 class="govuk-heading-m"><%= t("project_information.show.school_details.title") %></h3>
-  <%= govuk_summary_list(actions: false) do |summary_list|
+  <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.school_details.rows.original_school_name") }
           row.with_value { (establishment.name + "<br/>" + link_to_school_on_gias(establishment.urn)).html_safe }
@@ -28,6 +28,7 @@
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.school_details.rows.sharepoint_folder") }
           row.with_value { safe_link_to(t("project_information.show.school_details.values.sharepoint_folder"), project.establishment_sharepoint_link) }
+          row.with_action(text: "Change", href: conversions_edit_path(@project), visually_hidden_text: "edit sharepoint folder link")
         end
       end %>
 </div>

--- a/app/views/conversions/projects/edit.html.erb
+++ b/app/views/conversions/projects/edit.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @project_form, url: conversions_update_path(@project), method: :post do |form| %>
+      <%= form.govuk_error_summary %>
+      <%= form.govuk_text_field :establishment_sharepoint_link, width: 20, label: {size: "m", text: t("project.edit.labels.school_sharepoint_link")} %>
+      <%= form.govuk_text_field :incoming_trust_sharepoint_link, width: 20, label: {size: "m", text: t("project.edit.labels.incoming_trust_sharepoint_link")} %>
+
+      <%= form.govuk_submit do %>
+        <%= govuk_link_to "Cancel", project_information_path(@project) %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<%= render partial: "shared/autocomplete", locals: {selector: ".accessible-autocomplete-target"} %>

--- a/app/views/shared/project_information/_incoming_trust_details.html.erb
+++ b/app/views/shared/project_information/_incoming_trust_details.html.erb
@@ -30,7 +30,11 @@
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.incoming_trust_details.rows.sharepoint_folder") }
           row.with_value { safe_link_to(t("project_information.show.incoming_trust_details.values.sharepoint_folder"), project.incoming_trust_sharepoint_link) }
-          row.with_action(text: "Change", href: conversions_edit_path(@project), visually_hidden_text: "edit sharepoint folder link")
+          if project.type == "Conversion"
+            row.with_action(text: "Change", href: conversions_edit_path(@project), visually_hidden_text: "edit sharepoint folder link")
+          else
+            row.with_action(text: "Change", href: transfers_edit_path(@project), visually_hidden_text: "edit sharepoint folder link")
+          end
         end
       end %>
 </div>

--- a/app/views/shared/project_information/_incoming_trust_details.html.erb
+++ b/app/views/shared/project_information/_incoming_trust_details.html.erb
@@ -1,6 +1,6 @@
 <div id="incomingTrustDetails" class="project-information-block">
   <h3 class="govuk-heading-m"><%= t("project_information.show.incoming_trust_details.title") %></h3>
-  <%= govuk_summary_list(actions: false) do |summary_list|
+  <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.incoming_trust_details.rows.incoming_trust_name") }
           row.with_value { (incoming_trust.name + "<br/>" + link_to_trust_on_gias(incoming_trust.ukprn)).html_safe }
@@ -30,6 +30,7 @@
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.incoming_trust_details.rows.sharepoint_folder") }
           row.with_value { safe_link_to(t("project_information.show.incoming_trust_details.values.sharepoint_folder"), project.incoming_trust_sharepoint_link) }
+          row.with_action(text: "Change", href: conversions_edit_path(@project), visually_hidden_text: "edit sharepoint folder link")
         end
       end %>
 </div>

--- a/app/views/transfers/project_information/_academy_details.html.erb
+++ b/app/views/transfers/project_information/_academy_details.html.erb
@@ -1,6 +1,6 @@
 <div id="academyDetails" class="project-information-block">
   <h3 class="govuk-heading-m"><%= t("project_information.show.academy_details.title") %></h3>
-  <%= govuk_summary_list(actions: false) do |summary_list|
+  <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.academy_details.rows.academy_name") }
           row.with_value { (academy.name + "<br/>" + link_to_school_on_gias(academy.urn)).html_safe }
@@ -24,6 +24,7 @@
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.academy_details.rows.sharepoint_folder") }
           row.with_value { safe_link_to(t("project_information.show.academy_details.values.sharepoint_folder"), project.establishment_sharepoint_link) }
+          row.with_action(text: "Change", href: transfers_edit_path(@project), visually_hidden_text: "edit sharepoint folder link")
         end
       end %>
 </div>

--- a/app/views/transfers/project_information/_outgoing_trust_details.html.erb
+++ b/app/views/transfers/project_information/_outgoing_trust_details.html.erb
@@ -1,6 +1,6 @@
 <div id="outgoingTrustDetails" class="project-information-block">
   <h3 class="govuk-heading-m"><%= t("project_information.show.outgoing_trust_details.title") %></h3>
-  <%= govuk_summary_list(actions: false) do |summary_list|
+  <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.outgoing_trust_details.rows.outgoing_trust_name") }
           row.with_value { (outgoing_trust.name + "<br/>" + link_to_trust_on_gias(outgoing_trust.ukprn)).html_safe }
@@ -30,6 +30,7 @@
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.outgoing_trust_details.rows.sharepoint_folder") }
           row.with_value { safe_link_to(t("project_information.show.outgoing_trust_details.values.sharepoint_folder"), project.outgoing_trust_sharepoint_link) }
+          row.with_action(text: "Change", href: transfers_edit_path(@project), visually_hidden_text: "edit sharepoint folder link")
         end
       end %>
 </div>

--- a/app/views/transfers/projects/edit.html.erb
+++ b/app/views/transfers/projects/edit.html.erb
@@ -1,0 +1,16 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @project_form, url: transfers_update_path(@project), method: :post do |form| %>
+      <%= form.govuk_error_summary %>
+      <%= form.govuk_text_field :establishment_sharepoint_link, width: 20, label: {size: "m", text: t("project.edit.labels.school_sharepoint_link")} %>
+      <%= form.govuk_text_field :incoming_trust_sharepoint_link, width: 20, label: {size: "m", text: t("project.edit.labels.incoming_trust_sharepoint_link")} %>
+      <%= form.govuk_text_field :outgoing_trust_sharepoint_link, width: 20, label: {size: "m", text: t("project.edit.labels.outgoing_trust_sharepoint_link")} %>
+
+      <%= form.govuk_submit do %>
+        <%= govuk_link_to "Cancel", project_information_path(@project) %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<%= render partial: "shared/autocomplete", locals: {selector: ".accessible-autocomplete-target"} %>

--- a/config/locales/sharepoint_link_en.yml
+++ b/config/locales/sharepoint_link_en.yml
@@ -1,0 +1,8 @@
+en:
+  project:
+    edit:
+      labels:
+        school_sharepoint_link: School SharePoint folder link
+        incoming_trust_sharepoint_link: Incoming trust SharePoint folder link
+      update:
+        success: SharePoint link has been updated

--- a/config/locales/sharepoint_link_en.yml
+++ b/config/locales/sharepoint_link_en.yml
@@ -4,5 +4,6 @@ en:
       labels:
         school_sharepoint_link: School SharePoint folder link
         incoming_trust_sharepoint_link: Incoming trust SharePoint folder link
+        outgoing_trust_sharepoint_link: Outgoing trust SharePoint folder link
       update:
         success: SharePoint link has been updated

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,8 @@ Rails.application.routes.draw do
     namespace :conversions do
       get "new", to: "projects#new"
       post "/", to: "projects#create"
+      get ":id", to: "projects#edit", as: :edit
+      post ":id", to: "projects#update", as: :update
     end
     namespace :transfers do
       get "new", to: "projects#new"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,8 @@ Rails.application.routes.draw do
     namespace :transfers do
       get "new", to: "projects#new"
       post "/", to: "projects#create"
+      get ":id", to: "projects#edit", as: :edit
+      post ":id", to: "projects#update", as: :update
     end
   end
 

--- a/spec/features/conversions/users_can_change_the_sharepoint_links_spec.rb
+++ b/spec/features/conversions/users_can_change_the_sharepoint_links_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.feature "Users can change a conversion projects sharepoint links" do
+  let(:user) { create(:user, :caseworker) }
+  let(:project) { create(:conversion_project, establishment_sharepoint_link: "https://educationgovuk-my.sharepoint.com/establishment-folder", incoming_trust_sharepoint_link: "https://educationgovuk-my.sharepoint.com/incoming-trust-folder", assigned_to: user) }
+
+  before do
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  scenario "they can navigate to the edit page" do
+    visit project_information_path(project)
+
+    within "#schoolDetails" do
+      expect(page).to have_link("Change")
+    end
+
+    within "#incomingTrustDetails" do
+      expect(page).to have_link("Change")
+    end
+  end
+
+  context "when a project update successfully saves" do
+    scenario "they can change the sharepoint link for an establishment and see a confirmation message" do
+      visit conversions_update_path(project.id)
+
+      fill_in "School SharePoint folder link", with: "https://educationgovuk-my.sharepoint.com/establishment-folder-updated-link"
+      click_on "Continue"
+
+      expect(page).to have_content(I18n.t("project.update.success"))
+    end
+
+    scenario "they can change the sharepoint link for an incoming trust and see a confirmation message" do
+      visit conversions_update_path(project.id)
+
+      fill_in "Incoming trust SharePoint folder link", with: "https://educationgovuk-my.sharepoint.com/incoming-trust-folder-updated-link"
+      click_on "Continue"
+
+      expect(page).to have_content(I18n.t("project.update.success"))
+    end
+  end
+
+  scenario "they can cancel the change if needed" do
+    visit conversions_update_path(project.id)
+
+    click_on "Cancel"
+
+    expect(page).to have_content(project.establishment.name)
+  end
+
+  context "when the form is invalid" do
+    scenario "redirected to the edit page with a validation error" do
+      visit conversions_update_path(project.id)
+
+      fill_in "School SharePoint folder link", with: "this is not a link"
+      fill_in "Incoming trust SharePoint folder link", with: "sdkjsdfkjhdsf"
+      click_on "Continue"
+
+      expect(page).to have_content("Enter a school SharePoint link in the correct format")
+      expect(page).to have_content("The incoming trust SharePoint link must have the https scheme")
+    end
+  end
+end

--- a/spec/features/transfers/users_can_change_the_sharepoint_links_spec.rb
+++ b/spec/features/transfers/users_can_change_the_sharepoint_links_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.feature "Users can change a transfer projects sharepoint links" do
+  let(:user) { create(:user, :caseworker) }
+  let(:project) { create(:transfer_project, establishment_sharepoint_link: "https://educationgovuk-my.sharepoint.com/establishment-folder", incoming_trust_sharepoint_link: "https://educationgovuk-my.sharepoint.com/incoming-trust-folder", assigned_to: user) }
+
+  before do
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  scenario "they can navigate to the edit page" do
+    visit project_information_path(project)
+
+    within "#academyDetails" do
+      expect(page).to have_link("Change")
+    end
+
+    within "#incomingTrustDetails" do
+      expect(page).to have_link("Change")
+    end
+
+    within "#outgoingTrustDetails" do
+      expect(page).to have_link("Change")
+    end
+  end
+
+  context "when a project update successfully saves" do
+    scenario "they can change the sharepoint link for an establishment and see a confirmation message" do
+      visit transfers_update_path(project.id)
+
+      fill_in "School SharePoint folder link", with: "https://educationgovuk-my.sharepoint.com/establishment-folder-updated-link"
+      click_on "Continue"
+
+      expect(page).to have_content(I18n.t("project.update.success"))
+    end
+
+    scenario "they can change the sharepoint link for an incoming trust and see a confirmation message" do
+      visit transfers_update_path(project.id)
+
+      fill_in "Incoming trust SharePoint folder link", with: "https://educationgovuk-my.sharepoint.com/incoming-trust-folder-updated-link"
+      click_on "Continue"
+
+      expect(page).to have_content(I18n.t("project.update.success"))
+    end
+
+    scenario "they can change the sharepoint link for an outgoing trust and see a confirmation message" do
+      visit transfers_update_path(project.id)
+
+      fill_in "Outgoing trust SharePoint folder link", with: "https://educationgovuk-my.sharepoint.com/outgoing-trust-folder-updated-link"
+      click_on "Continue"
+
+      expect(page).to have_content(I18n.t("project.update.success"))
+    end
+  end
+
+  scenario "they can cancel the change if needed" do
+    visit transfers_update_path(project.id)
+
+    click_on "Cancel"
+
+    expect(page).to have_content(project.establishment.name)
+  end
+
+  context "when the form is invalid" do
+    scenario "redirected to the edit page with a validation error" do
+      visit transfers_update_path(project.id)
+
+      fill_in "School SharePoint folder link", with: "this is not a link"
+      fill_in "Incoming trust SharePoint folder link", with: "sdkjsdfkjhdsf"
+      fill_in "Outgoing trust SharePoint folder link", with: "this is also not a link"
+      click_on "Continue"
+
+      expect(page).to have_content("Enter a school SharePoint link in the correct format")
+      expect(page).to have_content("The incoming trust SharePoint link must have the https scheme")
+      expect(page).to have_content("Enter a outgoing trust SharePoint link in the correct format")
+    end
+  end
+end

--- a/spec/forms/conversion/edit_project_sharepoint_link_form_spec.rb
+++ b/spec/forms/conversion/edit_project_sharepoint_link_form_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Conversion::EditProjectSharepointLinkForm, type: :model do
+  let(:project) { build(:conversion_project, assigned_to: user) }
+  let(:user) { build(:user, :caseworker) }
+
+  before do
+    mock_successful_api_responses(urn: any_args, ukprn: any_args)
+  end
+
+  describe "#save" do
+    context "when the form is valid" do
+      it "updates an exsiting sharepoint link" do
+        sharepoint_link_form = Conversion::EditProjectSharepointLinkForm.new(project: project, args: {establishment_sharepoint_link: "https://educationgovuk-my.sharepoint.com/establishment-folder", incoming_trust_sharepoint_link: "https://educationgovuk-my.sharepoint.com/incoming-trust-folder"})
+        sharepoint_link_form.establishment_sharepoint_link = "https://educationgovuk-my.sharepoint.com/establishment-folder-updated-link"
+        sharepoint_link_form.incoming_trust_sharepoint_link = "https://educationgovuk-my.sharepoint.com/incoming-trust-folder-updated-link"
+        sharepoint_link_form.save
+
+        expect(project.establishment_sharepoint_link).to eql("https://educationgovuk-my.sharepoint.com/establishment-folder-updated-link")
+        expect(project.incoming_trust_sharepoint_link).to eql("https://educationgovuk-my.sharepoint.com/incoming-trust-folder-updated-link")
+      end
+    end
+  end
+end

--- a/spec/forms/transfer/edit_project_sharepoint_link_form_spec.rb
+++ b/spec/forms/transfer/edit_project_sharepoint_link_form_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Transfer::EditProjectSharepointLinkForm, type: :model do
+  let(:project) { build(:transfer_project, assigned_to: user) }
+  let(:user) { build(:user, :caseworker) }
+
+  before do
+    mock_successful_api_responses(urn: any_args, ukprn: any_args)
+  end
+
+  describe "#save" do
+    context "when the form is valid" do
+      it "updates an exsiting sharepoint link" do
+        sharepoint_link_form = Transfer::EditProjectSharepointLinkForm.new(project: project, args: {establishment_sharepoint_link: "https://educationgovuk-my.sharepoint.com/establishment-folder", incoming_trust_sharepoint_link: "https://educationgovuk-my.sharepoint.com/incoming-trust-folder"})
+        sharepoint_link_form.establishment_sharepoint_link = "https://educationgovuk-my.sharepoint.com/establishment-folder-updated-link"
+        sharepoint_link_form.incoming_trust_sharepoint_link = "https://educationgovuk-my.sharepoint.com/incoming-trust-folder-updated-link"
+        sharepoint_link_form.save
+
+        expect(project.establishment_sharepoint_link).to eql("https://educationgovuk-my.sharepoint.com/establishment-folder-updated-link")
+        expect(project.incoming_trust_sharepoint_link).to eql("https://educationgovuk-my.sharepoint.com/incoming-trust-folder-updated-link")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes

We know that the SharePoint links can be added incorrectly or need updating.
This provides a simple way to update the SharePoint Links through the UI.

Each SharePoint link within the `Project Information` section now has a `Change` link, which takes the user to an edit page.

A conversion project will only display the School and Incoming trust's SharePoint links
<img width="709" alt="Screenshot 2023-10-24 at 16 58 28" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/59832893/d47818ae-f343-4157-903b-06ca30cd752f">

A transfer project will also display the outgoing trust SharePoint link too
<img width="709" alt="Screenshot 2023-10-24 at 16 15 06" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/59832893/a8079178-4799-4437-ac0a-2e4b24aee090">

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
