### PR TITLE
Update By month view language to reflect transfers and conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Move the existing exports into a `conversions` namespace (the urls for these
   pages will now include `conversions` and the downloaded file name will contain
   the word `conversions`)
+- Change langauge for `by month` view for all projects to reflect transfers as
+  well as conversions.
 
 ## [Release-47][release-47]
 

--- a/app/views/all/by_month/projects/_revised_table.html.erb
+++ b/app/views/all/by_month/projects/_revised_table.html.erb
@@ -1,12 +1,12 @@
 <% if projects.empty? %>
-  <%= govuk_inset_text(text: t("project.revised_conversion_date.empty_html")) %>
+  <%= govuk_inset_text(text: t("project.revised_date.empty_html")) %>
 <% else %>
   <table class="govuk-table" name="projects_table" aria-label="Projects table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.revised_conversion_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.revised_date") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.view") %></th>
       </tr>
     </thead>

--- a/app/views/all/by_month/projects/revised.html.erb
+++ b/app/views/all/by_month/projects/revised.html.erb
@@ -3,15 +3,16 @@
 <% end %>
 
 <% content_for :page_title do %>
-  <%= page_title(t("project.revised_conversion_date.title", date: @date)) %>
+  <%= page_title(t("project.revised_date.title", date: @date)) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 
     <h1 class="govuk-heading-l">
-      <%= t("project.revised_conversion_date.title", date: @date) %>
+      <%= t("project.revised_date.title", date: @date) %>
     </h1>
+    <p><%= t("project.revised_date.subtitle") %></p>
 
     <nav class="moj-sub-navigation" aria-label="Project index sub-navigation">
       <ul class="moj-sub-navigation__list">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,8 +97,8 @@ en:
     internal_contacts: Internal contacts
     member_of_parliament: Member of Parliament
     added_by_projects: Added by you
-    openers: Opening as planned
-    revised: Revised conversion date
+    openers: Proceeding as planned
+    revised: Revised date
     active_users: Active users
     inactive_users: Inactive users
   pages:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -172,7 +172,7 @@ en:
         conversion_date: Conversion date
         conversion_or_transfer_date: Conversion or transfer date
         created_at: Created at date
-        revised_conversion_date: Revised conversion date
+        revised_date: Revised date
         route: Route
         school_phase: School phase
         school_type: School type
@@ -235,8 +235,8 @@ en:
         empty: There are no users with projects
         caption: Table of users who have in-progress projects
     openers:
-      title: Academies opening in %{date}
-      subtitle: Schools that are expected to become academies.
+      title: Academies opening or transferring in %{date}
+      subtitle: Schools that will become academies, and academies that will move to a different trust.
       empty:
         html:
           <p>There are currently no schools expected to become academies in %{date}.</p>
@@ -256,8 +256,9 @@ en:
             academy_order: AO (Academy Order)
             directive_academy_order: DAO (Directive Academy Order)
             not_applicable: Not applicable
-    revised_conversion_date:
-      title: Academies that were expected to convert in %{date}
+    revised_date:
+      title: Academies that will no longer open or transfer in %{date}
+      subtitle: Projects where the conversion or transfer date has changed.
       empty_html:
           <p>None found.</p>
       table:

--- a/spec/accessibility/all_projects_spec.rb
+++ b/spec/accessibility/all_projects_spec.rb
@@ -38,17 +38,17 @@ RSpec.feature "All projects", driver: :headless_firefox, accessibility: true do
     check_accessibility(page)
   end
 
-  scenario "> Opening > Confirmed conversion date" do
+  scenario "> By month > Confirmed conversion date" do
     project = create(:conversion_project, assigned_to: user, urn: 123434, conversion_date: Date.today.next_month.at_beginning_of_month, conversion_date_provisional: false)
 
     visit confirmed_all_by_month_projects_path
 
     expect(page).to have_content(project.urn)
-    expect(page).to have_link("Opening")
+    expect(page).to have_link("Proceeding as planned")
     check_accessibility(page)
   end
 
-  scenario "> Opening > Revised conversion date" do
+  scenario "> By month > Revised conversion date" do
     project = create(:conversion_project, assigned_to: user, urn: 123434, conversion_date_provisional: false)
     create(:date_history, project: project, previous_date: Date.today.next_month.at_beginning_of_month)
     create(:date_history, project: project, previous_date: Date.today.next_month.at_beginning_of_month)
@@ -56,7 +56,7 @@ RSpec.feature "All projects", driver: :headless_firefox, accessibility: true do
     visit revised_all_by_month_projects_path
 
     expect(page).to have_content(project.urn)
-    expect(page).to have_link("Opening")
+    expect(page).to have_link("Proceeding as planned")
     check_accessibility(page)
   end
 end

--- a/spec/features/projects/revised_conversion_date/viewing_projects_with_a_revised_converison_date_spec.rb
+++ b/spec/features/projects/revised_conversion_date/viewing_projects_with_a_revised_converison_date_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.feature "Viewing projects with a revised conversion date" do
-  scenario "Users can view the projects that were due to convert for a given month and year" do
+RSpec.feature "Viewing projects with a revised conversion or transfer date" do
+  scenario "Users can view the projects that were due to convert or transfer for a given month and year" do
     user = create(:user)
 
     sign_in_with_user(user)
@@ -19,7 +19,7 @@ RSpec.feature "Viewing projects with a revised conversion date" do
 
     visit "/projects/all/by-month/revised/#{(Date.today + 3.months).month}/#{(Date.today + 3.months).year}"
 
-    expect(page).to have_content I18n.t("project.revised_conversion_date.title", date: (Date.today + 3.months).to_fs(:govuk_month))
+    expect(page).to have_content I18n.t("project.revised_date.title", date: (Date.today + 3.months).to_fs(:govuk_month))
     expect(page).to have_content project_with_matching_date.urn
     expect(page).not_to have_content project_with_confirmed_date.urn
     expect(page).not_to have_content project_with_other_date.urn

--- a/spec/requests/all/by_month/projects_controller_spec.rb
+++ b/spec/requests/all/by_month/projects_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe All::ByMonth::ProjectsController, type: :request do
         it "shows a page title with the month & year" do
           get "/projects/all/by-month/confirmed/1/2022"
 
-          expect(response.body).to include("Academies opening in January 2022")
+          expect(response.body).to include("Academies opening or transferring in January 2022")
         end
 
         it "returns project details in table form" do


### PR DESCRIPTION
## Changes

This is part of the iterative work to the `By month` view. 
First steps here are to make the `By month` view be descripive of both `transfer` and `conversion` projects and reflect the current state of data displayed.

<img width="1131" alt="Screenshot 2023-12-06 at 12 33 41" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/59832893/25813820-2add-4a9b-b54b-c8d6a15f759d">

<img width="1131" alt="Screenshot 2023-12-06 at 12 34 05" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/59832893/efaf4192-c417-4c98-96ad-4ec17498ca46">

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
