### PR TITLE
Chagne resolution of filename timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Reorder tasks in the "Get ready to transfer" section in the Transfer task
   list.
+- The file name used for the GIAS Establishment import data only includes the
+  seconds this prevents naming errors.
 
 ## [Release 43][release-43]
 

--- a/app/forms/service_support/upload/gias/upload_establishments_form.rb
+++ b/app/forms/service_support/upload/gias/upload_establishments_form.rb
@@ -25,7 +25,7 @@ class ServiceSupport::Upload::Gias::UploadEstablishmentsForm
   end
 
   def file_path
-    Rails.root.join("storage", "uploads", "gias", "establishments", "gias_establishments_#{DateTime.now.strftime("%Y-%m-%d-%H:%M:%s")}.csv")
+    Rails.root.join("storage", "uploads", "gias", "establishments", "gias_establishments_#{DateTime.now.strftime("%Y-%m-%d-%H%M%S")}.csv")
   end
 
   private def file_present

--- a/spec/forms/service_support/upload/gias/upload_establishments_form_spec.rb
+++ b/spec/forms/service_support/upload/gias/upload_establishments_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ServiceSupport::Upload::Gias::UploadEstablishmentsForm do
   end
 
   it "generates a unique filename" do
-    expected_file_path = Rails.root.join("storage", "uploads", "gias", "establishments", "gias_establishments_#{DateTime.now.strftime("%Y-%m-%d-%H:%M:%s")}.csv")
+    expected_file_path = Rails.root.join("storage", "uploads", "gias", "establishments", "gias_establishments_#{DateTime.now.strftime("%Y-%m-%d-%H%M%S")}.csv")
     form = described_class.new(uploaded_file, user)
     expect(form.file_path).to eq(expected_file_path)
   end


### PR DESCRIPTION
Once we had the import job running we found the resolution of the
filename was so high that the execution time between writing the file
and queuing the job was making the file name different.

Here we reduce the resolution to just seconds.

## Changes

_Add a summary of the changes in this pull request_

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
