### PR TITLE
(146600) Add questions to new transfer form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   information on the about the project tab
 - transfer projects now collect if they are the result of an inadequate Ofsted
   inspection and show this information on the about the project tab
+- transfer projects now collect if they are the result of financial,
+  safeguarding or governance issues and who this information on the about
+  project tab
 
 ## [Release-46][release-46]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - transfer projects now collect if they are the result of financial,
   safeguarding or governance issues and who this information on the about
   project tab
+- transfer projects now collect if the outgoing trust is expected to close once
+  the transfer is completed and this is shown on the about the project tab
 
 ## [Release-46][release-46]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add ability to import GIAS groups from csv data
+- transfer project now collect if they are a result of 2RI and show this
+  information on the about the project tab
 
 ## [Release-46][release-46]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add ability to import GIAS groups from csv data
 - transfer project now collect if they are a result of 2RI and show this
   information on the about the project tab
+- transfer project now collect if they are a result of 2RI and show this
+  information on the about the project tab
+- transfer projects now collect if they are the result of an inadequate Ofsted
+  inspection and show this information on the about the project tab
 
 ## [Release-46][release-46]
 

--- a/app/controllers/transfers/projects_controller.rb
+++ b/app/controllers/transfers/projects_controller.rb
@@ -60,7 +60,8 @@ class Transfers::ProjectsController < ApplicationController
       :handover_note_body,
       :two_requires_improvement,
       :inadequate_ofsted,
-      :financial_safeguarding_governance_issues
+      :financial_safeguarding_governance_issues,
+      :outgoing_trust_to_close
     )
   end
 end

--- a/app/controllers/transfers/projects_controller.rb
+++ b/app/controllers/transfers/projects_controller.rb
@@ -59,7 +59,8 @@ class Transfers::ProjectsController < ApplicationController
       :assigned_to_regional_caseworker_team,
       :handover_note_body,
       :two_requires_improvement,
-      :inadequate_ofsted
+      :inadequate_ofsted,
+      :financial_safeguarding_governance_issues
     )
   end
 end

--- a/app/controllers/transfers/projects_controller.rb
+++ b/app/controllers/transfers/projects_controller.rb
@@ -58,7 +58,8 @@ class Transfers::ProjectsController < ApplicationController
       :outgoing_trust_sharepoint_link,
       :assigned_to_regional_caseworker_team,
       :handover_note_body,
-      :two_requires_improvement
+      :two_requires_improvement,
+      :inadequate_ofsted
     )
   end
 end

--- a/app/controllers/transfers/projects_controller.rb
+++ b/app/controllers/transfers/projects_controller.rb
@@ -57,7 +57,8 @@ class Transfers::ProjectsController < ApplicationController
       :incoming_trust_sharepoint_link,
       :outgoing_trust_sharepoint_link,
       :assigned_to_regional_caseworker_team,
-      :handover_note_body
+      :handover_note_body,
+      :two_requires_improvement
     )
   end
 end

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -47,13 +47,6 @@ class Conversion::CreateProjectForm < CreateProjectForm
     ]
   end
 
-  def two_requires_improvement_responses
-    @two_requires_improvement_responses ||= [
-      OpenStruct.new(id: true, name: I18n.t("yes")),
-      OpenStruct.new(id: false, name: I18n.t("no"))
-    ]
-  end
-
   def save
     assigned_to = assigned_to_regional_caseworker_team ? nil : user
     assigned_at = assigned_to_regional_caseworker_team ? nil : DateTime.now

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -10,9 +10,8 @@ class Conversion::CreateProjectForm < CreateProjectForm
 
   validate :urn_unique_for_in_progress_conversions, if: -> { urn.present? }
 
-  validates :directive_academy_order,
-    :assigned_to_regional_caseworker_team,
-    :two_requires_improvement, inclusion: {in: [true, false]}
+  validates :directive_academy_order, :assigned_to_regional_caseworker_team, inclusion: {in: [true, false]}
+  validates :two_requires_improvement, inclusion: {in: [true, false], message: I18n.t("errors.conversion_project.attributes.two_requires_improvement.inclusion")}
 
   def initialize(params = {})
     @attributes_with_invalid_values = []

--- a/app/forms/create_project_form.rb
+++ b/app/forms/create_project_form.rb
@@ -45,8 +45,8 @@ class CreateProjectForm
     @attributes_with_invalid_values << :advisory_board_date
   end
 
