### PR TITLE
Move the existing ESFA and Funding letter exports to `conversion` namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add "Business support" as a team option for users.
 
+### Changed
+
+- Move the existing exports into a `conversions` namespace (the urls for these
+  pages will now include `conversions` and the downloaded file name will contain
+  the word `conversions`)
+
 ## [Release-47][release-47]
 
 ### Added

--- a/app/controllers/all/export/education_and_skills_funding_agency/conversions/projects_controller.rb
+++ b/app/controllers/all/export/education_and_skills_funding_agency/conversions/projects_controller.rb
@@ -1,4 +1,4 @@
-class All::Export::EducationAndSkillsFundingAgency::ProjectsController < ApplicationController
+class All::Export::EducationAndSkillsFundingAgency::Conversions::ProjectsController < ApplicationController
   def index
     authorize :export
     @months = export_months
@@ -16,7 +16,7 @@ class All::Export::EducationAndSkillsFundingAgency::ProjectsController < Applica
     projects = ProjectsForExportService.new.risk_protection_arrangement_projects(month: month, year: year)
     csv = Export::EducationAndSkillsFundingAgencyCsvExportService.new(projects).call
 
-    send_data csv, filename: "#{year}-#{month}_risk_protection_arrangement_export.csv", type: :csv, disposition: "attachment"
+    send_data csv, filename: "#{year}-#{month}_risk_protection_arrangement_conversions_export.csv", type: :csv, disposition: "attachment"
   end
 
   private def month

--- a/app/controllers/all/export/funding_agreement_letters/conversions/projects_controller.rb
+++ b/app/controllers/all/export/funding_agreement_letters/conversions/projects_controller.rb
@@ -1,4 +1,4 @@
-class All::Export::FundingAgreementLetters::ProjectsController < ApplicationController
+class All::Export::FundingAgreementLetters::Conversions::ProjectsController < ApplicationController
   def index
     authorize Project, :index?
 
@@ -15,7 +15,7 @@ class All::Export::FundingAgreementLetters::ProjectsController < ApplicationCont
     projects = ProjectsForExportService.new.funding_agreement_letters_projects(month: month, year: year)
     csv = Export::FundingAgreementLettersCsvExporterService.new(projects).call
 
-    send_data csv, filename: "#{year}-#{month}_funding_agreement_letters_export.csv", type: :csv, disposition: "attachment"
+    send_data csv, filename: "#{year}-#{month}_funding_agreement_letters_conversions_export.csv", type: :csv, disposition: "attachment"
   end
 
   private def month

--- a/app/controllers/all/export/grant_management_and_finance_unit/conversions/projects_controller.rb
+++ b/app/controllers/all/export/grant_management_and_finance_unit/conversions/projects_controller.rb
@@ -11,7 +11,7 @@ class All::Export::GrantManagementAndFinanceUnit::Conversions::ProjectsControlle
     projects = ProjectsForExportService.new.grant_management_and_finance_unit_projects(month: month, year: year)
     csv = Export::GrantManagementAndFinanceUnitCsvExportService.new(projects).call
 
-    send_data csv, filename: "#{year}-#{month}_grant_management_and_finance_unit_export.csv", type: :csv, disposition: "attachment"
+    send_data csv, filename: "#{year}-#{month}_grant_management_and_finance_unit_conversions_export.csv", type: :csv, disposition: "attachment"
   end
 
   private def month

--- a/app/views/all/export/education_and_skills_funding_agency/conversions/projects/index.html.erb
+++ b/app/views/all/export/education_and_skills_funding_agency/conversions/projects/index.html.erb
@@ -23,7 +23,7 @@
           <%= link_to t("project.table.body.view_projects_for_html", entity: month.to_fs(:govuk_month)), "/projects/all/by-month/revised/#{month.month}/#{month.year}" %>
         </td>
         <td class="govuk-table__cell">
-          <%= link_to t("project.table.body.export_for_html", date: month.to_fs(:govuk_month)), show_all_export_education_and_skills_funding_agency_projects_path(month.month, month.year) %>
+          <%= link_to t("project.table.body.export_for_html", date: month.to_fs(:govuk_month)), show_all_export_education_and_skills_funding_agency_conversions_projects_path(month.month, month.year) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/all/export/education_and_skills_funding_agency/conversions/projects/show.html.erb
+++ b/app/views/all/export/education_and_skills_funding_agency/conversions/projects/show.html.erb
@@ -8,13 +8,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_back_link(href: all_export_education_and_skills_funding_agency_projects_path) %>
+    <%= govuk_back_link(href: all_export_education_and_skills_funding_agency_conversions_projects_path) %>
     <h1 class="govuk-heading-xl"><%= t("export.education_and_skills_funding_agency.show.title", date: @month.to_fs(:govuk_month)) %></h1>
     <div class="govuk-body">
       <%= t("export.education_and_skills_funding_agency.show.body_html") %>
     </div>
     <div class="govuk-form-group">
