### PR TITLE
Add proposed capacity of the academy task to Conversion projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add a page to allow Grant management and finance unit members to download
   conversion projects by their Advisory board dates. This page is not currently
   linked in the application.
+- Add proposed capacity of the academy task to Conversion projects
 
 ### Changed
 

--- a/app/forms/conversion/task/proposed_capacity_of_the_academy_task_form.rb
+++ b/app/forms/conversion/task/proposed_capacity_of_the_academy_task_form.rb
@@ -1,0 +1,9 @@
+class Conversion::Task::ProposedCapacityOfTheAcademyTaskForm < BaseOptionalTaskForm
+  attribute :reception_to_six_years, :string
+  attribute :seven_to_eleven_years, :string
+  attribute :twelve_or_above_years, :string
+
+  validates :reception_to_six_years, presence: true, numericality: {only_numeric: true}, unless: :not_applicable?
+  validates :seven_to_eleven_years, presence: true, numericality: {only_numeric: true}, unless: :not_applicable?
+  validates :twelve_or_above_years, presence: true, numericality: {only_numeric: true}, unless: :not_applicable?
+end

--- a/app/models/conversion/task_list.rb
+++ b/app/models/conversion/task_list.rb
@@ -11,7 +11,8 @@ class Conversion::TaskList < ::BaseTaskList
           Conversion::Task::ConversionGrantTaskForm,
           Conversion::Task::SponsoredSupportGrantTaskForm,
           Conversion::Task::AcademyDetailsTaskForm,
-          Conversion::Task::MainContactTaskForm
+          Conversion::Task::MainContactTaskForm,
+          Conversion::Task::ProposedCapacityOfTheAcademyTaskForm
         ]
       },
       {

--- a/app/views/conversions/tasks/proposed_capacity_of_the_academy/edit.html.erb
+++ b/app/views/conversions/tasks/proposed_capacity_of_the_academy/edit.html.erb
@@ -1,0 +1,43 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.proposed_capacity_of_the_academy.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
+      <div class="govuk-form-group">
+        <h2 class="govuk-heading-l"><%= t("conversion.task.proposed_capacity_of_the_academy.text_field_section.title") %></h2>
+        <div class="app-task-section__hint">
+          <%= t("conversion.task.proposed_capacity_of_the_academy.text_field_section.hint.html") %>
+        </div>
+
+        <%= govuk_details(
+              summary_text: t("conversion.task.proposed_capacity_of_the_academy.text_field_section.guidance_link"),
+              text: t("conversion.task.proposed_capacity_of_the_academy.text_field_section.guidance.html")
+            ) %>
+
+        <%= form.govuk_text_field :reception_to_six_years, label: {text: t("conversion.task.proposed_capacity_of_the_academy.reception_to_six_years.title.html")}, hint: {text: t("conversion.task.proposed_capacity_of_the_academy.text_field.hint.html")}, class: "govuk-input govuk-!-width-one-quarter", inputmode: "numeric" %>
+        <%= form.govuk_text_field :seven_to_eleven_years, label: {text: t("conversion.task.proposed_capacity_of_the_academy.seven_to_eleven_years.title.html")}, hint: {text: t("conversion.task.proposed_capacity_of_the_academy.text_field.hint.html")}, class: "govuk-input govuk-!-width-one-quarter", inputmode: "numeric" %>
+        <%= form.govuk_text_field :twelve_or_above_years, label: {text: t("conversion.task.proposed_capacity_of_the_academy.twelve_or_above_years.title.html")}, hint: {text: t("conversion.task.proposed_capacity_of_the_academy.text_field.hint.html")}, class: "govuk-input govuk-!-width-one-quarter", inputmode: "numeric" %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/config/locales/conversion/tasks/proposed_capacity_of_the_academy.en.yml
+++ b/config/locales/conversion/tasks/proposed_capacity_of_the_academy.en.yml
@@ -1,0 +1,56 @@
+en:
+  conversion:
+    task:
+      proposed_capacity_of_the_academy:
+        title: Confirm the proposed capacity of the academy
+        hint:
+          html:
+            <p>You only need to complete this task if the new academy will get the full sponsored grant.</p>
+            <p>Give the maximum number of pupils the new academy will be able to teach.</p>
+        guidance_link: Why pupil capacity is needed
+        guidance:
+          html:
+            <p>Pupil capacity numbers enable the ESFA (Education and Skills Funding Agency) to calculate how much SUG (start-up grant) funding is needed in the GAG (general annual grant) payment the new academy will receive.</p>
+        not_applicable:
+          title: Not applicable
+        text_field_section:
+          title: Proposed capacity of the academy
+          hint:
+            html:
+              <p>Ask the school to confirm what the proposed pupil capacity of the new academy will be on the day it opens.</p>
+              <p>The amount of funding the academy gets depends on the amount of pupils and students it can teach in each age group.</p>
+          guidance_link: Help confirming the academy's proposed capacity
+          guidance:
+            html:
+              <p>The proposed capacity is the maximum number of pupils and students the academy can teach.</p>
+              <p>The capacity should show the maximum number of pupils and students in primary, secondary and further education. </p>
+              <p>It is broken down into 3 categories:</p>
+              <ul>
+                <li>reception to year 6, also known as the "primary" age range or school phase</li>
+                <li>years 7 to year 11, also known as the "secondary" age range or school phase</li>
+                <li>years 12 and above, also known as "post-16" age range or school phase</li>
+              </ul>
+              <p>If you need help with the proposed capacity, email <a href="mailto:academy.openers@education.gov.uk" class="govuk-link" target="_blank">academy.openers@education.gov.uk</a>.</p>
+        text_field:
+          hint:
+            html: <p>Enter 0 if the academy will not teach pupils in this age group.</p>
+        reception_to_six_years:
+          title:
+            html: <strong>What is the proposed capacity for pupils in reception to year 6?</strong>
+        seven_to_eleven_years:
+          title:
+            html: <strong>What is the proposed capacity for pupils in years 7 to 11?</strong>
+        twelve_or_above_years:
+          title:
+            html: <strong>What is the proposed capacity for students in year 12 or above?</strong>
+  errors:
+    attributes:
+      reception_to_six_years:
+        not_a_number: Proposed capacity must be a number, like 345
+        blank: Enter the proposed capacity for pupils in reception to year 6
+      seven_to_eleven_years:
+        not_a_number: Proposed capacity must be a number, like 345
+        blank: Enter the proposed capacity for pupils in years 7 to 11
+      twelve_or_above_years:
+        not_a_number: Proposed capacity must be a number, like 345
+        blank: Enter the proposed capacity for students in year 12 or above

--- a/db/migrate/20231122162528_add_proposed_capacity_of_the_academy_task.rb
+++ b/db/migrate/20231122162528_add_proposed_capacity_of_the_academy_task.rb
@@ -1,0 +1,8 @@
+class AddProposedCapacityOfTheAcademyTask < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_tasks_data, :proposed_capacity_of_the_academy_not_applicable, :boolean
+    add_column :conversion_tasks_data, :proposed_capacity_of_the_academy_reception_to_six_years, :string
+    add_column :conversion_tasks_data, :proposed_capacity_of_the_academy_seven_to_eleven_years, :string
+    add_column :conversion_tasks_data, :proposed_capacity_of_the_academy_twelve_or_above_years, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_16_110013) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_22_162528) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -142,6 +142,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_16_110013) do
     t.boolean "complete_notification_of_change_check_document"
     t.boolean "complete_notification_of_change_send_document"
     t.string "sponsored_support_grant_type"
