### PR TITLE
(Fix) Do not attempt to send "Assigned to" mail when assignee is nil

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -34,7 +34,7 @@ class AssignmentsController < ApplicationController
     @project.update(assigned_at: DateTime.now) if @project.assigned_at.nil?
 
     assignee = @project.assigned_to
-    AssignedToMailer.assigned_notification(assignee, @project).deliver_later if assignee.active
+    AssignedToMailer.assigned_notification(assignee, @project).deliver_later if assignee&.active
 
     return_to = assigned_to_params[:return_to] || project_internal_contacts_path(@project)
 

--- a/spec/requests/assignments_controller_spec.rb
+++ b/spec/requests/assignments_controller_spec.rb
@@ -200,6 +200,19 @@ RSpec.describe AssignmentsController, type: :request do
         end
       end
 
+      context "the assigned_to person is nil" do
+        subject(:perform_request) do
+          post project_assign_assigned_to_path(project_id), params: {conversion_project: {assigned_to_id: nil}}
+          response
+        end
+
+        it "does not attempt to send a notification" do
+          perform_request
+
+          expect(ActionMailer::MailDeliveryJob).to_not(have_been_enqueued.on_queue("default"))
+        end
+      end
+
       it "sets the `assigned_at` date value" do
         perform_request
 


### PR DESCRIPTION
Sentry error: https://sdd-n7.sentry.io/issues/4589134654/events/77ffc5f7670946b48667dfe044c8ebbd/

We were seeing an error on production where someone seemed to be trying to send an "assigned to" mail on a project with no assignee. The project's `assigned_to` value was nil, and no-one was being assigned to the project, and as a result the mailer was trying to sent an email to a nil person.