-  def assigned_to_regional_caseworker_team_responses
-    @assigned_to_regional_caseworker_team_responses ||= [
+  def yes_no_responses
+    @yes_no_responses ||= [
       OpenStruct.new(id: true, name: I18n.t("yes")),
       OpenStruct.new(id: false, name: I18n.t("no"))
     ]

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -5,6 +5,7 @@ class Transfer::CreateProjectForm < CreateProjectForm
   attribute :two_requires_improvement, :boolean
   attribute :inadequate_ofsted, :boolean
   attribute :financial_safeguarding_governance_issues, :boolean
+  attribute :outgoing_trust_to_close, :boolean
 
   validates :outgoing_trust_ukprn, presence: true, ukprn: true
   validates :provisional_transfer_date, presence: true
@@ -12,6 +13,7 @@ class Transfer::CreateProjectForm < CreateProjectForm
   validates :two_requires_improvement, inclusion: {in: [true, false], message: I18n.t("errors.transfer_project.attributes.two_requires_improvement.inclusion")}
   validates :inadequate_ofsted, inclusion: {in: [true, false], message: I18n.t("errors.transfer_project.attributes.inadequate_ofsted.inclusion")}
   validates :financial_safeguarding_governance_issues, inclusion: {in: [true, false], message: I18n.t("errors.transfer_project.attributes.financial_safeguarding_governance_issues.inclusion")}
+  validates :outgoing_trust_to_close, inclusion: {in: [true, false], message: I18n.t("errors.transfer_project.attributes.outgoing_trust_to_close.inclusion")}
 
   validate :urn_unique_for_in_progress_transfers, if: -> { urn.present? }
 
@@ -52,7 +54,8 @@ class Transfer::CreateProjectForm < CreateProjectForm
       @note = Note.create(body: handover_note_body, project: @project, user: user, task_identifier: :handover) if handover_note_body
       @project.tasks_data.update!(
         inadequate_ofsted: inadequate_ofsted,
-        financial_safeguarding_governance_issues: financial_safeguarding_governance_issues
+        financial_safeguarding_governance_issues: financial_safeguarding_governance_issues,
+        outgoing_trust_to_close: outgoing_trust_to_close
       )
     end
 

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -10,6 +10,7 @@ class Transfer::CreateProjectForm < CreateProjectForm
   validates :outgoing_trust_ukprn, presence: true, ukprn: true
   validates :provisional_transfer_date, presence: true
   validates :provisional_transfer_date, date_in_the_future: true, first_day_of_month: true
+  validates :assigned_to_regional_caseworker_team, inclusion: {in: [true, false]}
   validates :two_requires_improvement, inclusion: {in: [true, false], message: I18n.t("errors.transfer_project.attributes.two_requires_improvement.inclusion")}
   validates :inadequate_ofsted, inclusion: {in: [true, false], message: I18n.t("errors.transfer_project.attributes.inadequate_ofsted.inclusion")}
   validates :financial_safeguarding_governance_issues, inclusion: {in: [true, false], message: I18n.t("errors.transfer_project.attributes.financial_safeguarding_governance_issues.inclusion")}

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -4,12 +4,14 @@ class Transfer::CreateProjectForm < CreateProjectForm
   attribute :outgoing_trust_sharepoint_link
   attribute :two_requires_improvement, :boolean
   attribute :inadequate_ofsted, :boolean
+  attribute :financial_safeguarding_governance_issues, :boolean
 
   validates :outgoing_trust_ukprn, presence: true, ukprn: true
   validates :provisional_transfer_date, presence: true
   validates :provisional_transfer_date, date_in_the_future: true, first_day_of_month: true
   validates :two_requires_improvement, inclusion: {in: [true, false], message: I18n.t("errors.transfer_project.attributes.two_requires_improvement.inclusion")}
   validates :inadequate_ofsted, inclusion: {in: [true, false], message: I18n.t("errors.transfer_project.attributes.inadequate_ofsted.inclusion")}
+  validates :financial_safeguarding_governance_issues, inclusion: {in: [true, false], message: I18n.t("errors.transfer_project.attributes.financial_safeguarding_governance_issues.inclusion")}
 
   validate :urn_unique_for_in_progress_transfers, if: -> { urn.present? }
 
@@ -48,7 +50,10 @@ class Transfer::CreateProjectForm < CreateProjectForm
     ActiveRecord::Base.transaction do
       @project.save
       @note = Note.create(body: handover_note_body, project: @project, user: user, task_identifier: :handover) if handover_note_body
-      @project.tasks_data.update!(inadequate_ofsted: inadequate_ofsted)
+      @project.tasks_data.update!(
+        inadequate_ofsted: inadequate_ofsted,
+        financial_safeguarding_governance_issues: financial_safeguarding_governance_issues
+      )
     end
 
     @project

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -2,10 +2,12 @@ class Transfer::CreateProjectForm < CreateProjectForm
   attr_reader :provisional_transfer_date
 
   attribute :outgoing_trust_sharepoint_link
+  attribute :two_requires_improvement, :boolean
 
   validates :outgoing_trust_ukprn, presence: true, ukprn: true
   validates :provisional_transfer_date, presence: true
   validates :provisional_transfer_date, date_in_the_future: true, first_day_of_month: true
+  validates :two_requires_improvement, inclusion: {in: [true, false], message: I18n.t("errors.transfer_project.attributes.two_requires_improvement.inclusion")}
 
   validate :urn_unique_for_in_progress_transfers, if: -> { urn.present? }
 
@@ -30,6 +32,7 @@ class Transfer::CreateProjectForm < CreateProjectForm
       advisory_board_date: advisory_board_date,
       advisory_board_conditions: advisory_board_conditions,
       transfer_date: provisional_transfer_date,
+      two_requires_improvement: two_requires_improvement,
       regional_delivery_officer_id: user.id,
       team: user.team,
       assigned_to: user,
@@ -58,6 +61,13 @@ class Transfer::CreateProjectForm < CreateProjectForm
 
   def check_incoming_trust_and_outgoing_trust
     errors.add(:incoming_trust_ukprn, I18n.t("errors.attributes.incoming_trust_ukprn.ukprns_must_not_match")) if incoming_trust_ukprn == outgoing_trust_ukprn
+  end
+
+  def two_requires_improvement_responses
+    @two_requires_improvement_responses ||= [
+      OpenStruct.new(id: true, name: I18n.t("yes")),
+      OpenStruct.new(id: false, name: I18n.t("no"))
+    ]
   end
 
   private def outgoing_trust_exists

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -74,13 +74,6 @@ class Transfer::CreateProjectForm < CreateProjectForm
     errors.add(:incoming_trust_ukprn, I18n.t("errors.attributes.incoming_trust_ukprn.ukprns_must_not_match")) if incoming_trust_ukprn == outgoing_trust_ukprn
   end
 
-  def yes_no_responses
-    @yes_no_responses ||= [
-      OpenStruct.new(id: true, name: I18n.t("yes")),
-      OpenStruct.new(id: false, name: I18n.t("no"))
-    ]
-  end
-
   private def outgoing_trust_exists
     result = Api::AcademiesApi::Client.new.get_trust(outgoing_trust_ukprn)
     raise result.error if result.error.present?

--- a/app/views/conversions/projects/new.html.erb
+++ b/app/views/conversions/projects/new.html.erb
@@ -34,7 +34,7 @@
       </div>
 
       <div class="govuk-form-group">
-        <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, @project.assigned_to_regional_caseworker_team_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>
+        <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, @project.yes_no_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>
         <%= form.govuk_text_area :handover_note_body,
               label: {text: t("project.new.handover_comments_label"), size: "m"},
               hint: {text: t("project.new.handover_comments_hint").html_safe} %>
@@ -48,7 +48,7 @@
               legend: {text: t("helpers.legend.conversion_project.directive_academy_order")},
               form_group: {id: "directive-academy-order"} %>
         <%= form.govuk_collection_radio_buttons :two_requires_improvement,
-              @project.two_requires_improvement_responses,
+              @project.yes_no_responses,
               :id,
               :name,
               legend: {text: t("helpers.legend.conversion_project.two_requires_improvement")},

--- a/app/views/transfers/project_information/_information_list.erb
+++ b/app/views/transfers/project_information/_information_list.erb
@@ -2,6 +2,8 @@
 
 <%= render partial: "shared/project_information/project_details", locals: { project: @project } %>
 
+<%= render partial: "project_information/reasons_for_transfer", locals: { project: @project } %>
+
 <%= render partial: "shared/project_information/advisory_board_details", locals: { project: @project } %>
 
 <%= render partial: "academy_details", locals: { academy: @project.establishment, project: @project } %>

--- a/app/views/transfers/project_information/_outgoing_trust_details.html.erb
+++ b/app/views/transfers/project_information/_outgoing_trust_details.html.erb
@@ -32,5 +32,9 @@
           row.with_value { safe_link_to(t("project_information.show.outgoing_trust_details.values.sharepoint_folder"), project.outgoing_trust_sharepoint_link) }
           row.with_action(text: "Change", href: transfers_edit_path(@project), visually_hidden_text: "edit sharepoint folder link")
         end
+        summary_list.with_row do |row|
+          row.with_key { t("project_information.show.outgoing_trust_details.rows.outgoing_trust_to_close") }
+          row.with_value { t("project_information.show.#{@project.tasks_data.outgoing_trust_to_close}") }
+        end
       end %>
 </div>

--- a/app/views/transfers/project_information/_reasons_for_transfer.html.erb
+++ b/app/views/transfers/project_information/_reasons_for_transfer.html.erb
@@ -1,0 +1,9 @@
+<div id="reasonsfor" class="project-information-block">
+  <h3 class="govuk-heading-m"><%= t("project_information.show.reasons_for.transfer.title") %></h3>
+  <%= govuk_summary_list do |summary_list|
+        summary_list.with_row do |row|
+          row.with_key { t("project_information.show.reasons_for.two_requires_improvement.transfer_project.title") }
+          row.with_value { t("project_information.show.reasons_for.two_requires_improvement.#{project.two_requires_improvement}") }
+        end
+      end %>
+</div>

--- a/app/views/transfers/project_information/_reasons_for_transfer.html.erb
+++ b/app/views/transfers/project_information/_reasons_for_transfer.html.erb
@@ -5,5 +5,9 @@
           row.with_key { t("project_information.show.reasons_for.two_requires_improvement.transfer_project.title") }
           row.with_value { t("project_information.show.reasons_for.two_requires_improvement.#{project.two_requires_improvement}") }
         end
+        summary_list.with_row do |row|
+          row.with_key { t("project_information.show.reasons_for.inadequate_ofsted.transfer_project.title") }
+          row.with_value { t("project_information.show.reasons_for.inadequate_ofsted.#{project.tasks_data.inadequate_ofsted}") }
+        end
       end %>
 </div>

--- a/app/views/transfers/project_information/_reasons_for_transfer.html.erb
+++ b/app/views/transfers/project_information/_reasons_for_transfer.html.erb
@@ -3,15 +3,15 @@
   <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.reasons_for.two_requires_improvement.transfer_project.title") }
-          row.with_value { t("project_information.show.reasons_for..#{project.two_requires_improvement}") }
+          row.with_value { t("project_information.show.#{project.two_requires_improvement}") }
         end
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.reasons_for.inadequate_ofsted.transfer_project.title") }
-          row.with_value { t("project_information.show.reasons_for.#{project.tasks_data.inadequate_ofsted}") }
+          row.with_value { t("project_information.show.#{project.tasks_data.inadequate_ofsted}") }
         end
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.reasons_for.financial_safeguarding_governance_issues.transfer_project.title") }
-          row.with_value { t("project_information.show.reasons_for.#{project.tasks_data.financial_safeguarding_governance_issues}") }
+          row.with_value { t("project_information.show.#{project.tasks_data.financial_safeguarding_governance_issues}") }
         end
       end %>
 </div>

--- a/app/views/transfers/project_information/_reasons_for_transfer.html.erb
+++ b/app/views/transfers/project_information/_reasons_for_transfer.html.erb
@@ -3,11 +3,15 @@
   <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.reasons_for.two_requires_improvement.transfer_project.title") }
-          row.with_value { t("project_information.show.reasons_for.two_requires_improvement.#{project.two_requires_improvement}") }
+          row.with_value { t("project_information.show.reasons_for..#{project.two_requires_improvement}") }
         end
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.reasons_for.inadequate_ofsted.transfer_project.title") }
-          row.with_value { t("project_information.show.reasons_for.inadequate_ofsted.#{project.tasks_data.inadequate_ofsted}") }
+          row.with_value { t("project_information.show.reasons_for.#{project.tasks_data.inadequate_ofsted}") }
+        end
+        summary_list.with_row do |row|
+          row.with_key { t("project_information.show.reasons_for.financial_safeguarding_governance_issues.transfer_project.title") }
+          row.with_value { t("project_information.show.reasons_for.#{project.tasks_data.financial_safeguarding_governance_issues}") }
         end
       end %>
 </div>

--- a/app/views/transfers/projects/new.html.erb
+++ b/app/views/transfers/projects/new.html.erb
@@ -48,6 +48,12 @@
               :id,
               :name,
               form_group: {id: "inadequate-ofsted"} %>
+
+        <%= form.govuk_collection_radio_buttons :financial_safeguarding_governance_issues,
+              @project.yes_no_responses,
+              :id,
+              :name,
+              form_group: {id: "financial-safeguarding-governance-issues"} %>
       </div>
 
       <div class="govuk-form-group">

--- a/app/views/transfers/projects/new.html.erb
+++ b/app/views/transfers/projects/new.html.erb
@@ -36,6 +36,15 @@
       </div>
 
       <div class="govuk-form-group">
+        <%= form.govuk_collection_radio_buttons :two_requires_improvement,
+              @project.two_requires_improvement_responses,
+              :id,
+              :name,
+              form_group: {id: "two-requires-improvement"},
+              hint: {text: t("helpers.hint.transfer_project.two_requires_improvement")} %>
+      </div>
+
+      <div class="govuk-form-group">
         <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team,
               @project.assigned_to_regional_caseworker_team_responses,
               :id,

--- a/app/views/transfers/projects/new.html.erb
+++ b/app/views/transfers/projects/new.html.erb
@@ -37,11 +37,17 @@
 
       <div class="govuk-form-group">
         <%= form.govuk_collection_radio_buttons :two_requires_improvement,
-              @project.two_requires_improvement_responses,
+              @project.yes_no_responses,
               :id,
               :name,
               form_group: {id: "two-requires-improvement"},
               hint: {text: t("helpers.hint.transfer_project.two_requires_improvement")} %>
+
+        <%= form.govuk_collection_radio_buttons :inadequate_ofsted,
+              @project.yes_no_responses,
+              :id,
+              :name,
+              form_group: {id: "inadequate-ofsted"} %>
       </div>
 
       <div class="govuk-form-group">

--- a/app/views/transfers/projects/new.html.erb
+++ b/app/views/transfers/projects/new.html.erb
@@ -64,7 +64,7 @@
 
       <div class="govuk-form-group">
         <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team,
-              @project.assigned_to_regional_caseworker_team_responses,
+              @project.yes_no_responses,
               :id,
               :name,
               form_group: {id: "assigned-to-regional-caseworker-team"},

--- a/app/views/transfers/projects/new.html.erb
+++ b/app/views/transfers/projects/new.html.erb
@@ -54,6 +54,12 @@
               :id,
               :name,
               form_group: {id: "financial-safeguarding-governance-issues"} %>
+
+        <%= form.govuk_collection_radio_buttons :outgoing_trust_to_close,
+              @project.yes_no_responses,
+              :id,
+              :name,
+              form_group: {id: "outgoing-trust-to-close"} %>
       </div>
 
       <div class="govuk-form-group">

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -98,3 +98,7 @@ en:
       provisional_conversion_date:
         blank: Enter a month and year for the provisional conversion date, like 9 2023
         must_be_in_the_future: Provisional conversion date must be in the future
+    conversion_project:
+      attributes:
+        two_requires_improvement:
+          inclusion: State if the conversion is due to 2RI. Choose yes or no

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -362,7 +362,7 @@ en:
       directive_academy_order:
         inclusion: Select directive academy order or academy order, whichever has been used for this conversion
       assigned_to_regional_caseworker_team:
-        inclusion: Select yes or no
+        inclusion: State if this project will be handed over to the Regional casework services team. Choose yes or no
       two_requires_improvement:
         inclusion: Select yes or no
       academy_urn:

--- a/config/locales/project_information.en.yml
+++ b/config/locales/project_information.en.yml
@@ -21,6 +21,8 @@ en:
           conversion_project: Conversion
           transfer_project: Transfer
       reasons_for:
+        "true": "Yes"
+        "false": "No"
         conversion:
           title: Reasons for the conversion
         transfer:
@@ -36,13 +38,12 @@ en:
           "false": "No"
           transfer_project:
             title: Is this transfer due to 2RI?
-          "true": "Yes"
-          "false": "No"
         inadequate_ofsted:
           transfer_project:
             title: Is this transfer due to an inadequate Ofsted rating?
-          "true": "Yes"
-          "false": "No"
+        financial_safeguarding_governance_issues:
+          transfer_project:
+            title: Is this transfer due to financial, safeguarding or governance issues?
         nil: Unconfirmed
       advisory_board_details:
         title: Advisory board details

--- a/config/locales/project_information.en.yml
+++ b/config/locales/project_information.en.yml
@@ -1,6 +1,8 @@
 en:
   project_information:
     show:
+      "true": "Yes"
+      "false": "No"
       side_navigation:
         title: Jump to section
       project_details:
@@ -21,8 +23,6 @@ en:
           conversion_project: Conversion
           transfer_project: Transfer
       reasons_for:
-        "true": "Yes"
-        "false": "No"
         conversion:
           title: Reasons for the conversion
         transfer:
@@ -101,6 +101,7 @@ en:
       outgoing_trust_details:
         title: Outgoing trust details
         rows:
+          outgoing_trust_to_close: Will the outgoing trust close once this transfer is completed?
           outgoing_trust_name: Name
           address: Address
           ukprn: UKPRN (UK provider reference number)

--- a/config/locales/project_information.en.yml
+++ b/config/locales/project_information.en.yml
@@ -23,6 +23,8 @@ en:
       reasons_for:
         conversion:
           title: Reasons for the conversion
+        transfer:
+          title: Reasons for the transfer
         directive_academy_order:
           title: Has a directive academy order been issued?
           "true": "Yes"
@@ -30,6 +32,10 @@ en:
         two_requires_improvement:
           conversion_project:
             title: Is this conversion due to intervention following 2RI?
+          "true": "Yes"
+          "false": "No"
+          transfer_project:
+            title: Is this transfer due to 2RI?
           "true": "Yes"
           "false": "No"
       advisory_board_details:

--- a/config/locales/project_information.en.yml
+++ b/config/locales/project_information.en.yml
@@ -38,6 +38,12 @@ en:
             title: Is this transfer due to 2RI?
           "true": "Yes"
           "false": "No"
+        inadequate_ofsted:
+          transfer_project:
+            title: Is this transfer due to an inadequate Ofsted rating?
+          "true": "Yes"
+          "false": "No"
+        nil: Unconfirmed
       advisory_board_details:
         title: Advisory board details
         rows:

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -42,6 +42,7 @@ en:
       transfer_create_project_form:
         two_requires_improvement: Is this a transfer due to 2RI?
         inadequate_ofsted: Is this transfer due to an inadequate Ofsted rating?
+        financial_safeguarding_governance_issues: Is this transfer due to financial, safeguarding or governance issues?
     hint:
       transfer_project:
         urn:
@@ -84,3 +85,5 @@ en:
           inclusion: State if the transfer is due to 2RI. Choose yes or no
         inadequate_ofsted:
           inclusion: State if the transfer is due to an inadequate Ofsted rating. Choose yes or no
+        financial_safeguarding_governance_issues:
+          inclusion: State if the transfer is due to financial, safeguarding or governance issues. Choose yes or no

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -43,6 +43,7 @@ en:
         two_requires_improvement: Is this a transfer due to 2RI?
         inadequate_ofsted: Is this transfer due to an inadequate Ofsted rating?
         financial_safeguarding_governance_issues: Is this transfer due to financial, safeguarding or governance issues?
+        outgoing_trust_to_close: Will the outgoing trust close once this transfer is completed?
     hint:
       transfer_project:
         urn:
@@ -87,3 +88,5 @@ en:
           inclusion: State if the transfer is due to an inadequate Ofsted rating. Choose yes or no
         financial_safeguarding_governance_issues:
           inclusion: State if the transfer is due to financial, safeguarding or governance issues. Choose yes or no
+        outgoing_trust_to_close:
+          inclusion: State if the outgoing trust will close once this transfer is completed. Choose yes or no

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -39,6 +39,8 @@ en:
         advisory_board_date: Date of advisory board
         provisional_transfer_date: Provisional transfer date
         assigned_to_regional_caseworker_team: Are you handing this project over to Regional Casework Services?
+      transfer_create_project_form:
+        two_requires_improvement: Is this a transfer due to 2RI?
     hint:
       transfer_project:
         urn:
@@ -63,6 +65,7 @@ en:
             <li>who the Schools Financial Support and Oversight lead is</li>
             <li>any finanical package that has been finalised and agreed</li>
           </ul>
+        two_requires_improvement: If an academy receives 2 or more requires improvement ratings (2RI) from Ofsted, it can be transferred to a different trust to improve performance.
   errors:
     attributes:
       provisional_transfer_date:
@@ -73,3 +76,9 @@ en:
         invalid: Enter a outgoing trust SharePoint link in the correct format
         https_only: The outgoing trust SharePoint link must have the https scheme
         host_not_allowed: Enter an outgoing trust sharepoint link in the correct format. SharePoint links start with 'https://educationgovuk.sharepoint.com' or 'https://educationgovuk-my.sharepoint.com/'
+    transfer_project:
+      attributes:
+        two_requires_improvement:
+          inclusion: State if the transfer is due to 2RI. Choose yes or no
+        inadequate_ofsted:
+          inclusion: State if the transfer is due to an inadequate Ofsted rating. Choose yes or no

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -41,6 +41,7 @@ en:
         assigned_to_regional_caseworker_team: Are you handing this project over to Regional Casework Services?
       transfer_create_project_form:
         two_requires_improvement: Is this a transfer due to 2RI?
+        inadequate_ofsted: Is this transfer due to an inadequate Ofsted rating?
     hint:
       transfer_project:
         urn:

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -71,6 +71,7 @@ en:
       provisional_transfer_date:
         blank: Enter a month and year for the provisional transfer date, like 9 2023
         must_be_in_the_future: Provisional transfer date must be in the future
+        invalid: Enter a month and year for the provisional transfer date, like 9 2023
       outgoing_trust_sharepoint_link:
         blank: Enter an outgoing trust SharePoint link
         invalid: Enter a outgoing trust SharePoint link in the correct format

--- a/db/migrate/20231114112915_add_attibutes_for_transfer_reason.rb
+++ b/db/migrate/20231114112915_add_attibutes_for_transfer_reason.rb
@@ -2,6 +2,6 @@ class AddAttibutesForTransferReason < ActiveRecord::Migration[7.0]
   def change
     add_column :transfer_tasks_data, :inadequate_ofsted, :boolean, default: false
     add_column :transfer_tasks_data, :financial_safeguarding_governance_issues, :boolean, default: false
-    add_column :transfer_tasks_data, :trust_to_close, :boolean, default: false
+    add_column :transfer_tasks_data, :outgoing_trust_to_close, :boolean, default: false
   end
 end

--- a/db/migrate/20231114112915_add_attibutes_for_transfer_reason.rb
+++ b/db/migrate/20231114112915_add_attibutes_for_transfer_reason.rb
@@ -1,0 +1,7 @@
+class AddAttibutesForTransferReason < ActiveRecord::Migration[7.0]
+  def change
+    add_column :transfer_tasks_data, :inadequate_ofsted, :boolean, default: false
+    add_column :transfer_tasks_data, :financial_safeguarding_governance_issues, :boolean, default: false
+    add_column :transfer_tasks_data, :trust_to_close, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_08_110923) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_14_112915) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -379,6 +379,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_08_110923) do
     t.boolean "request_new_urn_and_record_complete"
     t.boolean "request_new_urn_and_record_receive"
     t.boolean "request_new_urn_and_record_give"
