### PR TITLE
Model Contact::Parliament

### DIFF
--- a/app/models/api/members_api/client.rb
+++ b/app/models/api/members_api/client.rb
@@ -44,7 +44,9 @@ class Api::MembersApi::Client
     constituency_data = constituency(search_term)
     raise constituency_data.error if constituency_data.error.present?
 
-    if constituency_data.object["items"].count > 1
+    if constituency_data.object["items"].count == 0
+      Result.new(nil, NotFoundError.new(NotFoundError.new(I18n.t("members_api.errors.search_term_not_found", constituency: search_term))))
+    elsif constituency_data.object["items"].count > 1
       Result.new(nil, MultipleResultsError.new(I18n.t("members_api.errors.multiple", search_term: search_term)))
     else
       Result.new(member_id_from_constituency(constituency_data), nil)

--- a/app/models/contact/parliament.rb
+++ b/app/models/contact/parliament.rb
@@ -1,0 +1,44 @@
+class Contact::Parliament
+  attr_reader :name, :email
+
+  def initialize(constituency:)
+    client = Api::MembersApi::Client.new
+    member = client.member_id(constituency)
+
+    raise member.error if member.error.present?
+
+    member_id = member.object
+    member_name = client.member_name(member_id).object
+    contact_details = client.member_contact_details(member_id).object.find { |details| details.type_id == 1 }
+
+    details = Api::MembersApi::MemberDetails.new(member_name, contact_details)
+
+    @constituency = constituency
+    @name = details.name
+    @email = details.email
+  end
+
+  def id
+    nil
+  end
+
+  def editable?
+    false
+  end
+
+  def category
+    "other"
+  end
+
+  def title
+    I18n.t("members_api.member.title", constituency: @constituency)
+  end
+
+  def phone
+    nil
+  end
+
+  def organisation_name
+    nil
+  end
+end

--- a/config/locales/members_api.en.yml
+++ b/config/locales/members_api.en.yml
@@ -6,3 +6,5 @@ en:
       search_term_not_found: "Constituency not found: %{constituency}"
       member_not_found: "Member not found: %{member_id}"
       contact_details_not_found: "Contact details not found for member %{member_id}"
+    member:
+      title: Member of Parliament for %{constituency}

--- a/config/locales/members_api.en.yml
+++ b/config/locales/members_api.en.yml
@@ -3,5 +3,6 @@ en:
     errors:
       other: There was an error connecting to the Members API
       multiple: "Multiple results found for search term: %{search_term}"
+      search_term_not_found: "Constituency not found: %{constituency}"
       member_not_found: "Member not found: %{member_id}"
       contact_details_not_found: "Contact details not found for member %{member_id}"

--- a/spec/models/api/members_api/client_spec.rb
+++ b/spec/models/api/members_api/client_spec.rb
@@ -140,6 +140,18 @@ RSpec.describe Api::MembersApi::Client do
         expect(subject.error.message).to eq(I18n.t("members_api.errors.multiple", search_term: "St A"))
       end
     end
+
+    context "when there are no results" do
+      subject { client.member_id("Mars") }
+
+      let(:fake_response) { [200, nil, {items: []}.to_json] }
+
+      it "returns a NotFoundError" do
+        expect(subject.object).to be_nil
+        expect(subject.error).to be_a(Api::MembersApi::Client::NotFoundError)
+        expect(subject.error.message).to eq(I18n.t("members_api.errors.search_term_not_found", constituency: "Mars"))
+      end
+    end
   end
 
   describe "#member_name" do

--- a/spec/models/contact/parliament_spec.rb
+++ b/spec/models/contact/parliament_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe Contact::Parliament do
+  let(:client) { Api::MembersApi::Client }
+  let(:client_instance) { double }
+  let(:name) { double(Api::MembersApi::MemberName, name_display_as: "Joe Bloggs") }
+  let(:contact_details) { double(find: Api::MembersApi::MemberContactDetails.new.from_hash({email: "joe.bloggs@email.com", line1: "Houses of Parliment", postcode: "SW1A 0AA"})) }
+
+  around do |spec|
+    ClimateControl.modify(
+      MEMBERS_API_HOST: "https://members-api.test"
+    ) do
+      spec.run
+    end
+  end
+
+  before do
+    allow(client).to receive(:new).and_return(client_instance)
+    allow(client_instance).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(4744, nil))
+    allow(client_instance).to receive(:member_name).and_return(Api::MembersApi::Client::Result.new(name, nil))
+    allow(client_instance).to receive(:member_contact_details).and_return(Api::MembersApi::Client::Result.new(contact_details, nil))
+  end
+
+  describe "#initialize" do
+    it "initializes a new instance with the member details" do
+      member_of_parliament = described_class.new(constituency: "St Albans")
+
+      expect(member_of_parliament.name).to eq("Joe Bloggs")
+      expect(member_of_parliament.title).to eq("Member of Parliament for St Albans")
+      expect(member_of_parliament.category).to eq("other")
+      expect(member_of_parliament.id).to be_nil
+      expect(member_of_parliament.organisation_name).to be_nil
+    end
+  end
+
+  describe "#editable?" do
+    it "is always false" do
+      expect(described_class.new(constituency: "St Albans").editable?).to be false
+    end
+  end
+
+  context "when the Member of Parliament is not found" do
+    before do
+      allow(client).to receive(:new).and_return(client_instance)
+      allow(client_instance).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::NotFoundError))
+    end
+
+    it "raises a not found error" do
+      expect { described_class.new(constituency: "Nowhereville") }.to raise_error(Api::MembersApi::Client::NotFoundError)
+    end
+  end
+
+  context "when the Members API returns multiple results for the constituency" do
+    before do
+      allow(client).to receive(:new).and_return(client_instance)
+      allow(client_instance).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::MultipleResultsError))
+    end
+
+    it "raises a a multiple results error" do
+      expect { described_class.new(constituency: "Middlesbrough") }.to raise_error(Api::MembersApi::Client::MultipleResultsError)
+    end
+  end
+
+  context "when the Members API returns an error response" do
+    before do
+      allow(client).to receive(:new).and_return(client_instance)
+      allow(client_instance).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::Error))
+    end
+
+    it "raises a generic error" do
+      expect { described_class.new(constituency: "Westminster") }.to raise_error(Api::MembersApi::Client::Error)
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Model the Member of Parliament contact like the other contact types. However, this contact doesn't persist in our database - they are fetched from the Members API via the constituency name, and only modeled as a transient object.

If there are any errors from the Members API, raise them. We will have to ensure we handle these errors in the relevant controllers.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