-      <%= govuk_button_link_to t("export.education_and_skills_funding_agency.show.button"), "/projects/all/export/esfa/#{@month.month}/#{@month.year}/csv" %>
+      <%= govuk_button_link_to t("export.education_and_skills_funding_agency.show.button"), "/projects/all/export/esfa/conversions/#{@month.month}/#{@month.year}/csv" %>
     </div>
   </div>
 </div>

--- a/app/views/all/export/funding_agreement_letters/conversions/projects/index.html.erb
+++ b/app/views/all/export/funding_agreement_letters/conversions/projects/index.html.erb
@@ -23,7 +23,7 @@
           <%= link_to t("project.table.body.view_projects_for_html", entity: month.to_fs(:govuk_month)), "/projects/all/by-month/revised/#{month.month}/#{month.year}" %>
         </td>
         <td class="govuk-table__cell">
-          <%= link_to t("project.table.body.export_for_html", date: month.to_fs(:govuk_month)), "/projects/all/export/funding-agreement-letters/#{month.month}/#{month.year}" %>
+          <%= link_to t("project.table.body.export_for_html", date: month.to_fs(:govuk_month)), "/projects/all/export/funding-agreement-letters/conversions/#{month.month}/#{month.year}" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/all/export/funding_agreement_letters/conversions/projects/show.html.erb
+++ b/app/views/all/export/funding_agreement_letters/conversions/projects/show.html.erb
@@ -8,13 +8,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_back_link(href: all_export_funding_agreement_letters_projects_path) %>
+    <%= govuk_back_link(href: all_export_funding_agreement_letters_conversions_projects_path) %>
     <h1 class="govuk-heading-xl"><%= t("export.funding_agreement_letters.show.title", date: @month.to_fs(:govuk_month)) %></h1>
     <div class="govuk-body">
       <%= t("export.funding_agreement_letters.show.body_html") %>
     </div>
     <div class="govuk-form-group">
-      <%= govuk_button_link_to t("export.funding_agreement_letters.show.button"), "/projects/all/export/funding-agreement-letters/#{@month.month}/#{@month.year}/csv" %>
+      <%= govuk_button_link_to t("export.funding_agreement_letters.show.button"), "/projects/all/export/funding-agreement-letters/conversions/#{@month.month}/#{@month.year}/csv" %>
     </div>
   </div>
 </div>

--- a/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
@@ -24,7 +24,7 @@
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.statistics"), path: all_statistics_projects_path, namespace: "/projects/all/statistics"} %>
 
-          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.exports"), path: all_export_education_and_skills_funding_agency_projects_path, namespace: "/projects/all/export"} if policy(:export).index? %>
+          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.exports"), path: all_export_education_and_skills_funding_agency_conversions_projects_path, namespace: "/projects/all/export"} if policy(:export).index? %>
 
         </ul>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,14 +135,18 @@ Rails.application.routes.draw do
           end
           namespace :export do
             namespace :funding_agreement_letters, path: "funding-agreement-letters" do
-              get "/", to: "projects#index"
-              get ":month/:year", to: "projects#show", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :show
-              get ":month/:year/csv", to: "projects#csv", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :csv
+              namespace :conversions do
+                get "/", to: "projects#index"
+                get ":month/:year", to: "projects#show", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :show
+                get ":month/:year/csv", to: "projects#csv", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :csv
+              end
             end
             namespace :education_and_skills_funding_agency, path: "esfa" do
-              get "/", to: "projects#index"
-              get ":month/:year", to: "projects#show", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :show
-              get ":month/:year/csv", to: "projects#csv", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :csv
+              namespace :conversions do
+                get "/", to: "projects#index"
+                get ":month/:year", to: "projects#show", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :show
+                get ":month/:year/csv", to: "projects#csv", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :csv
+              end
             end
             namespace :grant_management_and_finance_unit, path: "grant-management-and-finance-unit" do
               namespace :conversions do

