### PR TITLE
Fix statistics page to show accurate data for Transfer's `by region`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   handed over to Regional casework services
 - Fix Conversion project incoming sharepoint link edit view to not display
   outgoing trust sharepoint link field.
+- Fix statistics page to show accurate data for Transfer's `by region` table.
 
 ## [Release-49][release-49]
 

--- a/app/views/all/statistics/statistics/index.html.erb
+++ b/app/views/all/statistics/statistics/index.html.erb
@@ -185,7 +185,7 @@
           </thead>
           <tbody class="govuk-table__body">
           <% Project.regions.keys.each do |region| %>
-            <% statistics = @project_statistics.conversion_project_statistics_for_region(region) %>
+            <% statistics = @project_statistics.transfer_project_statistics_for_region(region) %>
             <tr class="govuk-table__row" id="<%= region.dasherize %>">
               <th scope="row" class="govuk-table__cell"><%= t("project.region.#{region}") %></th>
               <td class="govuk-table__cell govuk-table__cell--numeric"><%= statistics.in_progress %></td>


### PR DESCRIPTION
## Changes

This is a small fix to the statistics page, to the `by region` table for `Transfer's`. It was incorrectly pulling the `Conversion` data for `by region`.
This is now pulling the `Transfer` data for `by region`

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
