### PR TITLE
Extend search service to search by establishment name and GIAS number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Allow search by words (establishment name)
+- Allow search by GIAS establishment number
 
 ## [Release-44][release-44]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Allow search by words (establishment name)
+
 ## [Release-44][release-44]
 
 ### Fixed

--- a/app/services/project_search_service.rb
+++ b/app/services/project_search_service.rb
@@ -8,6 +8,10 @@ class ProjectSearchService
       return search_by_ukprn(query)
     end
 
+    if word_pattern(query)
+      return search_by_words(query)
+    end
+
     []
   end
 
@@ -20,11 +24,27 @@ class ProjectSearchService
       .or(Project.where("outgoing_trust_ukprn = ?", ukprn))
   end
 
+  def search_by_words(query)
+    establishment_results = search_establishments_by_name(query)
+    return [] if establishment_results.empty?
+
+    urns = establishment_results.pluck(:urn)
+    search_by_urns(urns)
+  end
+
+  private def search_establishments_by_name(query)
+    Gias::Establishment.where("LOWER(name) LIKE ?", "%#{query.downcase}%")
+  end
+
   private def urn_pattern(query)
     query.match?(/^\d{6}$/)
   end
 
   private def ukprn_pattern(query)
     query.match?(/^\d{8}$/)
+  end
+
+  private def word_pattern(query)
+    query.match?(/\D/)
   end
 end

--- a/app/services/project_search_service.rb
+++ b/app/services/project_search_service.rb
@@ -12,6 +12,10 @@ class ProjectSearchService
       return search_by_words(query)
     end
 
+    if establishment_number_pattern(query)
+      return search_by_establishment_number(query)
+    end
+
     []
   end
 
@@ -36,6 +40,18 @@ class ProjectSearchService
     Gias::Establishment.where("LOWER(name) LIKE ?", "%#{query.downcase}%")
   end
 
+  def search_by_establishment_number(query)
+    establishment_results = search_establishments_by_establishment_number(query)
+    return [] if establishment_results.empty?
+
+    urns = establishment_results.pluck(:urn)
+    search_by_urns(urns)
+  end
+
+  private def search_establishments_by_establishment_number(query)
+    Gias::Establishment.where(establishment_number: query)
+  end
+
   private def urn_pattern(query)
     query.match?(/^\d{6}$/)
   end
@@ -46,5 +62,9 @@ class ProjectSearchService
 
   private def word_pattern(query)
     query.match?(/\D/)
+  end
+
+  private def establishment_number_pattern(query)
+    query.match?(/^\d{4}$/)
   end
 end

--- a/app/services/project_search_service.rb
+++ b/app/services/project_search_service.rb
@@ -1,22 +1,14 @@
 class ProjectSearchService
   def search(query)
     if urn_pattern(query)
-      return search_by_urns(query)
+      search_by_urns(query)
+    elsif ukprn_pattern(query)
+      search_by_ukprn(query)
+    elsif establishment_number_pattern(query)
+      search_by_establishment_number(query)
+    else
+      search_by_words(query)
     end
-
-    if ukprn_pattern(query)
-      return search_by_ukprn(query)
-    end
-
-    if word_pattern(query)
-      return search_by_words(query)
-    end
-
-    if establishment_number_pattern(query)
-      return search_by_establishment_number(query)
-    end
-
-    []
   end
 
   def search_by_urns(urns)
@@ -58,10 +50,6 @@ class ProjectSearchService
 
   private def ukprn_pattern(query)
     query.match?(/^\d{8}$/)
-  end
-
-  private def word_pattern(query)
-    query.match?(/\D/)
   end
 
   private def establishment_number_pattern(query)

--- a/app/services/project_search_service.rb
+++ b/app/services/project_search_service.rb
@@ -25,6 +25,6 @@ class ProjectSearchService
   end
 
   private def ukprn_pattern(query)
-    query.match?(/\d{8}$/)
+    query.match?(/^\d{8}$/)
   end
 end

--- a/app/services/project_search_service.rb
+++ b/app/services/project_search_service.rb
@@ -1,7 +1,7 @@
 class ProjectSearchService
   def search(query)
     if urn_pattern(query)
