### PR TITLE
Move existing export services into a conversions namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the word `conversions`)
 - Change langauge for `by month` view for all projects to reflect transfers as
   well as conversions.
+- Move existing export services into a conversions namespace
 
 ## [Release-47][release-47]
 

--- a/app/controllers/all/export/education_and_skills_funding_agency/conversions/projects_controller.rb
+++ b/app/controllers/all/export/education_and_skills_funding_agency/conversions/projects_controller.rb
@@ -14,7 +14,7 @@ class All::Export::EducationAndSkillsFundingAgency::Conversions::ProjectsControl
     authorize Project, :index?
 
     projects = ProjectsForExportService.new.risk_protection_arrangement_projects(month: month, year: year)
-    csv = Export::EducationAndSkillsFundingAgencyCsvExportService.new(projects).call
+    csv = Export::Conversions::EducationAndSkillsFundingAgencyCsvExportService.new(projects).call
 
     send_data csv, filename: "#{year}-#{month}_risk_protection_arrangement_conversions_export.csv", type: :csv, disposition: "attachment"
   end

--- a/app/controllers/all/export/funding_agreement_letters/conversions/projects_controller.rb
+++ b/app/controllers/all/export/funding_agreement_letters/conversions/projects_controller.rb
@@ -13,7 +13,7 @@ class All::Export::FundingAgreementLetters::Conversions::ProjectsController < Ap
     authorize Project, :index?
 
     projects = ProjectsForExportService.new.funding_agreement_letters_projects(month: month, year: year)
-    csv = Export::FundingAgreementLettersCsvExporterService.new(projects).call
+    csv = Export::Conversions::FundingAgreementLettersCsvExporterService.new(projects).call
 
     send_data csv, filename: "#{year}-#{month}_funding_agreement_letters_conversions_export.csv", type: :csv, disposition: "attachment"
   end

--- a/app/controllers/all/export/grant_management_and_finance_unit/conversions/projects_controller.rb
+++ b/app/controllers/all/export/grant_management_and_finance_unit/conversions/projects_controller.rb
@@ -9,7 +9,7 @@ class All::Export::GrantManagementAndFinanceUnit::Conversions::ProjectsControlle
     authorize Project, :index?
 
     projects = ProjectsForExportService.new.grant_management_and_finance_unit_projects(month: month, year: year)
-    csv = Export::GrantManagementAndFinanceUnitCsvExportService.new(projects).call
+    csv = Export::Conversions::GrantManagementAndFinanceUnitCsvExportService.new(projects).call
 
     send_data csv, filename: "#{year}-#{month}_grant_management_and_finance_unit_conversions_export.csv", type: :csv, disposition: "attachment"
   end

--- a/app/services/export/conversions/education_and_skills_funding_agency_csv_export_service.rb
+++ b/app/services/export/conversions/education_and_skills_funding_agency_csv_export_service.rb
@@ -1,23 +1,28 @@
-class Export::GrantManagementAndFinanceUnitCsvExportService
+class Export::Conversions::EducationAndSkillsFundingAgencyCsvExportService
   require "csv"
 
   COLUMN_HEADERS = %i[
     school_urn
     school_name
-    school_type
-    school_phase
-    local_authority_name
-    region
-    incoming_trust_name
+    academy_urn
+    academy_name
+    reception_to_six_years
+    seven_to_eleven_years
+    twelve_or_above_years
     incoming_trust_identifier
-    advisory_board_date
+    incoming_trust_companies_house_number
+    incoming_trust_name
     conversion_date
+    all_conditions_met
+    risk_protection_arrangement
     academy_order_type
     two_requires_improvement
     sponsored_grant_type
     assigned_to_name
     assigned_to_email
-    link_to_project
+    main_contact_name
+    main_contact_email
+    main_contact_title
   ]
 
   def initialize(projects)

