### PR TITLE
Remove any references to Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   met task
 - Content: change main contact to primary contact in confirm incoming trusts has
   completed actions transfers task
+- Removed any references to Sentry.io
 
 ## [Release 43][release-43]
 

--- a/Gemfile
+++ b/Gemfile
@@ -48,10 +48,6 @@ gem "govuk_markdown"
 
 gem "faraday"
 
-# sentry.io error reporting 
-gem "sentry-ruby"
-gem "sentry-rails"
-
 # postcode validator
 gem "uk_postcode", "~> 2.1.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,11 +356,6 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-rails (5.10.0)
-      railties (>= 5.0)
-      sentry-ruby (~> 5.10.0)
-    sentry-ruby (5.10.0)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
     sidekiq (6.5.12)
@@ -475,8 +470,6 @@ DEPENDENCIES
   rspec-rails
   sass-rails
   selenium-webdriver
-  sentry-rails
-  sentry-ruby
   shoulda-matchers (~> 5.1)
   sidekiq (< 7.0)
   simplecov (~> 0.22.0)

--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ environment has a dashboard:
 - [test dashboard](https://portal.azure.com/#@platform.education.gov.uk/dashboard/arm/subscriptions/8e6b3792-ae2c-4424-9815-19d6a77b0600/resourcegroups/s184t01-comp/providers/microsoft.portal/dashboards/5918b480-2d54-4540-94c8-bfd73dc3befe-dashboard)
 - [production dashboard](https://portal.azure.com/#@platform.education.gov.uk/dashboard/arm/subscriptions/e8bc9314-d27f-403a-bbe0-6b189d2efad2/resourcegroups/s184p01-comp/providers/microsoft.portal/dashboards/b473541d-3b3b-45d5-b025-97974730e369-dashboard)
 
-Historically we used
-[sentry.io](https://sentry.io/organizations/sdd-n7/projects/complete-conversions-transfers-and-changes/?project=6684508)
-which may still be available.
-
 ## Architecture decision records
 
 You can find the ADRs for this project in [doc/decisions](/doc/decisions).

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,7 +31,7 @@ module ApplicationHelper
   end
 
   def enable_google_tag_manager?
-    return false unless ENV["SENTRY_ENV"] == "production"
+    return false unless ENV["USER_ENV"] == "production"
     return false unless ENV["GOOGLE_TAG_MANAGER_ID"].present?
     return false unless cookies[:ACCEPT_OPTIONAL_COOKIES] == "true"
     true

--- a/app/helpers/environment_banner_helper.rb
+++ b/app/helpers/environment_banner_helper.rb
@@ -6,16 +6,16 @@ module EnvironmentBannerHelper
   }.freeze.with_indifferent_access
 
   def environment_banner
-    return if ENVIRONMENT_COLOURS.keys.none?(sentry_env)
+    return if ENVIRONMENT_COLOURS.keys.none?(user_env)
 
     govuk_tag(
-      text: "#{sentry_env.tr("_", " ").upcase} ENVIRONMENT",
-      colour: ENVIRONMENT_COLOURS[sentry_env],
+      text: "#{user_env.tr("_", " ").upcase} ENVIRONMENT",
+      colour: ENVIRONMENT_COLOURS[user_env],
       classes: "environment-banner"
     )
   end
 
-  private def sentry_env
+  private def user_env
     ENV.fetch("USER_ENV", "local_development")
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,0 @@
-if Rails.env.production?
-  Sentry.init do |config|
-    config.environment = ENV.fetch("SENTRY_ENV")
-  end
-end

--- a/doc/environment-variables.md
+++ b/doc/environment-variables.md
@@ -34,20 +34,6 @@ hostname, see:
 
 https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization
 
-`SENTRY_ENV`
-
-This is the environment name that will appear in Sentry, so one of development,
-test or production.
-
-See: https://docs.sentry.io/product/sentry-basics/environments/
-
-`SENTRY_DSN`
-
-This is the 'Client Keys' for the project in Sentry UI, it is a url starting
-https://
-
-See: https://docs.sentry.io/product/sentry-basics/dsn-explainer/
-
 `NO_COVERAGE`
 
 Set this to `true` to stop Simplecov generating coverage reports.

--- a/docker-compose.checks.yml
+++ b/docker-compose.checks.yml
@@ -23,7 +23,7 @@ services:
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       SECRET_KEY_BASE: secret
       CI: "true"
-      SENTRY_ENV: test
+      USER_ENV: test
       REDIS_URL: redis://test-redis:6379
     networks:
       - test-ci

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     context "when not in production" do
       it "returns false" do
         ClimateControl.modify(
-          SENTRY_ENV: "development",
+          USER_ENV: "development",
           GOOGLE_TAG_MANAGER_ID: ""
         ) do
           cookies[:ACCEPT_OPTIONAL_COOKIES] = true
@@ -109,7 +109,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     context "when there is no tag manager id" do
       it "returns false" do
         ClimateControl.modify(
-          SENTRY_ENV: "production",
+          USER_ENV: "production",
           GOOGLE_TAG_MANAGER_ID: ""
         ) do
           cookies[:ACCEPT_OPTIONAL_COOKIES] = true
@@ -122,7 +122,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     context "when the user has rejected cookies" do
       it "returns false" do
         ClimateControl.modify(
-          SENTRY_ENV: "production",
+          USER_ENV: "production",
           GOOGLE_TAG_MANAGER_ID: "THISISANID"
         ) do
           cookies[:ACCEPT_OPTIONAL_COOKIES] = false
@@ -135,7 +135,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     context "when the user has accepted cookies" do
       it "returns true" do
         ClimateControl.modify(
-          SENTRY_ENV: "production",
+          USER_ENV: "production",
           GOOGLE_TAG_MANAGER_ID: "THISISANID"
         ) do
           cookies[:ACCEPT_OPTIONAL_COOKIES] = "true"


### PR DESCRIPTION


## Changes

We no longer use Sentry. We now use the `USER_ENV` env variable to determine which environment we're in, and we use Application Insights for error reporting.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
