### PR TITLE
(151107) Add date field to Conversions Receive grant payment certificate task, and split "Check and save" action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add the ability to download Transfer projects for the Grant management and
   finance team
+- Added a field to enter the date a grant payment certificate was received to
+  the Conversions Receive grant payment certificate task.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Changed the existing Grant management and finance team Conversions download
   page to include an information page about the download, and a tabbed view on
   the index page to switch between Transfers and Conversions
+- Split the "Check and save" action in the Conversions Receive grant payment
+  certificate task. The actions are now "Check" and "Save" separately.
 
 ## [Release-49][release-49]
 

--- a/app/forms/conversion/task/receive_grant_payment_certificate_task_form.rb
+++ b/app/forms/conversion/task/receive_grant_payment_certificate_task_form.rb
@@ -1,3 +1,77 @@
 class Conversion::Task::ReceiveGrantPaymentCertificateTaskForm < BaseTaskForm
   attribute :check_and_save, :boolean
+  attribute "date_received(1i)"
+  attribute "date_received(2i)"
+  attribute "date_received(3i)"
+  attribute :date_received, :date
+
+  validate :date_format
+
+  def initialize(tasks_data, user)
+    @tasks_data = tasks_data
+    @user = user
+    @project = tasks_data.project
+    super(@tasks_data, @user)
+
+    self.date_received = @project.tasks_data.receive_grant_payment_certificate_date_received
+  end
+
+  def save
+    @tasks_data.assign_attributes(
+      receive_grant_payment_certificate_date_received: formatted_date_received,
+      receive_grant_payment_certificate_check_and_save: check_and_save
+    )
+    @tasks_data.save!
+  end
+
+  def formatted_date_received
+    return @project.tasks_data.receive_grant_payment_certificate_date_received if @project.tasks_data.receive_grant_payment_certificate_date_received.present?
+    return nil if month.blank? || year.blank? || day.blank?
+    Date.new(year, month, day)
+  end
+
+  private def date_format
+    return if month.blank? && year.blank? && day.blank?
+
+    Date.new(year, month, day)
+  rescue TypeError, Date::Error
+    errors.add(:date_received, I18n.t("conversion.task.receive_grant_payment_certificate.date_received.errors.format"))
+  end
+
+  private def day
+    day = attributes["date_received(3i)"]
+    return if day.blank?
+
+    day.to_i
+  end
+
+  private def month
+    month = attributes["date_received(2i)"]
+    return if month.blank?
+
+    month.to_i
+  end
+
+  private def year
+    year = attributes["date_received(1i)"]
+    return if year.blank?
+
+    year.to_i
+  end
+
+  def completed?
+    attributes.except(
+      "date_received(3i)",
+      "date_received(2i)",
+      "date_received(1i)"
+    ).values.all?(&:present?)
+  end
+
+  def in_progress?
+    attributes.except(
+      "date_received(3i)",
+      "date_received(2i)",
+      "date_received(1i)"
+    ).values.any?(&:present?)
+  end
 end

--- a/app/forms/conversion/task/receive_grant_payment_certificate_task_form.rb
+++ b/app/forms/conversion/task/receive_grant_payment_certificate_task_form.rb
@@ -1,5 +1,6 @@
 class Conversion::Task::ReceiveGrantPaymentCertificateTaskForm < BaseTaskForm
-  attribute :check_and_save, :boolean
+  attribute :check_certificate, :boolean
+  attribute :save_certificate, :boolean
   attribute "date_received(1i)"
   attribute "date_received(2i)"
   attribute "date_received(3i)"
@@ -19,7 +20,8 @@ class Conversion::Task::ReceiveGrantPaymentCertificateTaskForm < BaseTaskForm
   def save
     @tasks_data.assign_attributes(
       receive_grant_payment_certificate_date_received: formatted_date_received,
-      receive_grant_payment_certificate_check_and_save: check_and_save
+      receive_grant_payment_certificate_check_certificate: check_certificate,
+      receive_grant_payment_certificate_save_certificate: save_certificate
     )
     @tasks_data.save!
   end

--- a/app/views/conversions/tasks/receive_grant_payment_certificate/edit.html.erb
+++ b/app/views/conversions/tasks/receive_grant_payment_certificate/edit.html.erb
@@ -14,6 +14,20 @@
       <%= form.govuk_error_summary %>
 
       <div class="govuk-form-group">
