### PR TITLE
Acutally send the GIAS headteacher import email

### DIFF
--- a/app/jobs/import/gias_headteacher_import_job.rb
+++ b/app/jobs/import/gias_headteacher_import_job.rb
@@ -2,7 +2,9 @@ class Import::GiasHeadteacherImportJob < ApplicationJob
   queue_as :default
 
   def perform(file_path, user)
-    Import::GiasHeadteacherCsvImporterService.new(file_path).import!
+    result = Import::GiasHeadteacherCsvImporterService.new(file_path).import!
+
+    GiasHeadteacherImportMailer.import_notification(user, result).deliver_later
 
     delete_file(file_path)
   end

--- a/spec/jobs/import/gias_headteacher_import_job_spec.rb
+++ b/spec/jobs/import/gias_headteacher_import_job_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe Import::GiasHeadteacherImportJob, type: :job do
       expect(importer).to have_received(:import!)
     end
 
+    it "queues an email to the user with the import report" do
+      mock_mailer = double(GiasHeadteacherImportMailer, deliver_later: true)
+      expect(GiasHeadteacherImportMailer).to receive(:import_notification).and_return(mock_mailer)
+
+      subject.perform_now(file_path, user)
+
+      expect(mock_mailer).to have_received(:deliver_later).exactly(1).time
+    end
+
     it "deletes the file afterwards" do
       subject.perform_now(file_path, user)
       expect(File).to have_received(:delete).with(file_path)


### PR DESCRIPTION
## Changes

When working on the GIAS headteacher importing, we missed actually
sending the email at the end of the process.