+    t.boolean "inadequate_ofsted", default: false
+    t.boolean "financial_safeguarding_governance_issues", default: false
+    t.boolean "trust_to_close", default: false
   end
 
   create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -363,13 +363,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_112915) do
     t.boolean "deed_termination_church_agreement_signed_secretary_state"
     t.boolean "deed_termination_church_agreement_saved_after_signing_by_secretary_state"
     t.boolean "deed_termination_church_agreement_not_applicable"
+    t.boolean "confirm_incoming_trust_has_completed_all_actions_emailed"
+    t.boolean "confirm_incoming_trust_has_completed_all_actions_saved"
     t.boolean "closure_or_transfer_declaration_not_applicable"
     t.boolean "closure_or_transfer_declaration_received"
     t.boolean "closure_or_transfer_declaration_cleared"
     t.boolean "closure_or_transfer_declaration_saved"
     t.boolean "closure_or_transfer_declaration_sent"
-    t.boolean "confirm_incoming_trust_has_completed_all_actions_emailed"
-    t.boolean "confirm_incoming_trust_has_completed_all_actions_saved"
     t.boolean "redact_and_send_documents_send_to_esfa"
     t.boolean "redact_and_send_documents_redact"
     t.boolean "redact_and_send_documents_saved"
@@ -381,7 +381,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_112915) do
     t.boolean "request_new_urn_and_record_give"
     t.boolean "inadequate_ofsted", default: false
     t.boolean "financial_safeguarding_governance_issues", default: false
