### PR TITLE
Users are not directed to update KIM in 'Receive grant payment certificate' task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - transfer projects now collect if the outgoing trust is expected to close once
   the transfer is completed and this is shown on the about the project tab
 
+### Changed
+
+- Users are not directed to update KIM for the 'Receive grant payment
+  certificate' task
+
 ## [Release-46][release-46]
 
 ### Added

--- a/app/forms/conversion/task/receive_grant_payment_certificate_task_form.rb
+++ b/app/forms/conversion/task/receive_grant_payment_certificate_task_form.rb
@@ -1,4 +1,3 @@
 class Conversion::Task::ReceiveGrantPaymentCertificateTaskForm < BaseTaskForm
   attribute :check_and_save, :boolean
-  attribute :update_kim, :boolean
 end

--- a/app/views/conversions/tasks/receive_grant_payment_certificate/edit.html.erb
+++ b/app/views/conversions/tasks/receive_grant_payment_certificate/edit.html.erb
@@ -15,7 +15,6 @@
 
       <div class="govuk-form-group">
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :check_and_save)) %>
-        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :update_kim)) %>
       </div>
 
       <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>

--- a/config/locales/conversion/tasks/receive_grant_payment_certificate.en.yml
+++ b/config/locales/conversion/tasks/receive_grant_payment_certificate.en.yml
@@ -14,8 +14,3 @@ en:
           guidance:
             html:
               <p>You should ask the school to send the certificate. You must record the date each time you contact them in <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&amp;file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&amp;action=default&amp;mobileredirect=true" target="_blank">the support grant assurance report (opens in new tab)</a>.</p>
-
-        update_kim:
-          title: Update KIM with date certificate is received
-          hint:
-            html: <p>Find this information in the ESFA handover section in KIM.</p>

--- a/db/migrate/20231116110013_remove_update_kim_action_from_receive_grant_payment_task.rb
+++ b/db/migrate/20231116110013_remove_update_kim_action_from_receive_grant_payment_task.rb
@@ -1,0 +1,5 @@
+class RemoveUpdateKimActionFromReceiveGrantPaymentTask < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :conversion_tasks_data, :receive_grant_payment_certificate_update_kim, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_14_112915) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_16_110013) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -97,7 +97,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_112915) do
     t.boolean "redact_and_send_send_redaction"
     t.boolean "update_esfa_update"
     t.boolean "receive_grant_payment_certificate_check_and_save"
-    t.boolean "receive_grant_payment_certificate_update_kim"
     t.boolean "one_hundred_and_twenty_five_year_lease_email"
     t.boolean "one_hundred_and_twenty_five_year_lease_receive"
     t.boolean "one_hundred_and_twenty_five_year_lease_save_lease"

--- a/spec/accessibility/projects_spec.rb
+++ b/spec/accessibility/projects_spec.rb
@@ -33,9 +33,7 @@ RSpec.feature "Test projects accessibility", driver: :headless_firefox, accessib
   end
 
   scenario "project completed page" do
-    tasks_data = create(:conversion_tasks_data,
-      receive_grant_payment_certificate_check_and_save: true,
-      receive_grant_payment_certificate_update_kim: true)
+    tasks_data = create(:conversion_tasks_data, receive_grant_payment_certificate_check_and_save: true)
     project = create(:conversion_project,
       regional_delivery_officer: user,
       assigned_to: user,

--- a/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
+++ b/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
@@ -10,9 +10,7 @@ RSpec.feature "Users can complete a conversion project" do
 
   context "when all conditions have been met and the academy has opened" do
     let(:tasks_data) {
-      create(:conversion_tasks_data,
-        receive_grant_payment_certificate_check_and_save: true,
-        receive_grant_payment_certificate_update_kim: true)
+      create(:conversion_tasks_data, receive_grant_payment_certificate_check_and_save: true)
     }
     let(:project) {
       create(:conversion_project,

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -108,9 +108,7 @@ RSpec.describe Conversion::Project do
 
     context "when the ReceiveGrantPaymentCertificateTaskForm is NOT completed" do
       let(:tasks_data) {
-        create(:conversion_tasks_data,
-          receive_grant_payment_certificate_check_and_save: nil,
-          receive_grant_payment_certificate_update_kim: nil)
+        create(:conversion_tasks_data, receive_grant_payment_certificate_check_and_save: nil)
       }
 
       it "returns false" do
@@ -120,9 +118,7 @@ RSpec.describe Conversion::Project do
 
     context "when the ReceiveGrantPaymentCertificateTaskForm is completed" do
       let(:tasks_data) {
-        create(:conversion_tasks_data,
-          receive_grant_payment_certificate_check_and_save: true,
-          receive_grant_payment_certificate_update_kim: true)
+        create(:conversion_tasks_data, receive_grant_payment_certificate_check_and_save: true)
       }
 
       it "returns true" do


### PR DESCRIPTION
## Changes

We are gradually removing any need for or mention of KIM in our applications, so remove this action in the Receive Grant Payment Certificate task as we do not want to encourage people to still use KIM.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
