### PR TITLE
Add new "business_support" team for users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Add "Business support" as a team option for users.
+
 ## [Release-47][release-47]
 
 ### Added

--- a/app/models/concerns/teamable.rb
+++ b/app/models/concerns/teamable.rb
@@ -17,7 +17,8 @@ module Teamable
     regional_casework_services: "regional_casework_services",
     service_support: "service_support",
     academies_operational_practice_unit: "academies_operational_practice_unit",
-    education_and_skills_funding_agency: "education_and_skills_funding_agency"
+    education_and_skills_funding_agency: "education_and_skills_funding_agency",
+    business_support: "business_support"
   })
 
   PROJECT_TEAMS = REGIONAL_TEAMS.merge({regional_casework_services: "regional_casework_services"})

--- a/config/locales/teams.en.yml
+++ b/config/locales/teams.en.yml
@@ -13,3 +13,4 @@ en:
     service_support: Service support
     academies_operational_practice_unit: Academies operational practice unit
     education_and_skills_funding_agency: Education and skills funding agency
+    business_support: Business support

--- a/config/locales/user.en.yml
+++ b/config/locales/user.en.yml
@@ -63,6 +63,7 @@ en:
       service_support: Service Support
       academies_operational_practice_unit: AOPU (Academies Operational Practice Unit)
       education_and_skills_funding_agency: ESFA (Education and Skills Funding Agency)
+      business_support: Business support
   helpers:
     legend:
       user:

--- a/spec/models/statistics/user_statistics_spec.rb
+++ b/spec/models/statistics/user_statistics_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Statistics::UserStatistics, type: :model do
 
       expect(subject.users_count_per_team).to eq({
         academies_operational_practice_unit: 0,
+        business_support: 0,
         east_midlands: 0,
         east_of_england: 0,
         education_and_skills_funding_agency: 1,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -259,11 +259,11 @@ RSpec.describe User do
     it "returns the correct team options for a user" do
       options = described_class.new.team_options
 
-      expect(options.count).to eql 13
+      expect(options.count).to eql 14
       expect(options.first.id).to eql "london"
       expect(options.first.name).to eql "London"
-      expect(options.last.id).to eql "education_and_skills_funding_agency"
-      expect(options.last.name).to eql "ESFA (Education and Skills Funding Agency)"
+      expect(options.last.id).to eql "business_support"
+      expect(options.last.name).to eql "Business support"
     end
   end
 
@@ -303,7 +303,7 @@ RSpec.describe User do
     end
 
     it "has the expected enum values" do
-      expect(User.teams.count).to eq(13)
+      expect(User.teams.count).to eq(14)
     end
   end
 


### PR DESCRIPTION

## Changes

We need a new user team to represent Business support users. Eventually these users will have access to all the exports in the system.

<img width="526" alt="Screenshot 2023-11-30 at 13 40 35" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/5196e9e3-e917-4678-a21f-e75f48d21b61">


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
