### PR TITLE
Override the maximum number of replicas deployed for the worker

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -203,6 +203,7 @@ No resources.
 | <a name="input_tfvars_filename"></a> [tfvars\_filename](#input\_tfvars\_filename) | tfvars filename. This file is uploaded and stored encrupted within Key Vault, to ensure that the latest tfvars are stored in a shared place. | `string` | n/a | yes |
 | <a name="input_virtual_network_address_space"></a> [virtual\_network\_address\_space](#input\_virtual\_network\_address\_space) | Virtual network address space CIDR | `string` | n/a | yes |
 | <a name="input_worker_container_command"></a> [worker\_container\_command](#input\_worker\_container\_command) | Container command for the Worker container. `enable_worker_container` must be set to true for this to have any effect. | `list(string)` | n/a | yes |
+| <a name="input_worker_container_max_replicas"></a> [worker\_container\_max\_replicas](#input\_worker\_container\_max\_replicas) | Worker container max replicas | `number` | `1` | no |
 
 ## Outputs
 

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -14,8 +14,9 @@ module "azure_container_apps_hosting" {
   container_command                      = local.container_command
   container_secret_environment_variables = local.container_secret_environment_variables
 
-  enable_worker_container  = local.enable_worker_container
-  worker_container_command = local.worker_container_command
+  enable_worker_container       = local.enable_worker_container
+  worker_container_command      = local.worker_container_command
+  worker_container_max_replicas = local.worker_container_max_replicas
 
   enable_event_hub                          = local.enable_event_hub
   enable_logstash_consumer                  = local.enable_logstash_consumer

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -13,6 +13,7 @@ locals {
   storage_account_public_access_enabled        = var.storage_account_public_access_enabled
   enable_worker_container                      = var.enable_worker_container
   worker_container_command                     = var.worker_container_command
+  worker_container_max_replicas                = var.worker_container_max_replicas
   enable_mssql_database                        = var.enable_mssql_database
   mssql_server_admin_password                  = var.mssql_server_admin_password
   mssql_azuread_admin_username                 = var.mssql_azuread_admin_username

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -147,6 +147,12 @@ variable "worker_container_command" {
   type        = list(string)
 }
 
+variable "worker_container_max_replicas" {
+  description = "Worker container max replicas"
+  type        = number
+  default     = 1
+}
+
 variable "enable_cdn_frontdoor" {
   description = "Enable Azure CDN FrontDoor. This will use the Container Apps endpoint as the origin."
   type        = bool


### PR DESCRIPTION
## Changes

The default scale rules of the Container App Terraform module allows the worker container to scale from 1 to 2 replicas. We would like to be able to control that using a Terraform variable