+        <% if @project.tasks_data.receive_grant_payment_certificate_date_received.nil? %>
+          <%= form.govuk_date_field :date_received,
+                legend: {text: t("conversion.task.receive_grant_payment_certificate.date_received.title"), size: "s"} do %>
+            <div class="govuk-hint"><%= t("conversion.task.receive_grant_payment_certificate.date_received.hint.html") %></div>
+          <% end %>
+        <% else %>
+          <div class="govuk-details__text">
+            <p><%= t("conversion.task.receive_grant_payment_certificate.date_received.received_info.html", date: @project.tasks_data.receive_grant_payment_certificate_date_received.to_fs(:govuk)) %></p>
+          </div>
+        <% end %>
+
+      </div>
+
+      <div class="govuk-form-group">
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :check_and_save)) %>
       </div>
 

--- a/app/views/conversions/tasks/receive_grant_payment_certificate/edit.html.erb
+++ b/app/views/conversions/tasks/receive_grant_payment_certificate/edit.html.erb
@@ -28,7 +28,8 @@
       </div>
 
       <div class="govuk-form-group">
-        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :check_and_save)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :check_certificate)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :save_certificate)) %>
       </div>
 
       <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>

--- a/config/locales/conversion/tasks/receive_grant_payment_certificate.en.yml
+++ b/config/locales/conversion/tasks/receive_grant_payment_certificate.en.yml
@@ -6,14 +6,17 @@ en:
         hint:
           html: <p>You should already have sent a copy of the <a href="https://www.gov.uk/government/publications/academy-support-grant" target="_blank">grant payment certificate (opens in new tab)</a> when confirming the academy's opening date.</p>
 
-        check_and_save:
-          title: Check and save the grant payment certificate in the school's SharePoint folder
+        check_certificate:
+          title: Check the grant payment certificate is correct
           hint:
-            html: <p>Make sure the right template has been used and there is no missing information. Regional Casework Services must also <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&amp;file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&amp;action=default&amp;mobileredirect=true" target="_blank">update the support grant assurance report spreadsheet (opens in new tab)</a>. Do not update this grant assurance report spreadsheet if you work in a team in one of the Regions.</p>
-          guidance_link: What to do if you have not received the grant payment certificate
+            html: <p>Once they have sent it to you, check they've used the right template and there is no missing information.</p>
+          guidance_link: Using the right certificate
           guidance:
             html:
-              <p>You should ask the school to send the certificate. You must record the date each time you contact them in <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&amp;file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&amp;action=default&amp;mobileredirect=true" target="_blank">the support grant assurance report (opens in new tab)</a>.</p>
+              <p>If the school only recieved the £25,000 converter grant, they need to download and <a href="https://www.gov.uk/government/publications/academy-support-grant" target="_blank">complete the academy conversions, support grant certificate (opens in new tab)</a>.</p>
+              <p>If the school or trust received a sponsored grant, they need to <a href="https://www.gov.uk/government/publications/sponsored-academies-funding-guidance-for-sponsors" target="_blank">complete the certificate in Annex 2 of the Sponsored academies funding - advice for sponsors PDF (opens in a new tab)</a>.</p>
+        save_certificate:
+          title: Save the grant payment certifcate in the academy's SharePoint folder
         date_received:
           title: Enter the date you received the grant payment certificate
           hint:

--- a/config/locales/conversion/tasks/receive_grant_payment_certificate.en.yml
+++ b/config/locales/conversion/tasks/receive_grant_payment_certificate.en.yml
@@ -14,3 +14,11 @@ en:
           guidance:
             html:
               <p>You should ask the school to send the certificate. You must record the date each time you contact them in <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&amp;file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&amp;action=default&amp;mobileredirect=true" target="_blank">the support grant assurance report (opens in new tab)</a>.</p>
+        date_received:
+          title: Enter the date you received the grant payment certificate
+          hint:
+            html: <p>For example, 27 5 2007</p>
+          received_info:
+            html: DfE received the grant payment certificate on %{date}.
+          errors:
+            format: Please enter a valid date

--- a/config/locales/conversion/tasks/receive_grant_payment_certificate.en.yml
+++ b/config/locales/conversion/tasks/receive_grant_payment_certificate.en.yml
@@ -4,8 +4,12 @@ en:
       receive_grant_payment_certificate:
         title: Receive grant payment certificate
         hint:
-          html: <p>You should already have sent a copy of the <a href="https://www.gov.uk/government/publications/academy-support-grant" target="_blank">grant payment certificate (opens in new tab)</a> when confirming the academy's opening date.</p>
-
+          html: <p>Remind the school and trust to complete the grant payment certificate.</p>
+        guidance_link: What to do if you have not received the grant payment certificate
+        guidance:
+          html:
+            <p>If you do not recieve the grant certificate, you should keep reminding the school and trust to send it to you.</p>
+            <p>Regional Casework Services must also <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&action=default&mobileredirect=true" target="_blank">update the support grant assurance report spreadsheet (opens in new tab)</a>. Do not update this grant assurance report spreadsheet if you work in a team in one of the Regions.</p>
         check_certificate:
           title: Check the grant payment certificate is correct
           hint:

--- a/db/migrate/20240108113131_add_date_received_to_conversion_grant_payment_certificate_task.rb
+++ b/db/migrate/20240108113131_add_date_received_to_conversion_grant_payment_certificate_task.rb
@@ -1,0 +1,5 @@
+class AddDateReceivedToConversionGrantPaymentCertificateTask < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_tasks_data, :receive_grant_payment_certificate_date_received, :date
+  end
+end

--- a/db/migrate/20240109143032_split_conversion_grant_certificate_check_and_save_task.rb
+++ b/db/migrate/20240109143032_split_conversion_grant_certificate_check_and_save_task.rb
@@ -1,0 +1,18 @@
+class SplitConversionGrantCertificateCheckAndSaveTask < ActiveRecord::Migration[7.0]
+  def up
+    rename_column :conversion_tasks_data, :receive_grant_payment_certificate_check_and_save, :receive_grant_payment_certificate_save_certificate
+    add_column :conversion_tasks_data, :receive_grant_payment_certificate_check_certificate, :boolean
+
+    Conversion::Project.all do |project|
+      tasks_data = project.tasks_data
+      next unless tasks_data
+      tasks_data.receive_grant_payment_certificate_check_certificate = tasks_data.receive_grant_payment_certificate_save_certificate
+      tasks_data.save(validate: false)
+    end
+  end
+
+  def down
+    rename_column :conversion_tasks_data, :receive_grant_payment_certificate_save_certificate, :receive_grant_payment_certificate_check_and_save
+    remove_column :conversion_tasks_data, :receive_grant_payment_certificate_check_certificate
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_28_152937) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_08_113131) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -146,6 +146,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_28_152937) do
     t.string "proposed_capacity_of_the_academy_reception_to_six_years"
     t.string "proposed_capacity_of_the_academy_seven_to_eleven_years"
     t.string "proposed_capacity_of_the_academy_twelve_or_above_years"
+    t.date "receive_grant_payment_certificate_date_received"
   end
 
   create_table "events", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_08_113131) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_09_143032) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -96,7 +96,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_08_113131) do
     t.boolean "redact_and_send_save_redaction"
     t.boolean "redact_and_send_send_redaction"
     t.boolean "update_esfa_update"
-    t.boolean "receive_grant_payment_certificate_check_and_save"
+    t.boolean "receive_grant_payment_certificate_save_certificate"
     t.boolean "one_hundred_and_twenty_five_year_lease_email"
     t.boolean "one_hundred_and_twenty_five_year_lease_receive"
     t.boolean "one_hundred_and_twenty_five_year_lease_save_lease"
@@ -147,6 +147,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_08_113131) do
     t.string "proposed_capacity_of_the_academy_seven_to_eleven_years"
     t.string "proposed_capacity_of_the_academy_twelve_or_above_years"
     t.date "receive_grant_payment_certificate_date_received"
+    t.boolean "receive_grant_payment_certificate_check_certificate"
   end
 
   create_table "events", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/accessibility/projects_spec.rb
+++ b/spec/accessibility/projects_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Test projects accessibility", driver: :headless_firefox, accessib
   end
 
   scenario "project completed page" do
