### PR TITLE
Fix: Update GIAS job handling

### DIFF
--- a/app/forms/service_support/upload/gias/upload_establishments_form.rb
+++ b/app/forms/service_support/upload/gias/upload_establishments_form.rb
@@ -19,9 +19,10 @@ class ServiceSupport::Upload::Gias::UploadEstablishmentsForm
   end
 
   def save
-    FileUtils.copy_file(@uploaded_file.path, file_path)
+    file_path_with_timestamp = file_path
+    FileUtils.copy_file(@uploaded_file.path, file_path_with_timestamp)
 
-    Import::GiasEstablishmentImportJob.set(wait_until: Date.tomorrow.in_time_zone.change(hour: IMPORT_TIME)).perform_later(file_path.to_s, @user)
+    Import::GiasEstablishmentImportJob.set(wait_until: Date.tomorrow.in_time_zone.change(hour: IMPORT_TIME)).perform_later(file_path_with_timestamp.to_s, @user)
   end
 
   def file_path

--- a/app/mailers/gias_establishment_import_mailer.rb
+++ b/app/mailers/gias_establishment_import_mailer.rb
@@ -11,11 +11,11 @@ class GiasEstablishmentImportMailer < ApplicationMailer
 
   private def format_result(result)
     <<~TEXT
-      Total CSV rows: #{result[:result][:total_csv_rows]}
-      New records: #{result[:result][:new_records]}
-      Changed records: #{result[:result][:changed_records]}
-      Time: #{result[:result][:time].strftime("%Y-%m-%d %H:%M")}
-      Errors: #{result[:result][:errors].count}
+      Total CSV rows: #{result[:total_csv_rows]}
+      New records: #{result[:new_records]}
+      Changed records: #{result[:changed_records]}
+      Time: #{result[:time]}
+      Errors: #{result[:errors].count}
     TEXT
   end
 end

--- a/app/services/import/gias_establishment_csv_importer_service.rb
+++ b/app/services/import/gias_establishment_csv_importer_service.rb
@@ -89,7 +89,7 @@ class Import::GiasEstablishmentCsvImporterService
         establishment = Gias::Establishment.find_or_create_by(urn: urn)
 
         unless establishment
-          @errors[urn.to_i] = "Could not find or create a record for urn: #{urn}"
+          @errors[urn.to_sym] = "Could not find or create a record for urn: #{urn}"
           next
         end
 
@@ -98,7 +98,7 @@ class Import::GiasEstablishmentCsvImporterService
 
         if row_changes.any?
           unless establishment.update(csv_attributes)
-            @errors[urn.to_i] = "Could not update record for urn: #{urn}"
+            @errors[urn.to_sym] = "Could not update record for urn: #{urn}"
             next
           end
           @changed_rows[establishment.urn] = row_changes

--- a/spec/mailers/gias_establishment_import_mailer_spec.rb
+++ b/spec/mailers/gias_establishment_import_mailer_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe GiasEstablishmentImportMailer do
     let(:user) { create(:user, :service_support) }
     let(:template_id) { "316ef413-5e53-48e4-8a78-2aeaa9b98114" }
     let(:result) do
-      {result: {total_csv_rows: 10,
-                new_records: 1,
-                changed_records: 2,
-                changes: 0,
-                time: DateTime.now,
-                errors: []}}
+      {total_csv_rows: 10,
+       new_records: 1,
+       changed_records: 2,
+       changes: 0,
+       time: 189.23232,
+       errors: []}
     end
-    let(:expected_personalisation) { {result: "Total CSV rows: 10\nNew records: 1\nChanged records: 2\nTime: #{DateTime.now.strftime("%Y-%m-%d %H:%M")}\nErrors: 0\n"} }
+    let(:expected_personalisation) { {result: "Total CSV rows: 10\nNew records: 1\nChanged records: 2\nTime: 189.23232\nErrors: 0\n"} }
 
     subject(:send_mail) { described_class.import_notification(user, result).deliver_now }
 

--- a/spec/services/import/gias_establishment_csv_importer_service_spec.rb
+++ b/spec/services/import/gias_establishment_csv_importer_service_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Import::GiasEstablishmentCsvImporterService do
 
       result = service.import!
 
-      expect(result.dig(:errors, 144731)).to eq("Could not find or create a record for urn: 144731")
+      expect(result.dig(:errors, :"144731")).to eq("Could not find or create a record for urn: 144731")
     end
 
     it "returns a hash that includes an error if any row cannot be updated" do
@@ -106,7 +106,7 @@ RSpec.describe Import::GiasEstablishmentCsvImporterService do
 
       result = service.import!
 
-      expect(result.dig(:errors, 144731)).to eq("Could not update record for urn: 144731")
+      expect(result.dig(:errors, :"144731")).to eq("Could not update record for urn: 144731")
     end
   end
 


### PR DESCRIPTION
We change three main things here:

We recently lowered the resolution of the file name timestamp as we were
seeing them not matching up with the two calls, but even with seconds,
it was still possible to make the second `file_path` call in the 'next'
second, making the job be queued with the wrong filename.

To remove this issue all together, we assign the file name and use that
instead, this guarentees that the filename is the same.

We fix a bug in the results email which added one too many 'results'
causing nil errors.

We also change the keys of the results hash to be symbols instead of
integers as ActiveJob does not support integer as hash keys:

https://guides.rubyonrails.org/active_job_basics.html#supported-types-for-arguments
