### PR TITLE
(151369) Add new Transfer Check and confirm financial information task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the Conversions Receive grant payment certificate task.
 - Script to backfill dates in the Conversions Receive grant payment certificate
   task
+- Add Transfer Check and confirm financial information task
 
 ### Changed
 

--- a/app/forms/transfer/task/check_and_confirm_financial_information_task_form.rb
+++ b/app/forms/transfer/task/check_and_confirm_financial_information_task_form.rb
@@ -1,0 +1,8 @@
+class Transfer::Task::CheckAndConfirmFinancialInformationTaskForm < BaseOptionalTaskForm
+  attribute :academy_surplus_deficit, :string
+  attribute :trust_surplus_deficit, :string
+
+  def type_options
+    [:surplus, :deficit]
+  end
+end

--- a/app/models/transfer/task_list.rb
+++ b/app/models/transfer/task_list.rb
@@ -7,7 +7,8 @@ class Transfer::TaskList < ::BaseTaskList
           Transfer::Task::HandoverTaskForm,
           Transfer::Task::StakeholderKickOffTaskForm,
           Transfer::Task::MainContactTaskForm,
-          Transfer::Task::RequestNewUrnAndRecordTaskForm
+          Transfer::Task::RequestNewUrnAndRecordTaskForm,
+          Transfer::Task::CheckAndConfirmFinancialInformationTaskForm
         ]
       },
       {

--- a/app/views/transfers/tasks/check_and_confirm_financial_information/edit.html.erb
+++ b/app/views/transfers/tasks/check_and_confirm_financial_information/edit.html.erb
@@ -1,0 +1,53 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.check_and_confirm_financial_information.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
+      <div class="govuk-form-group govuk-!-margin-bottom-9">
+        <%= form.govuk_radio_buttons_fieldset(:academy_surplus_deficit, legend: {size: "l", text: t("transfer.task.check_and_confirm_financial_information.academy_surplus_deficit.title")}) do %>
+          <div class="app-task-section__hint">
+            <%= t("transfer.task.check_and_confirm_financial_information.academy_surplus_deficit.hint.html") %>
+          </div>
+          <% @task.type_options.each do |option| %>
+            <%= form.govuk_radio_button :academy_surplus_deficit,
+                  option,
+                  label: {text: t("transfer.task.check_and_confirm_financial_information.options.#{option}")} %>
+          <% end %>
+        <% end %>
+      </div>
+
+      <div class="govuk-form-group govuk-!-margin-bottom-9">
+        <%= form.govuk_radio_buttons_fieldset(:trust_surplus_deficit, legend: {size: "l", text: t("transfer.task.check_and_confirm_financial_information.trust_surplus_deficit.title")}) do %>
+          <div class="app-task-section__hint">
+            <%= t("transfer.task.check_and_confirm_financial_information.trust_surplus_deficit.hint.html") %>
+          </div>
+          <% @task.type_options.each do |option| %>
+            <%= form.govuk_radio_button :trust_surplus_deficit,
+                  option,
+                  label: {text: t("transfer.task.check_and_confirm_financial_information.options.#{option}")} %>
+          <% end %>
+        <% end %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/config/locales/transfer/tasks/check_and_confirm_financial_information.en.yml
+++ b/config/locales/transfer/tasks/check_and_confirm_financial_information.en.yml
@@ -1,0 +1,26 @@
+en:
+  transfer:
+    task:
+      check_and_confirm_financial_information:
+        title: Check and confirm academy and trust financial information
+        hint:
+          html:
+            <p>The academy or incoming trust must use any budget surplus they have to fund the transfer.
+            <p>If the cost of the transfer exceeds their budget surplus, they may be eligible for a transfer grant.</p>
+            <p>These grants are available to help with the costs of an academy transfer. They can also fund some academy improvements.</p>
+            <p>Mark this task as not applicable if no transfer grant will be used.</p>
+        not_applicable:
+          title: Not applicable
+        academy_surplus_deficit:
+          title: Is the academy in surplus or deficit?
+          hint:
+            html:
+              <p>Ask the academy for this information if you don't have it already. </p>
+        trust_surplus_deficit:
+          title: Is the incoming trust in surplus or deficit?
+          hint:
+            html:
+              <p>You should work with SFSO (Schools Finance and Support Oversight) to ask the trust for this information if you don't have it already.</p>
+        options:
+          surplus: Surplus
+          deficit: Deficit

--- a/db/migrate/20240111162641_add_transfer_check_and_confirm_financial_information_task_attributes.rb
+++ b/db/migrate/20240111162641_add_transfer_check_and_confirm_financial_information_task_attributes.rb
@@ -1,0 +1,7 @@
+class AddTransferCheckAndConfirmFinancialInformationTaskAttributes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :transfer_tasks_data, :check_and_confirm_financial_information_not_applicable, :boolean
+    add_column :transfer_tasks_data, :check_and_confirm_financial_information_academy_surplus_deficit, :string
+    add_column :transfer_tasks_data, :check_and_confirm_financial_information_trust_surplus_deficit, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_10_145231) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_11_162641) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -387,6 +387,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_10_145231) do
     t.boolean "financial_safeguarding_governance_issues", default: false
     t.boolean "outgoing_trust_to_close", default: false
     t.boolean "bank_details_changing_yes_no", default: false