--- a/spec/features/all_projects/export/grant_management_and_finance_users_can_export_download_spec.rb
+++ b/spec/features/all_projects/export/grant_management_and_finance_users_can_export_download_spec.rb
@@ -21,6 +21,6 @@ RSpec.feature "Grant management and finance unit users can export projects by Ad
     expect(page).to have_link("Export for #{(Date.today - 11.months).to_fs(:govuk_month)}")
 
     click_on "Export for #{Date.today.to_fs(:govuk_month)}"
-    expect(page.response_headers["Content-Disposition"]).to include("#{Date.today.year}-#{Date.today.month}_grant_management_and_finance_unit_export.csv")
+    expect(page.response_headers["Content-Disposition"]).to include("#{Date.today.year}-#{Date.today.month}_grant_management_and_finance_unit_conversions_export.csv")
   end
 end

--- a/spec/features/projects/export/education_and_skills_funding_agency/users_can_export_esfa_data_spec.rb
+++ b/spec/features/projects/export/education_and_skills_funding_agency/users_can_export_esfa_data_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Users can export ESFA data" do
     last_month = Date.today.last_month.at_beginning_of_month
     create(:conversion_project, conversion_date: last_month, conversion_date_provisional: false)
 
-    visit "/projects/all/export/esfa/"
+    visit "/projects/all/export/esfa/conversions/"
 
     expect(page).to have_content(last_month.to_fs(:govuk_month))
     expect(page).to have_link("Export")
@@ -22,7 +22,7 @@ RSpec.feature "Users can export ESFA data" do
     this_month = Date.today.at_beginning_of_month
     create(:conversion_project, conversion_date: this_month, conversion_date_provisional: false)
 
-    visit "/projects/all/export/esfa/"
+    visit "/projects/all/export/esfa/conversions/"
 
     expect(page).to have_content(this_month.to_fs(:govuk_month))
     expect(page).to have_link("Export")
@@ -33,7 +33,7 @@ RSpec.feature "Users can export ESFA data" do
     four_months_time = (Date.today + 4.months).at_beginning_of_month
     create(:conversion_project, conversion_date: four_months_time, conversion_date_provisional: false)
 
-    visit "/projects/all/export/esfa/"
+    visit "/projects/all/export/esfa/conversions/"
 
     expect(page).to have_content(four_months_time.to_fs(:govuk_month))
     expect(page).to have_link("Export")
@@ -44,7 +44,7 @@ RSpec.feature "Users can export ESFA data" do
     this_month = Date.today.at_beginning_of_month
     create(:conversion_project, conversion_date: this_month, conversion_date_provisional: false)
 
-    visit "/projects/all/export/esfa/#{this_month.month}/#{this_month.year}"
+    visit "/projects/all/export/esfa/conversions/#{this_month.month}/#{this_month.year}"
 
     expect(page).to have_content(this_month.to_fs(:govuk_month))
     expect(page).to have_link("Download")

--- a/spec/features/projects/export/funding_agreement_letters/users_can_export_fal_data_spec.rb
+++ b/spec/features/projects/export/funding_agreement_letters/users_can_export_fal_data_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Users can export funding agreement lettes data" do
     last_month = Date.today.last_month.at_beginning_of_month
     create(:conversion_project, conversion_date: last_month, conversion_date_provisional: false)
 
-    visit "/projects/all/export/funding-agreement-letters/"
+    visit "/projects/all/export/funding-agreement-letters/conversions/"
 
     expect(page).to have_content(last_month.to_fs(:govuk_month))
     expect(page).to have_link("Export")
@@ -22,7 +22,7 @@ RSpec.feature "Users can export funding agreement lettes data" do
     this_month = Date.today.at_beginning_of_month
     create(:conversion_project, conversion_date: this_month, conversion_date_provisional: false)
 
-    visit "/projects/all/export/funding-agreement-letters/"
+    visit "/projects/all/export/funding-agreement-letters/conversions/"
 
     expect(page).to have_content(this_month.to_fs(:govuk_month))
     expect(page).to have_link("Export")
@@ -33,7 +33,7 @@ RSpec.feature "Users can export funding agreement lettes data" do
     four_months_time = (Date.today + 4.months).at_beginning_of_month
     create(:conversion_project, conversion_date: four_months_time, conversion_date_provisional: false)
 
