### PR TITLE
(148320) Build exports landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   not publicly viewable)
 - Add reduced support service banner to the service for the christmas period
 - Build the export journey for Academies due to transfer in a time period
+- Build a landing page for all exports, under the Exports tab. This page is
+  viewable by all teams who have access to exports.
 
 ### Changed
 

--- a/app/assets/stylesheets/components/app-content.scss
+++ b/app/assets/stylesheets/components/app-content.scss
@@ -2,7 +2,6 @@
   h4,
   h5,
   h6,
-  p,
   ul:not(.app-task-list):not(.app-tabs):not(.moj-sub-navigation__list):not(
       .app-task-list__items
     ):not(.projects-list),

--- a/app/controllers/all/export/projects_controller.rb
+++ b/app/controllers/all/export/projects_controller.rb
@@ -1,0 +1,5 @@
+class All::Export::ProjectsController < ApplicationController
+  def index
+    authorize :export
+  end
+end

--- a/app/views/all/export/projects/index.html.erb
+++ b/app/views/all/export/projects/index.html.erb
@@ -1,0 +1,32 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("export.landing_page.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h3 class="govuk-heading-l"><%= t("export.landing_page.title") %></h3>
+    <p class="govuk-body"><%= t("export.landing_page.body") %></p>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h4 class="govuk-heading-m"><%= t("export.landing_page.conversions.title") %></h4>
+    <p class="govuk-body"><%= t("export.landing_page.conversions.body") %></p>
+    <p class="govuk-body"><%= t("export.landing_page.conversions.funding_agreement_letters_html", link: all_export_funding_agreement_letters_conversions_projects_path) %></p>
+    <p class="govuk-body"><%= t("export.landing_page.conversions.risk_protection_arrangements_html", link: all_export_education_and_skills_funding_agency_conversions_projects_path) %></p>
+    <p class="govuk-body"><%= t("export.landing_page.conversions.grant_management_html", link: all_export_grant_management_and_finance_unit_conversions_projects_path) %></p>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h4 class="govuk-heading-m"><%= t("export.landing_page.transfers.title") %></h4>
+    <p class="govuk-body"><%= t("export.landing_page.transfers.body") %></p>
+    <p class="govuk-body"><%= t("export.landing_page.transfers.academies_due_to_transfer_html", link: all_export_by_month_transfers_projects_path) %></p>
+  </div>
+</div>

--- a/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
@@ -24,7 +24,7 @@
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.statistics"), path: all_statistics_projects_path, namespace: "/projects/all/statistics"} %>
 
-          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.exports"), path: all_export_education_and_skills_funding_agency_conversions_projects_path, namespace: "/projects/all/export"} if policy(:export).index? %>
+          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.exports"), path: all_export_projects_path, namespace: "/projects/all/export"} if policy(:export).index? %>
 
         </ul>
 

--- a/config/locales/export/landing_page.en.yml
+++ b/config/locales/export/landing_page.en.yml
@@ -1,0 +1,15 @@
+en:
+  export:
+    landing_page:
+      title: Exports
+      body: Check tables that show the progress of projects that will convert or transfer soon. You can also download .CSV file spreadsheets of the data.
+      conversions:
+        title: Conversion project data
+        body: View tables and download spreadsheets that show information about conversions.
+        funding_agreement_letters_html: You can <a href="%{link}">find out who should be sent the funding agreement letters</a>.
+        risk_protection_arrangements_html: You can <a href="%{link}">check details about schools' risk protection arrangements and start-up grant funding</a>.
+        grant_management_html: You can <a href="%{link}">get information pre-opening grants for schools becoming academies</a>.
+      transfers:
+        title: Transfer project data
+        body: View tables and download spreadsheets that show information about transfers.
+        academies_due_to_transfer_html: You can <a href="%{link}">check which academies are due to transfer in an particular month</a>.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,6 +134,7 @@ Rails.application.routes.draw do
             get ":user_id", to: "projects#show", as: :by_user, constraints: {user_id: VALID_UUID_REGEX}
           end
           namespace :export do
+            get "/", to: "projects#index"
             namespace :funding_agreement_letters, path: "funding-agreement-letters" do
               namespace :conversions do
                 get "/", to: "projects#index"

--- a/spec/features/all_projects/export/esfa_users_can_export_download_spec.rb
+++ b/spec/features/all_projects/export/esfa_users_can_export_download_spec.rb
@@ -27,6 +27,8 @@ RSpec.feature "ESFA users can export" do
 
     click_on "Exports"
 
+    click_on "check details about schools' risk protection arrangements and start-up grant funding"
+
     expect(page).to have_link(Date.today.to_fs(:govuk_month))
     expect(page).to have_link(Date.today.next_month.to_fs(:govuk_month))
   end
@@ -38,6 +40,8 @@ RSpec.feature "ESFA users can export" do
     visit all_in_progress_projects_path
 
     click_on "Exports"
+
+    click_on "check details about schools' risk protection arrangements and start-up grant funding"
 
     click_on "Export for #{Date.today.to_fs(:govuk_month)}"
 

--- a/spec/features/all_projects/export/export_users_can_see_an_export_landing_page_spec.rb
+++ b/spec/features/all_projects/export/export_users_can_see_an_export_landing_page_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.feature "Export users can see the exports landing page" do
+  scenario "other users do not see the navigation" do
+    user = create(:regional_delivery_officer_user)
+
+    sign_in_with_user(user)
+    visit all_in_progress_projects_path
+
+    expect(page).not_to have_link("Exports")
+  end
+
+  scenario "an ESFA user can see the exports landing page" do
+    user = create(:user, team: :education_and_skills_funding_agency)
+
+    sign_in_with_user(user)
+    click_on "Exports"
+
+    expect(page).to have_content("You can find out who should be sent the funding agreement letters.")
+    expect(page).to have_content("You can check details about schools' risk protection arrangements and start-up grant funding.")
+    expect(page).to have_content("You can get information pre-opening grants for schools becoming academies.")
+  end
+
+  scenario "an AOPU user can see the exports landing page" do
+    user = create(:user, team: :academies_operational_practice_unit)
+
+    sign_in_with_user(user)
+    click_on "Exports"
+
+    expect(page).to have_content("You can find out who should be sent the funding agreement letters.")
+    expect(page).to have_content("You can check details about schools' risk protection arrangements and start-up grant funding.")
+    expect(page).to have_content("You can get information pre-opening grants for schools becoming academies.")
+  end
+end


### PR DESCRIPTION
## Changes

To be merged after https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/1254

[Task 148320](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/148320): Build landing page for all exports for all users

We now have several different export types, and previously access to them was
constrained by the user's team (e.g. only ESFA users could see the ESFA exports)

We now want access to exports to be easier, and to do this we have added an
exports landing page. This lists all available exports, instead of restricting
access to exports by team type.

This export landing page is available to anyone who can view exports (currently
the `academies_operational_practice_unit` and `education_and_skills_funding_agency`
teams)

<img width="1120" alt="Screenshot 2023-12-15 at 11 03 43" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/98c2ac4e-3a3d-4e2c-8530-505e131027dc">

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
