### PR TITLE
Hash keys passed to ActiveJob cannot be integers

### DIFF
--- a/app/services/import/gias_establishment_csv_importer_service.rb
+++ b/app/services/import/gias_establishment_csv_importer_service.rb
@@ -113,7 +113,7 @@ class Import::GiasEstablishmentCsvImporterService
         contact = Contact::Establishment.find_or_create_by(establishment_urn: urn)
 
         unless establishment
-          @errors[:establishment][urn.to_sym] = "Could not find or create a record for urn: #{urn}"
+          @errors[:establishment][urn.to_s] = "Could not find or create a record for urn: #{urn}"
           next
         end
 
@@ -125,16 +125,16 @@ class Import::GiasEstablishmentCsvImporterService
 
         if establishment_row_changes.any?
           unless establishment.update(establishment_csv_attributes)
-            @errors[:establishment][urn.to_sym] = "Could not update establishment record for urn: #{urn}"
+            @errors[:establishment][urn.to_s] = "Could not update establishment record for urn: #{urn}"
             next
           end
-          @changed_rows[:establishment][establishment.urn] = establishment_row_changes
+          @changed_rows[:establishment][establishment.urn.to_s] = establishment_row_changes
 
           if contact_row_changes.any?
             unless contact.update(contact_csv_attributes)
-              @errors[:contact][urn.to_sym] = "Could not update contact record for establishment_urn: #{urn}"
+              @errors[:contact][urn.to_s] = "Could not update contact record for establishment_urn: #{urn}"
             end
-            @changed_rows[:contact][contact.establishment_urn] = contact_row_changes
+            @changed_rows[:contact][contact.establishment_urn.to_s] = contact_row_changes
           end
         end
 

--- a/spec/services/import/gias_establishment_csv_importer_service_spec.rb
+++ b/spec/services/import/gias_establishment_csv_importer_service_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Import::GiasEstablishmentCsvImporterService do
       service = described_class.new(path)
 
       result = service.import!
-      changes = result.dig(:changes, :establishment, 144865)
+      changes = result.dig(:changes, :establishment, "144865")
 
       expect(changes.dig("name", :new_value)).to eql("Lightcliffe C of E Primary School")
       expect(changes.dig("name", :previous_value)).to eql("School name")
@@ -129,7 +129,7 @@ RSpec.describe Import::GiasEstablishmentCsvImporterService do
 
       result = service.import!
 
-      expect(result.dig(:errors, :establishment, :"144731")).to eq("Could not find or create a record for urn: 144731")
+      expect(result.dig(:errors, :establishment, "144731")).to eq("Could not find or create a record for urn: 144731")
     end
 
     it "returns a hash that includes an error if any establishment row data cannot be updated" do
@@ -140,7 +140,7 @@ RSpec.describe Import::GiasEstablishmentCsvImporterService do
 
       result = service.import!
 
-      expect(result.dig(:errors, :establishment, :"144731")).to eq("Could not update establishment record for urn: 144731")
+      expect(result.dig(:errors, :establishment, "144731")).to eq("Could not update establishment record for urn: 144731")
     end
 
     it "returns a hash that includes an error if any contact row data cannot be updated" do
@@ -151,7 +151,7 @@ RSpec.describe Import::GiasEstablishmentCsvImporterService do
 
       result = service.import!
 
-      expect(result.dig(:errors, :contact, :"144731")).to eq("Could not update contact record for establishment_urn: 144731")
+      expect(result.dig(:errors, :contact, "144731")).to eq("Could not update contact record for establishment_urn: 144731")
     end
 
     it "does not update an establishment contact if the establishment could not be updated" do


### PR DESCRIPTION
We changed the two instances above, but missed this one.

When this results object is passed to the ActiveJob that sends the
'import complete' email, it fails.

Here we switch all the keys to strings for consistency, we cannot
symbolize an integer.