-    t.boolean "trust_to_close", default: false
+    t.boolean "outgoing_trust_to_close", default: false
   end
 
   create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/factories/transfer/create_project_form_factory.rb
+++ b/spec/factories/transfer/create_project_form_factory.rb
@@ -12,5 +12,6 @@ FactoryBot.define do
     handover_note_body { "This is a handover note." }
     two_requires_improvement { false }
     inadequate_ofsted { false }
+    financial_safeguarding_governance_issues { false }
   end
 end

--- a/spec/factories/transfer/create_project_form_factory.rb
+++ b/spec/factories/transfer/create_project_form_factory.rb
@@ -11,5 +11,6 @@ FactoryBot.define do
     user { association :user, :regional_delivery_officer }
     handover_note_body { "This is a handover note." }
     two_requires_improvement { false }
+    inadequate_ofsted { false }
   end
 end

--- a/spec/factories/transfer/create_project_form_factory.rb
+++ b/spec/factories/transfer/create_project_form_factory.rb
@@ -13,5 +13,6 @@ FactoryBot.define do
     two_requires_improvement { false }
     inadequate_ofsted { false }
     financial_safeguarding_governance_issues { false }
+    outgoing_trust_to_close { false }
   end
 end

--- a/spec/factories/transfer/create_project_form_factory.rb
+++ b/spec/factories/transfer/create_project_form_factory.rb
@@ -14,5 +14,6 @@ FactoryBot.define do
     inadequate_ofsted { false }
     financial_safeguarding_governance_issues { false }
     outgoing_trust_to_close { false }