-      return search_by_urn(query)
+      return search_by_urns(query)
     end
 
     if ukprn_pattern(query)
@@ -11,8 +11,8 @@ class ProjectSearchService
     []
   end
 
-  def search_by_urn(urn)
-    Project.where("urn = ?", urn)
+  def search_by_urns(urns)
+    Project.where(urn: urns)
   end
 
   def search_by_ukprn(ukprn)

--- a/spec/services/project_search_service_spec.rb
+++ b/spec/services/project_search_service_spec.rb
@@ -51,34 +51,56 @@ RSpec.describe ProjectSearchService do
     end
   end
 
-  describe "#search_by_urn" do
-    context "when a match is found" do
-      it "returns an array with the matches" do
-        matching_project = create(:conversion_project, urn: 100000)
-        another_matching_project = create(:transfer_project, urn: 100000)
-        not_matching_project = create(:conversion_project, urn: 123456)
+  describe "#search_by_urns" do
+    context "when one urn is passed" do
+      context "when a match is found" do
+        it "returns an array with the matches" do
+          matching_project = create(:conversion_project, urn: 100000)
+          another_matching_project = create(:transfer_project, urn: 100000)
+          not_matching_project = create(:conversion_project, urn: 123456)
 
-        service = described_class.new
-        result = service.search_by_urn("100000")
+          service = described_class.new
+          result = service.search_by_urns("100000")
 
-        expect(result.count).to eql 2
+          expect(result.count).to eql 2
 
-        expect(result).to include(matching_project)
-        expect(result).to include(another_matching_project)
+          expect(result).to include(matching_project)
+          expect(result).to include(another_matching_project)
 
-        expect(result).not_to include(not_matching_project)
+          expect(result).not_to include(not_matching_project)
+        end
+      end
+
+      context "when a match is not found" do
+        it "returns an empty result" do
+          create(:conversion_project, urn: 100000)
+          create(:transfer_project, urn: 100000)
+
+          service = described_class.new
+          result = service.search_by_urns("123456")
+
+          expect(result.count).to be_zero
+        end
       end
     end
 
-    context "when a match is not found" do
-      it "returns an empty result" do
-        create(:conversion_project, urn: 100000)
-        create(:transfer_project, urn: 100000)
+    context "when an array of urns is passed" do
+      context "when matches are found" do
+        it "returns an array with the matches" do
+          matching_project = create(:conversion_project, urn: 100000)
+          another_matching_project = create(:transfer_project, urn: 999999)
+          not_matching_project = create(:conversion_project, urn: 123456)
 
-        service = described_class.new
-        result = service.search_by_urn("123456")
+          service = described_class.new
+          result = service.search_by_urns(["100000", "999999"])
 
-        expect(result.count).to be_zero
+          expect(result.count).to eql 2
+
+          expect(result).to include(matching_project)
+          expect(result).to include(another_matching_project)
+
+          expect(result).not_to include(not_matching_project)
+        end
       end
     end
   end

--- a/spec/services/project_search_service_spec.rb
+++ b/spec/services/project_search_service_spec.rb
@@ -41,12 +41,39 @@ RSpec.describe ProjectSearchService do
       end
     end
 
-    context "when passed a string" do
-      it "returns an empty result" do
-        service = described_class.new
-        result = service.search("School name search not implemented")
+    context "when passed a string that looks like words, i.e. a school name" do
+      it "returns the match by school name" do
+        _matching_establishment = create(:gias_establishment, name: "St Albans Primary", urn: 100000)
+        _non_matching_establishment = create(:gias_establishment, name: "Honeywell Primary", urn: 999999)
 
-        expect(result.count).to be_zero
+        matching_project = create(:transfer_project, urn: 100000)
+        non_matching_project = create(:conversion_project, urn: 999999)
+
+        service = described_class.new
+        result = service.search("st albans")
+
+        expect(result).to include(matching_project)
+        expect(result).not_to include(non_matching_project)
+      end
+    end
+
+    context "when passed anything that does not match the recognized patterns" do
+      context "a too-long number" do
+        it "returns an empty result" do
+          service = described_class.new
+          result = service.search("999999999999")
+
+          expect(result.count).to be_zero
+        end
+      end
+
+      context "a mix of numbers and letters" do
+        it "returns an empty result" do
+          service = described_class.new
+          result = service.search("111-this-is-not-a-school-999")
+
+          expect(result.count).to be_zero
+        end
       end
     end
   end
