### PR TITLE
(150256) Build an export for Academies due to Transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add "Business support" as a team option for users.
+- Add a CSV export for Academies due to transfer in a time period (this work is
+  not publicly viewable)
 
 ### Changed
 

--- a/app/presenters/export/csv/incoming_trust_presenter_module.rb
+++ b/app/presenters/export/csv/incoming_trust_presenter_module.rb
@@ -5,6 +5,12 @@ module Export::Csv::IncomingTrustPresenterModule
     @project.incoming_trust.group_identifier.to_s
   end
 
+  def incoming_trust_ukprn
+    return unless @project.incoming_trust_ukprn.present?
+
+    @project.incoming_trust_ukprn.to_s
+  end
+
   def incoming_trust_companies_house_number
     return unless @project.incoming_trust.present?
 

--- a/app/presenters/export/csv/outgoing_trust_presenter_module.rb
+++ b/app/presenters/export/csv/outgoing_trust_presenter_module.rb
@@ -1,0 +1,19 @@
+module Export::Csv::OutgoingTrustPresenterModule
+  def outgoing_trust_ukprn
+    return unless @project.outgoing_trust_ukprn.present?
+
+    @project.outgoing_trust_ukprn.to_s
+  end
+
+  def outgoing_trust_companies_house_number
+    return unless @project.outgoing_trust.present?
+
+    @project.outgoing_trust.companies_house_number.to_s
+  end
+
+  def outgoing_trust_name
+    return unless @project.outgoing_trust.present?
+
+    @project.outgoing_trust.name
+  end
+end

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -3,6 +3,7 @@ class Export::Csv::ProjectPresenter
   include Export::Csv::AcademyPresenterModule
   include Export::Csv::DirectorOfChildServicesPresenterModule
   include Export::Csv::IncomingTrustPresenterModule
+  include Export::Csv::OutgoingTrustPresenterModule
   include Export::Csv::LocalAuthorityPresenterModule
   include Export::Csv::MpPresenterModule
 

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -36,6 +36,12 @@ class Export::Csv::ProjectPresenter
     @project.conversion_date.to_fs(:csv)
   end
 
+  def transfer_date
+    return I18n.t("export.csv.project.values.unconfirmed") if @project.significant_date_provisional?
+
+    @project.significant_date.to_fs(:csv)
+  end
+
   def all_conditions_met
     if @project.all_conditions_met.nil?
       return I18n.t("export.csv.project.values.no")
@@ -64,10 +70,52 @@ class Export::Csv::ProjectPresenter
   end
 
   def two_requires_improvement
-    return I18n.t("export.csv.project.values.not_applicable") if @project.is_a?(Transfer::Project)
     return I18n.t("export.csv.project.values.yes") if @project.two_requires_improvement?
 
     I18n.t("export.csv.project.values.no")
+  end
+
+  def financial_safeguarding_governance_issues
+    return I18n.t("export.csv.project.values.not_applicable") if @project.is_a?(Conversion::Project)
+
+    return I18n.t("export.csv.project.values.yes") if @project.tasks_data.financial_safeguarding_governance_issues
+
+    I18n.t("export.csv.project.values.no")
+  end
+
+  def inadequate_ofsted
+    return I18n.t("export.csv.project.values.not_applicable") if @project.is_a?(Conversion::Project)
+
+    return I18n.t("export.csv.project.values.yes") if @project.tasks_data.inadequate_ofsted
+
+    I18n.t("export.csv.project.values.no")
+  end
+
+  def outgoing_trust_to_close
+    return I18n.t("export.csv.project.values.not_applicable") if @project.is_a?(Conversion::Project)
+
+    return I18n.t("export.csv.project.values.yes") if @project.tasks_data.outgoing_trust_to_close
+
+    I18n.t("export.csv.project.values.no")
+  end
+
+  def bank_details_changing
+    return I18n.t("export.csv.project.values.not_applicable") if @project.is_a?(Conversion::Project)
+
+    return I18n.t("export.csv.project.values.yes") if @project.tasks_data.bank_details_changing_yes_no
+
+    I18n.t("export.csv.project.values.no")
+  end
+
+  def request_new_urn_and_record
+    return I18n.t("export.csv.project.values.not_applicable") if @project.is_a?(Conversion::Project)
+    return I18n.t("export.csv.project.values.not_applicable") if @project.tasks_data.request_new_urn_and_record_not_applicable
+
+    if @project.tasks_data.request_new_urn_and_record_complete && @project.tasks_data.request_new_urn_and_record_receive && @project.tasks_data.request_new_urn_and_record_give
+      I18n.t("export.csv.project.values.confirmed")
+    else
+      I18n.t("export.csv.project.values.unconfirmed")
+    end
   end
 
   def sponsored_grant_type