+    assigned_to_regional_caseworker_team { false }
   end
 end

--- a/spec/factories/transfer/create_project_form_factory.rb
+++ b/spec/factories/transfer/create_project_form_factory.rb
@@ -10,5 +10,6 @@ FactoryBot.define do
     outgoing_trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/outgoing-trust-folder" }
     user { association :user, :regional_delivery_officer }
     handover_note_body { "This is a handover note." }
+    two_requires_improvement { false }
   end
 end

--- a/spec/factories/transfer/project_factory.rb
+++ b/spec/factories/transfer/project_factory.rb
@@ -14,5 +14,6 @@ FactoryBot.define do
     regional_delivery_officer { association :user, :regional_delivery_officer }
     tasks_data { association :transfer_tasks_data }
     outgoing_trust_ukprn { 10059062 }
+    two_requires_improvement { false }
   end
 end

--- a/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
+++ b/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
@@ -72,5 +72,9 @@ RSpec.feature "Users can create new conversion projects" do
       fill_in "Month", with: two_months_time.month
       fill_in "Year", with: two_months_time.year
     end
+
+    within "#assigned-to-regional-caseworker-team" do
+      choose "No"
+    end
   end
 end

--- a/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
+++ b/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
@@ -50,6 +50,10 @@ RSpec.feature "Users can create new conversion projects" do
       fill_in "Year", with: two_weeks_ago.year
     end
 
