### PR TITLE
Fix Conversion project incoming trust sharepoint link edit view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - An email is now sent to team leaders when a transfer project is created and
   handed over to Regional casework services
+- Fix Conversion project incoming sharepoint link edit view to not display
+  outgoing trust sharepoint link field.
 
 ## [Release-49][release-49]
 

--- a/app/views/shared/project_information/_incoming_trust_details.html.erb
+++ b/app/views/shared/project_information/_incoming_trust_details.html.erb
@@ -30,7 +30,7 @@
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.incoming_trust_details.rows.sharepoint_folder") }
           row.with_value { safe_link_to(t("project_information.show.incoming_trust_details.values.sharepoint_folder"), project.incoming_trust_sharepoint_link) }
-          if project.type == "Conversion"
+          if project.type == "Conversion::Project"
             row.with_action(text: "Change", href: conversions_edit_path(@project), visually_hidden_text: "edit sharepoint folder link")
           else
             row.with_action(text: "Change", href: transfers_edit_path(@project), visually_hidden_text: "edit sharepoint folder link")


### PR DESCRIPTION
## Changes

The `Conversion` project's `incoming trust sharepoint link` edit view was displaying the `outgoing trust sharepoint link` field too. 

This fixes this issue to correctly display only the `incoming trust sharepoint link` field.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
