### PR TITLE
(Fix) The Sponsored support grant task is not completable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix Conversion project incoming sharepoint link edit view to not display
   outgoing trust sharepoint link field.
 - Fix statistics page to show accurate data for Transfer's `by region` table.
+- The Sponsored support grant task in Conversions was not completable - fixed
 
 ### Added
 

--- a/app/forms/conversion/task/sponsored_support_grant_task_form.rb
+++ b/app/forms/conversion/task/sponsored_support_grant_task_form.rb
@@ -1,5 +1,4 @@
 class Conversion::Task::SponsoredSupportGrantTaskForm < BaseOptionalTaskForm
-  attribute :eligibility, :boolean
   attribute :payment_amount, :boolean
   attribute :payment_form, :boolean
   attribute :send_information, :boolean

--- a/db/migrate/20240110145231_remove_eligibility_from_sponsored_support_grant_task.rb
+++ b/db/migrate/20240110145231_remove_eligibility_from_sponsored_support_grant_task.rb
@@ -1,0 +1,5 @@
+class RemoveEligibilityFromSponsoredSupportGrantTask < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :conversion_tasks_data, :sponsored_support_grant_eligibility, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_09_143032) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_10_145231) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -126,7 +126,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_09_143032) do
     t.boolean "trust_modification_order_not_applicable"
     t.boolean "stakeholder_kick_off_check_provisional_conversion_date"
     t.boolean "conversion_grant_not_applicable"
-    t.boolean "sponsored_support_grant_eligibility"
     t.boolean "sponsored_support_grant_payment_amount"
     t.boolean "sponsored_support_grant_payment_form"
     t.boolean "sponsored_support_grant_send_information"

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -233,6 +233,25 @@ RSpec.feature "Users can complete conversion tasks" do
 
       expect(project.reload.tasks_data.sponsored_support_grant_type).to eq "full_sponsored"
     end
+
+    scenario "the task can be completed" do
+      choose "Full sponsored"
+      page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
+      # uncheck the Not applicable box
+      page.find(".govuk-checkboxes__label", text: "Not applicable").click
+      click_on I18n.t("task_list.continue_button.text")
+
+      table_row = page.find("li.app-task-list__item", text: I18n.t("conversion.task.sponsored_support_grant.title"))
+      expect(table_row).to have_content("Completed")
+    end
+
+    scenario "the task can be marked as Not applicable" do
+      page.find(".govuk-checkboxes__label", text: "Not applicable").click
+      click_on I18n.t("task_list.continue_button.text")
+
+      table_row = page.find("li.app-task-list__item", text: I18n.t("conversion.task.sponsored_support_grant.title"))
+      expect(table_row).to have_content("Not applicable")
+    end
   end
 
   describe "the confirm all conditions met task" do


### PR DESCRIPTION
In commit https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/commit/640256d1da7ce2f76086f043979f5744d41b8597 we removed the old `eligibility` question from the `SponsoredSupportGrantTaskForm` and replaced it with a series of radio buttons instead. However, the eligibility attribute and associate database column were not removed.

As we had removed the checkbox from the UI, users were unable to check off the `eligibility` question and therefore the task was never completable.

Remove the eligibility attribute from the task form, and the associated db column. Also add a test to demonstrate the task is still completable - this was missing before and the reason we didn't pick up the bug.


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