+    within("#two-requires-improvement") do
+      choose "No"
+    end
+
     fill_in "Handover comments", with: "This is a handover note."
 
     within("#provisional-transfer-date") do

--- a/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
+++ b/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
@@ -62,6 +62,10 @@ RSpec.feature "Users can create new conversion projects" do
       choose "No"
     end
 
+    within("#outgoing-trust-to-close") do
+      choose "No"
+    end
+
     fill_in "Handover comments", with: "This is a handover note."
 
     within("#provisional-transfer-date") do

--- a/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
+++ b/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
@@ -58,6 +58,10 @@ RSpec.feature "Users can create new conversion projects" do
       choose "No"
     end
 
+    within("#financial-safeguarding-governance-issues") do
+      choose "No"
+    end
+
     fill_in "Handover comments", with: "This is a handover note."
 
     within("#provisional-transfer-date") do

--- a/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
+++ b/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
@@ -54,6 +54,10 @@ RSpec.feature "Users can create new conversion projects" do
       choose "No"
     end
 
+    within("#inadequate-ofsted") do
+      choose "No"
+    end
+
     fill_in "Handover comments", with: "This is a handover note."
 
     within("#provisional-transfer-date") do

--- a/spec/features/transfers/users_can_view_a_transfer_spec.rb
+++ b/spec/features/transfers/users_can_view_a_transfer_spec.rb
@@ -41,6 +41,7 @@ RSpec.feature "Users can view a transfer" do
 
     expect(page).to have_content(transfer_project.urn)
     expect(page).to have_content("Project details")
