### PR TITLE
Conversion handover comments content update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow service support users to upload GIAS data for asynchronous ingestion
 - Content: Adding hint text to transfers supplemental funding task to match
   conversions
+- Content: Bullet point guidance to conversion handover notes on add a
+  conversion page about SFSO lead's name
 
 ### Changed
 

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -66,12 +66,13 @@ en:
     new:
       handover_comments_label: Handover comments
       handover_comments_hint:
-        <p class="govuk-body">You should give a brief overview of how the project has progressed so far, including any issues or concerns.</p>
-        <p class="govuk-body">Include information about whether the:</p>
+        <p class="govuk-body">You must describe how the project has progressed so far and highlight any issues or concerns.</p>
+        <p class="govuk-body">Include information about:</p>
               <ul class="govuk-list govuk-list--bullet">
-                <li>provisional conversion date has been discussed with the local authority</li>
-                <li>local authority proforma has been received or requested</li>
-                <li>introduction and next steps email has been sent to external stakeholders</li>
+                <li>whether the provisional conversion date has been discussed with the local authority</li>
+                <li>if the local authority proforma has been received or requested</li>
+                <li>who the Schools Financial Support and Oversight lead is</li>
+                <li>if the introduction and next steps email has been sent to external stakeholders</li>
               </ul>
     academy_urn:
       title: Create academy URN for %{school_name} conversion


### PR DESCRIPTION
## Changes

Adding a bullet point about including the SFSO lead's name in the handover comments for a conversion.

Also slight change to the first line of that guidance to make it consistent with how it appears in transfers.

## Before

![Screenshot 2023-10-17 at 3 00 40 pm](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/e3262dfa-2893-4e01-b0c2-a7c0ba65c458)

## After

![Screenshot 2023-10-17 at 3 01 00 pm](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/41e4c009-d3f0-4559-987a-c617c79fa7cf)


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
