### PR TITLE
Add New project table view for your team projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Allow search by words (establishment name)
 - Allow search by GIAS establishment number
+- Add `New` project table view for your team projects
 
 ## [Release-44][release-44]
 

--- a/app/controllers/team/projects_controller.rb
+++ b/app/controllers/team/projects_controller.rb
@@ -2,6 +2,11 @@ class Team::ProjectsController < ApplicationController
   after_action :verify_authorized
   rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
 
+  def new
+    authorize Project, :index?
+    @pager, @projects = pagy_array(ByTeamProjectFetcherService.new(current_user.team).new)
+  end
+
   def in_progress
     authorize Project, :index?
     @pager, @projects = pagy_array(ByTeamProjectFetcherService.new(current_user.team).in_progress)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -54,6 +54,8 @@ class Project < ApplicationRecord
   scope :assigned_to_users, ->(users) { where(assigned_to_id: [users]) }
   scope :added_by, ->(user) { where(regional_delivery_officer: user) }
 
+  scope :ordered_by_created_at_date, -> { order(created_at: :asc) }
+
   scope :by_region, ->(region) { where(region: region) }
 
   scope :by_trust_ukprn, ->(ukprn) { where(incoming_trust_ukprn: ukprn) }

--- a/app/services/by_team_project_fetcher_service.rb
+++ b/app/services/by_team_project_fetcher_service.rb
@@ -3,6 +3,18 @@ class ByTeamProjectFetcherService
     @team = team
   end
 
+  def new
+    return [] if @team.nil?
+
+    projects = if @team.eql?("regional_casework_services")
+      Project.assigned_to_regional_caseworker_team.in_progress.includes(:assigned_to).ordered_by_created_at_date
+    else
+      Project.by_region(@team).in_progress.includes(:assigned_to).ordered_by_created_at_date
+    end
+
+    AcademiesApiPreFetcherService.new.call!(projects)
+  end
+
   def in_progress
     return [] if @team.nil?
 

--- a/app/views/shared/navigation/_team_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_team_projects_primary_navigation.html.erb
@@ -11,6 +11,8 @@
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.in_progress"), path: in_progress_team_projects_path, namespace: "/projects/team/in-progress"} %>
 
+          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.new"), path: team_projects_path, namespace: "/projects/team/new"} %>
+
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.by_month"), path: confirmed_team_by_month_projects_path, namespace: "/projects/team/by-month"} %>
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.team_projects.by_user"), path: team_users_projects_path, namespace: "/projects/team/user"} %>

--- a/app/views/team/projects/_new_table.html.erb
+++ b/app/views/team/projects/_new_table.html.erb
@@ -1,0 +1,44 @@
+<% if projects.empty? %>
+  <%= govuk_inset_text(text: t("project.table.in_progress.empty")) %>
+<% else %>
+  <table class="govuk-table" name="projects_table" aria-label="Projects table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.created_at") %></th>
+        <% if @current_user.is_regional_caseworker? %>
+          <th class="govuk-table__header" scope="col"><%= t("project.table.headers.region") %></th>
+        <% end %>
+        <% if @current_user.is_regional_delivery_officer? %>
+          <th class="govuk-table__header" scope="col"><%= t("project.table.headers.team") %></th>
+        <% end %>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% projects.each do |project| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__header govuk-table__cell">
+          <%= link_to project.establishment.name, project_path(project), class: "govuk-link govuk-link--no-visited-state" %>
+        </td>
+        <td class="govuk-table__cell"><%= project.urn %></td>
+        <td class="govuk-table__cell"><%= project.created_at.to_date.to_formatted_s(:significant_date) %></td>
+        <% if @current_user.is_regional_caseworker? %>
+          <td class="govuk-table__cell"><%= t("teams.#{project.region}") %></td>
+        <% end %>
+        <% if @current_user.is_regional_delivery_officer? %>
+          <td class="govuk-table__cell"><%= t("teams.#{project.team}") %></td>
+        <% end %>
+        <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
+        <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
+        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<%= govuk_pagination(pagy: pager) %>

--- a/app/views/team/projects/new.html.erb
+++ b/app/views/team/projects/new.html.erb
@@ -1,0 +1,19 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/team_projects_primary_navigation" %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("project.team.new.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">
+      <%= t("project.team.new.title") %>
+    </h1>
+
+    <%= render partial: "/team/projects/new_table", locals: {projects: @projects, pager: @pager} %>
+
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,6 +146,7 @@ en:
         exports: Exports
       team_projects:
         in_progress: In progress
+        new: New
         unassigned: Unassigned
         completed: Completed
         by_user: By user

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -36,6 +36,8 @@ en:
     team:
       in_progress:
         title: In progress
+      new:
+        title: New
       completed:
         title: Completed
       unassigned:
@@ -169,6 +171,7 @@ en:
         added_by: Added by
         conversion_date: Conversion date
         conversion_or_transfer_date: Conversion or transfer date
+        created_at: Created at date
         revised_conversion_date: Revised conversion date
         route: Route
         school_phase: School phase

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,6 +159,7 @@ Rails.application.routes.draw do
           get "completed", to: "projects#completed"
           get "unassigned", to: "projects#unassigned"
           get "handed-over", to: "projects#handed_over"
+          get "new", to: "projects#new"
           namespace :users do
             get "/", to: "projects#index"
             get "/:user_id", to: "projects#show", as: :by_user

--- a/spec/features/your_team_projects/users_can_view_their_team_projects_spec.rb
+++ b/spec/features/your_team_projects/users_can_view_their_team_projects_spec.rb
@@ -35,4 +35,18 @@ RSpec.feature "Users can view their team's projects" do
       end
     end
   end
+
+  context "within the new tab" do
+    let(:user) { create(:regional_delivery_officer_user, team: :london) }
+    scenario "they can navigate to the new page and see projects listed in created at date order" do
+      project_newest = create(:conversion_project, team: "regional_casework_services", conversion_date: Date.today.at_beginning_of_month + 1.month, created_at: DateTime.now)
+      project_oldest = create(:conversion_project, team: "regional_casework_services", conversion_date: Date.today.at_beginning_of_month + 1.month, created_at: DateTime.now)
+
+      visit team_projects_path
+
+      expect(page).to have_content("New")
+      expect(page).to have_content(project_newest.urn)
+      expect(page).to have_content(project_oldest.urn)
+    end
+  end
 end


### PR DESCRIPTION
## Changes

Our views of projects are usually sorted by the significant date, which is the most valuable, but there are some instances where it is valuable to know what projects have been added and to view them in order of when they were first created.

<img width="1330" alt="Screenshot 2023-11-08 at 12 15 11" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/59832893/b252e342-3a2a-4b66-ac95-c231973a5bd3">

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
