### PR TITLE
Users can access the proposed academy capacity numbers in the esfa data export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add proposed capacity of the academy task to Conversion projects
 - Add "Confirm if the bank details for the general annual grant payment to need
   to change" task to Transfer projects
+- Add proposed capacity of the academy to the csv export service
 
 ### Changed
 

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -10,6 +10,21 @@ class Export::Csv::ProjectPresenter
     @project = project
   end
 
+  def reception_to_six_years
+    return "Not applicable" if @project.tasks_data.proposed_capacity_of_the_academy_not_applicable
+    @project.tasks_data.proposed_capacity_of_the_academy_reception_to_six_years
+  end
+
+  def seven_to_eleven_years
+    return "Not applicable" if @project.tasks_data.proposed_capacity_of_the_academy_not_applicable
+    @project.tasks_data.proposed_capacity_of_the_academy_seven_to_eleven_years
+  end
+
+  def twelve_or_above_years
+    return "Not applicable" if @project.tasks_data.proposed_capacity_of_the_academy_not_applicable
+    @project.tasks_data.proposed_capacity_of_the_academy_twelve_or_above_years
+  end
+
   def project_type
     return I18n.t("export.csv.project.values.project_type.conversion") if @project.is_a?(Conversion::Project)
     I18n.t("export.csv.project.values.project_type.transfer") if @project.is_a?(Transfer::Project)

--- a/app/services/export/education_and_skills_funding_agency_csv_export_service.rb
+++ b/app/services/export/education_and_skills_funding_agency_csv_export_service.rb
@@ -6,6 +6,9 @@ class Export::EducationAndSkillsFundingAgencyCsvExportService
     school_name
     academy_urn
     academy_name
+    reception_to_six_years
+    seven_to_eleven_years
+    twelve_or_above_years
     incoming_trust_identifier
     incoming_trust_companies_house_number
     incoming_trust_name

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -9,6 +9,9 @@ en:
           risk_protection_arrangement: Risk protection arrangement
           advisory_board_date: Advisory board date
           academy_order_type: Academy order type
+          reception_to_six_years: Proposed capacity for pupils in reception to year 6
+          seven_to_eleven_years: Proposed capacity for pupils in years 7 to 11
+          twelve_or_above_years: Proposed capacity for students in year 12 or above
           two_requires_improvement: 2RI (Two Requires Improvement)
           sponsored_grant_type: Sponsored Grant Type
           assigned_to_name: Assigned to name

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -257,6 +257,32 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.region).to eql "London"
   end
 
+  context "when the proposed capacity of the academy is not applicable" do
+    it "returns not applicable" do
+      tasks_data = build(:conversion_tasks_data, proposed_capacity_of_the_academy_not_applicable: true)
+      project = build(:conversion_project, tasks_data: tasks_data)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.reception_to_six_years).to eql("Not applicable")
+      expect(presenter.seven_to_eleven_years).to eql("Not applicable")
+      expect(presenter.twelve_or_above_years).to eql("Not applicable")
+    end
+  end
+
+  context "when the proposed capacity of the academy is added" do
+    it "presents the proposed capacity of the academy" do
+      tasks_data = build(:conversion_tasks_data, proposed_capacity_of_the_academy_reception_to_six_years: 345, proposed_capacity_of_the_academy_seven_to_eleven_years: 500, proposed_capacity_of_the_academy_twelve_or_above_years: 400)
+      project = build(:conversion_project, tasks_data: tasks_data)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.reception_to_six_years).to eql("345")
+      expect(presenter.seven_to_eleven_years).to eql("500")
+      expect(presenter.twelve_or_above_years).to eql("400")
+    end
+  end
+
   def not_applicable_for_a_transfer
     project = build(:transfer_project)
 


### PR DESCRIPTION
## Changes

The proposed academy capacity numbers are now part of the ESFA csv export.
The headers are shown as:

![Screenshot 2023-11-28 at 17 05 38](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/59832893/a0336085-c139-4cea-8da7-331550ce4ef9)


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
