### PR TITLE
Ensure documentation is linted in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,6 +134,7 @@ COPY config ${APP_HOME}/config
 COPY lib ${APP_HOME}/lib
 COPY db ${APP_HOME}/db
 COPY app ${APP_HOME}/app
+COPY doc ${APP_HOME}/doc
 # End
 
 # Copy specs

--- a/doc/decisions/0007-use-the-academies-db-as-the-datastore.md
+++ b/doc/decisions/0007-use-the-academies-db-as-the-datastore.md
@@ -4,7 +4,8 @@ Date: 2022-07-14
 
 ## Status
 
-Superceded by [21. Use a seperate database server instance](0021-use-a-seperate-database-server-instance.md)
+Superceded by
+[21. Use a seperate database server instance](0021-use-a-seperate-database-server-instance.md)
 
 ## Summary
 

--- a/doc/decisions/0021-use-a-seperate-database-server-instance.md
+++ b/doc/decisions/0021-use-a-seperate-database-server-instance.md
@@ -6,7 +6,8 @@ Date: 2023-10-18
 
 Accepted
 
-Supercedes [7. Use the Academies DB as the datastore](0007-use-the-academies-db-as-the-datastore.md)
+Supercedes
+[7. Use the Academies DB as the datastore](0007-use-the-academies-db-as-the-datastore.md)
 
 ## Context
 


### PR DESCRIPTION
Our CI runs inside a container into which not everything is copied -
this results in a different set of errors when linting local to the CI.

Here we add the `doc` directory as this is covered by Prettier.

We also commit some missing fixes.
