### PR TITLE
Release 50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release-50][release-50]
+
 ### Fixed
 
 - An email is now sent to team leaders when a transfer project is created and
@@ -1495,7 +1497,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-49...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-50...HEAD
+[release-50]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-49...release-50
 [release-49]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-48...release-49
 [release-48]:


### PR DESCRIPTION
Fixed

- An email is now sent to team leaders when a transfer project is created and handed over to Regional casework services
- Fix Conversion project incoming sharepoint link edit view to not display outgoing trust sharepoint link field.
- Fix statistics page to show accurate data for Transfer's `by region` table.
- The Sponsored support grant task in Conversions was not completable - fixed

Added

- Add the ability to download Transfer projects for the Grant management and finance team
- Added a field to enter the date a grant payment certificate was received to the Conversions Receive grant payment certificate task.
- Script to backfill dates in the Conversions Receive grant payment certificate task
- Add Transfer Check and confirm financial information task
- Add the Check and confirm financial information fields to the Grant management and finance unit export for Transfers

Changed

- Changed the existing Grant management and finance team Conversions download page to include an information page about the download, and a tabbed view on the index page to switch between Transfers and Conversions
- Split the "Check and save" action in the Conversions Receive grant payment certificate task. The actions are now "Check" and "Save" separately.

## Changes

_Add a summary of the changes in this pull request_

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