+    expect(page).to have_content("Reasons for the transfer")
     expect(page).to have_content("Advisory board details")
     expect(page).to have_content("Academy details")
     expect(page).to have_content("Incoming trust details")

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -290,6 +290,18 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
         end
       end
     end
+
+    describe "two requires improvement" do
+      it "cannot be empty" do
+        form = build(
+          form_factory.to_sym,
+          two_requires_improvement: ""
+        )
+
+        expect(form).to be_invalid
+        expect(form.errors[:two_requires_improvement]).to include("State if the conversion is due to 2RI. Choose yes or no")
+      end
+    end
   end
 
   describe "urn" do

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -101,6 +101,14 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
         expect(form.errors.messages[:incoming_trust_ukprn]).to include I18n.t("errors.attributes.incoming_trust_ukprn.ukprns_must_not_match")
       end
     end
+
+    describe "inadequate Ofsted" do
+      it "cannot be blank" do
+        form = build(:create_transfer_project_form, inadequate_ofsted: "")
+
+        expect(form).to be_invalid
+      end
+    end
   end
 
   describe "urn" do
@@ -260,6 +268,14 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
         expect(Note.count).to eq(1)
         expect(Note.last.body).to eq("This is the handover note.")
         expect(Note.last.task_identifier).to eq("handover")