--- a/app/services/export/transfers/academies_due_to_transfer_csv_export_service.rb
+++ b/app/services/export/transfers/academies_due_to_transfer_csv_export_service.rb
@@ -1,0 +1,54 @@
+class Export::Transfers::AcademiesDueToTransferCsvExportService
+  require "csv"
+
+  COLUMN_HEADERS = %i[
+    school_name
+    school_urn
+    local_authority_name
+    outgoing_trust_name
+    outgoing_trust_companies_house_number
+    outgoing_trust_ukprn
+    incoming_trust_name
+    incoming_trust_companies_house_number
+    incoming_trust_ukprn
+    two_requires_improvement
+    inadequate_ofsted
+    financial_safeguarding_governance_issues
+    outgoing_trust_to_close
+    request_new_urn_and_record
+    bank_details_changing
+    region
+    assigned_to_email
+    transfer_date
+    all_conditions_met
+  ]
+
+  def initialize(projects)
+    @projects = projects
+  end
+
+  def call
+    @csv = CSV.generate("\uFEFF", headers: true, encoding: "UTF-8") do |csv|
+      csv << headers
+      if @projects.any?
+        @projects.each do |project|
+          csv << row(project)
+        end
+      end
+    end
+  end
+
+  private def headers
+    COLUMN_HEADERS.map do |column|
+      I18n.t("export.csv.project.headers.#{column}")
+    end
+  end
+
+  private def row(project)
+    presenter = Export::Csv::ProjectPresenter.new(project)
+
+    COLUMN_HEADERS.map do |column|
+      presenter.public_send(column)
+    end
+  end
+end

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -68,6 +68,16 @@ en:
           school_phase: School phase
           link_to_project: Link to project
           region: Region
+          outgoing_trust_name: Outgoing trust name
+          outgoing_trust_companies_house_number: Outgoing trust companies house number
+          outgoing_trust_ukprn: Outgoing trust UKPRN
+          incoming_trust_ukprn: Incoming trust UKPRN
+          inadequate_ofsted: Transfer due to inadequate
+          financial_safeguarding_governance_issues: Transfer due to financial, safeguarding or governance
+          outgoing_trust_to_close: Outgoing trust to close
+          request_new_urn_and_record: New URN/record requested
+          bank_details_changing: Bank details changing
+          transfer_date: Transfer date
         values:
           project_type:
             conversion: Conversion

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -77,6 +77,7 @@ en:
             intermidiate: intermidiate
             sponsored: sponsored
           unconfirmed: unconfirmed
+          confirmed: confirmed
           not_applicable: not applicable
           "yes": "yes"
           "no": "no"

--- a/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Export::Csv::IncomingTrustPresenterModule do
     expect(subject.incoming_trust_identifier).to eql "TR03819"
   end
 
+  it "presents the ukprn" do
+    expect(subject.incoming_trust_ukprn).to eql "121813"
+  end
+
   it "presents the companies house number" do
     expect(subject.incoming_trust_companies_house_number).to eql "10768218"
   end

