### PR TITLE
Add reduced support service banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add "Business support" as a team option for users.
 - Add a CSV export for Academies due to transfer in a time period (this work is
   not publicly viewable)
+- Add reduced support service banner to the service for the christmas period
 
 ### Changed
 

--- a/app/views/all/in_progress/projects/index.html.erb
+++ b/app/views/all/in_progress/projects/index.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: "shared/christmas_notification_banner" %>
+
 <% content_for :primary_navigation do %>
   <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
 <% end %>

--- a/app/views/service_support/projects/without_academy_urn.html.erb
+++ b/app/views/service_support/projects/without_academy_urn.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: "shared/christmas_notification_banner" %>
+
 <% content_for :primary_navigation do %>
   <%= render partial: "shared/navigation/service_support_primary_navigation" %>
 <% end %>

--- a/app/views/shared/_christmas_notification_banner.html.erb
+++ b/app/views/shared/_christmas_notification_banner.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <h3 class="govuk-notification-banner__heading">
+      Reduced support service
+    </h3>
+    <p class="govuk-body">
+      Email the Service Support team at <a href="mailto:regionalservices.rg@education.gov.uk">regionalservices.rg@education.gov.uk</a> if you have an urgent problem using this service from Friday 22 December 2023 to Monday 3 January 2024. Normal query support will resume in the new year.
+    </p>
+  </div>
+</div>

--- a/app/views/team/projects/unassigned.html.erb
+++ b/app/views/team/projects/unassigned.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: "shared/christmas_notification_banner" %>
+
 <% content_for :primary_navigation do %>
   <%= render partial: "shared/navigation/team_projects_primary_navigation" %>
 <% end %>

--- a/app/views/your/projects/in_progress.html.erb
+++ b/app/views/your/projects/in_progress.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: "shared/christmas_notification_banner" %>
+
 <% content_for :primary_navigation do %>
   <%= render partial: "shared/navigation/your_projects_primary_navigation" %>
 <% end %>


### PR DESCRIPTION
## Changes

<img width="1159" alt="Screenshot 2023-12-13 at 16 39 27" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/59832893/69332196-efb3-4ae0-8ed6-181574178575">


This banner is only being applied to the landing pages within the service to communicate the reduced support available over the christmas period.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