+      end
+
+      it "updates the tasks data with the other values" do
+        form = build(:create_transfer_project_form, inadequate_ofsted: true)
+        form.save
+
+        expect(Transfer::TasksData.count).to be 1
+        expect(Transfer::TasksData.first.inadequate_ofsted).to be true
       end
     end
 

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -109,6 +109,14 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
         expect(form).to be_invalid
       end
     end
+
+    describe "financial, safeguarding or governance issues" do
+      it "cannot be blank" do
+        form = build(:create_transfer_project_form, financial_safeguarding_governance_issues: "")
+
+        expect(form).to be_invalid
+      end
+    end
   end
 
   describe "urn" do
@@ -271,11 +279,15 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
       end
 
       it "updates the tasks data with the other values" do
-        form = build(:create_transfer_project_form, inadequate_ofsted: true)
+        form = build(
+          :create_transfer_project_form, inadequate_ofsted: true,
+          financial_safeguarding_governance_issues: true
+        )
         form.save
 
         expect(Transfer::TasksData.count).to be 1
         expect(Transfer::TasksData.first.inadequate_ofsted).to be true
+        expect(Transfer::TasksData.first.financial_safeguarding_governance_issues).to be true
       end
     end
 

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -184,6 +184,14 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
     end
   end
 
+  describe "two requires improvement" do
+    it "cannot be blank" do
+      form = build(:create_transfer_project_form, two_requires_improvement: "")
+
+      expect(form).to be_invalid
+    end
+  end
+
   describe "region" do
     it "sets the region code from the establishment" do
       project = build(:create_transfer_project_form).save

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -117,6 +117,14 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
         expect(form).to be_invalid
       end
     end
+
+    describe "Outgoing trust to close" do
+      it "cannot be blank" do
+        form = build(:create_transfer_project_form, outgoing_trust_to_close: "")
+
+        expect(form).to be_invalid
+      end
+    end
   end
 
   describe "urn" do
@@ -281,13 +289,15 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
       it "updates the tasks data with the other values" do
         form = build(
           :create_transfer_project_form, inadequate_ofsted: true,
-          financial_safeguarding_governance_issues: true
+          financial_safeguarding_governance_issues: true,
+          outgoing_trust_to_close: true
         )
         form.save
 
         expect(Transfer::TasksData.count).to be 1
         expect(Transfer::TasksData.first.inadequate_ofsted).to be true
         expect(Transfer::TasksData.first.financial_safeguarding_governance_issues).to be true
+        expect(Transfer::TasksData.first.outgoing_trust_to_close).to be true
       end
     end
 

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -44,14 +44,6 @@ RSpec.describe Conversion::Project do
       it { is_expected.to allow_value(true).for(:two_requires_improvement) }
       it { is_expected.to allow_value(false).for(:two_requires_improvement) }
       it { is_expected.to_not allow_value(nil).for(:two_requires_improvement) }
-
-      context "error messages" do
-        it "adds an appropriate error message if the value is nil" do
-          subject.assign_attributes(two_requires_improvement: nil)
-          subject.valid?
-          expect(subject.errors[:two_requires_improvement]).to include("Select yes or no")
-        end
-      end
     end
   end
 


### PR DESCRIPTION
Transfer projects are initiated for a bunch of different reasons that we need to capture and either resruface or use to make decisions within the business logic of the application.

Our first step is to collect the values and store them when creating a new transfer project.

Whilst it is likely some of this information is or should be captured earlier in the service, we are not yet in a position to fetch it, leaving this only best option right now.

The 'result of 2RI' reason already exists on a conversion project, so we reuse that.

The others are all new and since they only relate to a transfer, we decided to store the values on the transfer specific `tasks_data` as this is the intention for that table.

We expose each value on the 'About the project' tab as a first step.

This work does leave us with some transfer projects in production where the values are `nil` and will need to be resolved in some way - that is no in the scope of this work.

[User Story 146600](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/146600): Users can supply the required values when adding a new transfer project