### PR TITLE
Add "Bank details changing" task to Transfer projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   conversion projects by their Advisory board dates. This page is not currently
   linked in the application.
 - Add proposed capacity of the academy task to Conversion projects
+- Add "Confirm if the bank details for the general annual grant payment to need
+  to change" task to Transfer projects
 
 ### Changed
 

--- a/app/forms/transfer/task/bank_details_changing_task_form.rb
+++ b/app/forms/transfer/task/bank_details_changing_task_form.rb
@@ -1,0 +1,3 @@
+class Transfer::Task::BankDetailsChangingTaskForm < BaseTaskForm
+  attribute :yes_no, :boolean
+end

--- a/app/models/transfer/task_list.rb
+++ b/app/models/transfer/task_list.rb
@@ -31,6 +31,7 @@ class Transfer::TaskList < ::BaseTaskList
         identifier: :get_ready_for_opening,
         tasks: [
           Transfer::Task::RpaPolicyTaskForm,
+          Transfer::Task::BankDetailsChangingTaskForm,
           Transfer::Task::ConfirmIncomingTrustHasCompletedAllActionsTaskForm,
           Transfer::Task::ConditionsMetTaskForm
         ]

--- a/app/views/transfers/tasks/bank_details_changing/edit.html.erb
+++ b/app/views/transfers/tasks/bank_details_changing/edit.html.erb
@@ -1,0 +1,30 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.bank_details_changing.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_radio_buttons_fieldset(:yes_no, legend: {size: "m", text: t("transfer.task.bank_details_changing.subtitle")}) do %>
+        <%= form.govuk_radio_button :yes_no, "true", label: {text: t("yes")} do %>
+          <%= t("transfer.task.bank_details_changing.yesno.hint.html") %>
+        <% end %>
+        <%= form.govuk_radio_button :yes_no, "false", label: {text: t("no")} %>
+      <% end %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/config/locales/transfer/tasks/bank_details_changing.en.yml
+++ b/config/locales/transfer/tasks/bank_details_changing.en.yml
@@ -1,0 +1,21 @@
+en:
+  transfer:
+    task:
+      bank_details_changing:
+        title: Confirm if the bank details for the general annual grant payment need to change
+        subtitle: Do the bank details need to be updated?
+        hint:
+          html:
+            <p>Bank details must be updated if the:</p>
+            <ul>
+            <li>outgoing trust currently receives the general annual grant</li>
+            <li>incoming trust or academy want to change their bank details</li>
+            <li>neither the incoming trust nor the academy have a vendor account</li>
+            </ul>
+        yesno:
+          hint:
+            html:
+              <p>Tell the academy or incoming trust to <a href="https://form.education.gov.uk/service/Provide-information-about-your-banking-and-payments-to-DfE" target="_blank">complete the Provide information about your banking and payments to DfE form (opens in new tab)</a>. Ask them to tell you when they have submitted this form.</p>
+              <p>This must contain the bank details of the organisation that will receive the general annual grant once the academy transfers to the incoming trust.</p>
+              <p>If this is not completed the general annual grant might get sent to the outgoing trust.</p>
+              <p>The organisation receiving the general annual grant payment must have a vendor account. You can <a href="https://educationgovuk.sharepoint.com/sites/lvedfe00083/SitePages/Set-up-and-mainta.aspx" target="_blank">check if they have a vendor account (opens in new tab)</a> on SharePoint.</p>

--- a/db/migrate/20231128152937_add_transfer_bank_details_changing_task_attributes.rb
+++ b/db/migrate/20231128152937_add_transfer_bank_details_changing_task_attributes.rb
@@ -1,0 +1,5 @@
+class AddTransferBankDetailsChangingTaskAttributes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :transfer_tasks_data, :bank_details_changing_yes_no, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_22_162528) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_28_152937) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -385,6 +385,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_22_162528) do
     t.boolean "inadequate_ofsted", default: false
     t.boolean "financial_safeguarding_governance_issues", default: false
     t.boolean "outgoing_trust_to_close", default: false
+    t.boolean "bank_details_changing_yes_no", default: false
   end
 
   create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
+++ b/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
@@ -37,6 +37,7 @@ RSpec.feature "Users can complete transfer tasks" do
     stakeholder_kick_off
     conditions_met
     main_contact
+    bank_details_changing
   ]
 
   it "confirms that all tasks are tested here" do

--- a/spec/models/transfer/task_list_spec.rb
+++ b/spec/models/transfer/task_list_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Transfer::TaskList do
         :commercial_transfer_agreement,
         :closure_or_transfer_declaration,
         :rpa_policy,
+        :bank_details_changing,
         :confirm_incoming_trust_has_completed_all_actions,
         :conditions_met,
         :redact_and_send_documents
@@ -48,7 +49,7 @@ RSpec.describe Transfer::TaskList do
       project = create(:transfer_project)
       task_list = described_class.new(project, user)
 
-      expect(task_list.tasks.count).to eql 20
+      expect(task_list.tasks.count).to eql 21
       expect(task_list.tasks.first).to be_a Transfer::Task::HandoverTaskForm
       expect(task_list.tasks.last).to be_a Transfer::Task::RedactAndSendDocumentsTaskForm
     end


### PR DESCRIPTION
## Changes

This task indicates in the bank details for an establishment are changing on transfer.

<img width="943" alt="Screenshot 2023-11-28 at 15 56 17" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/db373b08-86d5-4124-a93e-89d9844720ca">

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