+    t.boolean "check_and_confirm_financial_information_not_applicable"
+    t.string "check_and_confirm_financial_information_academy_surplus_deficit"
+    t.string "check_and_confirm_financial_information_trust_surplus_deficit"
   end
 
   create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
+++ b/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
@@ -38,6 +38,7 @@ RSpec.feature "Users can complete transfer tasks" do
     conditions_met
     main_contact
     bank_details_changing
+    check_and_confirm_financial_information
   ]
 
   it "confirms that all tasks are tested here" do
@@ -81,6 +82,66 @@ RSpec.feature "Users can complete transfer tasks" do
 
         click_on I18n.t("task_list.continue_button.text")
         table_row = page.find("li.app-task-list__item", text: I18n.t("transfer.task.#{task}.title"))
+
+        expect(table_row).to have_content("Completed")
+      end
+    end
+  end
+
+  describe "tasks with collected data" do
+    describe "the check_and_confirm_financial_information task" do
+      before do
+        visit project_tasks_path(project)
+        click_on "Check and confirm academy and trust financial information"
+      end
+
+      it "can collect surplus for academy and trust finances" do
+        within_fieldset("Is the academy in surplus or deficit?") do
+          choose "Surplus"
+        end
+
+        within_fieldset("Is the incoming trust in surplus or deficit?") do
+          choose "Surplus"
+        end
+
+        click_on I18n.t("task_list.continue_button.text")
+
+        expect(project.reload.tasks_data.check_and_confirm_financial_information_academy_surplus_deficit).to eq "surplus"
+        expect(project.reload.tasks_data.check_and_confirm_financial_information_trust_surplus_deficit).to eq "surplus"
+      end
+
+      it "can collect deficit for academy and trust finances" do
+        within_fieldset("Is the academy in surplus or deficit?") do
+          choose "Deficit"
+        end
+
+        within_fieldset("Is the incoming trust in surplus or deficit?") do
+          choose "Deficit"
+        end
+
+        click_on I18n.t("task_list.continue_button.text")
+
+        expect(project.reload.tasks_data.check_and_confirm_financial_information_academy_surplus_deficit).to eq "deficit"
+        expect(project.reload.tasks_data.check_and_confirm_financial_information_trust_surplus_deficit).to eq "deficit"
+      end
+
+      it "can be not applicable" do
+        click_not_applicable(page)
+        click_on I18n.t("task_list.continue_button.text")
+        expect(project.reload.tasks_data.check_and_confirm_financial_information_not_applicable).to be true
+      end
+
+      it "can be completed" do
+        within_fieldset("Is the academy in surplus or deficit?") do
+          choose "Surplus"
+        end
+
+        within_fieldset("Is the incoming trust in surplus or deficit?") do
+          choose "Deficit"
+        end
+
+        click_on I18n.t("task_list.continue_button.text")
+        table_row = page.find("li.app-task-list__item", text: I18n.t("transfer.task.check_and_confirm_financial_information.title"))
 
         expect(table_row).to have_content("Completed")
       end

--- a/spec/models/transfer/task_list_spec.rb
+++ b/spec/models/transfer/task_list_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Transfer::TaskList do
         :stakeholder_kick_off,
         :main_contact,
         :request_new_urn_and_record,
+        :check_and_confirm_financial_information,
         :form_m,
         :land_consent_letter,
         :supplemental_funding_agreement,
@@ -49,7 +50,7 @@ RSpec.describe Transfer::TaskList do
       project = create(:transfer_project)
       task_list = described_class.new(project, user)
 
-      expect(task_list.tasks.count).to eql 21
+      expect(task_list.tasks.count).to eql 22
       expect(task_list.tasks.first).to be_a Transfer::Task::HandoverTaskForm
       expect(task_list.tasks.last).to be_a Transfer::Task::RedactAndSendDocumentsTaskForm
     end


### PR DESCRIPTION
A new task where users can state if an academy and trust for a transferring academy are in a financial surplus or deficit. The collected answers are strings ("surplus" or "deficit"), or the task can be marked as Not applicable.

Add the task to the bottom of the kick-off section.

<img width="887" alt="Screenshot 2024-01-12 at 14 30 54" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/5c524105-555b-4528-a660-faf970eef6de">


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
