### PR TITLE
Add Gias::Group model

### DIFF
--- a/app/models/gias/group.rb
+++ b/app/models/gias/group.rb
@@ -1,0 +1,5 @@
+class Gias::Group < ApplicationRecord
+  self.table_name = :gias_groups
+
+  validates :unique_group_identifier, presence: true
+end

--- a/db/migrate/20231108110923_add_gias_group.rb
+++ b/db/migrate/20231108110923_add_gias_group.rb
@@ -1,0 +1,18 @@
+class AddGiasGroup < ActiveRecord::Migration[7.0]
+  def change
+    create_table :gias_groups, id: :uuid do |t|
+      t.integer :ukprn, index: true
+      t.integer :unique_group_identifier, index: {unique: true}
+      t.string :group_identifier, index: true
+      t.string :original_name
+      t.string :companies_house_number
+      t.string :address_street
+      t.string :address_locality
+      t.string :address_additional
+      t.string :address_town
+      t.string :address_county
+      t.string :address_postcode
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_12_105157) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_08_110923) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -191,6 +191,25 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_12_105157) do
     t.index ["name"], name: "index_gias_establishments_on_name"
     t.index ["ukprn"], name: "index_gias_establishments_on_ukprn"
     t.index ["urn"], name: "index_gias_establishments_on_urn", unique: true
+  end
+
+  create_table "gias_groups", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+    t.integer "ukprn"
+    t.integer "unique_group_identifier"
+    t.string "group_identifier"
+    t.string "original_name"
+    t.string "companies_house_number"
+    t.string "address_street"
+    t.string "address_locality"
+    t.string "address_additional"
+    t.string "address_town"
+    t.string "address_county"
+    t.string "address_postcode"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_identifier"], name: "index_gias_groups_on_group_identifier"
+    t.index ["ukprn"], name: "index_gias_groups_on_ukprn"
+    t.index ["unique_group_identifier"], name: "index_gias_groups_on_unique_group_identifier", unique: true
   end
 
   create_table "local_authorities", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/factories/gias/group_factory.rb
+++ b/spec/factories/gias/group_factory.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :gias_group, class: "Gias::Group" do
+    unique_group_identifier { 1234 }
+    ukprn { 10061021 }
+    companies_house_number { "09702162" }
+    group_identifier { "TR03094" }
+    original_name { "The Academy Group" }
+    address_street { "Academy Lane" }
+    address_locality { "Chilwell" }
+    address_additional { "Beeston" }
+    address_town { "Nottingham" }
+    address_county { "Nottinghamshire" }
+    address_postcode { "NG1 4PQ" }
+  end
+end

--- a/spec/models/gias/group_spec.rb
+++ b/spec/models/gias/group_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Gias::Group do
+  describe "the basics" do
+    it "can create instances" do
+      establishment = create(:gias_group, ukprn: 12345678, original_name: "A test trust")
+
+      expect(establishment.ukprn).to eql 12345678
+      expect(establishment.original_name).to eql "A test trust"
+    end
+  end
+
+  describe "database constraints" do
+    it "ensures Unique Group Identifier is unique" do
+      create(:gias_group, unique_group_identifier: 1234)
+
+      expect { create(:gias_group, unique_group_identifier: 1234) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:unique_group_identifier) }
+  end
+end


### PR DESCRIPTION
A Gias Group is what we currently think of as a "trust", but the data from GIAS contains more than just trusts, so for safety's sake we are calling them Groups.

Note that the Companies House number is being stored as a string, because it can contain leading zeros which are significant. If we stored it as an integer, Rails would "helpfully" strip off leading zeroes.