-    tasks_data = create(:conversion_tasks_data, receive_grant_payment_certificate_check_and_save: true, receive_grant_payment_certificate_date_received: Date.today)
+    tasks_data = create(:conversion_tasks_data, receive_grant_payment_certificate_check_certificate: true, receive_grant_payment_certificate_save_certificate: true, receive_grant_payment_certificate_date_received: Date.today)
     project = create(:conversion_project,
       regional_delivery_officer: user,
       assigned_to: user,

--- a/spec/accessibility/projects_spec.rb
+++ b/spec/accessibility/projects_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Test projects accessibility", driver: :headless_firefox, accessib
   end
 
   scenario "project completed page" do
-    tasks_data = create(:conversion_tasks_data, receive_grant_payment_certificate_check_and_save: true)
+    tasks_data = create(:conversion_tasks_data, receive_grant_payment_certificate_check_and_save: true, receive_grant_payment_certificate_date_received: Date.today)
     project = create(:conversion_project,
       regional_delivery_officer: user,
       assigned_to: user,

--- a/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
+++ b/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Users can complete a conversion project" do
 
   context "when all conditions have been met and the academy has opened" do
     let(:tasks_data) {
-      create(:conversion_tasks_data, receive_grant_payment_certificate_check_and_save: true, receive_grant_payment_certificate_date_received: Date.today)
+      create(:conversion_tasks_data, receive_grant_payment_certificate_check_certificate: true, receive_grant_payment_certificate_save_certificate: true, receive_grant_payment_certificate_date_received: Date.today)
     }
     let(:project) {
       create(:conversion_project,

--- a/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
+++ b/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Users can complete a conversion project" do
 
   context "when all conditions have been met and the academy has opened" do
     let(:tasks_data) {
-      create(:conversion_tasks_data, receive_grant_payment_certificate_check_and_save: true)
+      create(:conversion_tasks_data, receive_grant_payment_certificate_check_and_save: true, receive_grant_payment_certificate_date_received: Date.today)
     }
     let(:project) {
       create(:conversion_project,

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Users can complete conversion tasks" do
     check_accuracy_of_higher_needs
     commercial_transfer_agreement
     land_questionnaire land_registry
-    receive_grant_payment_certificate redact_and_send
+    redact_and_send
     school_completed share_information single_worksheet
     supplemental_funding_agreement update_esfa
   ]
@@ -32,6 +32,7 @@ RSpec.feature "Users can complete conversion tasks" do
     conditions_met
     main_contact
     proposed_capacity_of_the_academy
+    receive_grant_payment_certificate
   ]
 
   it "confirms we are checking all tasks" do
@@ -244,6 +245,36 @@ RSpec.feature "Users can complete conversion tasks" do
       click_on I18n.t("task_list.continue_button.text")
 
       expect(project.reload.all_conditions_met).to be true
+    end
+  end
+
+  describe "the receive grant payment certificate task" do
+    let(:project) { create(:conversion_project, assigned_to: user) }
+
+    context "when the task does not have a date" do
+      scenario "they can add a date" do
+        visit project_tasks_path(project)
+        click_on "Receive grant payment certificate"
+        page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
+        fill_in "Day", with: "1"
+        fill_in "Month", with: "1"
+        fill_in "Year", with: "2024"
+        click_on I18n.t("task_list.continue_button.text")
+
+        expect(project.reload.tasks_data.receive_grant_payment_certificate_date_received).to eq Date.new(2024, 1, 1)
+      end
+    end
+
+    context "when the task has a date" do
+      let(:tasks_data) { create(:conversion_tasks_data, receive_grant_payment_certificate_date_received: Date.new(2024, 1, 1)) }
+      let(:project) { create(:conversion_project, assigned_to: user, tasks_data: tasks_data) }
+
+      scenario "they see the date on the page but cannot add a new one" do
+        visit project_tasks_path(project)
+        click_on "Receive grant payment certificate"
+        expect(page).to have_content("DfE received the grant payment certificate on 1 January 2024.")
+        expect(page).to_not have_content("Enter the date you received the grant payment certificate")
+      end
     end
   end
 

--- a/spec/forms/conversion/tasks/receive_grant_payment_certificate_task_form_spec.rb
+++ b/spec/forms/conversion/tasks/receive_grant_payment_certificate_task_form_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe Conversion::Task::ReceiveGrantPaymentCertificateTaskForm do
+  let(:user) { create(:user) }
+
+  describe "#save" do
+    before { mock_successful_api_response_to_create_any_project }
+
+    let(:project) { create(:conversion_project) }
+
+    context "when the date is a valid date" do
+      it "sets date_received to the supplied date" do
+        form = described_class.new(project.tasks_data, user)
+        form.assign_attributes("date_received(1i)": 2024, "date_received(2i)": 1, "date_received(3i)": 1)
+        form.save
+
+        expect(project.tasks_data.receive_grant_payment_certificate_date_received).to eq(Date.new(2024, 1, 1))
+      end
+
+      it "sets date_received to the supplied date (leap year)" do
+        form = described_class.new(project.tasks_data, user)
+        form.assign_attributes("date_received(1i)": 2024, "date_received(2i)": 2, "date_received(3i)": 29)
+        form.save
+
+        expect(project.tasks_data.receive_grant_payment_certificate_date_received).to eq(Date.new(2024, 2, 29))
+      end
+    end
+
+    context "when the date is partially missing" do
+      it "adds an error" do
+        form = described_class.new(project.tasks_data, user)
+        form.assign_attributes("date_received(1i)": 2024, "date_received(2i)": nil, "date_received(3i)": 1)
+
+        expect(form.valid?).to be false
+        expect(form.errors.messages[:date_received])
+          .to include(I18n.t("conversion.task.receive_grant_payment_certificate.date_received.errors.format"))
+        expect(project.tasks_data.receive_grant_payment_certificate_date_received).to be_nil
+      end
+    end
+
+    context "when the date is invalid" do
+      it "adds an error" do
+        form = described_class.new(project.tasks_data, user)
+        form.assign_attributes("date_received(1i)": 2024, "date_received(2i)": 2, "date_received(3i)": 30)
+
+        expect(form.valid?).to be false
+        expect(form.errors.messages[:date_received])
+          .to include(I18n.t("conversion.task.receive_grant_payment_certificate.date_received.errors.format"))
+        expect(project.tasks_data.receive_grant_payment_certificate_date_received).to be_nil
+      end
+    end
+
+    context "when the date is totally missing" do
+      it "saves without the date" do
+        form = described_class.new(project.tasks_data, user)
+        form.assign_attributes("date_received(1i)": nil, "date_received(2i)": nil, "date_received(3i)": nil)
+        form.save
+
+        expect(project.tasks_data.receive_grant_payment_certificate_date_received).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -104,11 +104,11 @@ RSpec.describe Conversion::Project do
 
   describe "#grant_payment_certificate_received?" do
     let(:user) { create(:user) }
-    let(:project) { build(:conversion_project, tasks_data: tasks_data) }
+    let!(:project) { create(:conversion_project, tasks_data: tasks_data) }
 
     context "when the ReceiveGrantPaymentCertificateTaskForm is NOT completed" do
       let(:tasks_data) {
-        create(:conversion_tasks_data, receive_grant_payment_certificate_check_and_save: nil)
+        create(:conversion_tasks_data, receive_grant_payment_certificate_check_and_save: nil, receive_grant_payment_certificate_date_received: nil)
       }
 
       it "returns false" do
@@ -118,7 +118,7 @@ RSpec.describe Conversion::Project do
 
     context "when the ReceiveGrantPaymentCertificateTaskForm is completed" do
       let(:tasks_data) {
-        create(:conversion_tasks_data, receive_grant_payment_certificate_check_and_save: true)
+        create(:conversion_tasks_data, receive_grant_payment_certificate_check_and_save: true, receive_grant_payment_certificate_date_received: Date.today)
       }
 
       it "returns true" do

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Conversion::Project do
 
     context "when the ReceiveGrantPaymentCertificateTaskForm is NOT completed" do
       let(:tasks_data) {
-        create(:conversion_tasks_data, receive_grant_payment_certificate_check_and_save: nil, receive_grant_payment_certificate_date_received: nil)
+        create(:conversion_tasks_data, receive_grant_payment_certificate_check_certificate: nil, receive_grant_payment_certificate_save_certificate: nil, receive_grant_payment_certificate_date_received: nil)
       }
 
       it "returns false" do
@@ -118,7 +118,7 @@ RSpec.describe Conversion::Project do
 
     context "when the ReceiveGrantPaymentCertificateTaskForm is completed" do
       let(:tasks_data) {
-        create(:conversion_tasks_data, receive_grant_payment_certificate_check_and_save: true, receive_grant_payment_certificate_date_received: Date.today)
+        create(:conversion_tasks_data, receive_grant_payment_certificate_check_certificate: true, receive_grant_payment_certificate_save_certificate: true, receive_grant_payment_certificate_date_received: Date.today)
       }
 
       it "returns true" do


### PR DESCRIPTION
1. We need to be able to enter the date the Grant payment certificate was received to the Conversion task list. This was not a simple piece of work as we do not yet have any tasks that collect dates.

Refactor the Grant payment certificate task form to collect a date, or show an existing date if one was previously entered. We have also modified the `Project#grant_payment_certificate_received?` method to take the date received into account.

2. Then, split the "Check and save" action on this task into "Check" and "Save". This has required a database data migration for existing projects. 

Without an entered date

<img width="578" alt="Screenshot 2024-01-09 at 16 07 08" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/83761b2e-0aec-4be0-a83d-0f8556dc526a">

With an entered date

<img width="1098" alt="Screenshot 2024-01-09 at 16 07 36" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/3e9226c7-432e-4af0-896f-d52157b66b59">

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