+    t.boolean "proposed_capacity_of_the_academy_not_applicable"
+    t.string "proposed_capacity_of_the_academy_reception_to_six_years"
+    t.string "proposed_capacity_of_the_academy_seven_to_eleven_years"
+    t.string "proposed_capacity_of_the_academy_twelve_or_above_years"
   end
 
   create_table "events", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -31,6 +31,7 @@ RSpec.feature "Users can complete conversion tasks" do
     sponsored_support_grant
     conditions_met
     main_contact
+    proposed_capacity_of_the_academy
   ]
 
   it "confirms we are checking all tasks" do

--- a/spec/models/conversion/task_list_spec.rb
+++ b/spec/models/conversion/task_list_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Conversion::TaskList do
         :sponsored_support_grant,
         :academy_details,
         :main_contact,
+        :proposed_capacity_of_the_academy,
         :land_questionnaire,
         :land_registry,
         :supplemental_funding_agreement,
@@ -55,7 +56,8 @@ RSpec.describe Conversion::TaskList do
               Conversion::Task::ConversionGrantTaskForm,
               Conversion::Task::SponsoredSupportGrantTaskForm,
               Conversion::Task::AcademyDetailsTaskForm,
-              Conversion::Task::MainContactTaskForm
+              Conversion::Task::MainContactTaskForm,
+              Conversion::Task::ProposedCapacityOfTheAcademyTaskForm
             ]
           },
           {
@@ -116,7 +118,7 @@ RSpec.describe Conversion::TaskList do
       project = create(:conversion_project)
       task_list = described_class.new(project, user)
 
-      expect(task_list.tasks.count).to eql 29
+      expect(task_list.tasks.count).to eql 30
       expect(task_list.tasks.first).to be_a Conversion::Task::HandoverTaskForm
       expect(task_list.tasks.last).to be_a Conversion::Task::ReceiveGrantPaymentCertificateTaskForm
     end


### PR DESCRIPTION
## Changes

This work adds in a new Conversion task, Proposed capacity of the academy, which has some customised validations for the text fields. 
If the `Not applicable` checkbox is not selected, then each text field is required to be filled with either the proposed capacity for that age group or with a `0`

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
