### PR TITLE
Fix: do not queue the import results hash

### DIFF
--- a/app/jobs/import/gias_establishment_import_job.rb
+++ b/app/jobs/import/gias_establishment_import_job.rb
@@ -5,6 +5,10 @@ class Import::GiasEstablishmentImportJob < ApplicationJob
     importer = Import::GiasEstablishmentCsvImporterService.new(file_path)
     result = importer.import!
 
-    GiasEstablishmentImportMailer.import_notification(user, result).deliver_later
+    GiasEstablishmentImportMailer.import_notification(user, emailable_result(result)).deliver_later
+  end
+
+  def emailable_result(result)
+    result.delete(:changes)
   end
 end

--- a/app/jobs/import/gias_headteacher_import_job.rb
+++ b/app/jobs/import/gias_headteacher_import_job.rb
@@ -4,9 +4,13 @@ class Import::GiasHeadteacherImportJob < ApplicationJob
   def perform(file_path, user)
     result = Import::GiasHeadteacherCsvImporterService.new(file_path).import!
 
-    GiasHeadteacherImportMailer.import_notification(user, result).deliver_later
+    GiasHeadteacherImportMailer.import_notification(user, emailable_result(result)).deliver_later
 
     delete_file(file_path)
+  end
+
+  def emailable_result(result)
+    result.delete(:changes)
   end
 
   private def delete_file(file_path)

--- a/app/mailers/gias_headteacher_import_mailer.rb
+++ b/app/mailers/gias_headteacher_import_mailer.rb
@@ -1,7 +1,7 @@
 class GiasHeadteacherImportMailer < ApplicationMailer
   def import_notification(user, result)
     template_mail(
-      "316ef413-5e53-48e4-8a78-2aeaa9b98114",
+      "6d4ea487-3d6f-4043-b7dc-2388ed373fbc",
       to: user.email,
       personalisation: {
         result: format_result(result)

--- a/spec/jobs/import/gias_establishment_import_job_spec.rb
+++ b/spec/jobs/import/gias_establishment_import_job_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Import::GiasEstablishmentImportJob, type: :job do
   describe "#perform" do
     let(:user) { create(:user, :service_support) }
     let(:file_path) { "gias_establishment_data_good.csv" }
-    let(:importer) { double(Import::GiasEstablishmentCsvImporterService, import!: true) }
+    let(:importer) { double(Import::GiasEstablishmentCsvImporterService, import!: {}) }
     subject { described_class }
 
     before do
@@ -28,6 +28,17 @@ RSpec.describe Import::GiasEstablishmentImportJob, type: :job do
       subject.perform_now(file_path, user)
 
       expect(mock_mailer).to have_received(:deliver_later).exactly(1).time
+    end
+  end
+
+  describe "#emailable_result" do
+    it "removes the changes from the result as the hash can be too large to queue with Sidekiq" do
+      test_result = {
+        included: 0,
+        changes: {}
+      }
+
+      expect(subject.emailable_result(test_result).has_key?(:changes)).to be false
     end
   end
 end

--- a/spec/jobs/import/gias_headteacher_import_job_spec.rb
+++ b/spec/jobs/import/gias_headteacher_import_job_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Import::GiasHeadteacherImportJob, type: :job do
   describe "#perform" do
     let(:user) { create(:user, :service_support) }
-    let(:importer) { double(Import::GiasHeadteacherCsvImporterService, import!: true) }
+    let(:importer) { double(Import::GiasHeadteacherCsvImporterService, import!: {}) }
     subject { described_class }
 
     before do
@@ -35,6 +35,17 @@ RSpec.describe Import::GiasHeadteacherImportJob, type: :job do
     it "deletes the file afterwards" do
       subject.perform_now(file_path, user)
       expect(File).to have_received(:delete).with(file_path)
+    end
+  end
+
+  describe "#emailable_result" do
+    it "removes the changes from the result as the hash can be too large to queue with Sidekiq" do
+      test_result = {
+        included: 0,
+        changes: {}
+      }
+
+      expect(subject.emailable_result(test_result).has_key?(:changes)).to be false
     end
   end
 end

--- a/spec/mailers/gias_headteacher_import_mailer_spec.rb
+++ b/spec/mailers/gias_headteacher_import_mailer_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe GiasHeadteacherImportMailer do
   describe "#import_notification" do
     let(:user) { create(:user, :service_support) }
-    let(:template_id) { "316ef413-5e53-48e4-8a78-2aeaa9b98114" }
+    let(:template_id) { "6d4ea487-3d6f-4043-b7dc-2388ed373fbc" }
     let(:result) do
       {
         file: "/a/file.csv",


### PR DESCRIPTION
After importing GIAS establishment and headteacher contacts we send an
email to the user that summerises the import.

When queuing the email we pass the whole `result` object from the import
service - this has the potential to be very large e.g. on inital import
of 50K rows, you can expect 50K x number of imported columns.

On testing in the development environment, we suspect this hash is
unreasonably large for Sidekiq to serialise.

As we do not include the changes in the email anyway, here we remove the
changes before queuing the job.

We also fix the template ID for the headteacher import email.