### PR TITLE
Release 47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release-47][release-47]
+
 ### Added
 
 - Add ability to import GIAS groups from csv data
@@ -1437,7 +1439,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-46...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-47...HEAD
+[release-47]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-46...release-47
 [release-46]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-45...release-46
 [release-45]:


### PR DESCRIPTION
Added

- Add ability to import GIAS groups from csv data
- transfer project now collect if they are a result of 2RI and show this information on the about the project tab
- transfer project now collect if they are a result of 2RI and show this information on the about the project tab
- transfer projects now collect if they are the result of an inadequate Ofsted inspection and show this information on the about the project tab
- transfer projects now collect if they are the result of financial, safeguarding or governance issues and who this information on the about project tab
- transfer projects now collect if the outgoing trust is expected to close once the transfer is completed and this is shown on the about the project tab
- Add a page to allow Grant management and finance unit members to download conversion projects by their Advisory board dates. This page is not currently linked in the application.
- Add proposed capacity of the academy task to Conversion projects
- Add "Confirm if the bank details for the general annual grant payment to need to change" task to Transfer projects
- Add proposed capacity of the academy to the csv export service

Changed

- Users are not directed to update KIM for the 'Receive grant payment certificate' task

