### PR TITLE
(148322) Build the export journey for Academies due to transfer in a given month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add a CSV export for Academies due to transfer in a time period (this work is
   not publicly viewable)
 - Add reduced support service banner to the service for the christmas period
+- Build the export journey for Academies due to transfer in a time period
 
 ### Changed
 

--- a/app/controllers/all/export/by_month/transfers/projects_controller.rb
+++ b/app/controllers/all/export/by_month/transfers/projects_controller.rb
@@ -1,0 +1,35 @@
+class All::Export::ByMonth::Transfers::ProjectsController < ApplicationController
+  def index
+    authorize :export
+    @months = export_months
+  end
+
+  def show
+    authorize :export
+    @month = Date.parse("#{year}-#{month}-1")
+  end
+
+  def csv
+    authorize :export
+    authorize Project, :index?
+
+    projects = ProjectsForExportService.new.transfer_by_month_projects(month: month, year: year)
+    csv = Export::Transfers::AcademiesDueToTransferCsvExportService.new(projects).call
+
+    send_data csv, filename: "#{year}-#{month}_academies_due_to_transfer.csv", type: :csv, disposition: "attachment"
+  end
+
+  private def month
+    params[:month]
+  end
+
+  private def year
+    params[:year]
+  end
+
+  private def export_months
+    6.times.map do |index|
+      Date.today.at_beginning_of_month + index.months
+    end
+  end
+end

--- a/app/services/projects_for_export_service.rb
+++ b/app/services/projects_for_export_service.rb
@@ -14,6 +14,15 @@ class ProjectsForExportService
     AcademiesApiPreFetcherService.new.call!(projects)
   end
 
+  def transfer_by_month_projects(month:, year:)
+    projects = transfer_projects_by_month_and_year(month, year)
+    AcademiesApiPreFetcherService.new.call!(projects)
+  end
+
+  private def transfer_projects_by_month_and_year(month, year)
+    Transfer::Project.confirmed.filtered_by_significant_date(month, year)
+  end
+
   private def conversion_projects_by_month_and_year(month, year)
     Conversion::Project.confirmed.filtered_by_significant_date(month, year)
   end

--- a/app/services/projects_for_export_service.rb
+++ b/app/services/projects_for_export_service.rb
@@ -1,24 +1,24 @@
 class ProjectsForExportService
   def risk_protection_arrangement_projects(month:, year:)
-    projects = projects_by_month_and_year(month, year)
+    projects = conversion_projects_by_month_and_year(month, year)
     AcademiesApiPreFetcherService.new.call!(projects)
   end
 
   def funding_agreement_letters_projects(month:, year:)
-    projects = projects_by_month_and_year(month, year)
+    projects = conversion_projects_by_month_and_year(month, year)
     AcademiesApiPreFetcherService.new.call!(projects)
   end
 
   def grant_management_and_finance_unit_projects(month:, year:)
-    projects = projects_by_advisory_board_date(month, year)
+    projects = conversion_projects_by_advisory_board_date(month, year)
     AcademiesApiPreFetcherService.new.call!(projects)
   end
 
-  private def projects_by_month_and_year(month, year)
+  private def conversion_projects_by_month_and_year(month, year)
     Conversion::Project.confirmed.filtered_by_significant_date(month, year)
   end
 
-  private def projects_by_advisory_board_date(month, year)
+  private def conversion_projects_by_advisory_board_date(month, year)
     Conversion::Project.confirmed.filtered_by_advisory_board_date(month, year)
   end
 end