--- a/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Export::Csv::OutgoingTrustPresenterModule do
+  let(:project) { build(:transfer_project, outgoing_trust_ukprn: 121813) }
+  subject { OutgoingTrustPresenterModuleTestClass.new(project) }
+
+  before do
+    allow(project).to receive(:outgoing_trust).and_return(known_trust)
+  end
+
+  it "presents the ukprn" do
+    expect(subject.outgoing_trust_ukprn).to eql "121813"
+  end
+
+  it "presents the companies house number" do
+    expect(subject.outgoing_trust_companies_house_number).to eql "10768218"
+  end
+
+  it "presents the name" do
+    expect(subject.outgoing_trust_name).to eql "The Grand Union Partnership"
+  end
+
+  def known_trust
+    double(
+      Api::AcademiesApi::Trust,
+      ukprn: 10066123,
+      companies_house_number: 10768218,
+      group_identifier: "TR03819",
+      name: "The Grand Union Partnership",
+      address_street: "New Bradwell County Combined School",
+      address_locality: "Bounty Street",
+      address_additional: nil,
+      address_town: "Milton Keynes",
+      address_county: nil,
+      address_postcode: "MK13 0BQ"
+    )
+  end
+end
+
+class OutgoingTrustPresenterModuleTestClass
+  include Export::Csv::OutgoingTrustPresenterModule
+
+  def initialize(project)
+    @project = project
+  end
+end

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -50,7 +50,94 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents the two requires improvement value for a transfer" do
-    not_applicable_for_a_transfer
+    project = build(:transfer_project, two_requires_improvement: true)
+
+    presenter = described_class.new(project)
+
+    expect(presenter.two_requires_improvement).to eql "yes"
+
+    project = build(:transfer_project, two_requires_improvement: false)
+
+    presenter = described_class.new(project)
+
+    expect(presenter.two_requires_improvement).to eql "no"
+  end
+
+  it "presents inadequate_ofsted value for a transfer" do
+    tasks_data = double(Transfer::TasksData, inadequate_ofsted: true)
+    project = double(Transfer::Project, tasks_data: tasks_data)
+    presenter = described_class.new(project)
+    expect(presenter.inadequate_ofsted).to eql "yes"
+
+    tasks_data = double(Transfer::TasksData, inadequate_ofsted: false)
+    project = double(Transfer::Project, tasks_data: tasks_data)
+    presenter = described_class.new(project)
+    expect(presenter.inadequate_ofsted).to eql "no"
+  end
+
+  it "presents financial_safeguarding_governance_issues value for a transfer" do
+    tasks_data = double(Transfer::TasksData, financial_safeguarding_governance_issues: true)
+    project = double(Transfer::Project, tasks_data: tasks_data)
+    presenter = described_class.new(project)
+    expect(presenter.financial_safeguarding_governance_issues).to eql "yes"
+
+    tasks_data = double(Transfer::TasksData, financial_safeguarding_governance_issues: false)
+    project = double(Transfer::Project, tasks_data: tasks_data)
+    presenter = described_class.new(project)
+    expect(presenter.financial_safeguarding_governance_issues).to eql "no"
+  end
+
+  it "presents outgoing_trust_to_close value for a transfer" do
+    tasks_data = double(Transfer::TasksData, outgoing_trust_to_close: true)
+    project = double(Transfer::Project, tasks_data: tasks_data)
+    presenter = described_class.new(project)
+    expect(presenter.outgoing_trust_to_close).to eql "yes"
+
+    tasks_data = double(Transfer::TasksData, outgoing_trust_to_close: false)
+    project = double(Transfer::Project, tasks_data: tasks_data)
+    presenter = described_class.new(project)
+    expect(presenter.outgoing_trust_to_close).to eql "no"
+  end
+
+  it "presents request_new_urn_and_record value for a transfer" do
+    tasks_data = double(Transfer::TasksData,
+      request_new_urn_and_record_complete: true,
+      request_new_urn_and_record_receive: true,
+      request_new_urn_and_record_give: true,
+      request_new_urn_and_record_not_applicable: false)
+    project = double(Transfer::Project, tasks_data: tasks_data)
+    presenter = described_class.new(project)
+    expect(presenter.request_new_urn_and_record).to eql "confirmed"
+
+    tasks_data = double(Transfer::TasksData,
+      request_new_urn_and_record_complete: false,
+      request_new_urn_and_record_receive: false,
+      request_new_urn_and_record_give: false,
+      request_new_urn_and_record_not_applicable: false)
+    project = double(Transfer::Project, tasks_data: tasks_data)
+    presenter = described_class.new(project)
+    expect(presenter.request_new_urn_and_record).to eql "unconfirmed"
+
+    tasks_data = double(Transfer::TasksData,
+      request_new_urn_and_record_complete: false,
+      request_new_urn_and_record_receive: false,
+      request_new_urn_and_record_give: false,
+      request_new_urn_and_record_not_applicable: true)
+    project = double(Transfer::Project, tasks_data: tasks_data)
+    presenter = described_class.new(project)
+    expect(presenter.request_new_urn_and_record).to eql "not applicable"
+  end
+
+  it "presents bank_details_changing value for a transfer" do
+    tasks_data = double(Transfer::TasksData, bank_details_changing_yes_no: true)
+    project = double(Transfer::Project, tasks_data: tasks_data)
+    presenter = described_class.new(project)
+    expect(presenter.bank_details_changing).to eql "yes"
+
+    tasks_data = double(Transfer::TasksData, bank_details_changing_yes_no: false)
+    project = double(Transfer::Project, tasks_data: tasks_data)
+    presenter = described_class.new(project)
+    expect(presenter.bank_details_changing).to eql "no"
   end
 
   it "presents the sponsored grant type" do