--- a/app/services/export/conversions/funding_agreement_letters_csv_exporter_service.rb
+++ b/app/services/export/conversions/funding_agreement_letters_csv_exporter_service.rb
@@ -1,4 +1,4 @@
-class Export::FundingAgreementLettersCsvExporterService
+class Export::Conversions::FundingAgreementLettersCsvExporterService
   require "csv"
 
   COLUMN_HEADERS = %i[

--- a/app/services/export/conversions/grant_management_and_finance_unit_csv_export_service.rb
+++ b/app/services/export/conversions/grant_management_and_finance_unit_csv_export_service.rb
@@ -1,28 +1,23 @@
-class Export::EducationAndSkillsFundingAgencyCsvExportService
+class Export::Conversions::GrantManagementAndFinanceUnitCsvExportService
   require "csv"
 
   COLUMN_HEADERS = %i[
     school_urn
     school_name
-    academy_urn
-    academy_name
-    reception_to_six_years
-    seven_to_eleven_years
-    twelve_or_above_years
-    incoming_trust_identifier
-    incoming_trust_companies_house_number
+    school_type
+    school_phase
+    local_authority_name
+    region
     incoming_trust_name
+    incoming_trust_identifier
+    advisory_board_date
     conversion_date
-    all_conditions_met
-    risk_protection_arrangement
     academy_order_type
     two_requires_improvement
     sponsored_grant_type
     assigned_to_name
     assigned_to_email
-    main_contact_name
-    main_contact_email
-    main_contact_title
+    link_to_project
   ]
 
   def initialize(projects)

--- a/spec/services/export/conversions/education_and_skills_funding_agency_csv_export_service_spec.rb
+++ b/spec/services/export/conversions/education_and_skills_funding_agency_csv_export_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Export::EducationAndSkillsFundingAgencyCsvExportService do
+RSpec.describe Export::Conversions::EducationAndSkillsFundingAgencyCsvExportService do
   describe "#call" do
     it "returns only the headers when there are no projects" do
       projects = []

--- a/spec/services/export/conversions/funding_letter_agreement_csv_exporter_service_spec.rb
+++ b/spec/services/export/conversions/funding_letter_agreement_csv_exporter_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Export::FundingAgreementLettersCsvExporterService do
+RSpec.describe Export::Conversions::FundingAgreementLettersCsvExporterService do
   describe "#call" do
     before do
       mock_successful_api_response_to_create_any_project
@@ -11,7 +11,7 @@ RSpec.describe Export::FundingAgreementLettersCsvExporterService do
       user = build(:user, email: "user.name@education.gov.uk")
       project = build(:conversion_project, urn: 123456, assigned_to: user)
 
-      csv_export = Export::FundingAgreementLettersCsvExporterService.new([project]).call
+      csv_export = Export::Conversions::FundingAgreementLettersCsvExporterService.new([project]).call
 
       expect(csv_export).to include("School URN")
       expect(csv_export).to include("123456")
@@ -22,14 +22,14 @@ RSpec.describe Export::FundingAgreementLettersCsvExporterService do
     it "prepends a BOM to the file" do
       project = build(:conversion_project, urn: 654321)
 
-      csv_export = Export::FundingAgreementLettersCsvExporterService.new([project]).call
+      csv_export = Export::Conversions::FundingAgreementLettersCsvExporterService.new([project]).call
       expect(csv_export.chr).to eq("\uFEFF")
     end
 
     it "sends the file in UTF-8 encoding" do
       project = build(:conversion_project, urn: 654321)
 
-      csv_export = Export::FundingAgreementLettersCsvExporterService.new([project]).call
+      csv_export = Export::Conversions::FundingAgreementLettersCsvExporterService.new([project]).call
       expect(csv_export.encoding.name).to eq("UTF-8")
     end
   end

--- a/spec/services/export/conversions/grand_management_and_finance_unit_csv_export_service_spec.rb
+++ b/spec/services/export/conversions/grand_management_and_finance_unit_csv_export_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Export::GrantManagementAndFinanceUnitCsvExportService do
+RSpec.describe Export::Conversions::GrantManagementAndFinanceUnitCsvExportService do
   describe "#call" do
     before do
       mock_successful_api_response_to_create_any_project
@@ -11,7 +11,7 @@ RSpec.describe Export::GrantManagementAndFinanceUnitCsvExportService do
       user = build(:user, email: "user.name@education.gov.uk")
       project = build(:conversion_project, urn: 123456, assigned_to: user)
 
-      csv_export = Export::GrantManagementAndFinanceUnitCsvExportService.new([project]).call
+      csv_export = Export::Conversions::GrantManagementAndFinanceUnitCsvExportService.new([project]).call
 
       expect(csv_export).to include("School URN")
       expect(csv_export).to include("123456")


### PR DESCRIPTION
## Changes

We currently only export services for `Conversions`, so this work is to accurately reflect what the export services do and to allow `Transfers` exports to be added in once that work is ready.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
