### PR TITLE
(150847) Send a notification when a Transfer is created and handed over to RCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- An email is now sent to team leaders when a transfer project is created and
+  handed over to Regional casework services
+
 ## [Release-49][release-49]
 
 ### Changed

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -32,7 +32,7 @@ class Conversion::CreateProjectForm < CreateProjectForm
 
   private def notify_team_leaders(project)
     User.team_leaders.each do |team_leader|
-      TeamLeaderMailer.new_project_created(team_leader, project).deliver_later if team_leader.active
+      TeamLeaderMailer.new_conversion_project_created(team_leader, project).deliver_later if team_leader.active
     end
   end
 

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -58,6 +58,7 @@ class Transfer::CreateProjectForm < CreateProjectForm
         financial_safeguarding_governance_issues: financial_safeguarding_governance_issues,
         outgoing_trust_to_close: outgoing_trust_to_close
       )
+      notify_team_leaders(@project) if assigned_to_regional_caseworker_team
     end
 
     @project
@@ -73,6 +74,12 @@ class Transfer::CreateProjectForm < CreateProjectForm
 
   def check_incoming_trust_and_outgoing_trust
     errors.add(:incoming_trust_ukprn, I18n.t("errors.attributes.incoming_trust_ukprn.ukprns_must_not_match")) if incoming_trust_ukprn == outgoing_trust_ukprn
+  end
+
+  private def notify_team_leaders(project)
+    User.team_leaders.each do |team_leader|
+      TeamLeaderMailer.new_transfer_project_created(team_leader, project).deliver_later if team_leader.active
+    end
   end
 
   private def outgoing_trust_exists

--- a/app/mailers/team_leader_mailer.rb
+++ b/app/mailers/team_leader_mailer.rb
@@ -9,4 +9,15 @@ class TeamLeaderMailer < ApplicationMailer
       }
     )
   end
+
+  def new_transfer_project_created(team_leader, project)
+    template_mail(
+      "b0df8e28-ea23-46c5-9a83-82abc6b29193",
+      to: team_leader.email,
+      personalisation: {
+        first_name: team_leader.first_name,
+        project_url: url_to_project(project)
+      }
+    )
+  end
 end

--- a/app/mailers/team_leader_mailer.rb
+++ b/app/mailers/team_leader_mailer.rb
@@ -1,5 +1,5 @@
 class TeamLeaderMailer < ApplicationMailer
-  def new_project_created(team_leader, project)
+  def new_conversion_project_created(team_leader, project)
     template_mail(
       "ea4f72e4-f5bb-4b1a-b5f9-a94cc1840353",
       to: team_leader.email,

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
 
         expect(ActionMailer::MailDeliveryJob)
           .to(have_been_enqueued.on_queue("default")
-                                .with("TeamLeaderMailer", "new_project_created", "deliver_now", args: [team_leader, project]))
+                                .with("TeamLeaderMailer", "new_conversion_project_created", "deliver_now", args: [team_leader, project]))
         expect(ActionMailer::MailDeliveryJob)
           .to(have_been_enqueued.on_queue("default")
-                                .with("TeamLeaderMailer", "new_project_created", "deliver_now", args: [another_team_leader, project]))
+                                .with("TeamLeaderMailer", "new_conversion_project_created", "deliver_now", args: [another_team_leader, project]))
       end
 
       context "if a team leader is deactivated" do

--- a/spec/mailers/team_leader_mailer_spec.rb
+++ b/spec/mailers/team_leader_mailer_spec.rb
@@ -19,4 +19,23 @@ RSpec.describe TeamLeaderMailer do
       send_mail
     end
   end
+
+  describe "#new_transfer_project_created" do
+    let(:team_leader) { create(:user, :team_leader) }
+    let(:project) { create(:transfer_project) }
+    let(:template_id) { "b0df8e28-ea23-46c5-9a83-82abc6b29193" }
+    let(:expected_personalisation) { {first_name: team_leader.first_name, project_url: project_url(project.id)} }
+
+    subject(:send_mail) { described_class.new_transfer_project_created(team_leader, project).deliver_now }
+
+    before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+    it "sends an email with the correct personalisation" do
+      expect_any_instance_of(Mail::Notify::Mailer)
+        .to receive(:template_mail)
+        .with(template_id, {to: team_leader.email, personalisation: expected_personalisation})
+
+      send_mail
+    end
+  end
 end

--- a/spec/mailers/team_leader_mailer_spec.rb
+++ b/spec/mailers/team_leader_mailer_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
 RSpec.describe TeamLeaderMailer do
-  describe "#new_project_created" do
+  describe "#new_conversion_project_created" do
     let(:team_leader) { create(:user, :team_leader) }
     let(:project) { create(:conversion_project) }
     let(:template_id) { "ea4f72e4-f5bb-4b1a-b5f9-a94cc1840353" }
     let(:expected_personalisation) { {first_name: team_leader.first_name, project_url: project_url(project.id)} }
 
-    subject(:send_mail) { described_class.new_project_created(team_leader, project).deliver_now }
+    subject(:send_mail) { described_class.new_conversion_project_created(team_leader, project).deliver_now }
 
     before { mock_successful_api_responses(urn: 123456, ukprn: 10061021) }
 


### PR DESCRIPTION
## Changes

When a new Conversion project is created and handed over to RCS, the team leaders receive an email informing them.

However, when we build the Transfer project journey, this functionality was missed out.

Create a new mailer to send an email to the team leaders, informing them when a new Transfer is created and handed over to RCS. This duplicates the Conversions functionality, but uses a slightly different email template in GovUK Notify.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
