### PR TITLE
Fix delete changes from import result

### DIFF
--- a/app/jobs/import/gias_establishment_import_job.rb
+++ b/app/jobs/import/gias_establishment_import_job.rb
@@ -10,5 +10,6 @@ class Import::GiasEstablishmentImportJob < ApplicationJob
 
   def emailable_result(result)
     result.delete(:changes)
+    result
   end
 end

--- a/app/jobs/import/gias_headteacher_import_job.rb
+++ b/app/jobs/import/gias_headteacher_import_job.rb
@@ -11,6 +11,7 @@ class Import::GiasHeadteacherImportJob < ApplicationJob
 
   def emailable_result(result)
     result.delete(:changes)
+    result
   end
 
   private def delete_file(file_path)


### PR DESCRIPTION
`delete` a hash key resturns the value of that key, so this method is
not working as expected returning the deleted value instaead of the new
(smaller) hash, causing the same problem that we wanted to remove the
changes for!