-    visit "/projects/all/export/funding-agreement-letters/"
+    visit "/projects/all/export/funding-agreement-letters/conversions/"
 
     expect(page).to have_content(four_months_time.to_fs(:govuk_month))
     expect(page).to have_link("Export")
@@ -44,9 +44,9 @@ RSpec.feature "Users can export funding agreement lettes data" do
     this_month = Date.today.at_beginning_of_month
     create(:conversion_project, conversion_date: this_month, conversion_date_provisional: false)
 
-    visit "/projects/all/export/funding-agreement-letters/#{this_month.month}/#{this_month.year}"
+    visit "/projects/all/export/funding-agreement-letters/conversions/#{this_month.month}/#{this_month.year}"
 
     expect(page).to have_content(this_month.to_fs(:govuk_month))
-    expect(page).to have_link("Download", href: "/projects/all/export/funding-agreement-letters/#{this_month.month}/#{this_month.year}/csv")
+    expect(page).to have_link("Download", href: "/projects/all/export/funding-agreement-letters/conversions/#{this_month.month}/#{this_month.year}/csv")
   end
 end

--- a/spec/requests/all/export/education_and_skills_funding_agency/conversions/projects_controller_spec.rb
+++ b/spec/requests/all/export/education_and_skills_funding_agency/conversions/projects_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe All::Export::EducationAndSkillsFundingAgency::ProjectsController, type: :request do
+RSpec.describe All::Export::EducationAndSkillsFundingAgency::Conversions::ProjectsController, type: :request do
   let(:user) { create(:user, team: :education_and_skills_funding_agency) }
 
   before do
@@ -12,14 +12,14 @@ RSpec.describe All::Export::EducationAndSkillsFundingAgency::ProjectsController,
     let!(:project) { create(:conversion_project, conversion_date: Date.new(2025, 5, 1), conversion_date_provisional: false) }
 
     it "returns the csv with a successful response" do
-      get csv_all_export_education_and_skills_funding_agency_projects_path(5, 2025)
+      get csv_all_export_education_and_skills_funding_agency_conversions_projects_path(5, 2025)
       expect(response.body).to include(project.urn.to_s)
       expect(response).to have_http_status(:success)
     end
 
     it "formats the csv filename with the month & year" do
-      get csv_all_export_education_and_skills_funding_agency_projects_path(5, 2025)
-      expect(response.header["Content-Disposition"]).to include("2025-5_risk_protection_arrangement_export.csv")
+      get csv_all_export_education_and_skills_funding_agency_conversions_projects_path(5, 2025)
+      expect(response.header["Content-Disposition"]).to include("2025-5_risk_protection_arrangement_conversions_export.csv")
     end
   end
 end

--- a/spec/requests/all/export/funding_agreement_letters/conversions/projects_controller_spec.rb
+++ b/spec/requests/all/export/funding_agreement_letters/conversions/projects_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe All::Export::FundingAgreementLetters::ProjectsController, type: :request do
+RSpec.describe All::Export::FundingAgreementLetters::Conversions::ProjectsController, type: :request do
   let(:team_leader) { create(:user, :team_leader) }
 
   before do
@@ -14,14 +14,14 @@ RSpec.describe All::Export::FundingAgreementLetters::ProjectsController, type: :
     before { mock_successful_member_details }
 
     it "returns the csv with a successful response" do
-      get csv_all_export_funding_agreement_letters_projects_path(5, 2025)
+      get csv_all_export_funding_agreement_letters_conversions_projects_path(5, 2025)
       expect(response.body).to include(project.urn.to_s)
       expect(response).to have_http_status(:success)
     end
 
     it "formats the csv filename with the month & year" do
-      get csv_all_export_funding_agreement_letters_projects_path(5, 2025)
-      expect(response.header["Content-Disposition"]).to include("2025-5_funding_agreement_letters_export.csv")
+      get csv_all_export_funding_agreement_letters_conversions_projects_path(5, 2025)
+      expect(response.header["Content-Disposition"]).to include("2025-5_funding_agreement_letters_conversions_export.csv")
     end
   end
 end


### PR DESCRIPTION
## Changes

We are starting to add exports for Transfers as well as Conversions.

In order to support this, we need to move the existing exports into a `conversions` namespace. This will allow us to keep the Conversion and Transfer exports separate (as they need to contain different data).

This follows the pattern already started for the Grant managment and finance unit exports, which already live in a `conversions` namespace.

For now, the `Export` link in the site navigation leads to the Conversion exports, as they are the only existing ones.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