@@ -134,6 +161,36 @@ RSpec.describe ProjectSearchService do
 
         service = described_class.new
         result = service.search_by_ukprn("12345678")
+
+        expect(result.count).to be_zero
+      end
+    end
+  end
+
+  describe "#search_by_words" do
+    context "when matches are found" do
+      it "returns an array with the matches" do
+        _matching_establishment_1 = create(:gias_establishment, name: "St Albans Primary", urn: 100000)
+        _matching_establishment_2 = create(:gias_establishment, name: "St Albans Secondary", urn: 100001)
+        _non_matching_establishment = create(:gias_establishment, name: "Honeywell Primary", urn: 999999)
+
+        matching_project_1 = create(:transfer_project, urn: 100000)
+        matching_project_2 = create(:conversion_project, urn: 100001)
+        non_matching_project = create(:conversion_project, urn: 999999)
+
+        service = described_class.new
+        result = service.search_by_words("st albans")
+
+        expect(result).to include(matching_project_1)
+        expect(result).to include(matching_project_2)
+        expect(result).not_to include(non_matching_project)
+      end
+    end
+
+    context "when no matches are found" do
+      it "returns an empty result" do
+        service = described_class.new
+        result = service.search_by_words("st albans")
 
         expect(result.count).to be_zero
       end

--- a/spec/services/project_search_service_spec.rb
+++ b/spec/services/project_search_service_spec.rb
@@ -57,11 +57,36 @@ RSpec.describe ProjectSearchService do
       end
     end
 
+    context "when passed an establishment number" do
+      it "returns the match by establishment number" do
+        _matching_establishment = create(:gias_establishment, urn: 100000, establishment_number: "1234")
+        _non_matching_establishment = create(:gias_establishment, urn: 999999, establishment_number: "1000")
+
+        matching_project = create(:transfer_project, urn: 100000)
+        non_matching_project = create(:conversion_project, urn: 999999)
+
+        service = described_class.new
+        result = service.search("1234")
+
+        expect(result).to include(matching_project)
+        expect(result).not_to include(non_matching_project)
+      end
+    end
+
     context "when passed anything that does not match the recognized patterns" do
       context "a too-long number" do
         it "returns an empty result" do
           service = described_class.new
           result = service.search("999999999999")
+
+          expect(result.count).to be_zero
+        end
+      end
+
+      context "a too-short number" do
+        it "returns an empty result" do
+          service = described_class.new
+          result = service.search("1")
 
           expect(result.count).to be_zero
         end
@@ -191,6 +216,33 @@ RSpec.describe ProjectSearchService do
       it "returns an empty result" do
         service = described_class.new
         result = service.search_by_words("st albans")
+
+        expect(result.count).to be_zero
+      end
+    end
+  end
+
+  describe "#search_by_establishment_number" do
+    context "when matches are found" do
+      it "returns an array with the matches" do
+        _matching_establishment = create(:gias_establishment, urn: 100000, establishment_number: 1234)
+        _non_matching_establishment = create(:gias_establishment, urn: 999999, establishment_number: 1000)
+
+        matching_project = create(:transfer_project, urn: 100000)
+        non_matching_project = create(:conversion_project, urn: 999999)
+
+        service = described_class.new
+        result = service.search_by_establishment_number("1234")
+
+        expect(result).to include(matching_project)
+        expect(result).not_to include(non_matching_project)
+      end
+    end
+
+    context "when no matches are found" do
+      it "returns an empty result" do
+        service = described_class.new
+        result = service.search_by_establishment_number("1234")
 
         expect(result.count).to be_zero
       end


### PR DESCRIPTION
## Changes

Note that the search service is still not available to users.

Extend the existing search service to search by words (establishment name) and GIAS number (4-digit string). 

The search by words allows partial matches and is case-insensitive.

The search by GIAS number expects an exact 4-digit number. 6 digit numbers are assumed to be URNs and 8-digit numbers are assumed to be UKPRNs. We cannot do partial number matches at the moment.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
