### PR TITLE
Fix govuk class name for your projects table view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Fix govuk class name for your projects table view from
+  `govuk-grid-column-full-width` to `govuk-grid-column-full`
+
 ### Added
 
 - Allow service support users to upload GIAS data for asynchronous ingestion

--- a/app/views/your/projects/in_progress.html.erb
+++ b/app/views/your/projects/in_progress.html.erb
@@ -21,7 +21,7 @@
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full-width">
+  <div class="govuk-grid-column-full">
     <%= render partial: "in_progress_table", locals: {projects: @projects, pager: @pager} %>
   </div>
 </div>


### PR DESCRIPTION
## Changes

All our other table views use the `govuk-grid-column-full` class so this change is to reflect that and keep the views consistent

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