@@ -110,6 +197,22 @@ RSpec.describe Export::Csv::ProjectPresenter do
     presenter = described_class.new(project)
 
     expect(presenter.conversion_date).to eql "unconfirmed"
+  end
+
+  it "presents the significant date (as transfer date)" do
+    project = double(Transfer::Project, significant_date: Date.parse("2023-1-1"), significant_date_provisional?: false)
+
+    presenter = described_class.new(project)
+
+    expect(presenter.transfer_date).to eql "2023-01-01"
+  end
+
+  it "presents unconfirmed when the significant date is provisional" do
+    project = double(Transfer::Project, significant_date: Date.parse("2023-1-1"), significant_date_provisional?: true)
+
+    presenter = described_class.new(project)
+
+    expect(presenter.transfer_date).to eql "unconfirmed"
   end
 
   it "presents all conditions met" do

--- a/spec/services/export/transfers/academies_due_to_transfer_csv_export_service_spec.rb
+++ b/spec/services/export/transfers/academies_due_to_transfer_csv_export_service_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Export::Transfers::AcademiesDueToTransferCsvExportService do
+  describe "#call" do
+    it "returns only the headers when there are no projects" do
+      projects = []
+
+      csv_export = described_class.new(projects).call
+
+      expect(csv_export).to include("School URN")
+      expect(csv_export).to include("Assigned to email")
+    end
+
+    it "returns a row of data" do
+      mock_all_academies_api_responses
+      project = build(:transfer_project)
+      projects = [project]
+
+      csv_export = described_class.new(projects).call
+
+      expect(csv_export).to include(project.establishment.name)
+      expect(csv_export).to include(project.outgoing_trust_ukprn.to_s)
+      expect(csv_export).to include(project.incoming_trust_ukprn.to_s)
+      expect(csv_export).to include(project.assigned_to.email)
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Devops: [Task 150256](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/150256): Build the CSV

We need to generate a CSV of Academies due to transfer. The required CSV headers are as per the linked ticket.

Firstly, we needed to extend the Project presenter to present the required information from Transfer projects. Because all our previous exports were for Conversion projects, we didn't have all the fields necessary for a Transfer project (both project types have slightly different tasks data).

Once we have the necessary methods in the presenters, build a service to create a CSV with the required columns and information.

This CSV export is not currently linked from anywhere, so this work is not publicly accessible or testable in the UI.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
