### PR TITLE
Change project summary information styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   completed actions transfers task
 - Removed any references to Sentry.io
 - Changed the "Your projects in progress" page to a table layout
+- Change project summary information styling to be consistent across
+  applications within the service
 
 ## [Release 43][release-43]
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,6 +32,8 @@ $govuk-button-background-colour: $dfe-blue;
 @import "components/notification-banner";
 @import "components/app-content";
 
+@import "patterns/project-summary";
+
 // The accessible autocomplete component does not use
 // GOV.UK fonts by default for suggestions.
 .autocomplete__wrapper * {

--- a/app/assets/stylesheets/patterns/_project-summary.scss
+++ b/app/assets/stylesheets/patterns/_project-summary.scss
@@ -1,0 +1,16 @@
+.dfe-summary-list--project-summary {
+  @include govuk-responsive-padding(0, "bottom");
+
+  .govuk-summary-list__row {
+    display: block;
+    border: 0;
+  }
+
+  .govuk-summary-list__key,
+  .govuk-summary-list__value {
+    width: auto;
+    @include govuk-responsive-padding(0, "bottom");
+    @include govuk-responsive-padding(2, "top");
+    @include govuk-responsive-padding(2, "right");
+  }
+}

--- a/app/views/conversions/shared/_project_summary.html.erb
+++ b/app/views/conversions/shared/_project_summary.html.erb
@@ -16,7 +16,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <%= govuk_summary_list(actions: false, html_attributes: {id: "project-summary"}) do |summary_list|
+    <%= govuk_summary_list(actions: false, html_attributes: {id: "project-summary", class: "dfe-summary-list--project-summary"}) do |summary_list|
           summary_list.with_row do |row|
             row.with_key { t("project.summary.converting_on.title") }
             row.with_value { significant_date(@project) }

--- a/app/views/transfers/shared/_project_summary.html.erb
+++ b/app/views/transfers/shared/_project_summary.html.erb
@@ -16,7 +16,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <%= govuk_summary_list(actions: false, html_attributes: {id: "project-summary"}) do |summary_list|
+    <%= govuk_summary_list(actions: false, html_attributes: {id: "project-summary", class: "dfe-summary-list--project-summary"}) do |summary_list|
           summary_list.with_row do |row|
             row.with_key { t("project.summary.transfer_date.title") }
             row.with_value { significant_date(@project) }


### PR DESCRIPTION
## Changes

The project summary information view has been simplified to ensure consistency across the different applications within the service

### Before
<img width="1344" alt="Screenshot 2023-10-31 at 15 14 17" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/59832893/912fb041-ff5a-4979-9ce4-d06c88ec299f">

### After
<img width="1344" alt="Screenshot 2023-10-31 at 15 13 35" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/59832893/9933ab0f-5db4-47aa-8851-ecc66d53d654">

<img width="1344" alt="Screenshot 2023-10-31 at 15 13 24" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/59832893/fe97d5ef-af97-4ee0-ab1e-693a60133565">


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