--- a/app/views/all/export/by_month/transfers/projects/index.html.erb
+++ b/app/views/all/export/by_month/transfers/projects/index.html.erb
@@ -1,0 +1,41 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("export.by_month.transfers.index.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h3 class="govuk-heading-l"><%= t("export.by_month.transfers.index.title") %></h3>
+    <%= t("export.by_month.transfers.index.body_html") %>
+  </div>
+</div>
+
+<table class="govuk-table" name="projects_table" aria-label="Transfers by month exports">
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header" scope="col"><%= t("project.table.headers.date") %></th>
+    <th class="govuk-table__header" scope="col"><%= t("project.table.headers.confirmed_transfer_date") %></th>
+    <th class="govuk-table__header" scope="col"><%= t("project.table.headers.revised_date") %></th>
+    <th class="govuk-table__header" scope="col"><%= t("project.table.headers.all_transfers") %></th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% @months.each do |month| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header govuk-table__cell"><%= month.to_fs(:govuk_month) %></td>
+      <td class="govuk-table__cell">
+        <%= link_to t("project.table.body.view_confirmed_transfer_projects_for", date: month.to_fs(:govuk_month_only)), "/projects/all/by-month/confirmed/#{month.month}/#{month.year}" %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= link_to t("project.table.body.view_revised_transfer_projects_for", date: month.to_fs(:govuk_month_only)), "/projects/all/by-month/revised/#{month.month}/#{month.year}" %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= link_to t("project.table.body.download_transfer_projects_for", date: month.to_fs(:govuk_month_only)), show_all_export_by_month_transfers_projects_path(month.month, month.year) %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/all/export/by_month/transfers/projects/show.html.erb
+++ b/app/views/all/export/by_month/transfers/projects/show.html.erb
@@ -1,0 +1,17 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("export.by_month.transfers.show.title", month: @month.to_fs(:govuk_month_only), year: @month.year)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h3 class="govuk-heading-l"><%= t("export.by_month.transfers.show.title", month: @month.to_fs(:govuk_month_only), year: @month.year) %></h3>
+    <%= t("export.by_month.transfers.show.body_html", month: @month.to_fs(:govuk_month_only), year: @month.year) %>
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_button_link_to t("export.by_month.transfers.show.button"), csv_all_export_by_month_transfers_projects_path(@month.month, @month.year) %>
+  </div>
+</div>

--- a/config/locales/export/by_month_csv_export.en.yml
+++ b/config/locales/export/by_month_csv_export.en.yml
@@ -1,0 +1,22 @@
+en:
+  export:
+    by_month:
+      transfers:
+        index:
+          title: Academies due to transfer
+          body_html:
+            <p class="govuk-body">A list of academies due to transfer over the next 6 months.</p>
+            <p class="govuk-body">This information is also available as a spreadsheet. You can download the spreadsheet version of each month's list.</p>
+            <p class="govuk-body">The spreadsheet includes information about whether the academy needs a new URN and if bank details for funding payments need to change.</p>
+        show:
+          title: Details of academies due to transfer in %{month} %{year}
+          body_html:
+            <p class="govuk-body">This .CSV spreadsheet shows you academies that will:</p>
+            <ul>
+            <li>transfer in %{month} %{year}</li>
+            <li>need a new URN</li>
+            <li>change bank details</li>
+            <li>no longer transfer in %{month} %{year}</li>
+            </ul>
+            <p class="govuk-body">It can take a little time to create these files. Thank you for your patience.</p>
+          button: Download .CSV file

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -195,6 +195,9 @@ en:
         team: Team
         incoming_trust: Incoming trust
         outgoing_trust: Outgoing trust
+        confirmed_transfer_date: Confirmed transfer date
+        revised_transfer_date: Revised transfer date
+        all_transfers: All transfers
       body:
         type_name:
           conversion_project: Conversion
@@ -206,6 +209,9 @@ en:
         view_projects_for_local_authority_html: View projects<span class="govuk-visually-hidden"> for %{local_authority_name}</span>
         view_projects_for_html: View projects<span class="govuk-visually-hidden"> for %{entity}</span>
         export_for_html: Export<span class="govuk-visually-hidden"> for %{date}</span>
+        view_confirmed_transfer_projects_for: View %{date}'s confirmed transfers
+        view_revised_transfer_projects_for: View %{date}'s revised transfers
+        download_transfer_projects_for: Download %{date}'s transfers
       empty:
         projects: There are no projects
       in_progress:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -155,6 +155,13 @@ Rails.application.routes.draw do
                 get ":month/:year/csv", to: "projects#csv", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :csv
               end
             end
+            namespace :by_month, path: "by-month" do
+              namespace :transfers do
+                get "/", to: "projects#index"
+                get ":month/:year", to: "projects#show", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :show
+                get ":month/:year/csv", to: "projects#csv", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :csv
+              end
+            end
           end
         end
       end

--- a/spec/requests/all/export/by_month/transfers/projects_controller_spec.rb
+++ b/spec/requests/all/export/by_month/transfers/projects_controller_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe All::Export::ByMonth::Transfers::ProjectsController, type: :request do
+  let(:user) { create(:user, team: :education_and_skills_funding_agency) }
+
+  before do
+    mock_all_academies_api_responses
+    sign_in_with(user)
+  end
+
+  describe "#index" do
+    it "shows the next 6 months and links to Academies transferring in those months" do
+      travel_to Date.new(2023, 1, 1) do
+        get all_export_by_month_transfers_projects_path
+        expect(response.body).to include(
+          "January 2023",
+          "February 2023",
+          "March 2023",
+          "April 2023",
+          "May 2023",
+          "June 2023"
+        )
+        expect(response.body).to include(
+          "View January&#39;s confirmed transfers",
+          "View January&#39;s revised transfers",
+          "Download January&#39;s transfers"
+        )
+      end
+    end
+  end
+
+  describe "#show" do
+    it "shows the info page for the CSV download" do
+      get show_all_export_by_month_transfers_projects_path(5, 2025)
+      expect(response.body).to include("Details of academies due to transfer in May 2025")
+    end
+  end
+
+  describe "#csv" do
+    let!(:project) { create(:transfer_project, significant_date: Date.new(2025, 5, 1), significant_date_provisional: false) }
+
+    it "returns the csv with a successful response" do
+      get csv_all_export_by_month_transfers_projects_path(5, 2025)
+      expect(response.body).to include(project.urn.to_s)
+      expect(response).to have_http_status(:success)
+    end
+
+    it "formats the csv filename with the month & year" do
+      get csv_all_export_by_month_transfers_projects_path(5, 2025)
+      expect(response.header["Content-Disposition"]).to include("2025-5_academies_due_to_transfer.csv")
+    end
+  end
+end

--- a/spec/services/projects_for_export_service_spec.rb
+++ b/spec/services/projects_for_export_service_spec.rb
@@ -64,6 +64,22 @@ RSpec.describe ProjectsForExportService do
     end
   end
 
+  describe "#transfer_by_month_projects" do
+    it "returns only transfer projects transferring in the supplied month & year" do
+      mock_academies_api_client_get_establishments_and_trusts
+
+      matching_project_1 = create(:transfer_project, significant_date_provisional: false, significant_date: Date.parse("2023-1-1"))
+      matching_project_2 = create(:transfer_project, significant_date_provisional: false, significant_date: Date.parse("2023-1-1"))
+      mismatching_project_1 = create(:transfer_project, significant_date_provisional: false, significant_date: Date.parse("2023-2-1"))
+      mismatching_project_2 = create(:conversion_project, significant_date_provisional: false, significant_date: Date.parse("2023-1-1"))
+
+      projects_for_export = described_class.new.transfer_by_month_projects(month: 1, year: 2023)
+
+      expect(projects_for_export).to include(matching_project_1, matching_project_2)
+      expect(projects_for_export).not_to include(mismatching_project_1, mismatching_project_2)
+    end
+  end
+
   def mock_academies_api_client_get_establishments_and_trusts
     api_client = Api::AcademiesApi::Client.new
     allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)


### PR DESCRIPTION
## Changes

[Task 148322](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/148322): Build the export journey to download the transfer reports

Now that we have a CSV export for Transfers in transferring in a given month, we can build a journey in the UI for the user to access this export.

First, the user visits an index page where they can see the next 6 months, with links to view the confirmed and revised transfers for each month.

<img width="1259" alt="Screenshot 2023-12-14 at 15 22 41" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/a8748fc8-760a-46f7-91b5-e6273d10ac4f">

Upon clicking on the Download link, the user is taken to a page where they see information about the export, and a link to download the CSV file

<img width="1242" alt="Screenshot 2023-12-14 at 15 22 51" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/49a612d0-b995-410b-8067-5842a6f66ac3">

The resulting CSV export has the required columns as per previous ticket [Task 150256](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/150256): Build the CSV

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
