### PR TITLE
(147050) Fetch academy details on Conversion project page from local Gias::Establishment records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - When service support adds a new academy URN to a conversion project, the urn
   is now checked against our local record of Establishments, and not the
   Academies API records (which do not contain details for unopened academies)
+- Fetch academy details for Conversions from local Gias::Establishment records
+  instead of the Academies API. This means we can show details for academies
+  which have not opened yet.
 
 ## [Release-50][release-50]
 

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -26,7 +26,7 @@ class Conversion::Project < Project
   end
 
   def academy
-    @academy ||= fetch_academy(academy_urn).object
+    @academy ||= fetch_academy(academy_urn)
   end
 
   def academy_found?
@@ -44,6 +44,6 @@ class Conversion::Project < Project
   end
 
   private def fetch_academy(urn)
-    Api::AcademiesApi::Client.new.get_establishment(urn)
+    Gias::Establishment.find_by(urn: urn)
   end
 end

--- a/app/models/gias/establishment.rb
+++ b/app/models/gias/establishment.rb
@@ -4,6 +4,7 @@ class Gias::Establishment < ApplicationRecord
   validates :urn, presence: true
 
   alias_attribute :phase, :phase_name
+  alias_attribute :type, :type_name
 
   DIOCESE_NOT_APPLICABLE_CODE = "0000"
 

--- a/app/views/projects/shared/_with_academy_urn_table.html.erb
+++ b/app/views/projects/shared/_with_academy_urn_table.html.erb
@@ -18,7 +18,7 @@
         <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
         <td class="govuk-table__cell"><%= project.urn %></td>
         <td class="govuk-table__cell"><%= project.conversion_date.to_formatted_s(:significant_date) %></td>
-        <td class="govuk-table__cell"><%= project.academy.name %></td>
+        <td class="govuk-table__cell"><%= project.academy&.name %></td>
         <td class="govuk-table__cell"><%= project.academy_urn %></td>
         <td class="govuk-table__cell">
           <a href="<%= project_path(project) %>">

--- a/spec/features/project_information/users_can_view_academy_details_spec.rb
+++ b/spec/features/project_information/users_can_view_academy_details_spec.rb
@@ -25,8 +25,6 @@ RSpec.feature "Users can view academy details" do
     let(:project) { create(:conversion_project, assigned_to: user, academy_urn: 149061) }
 
     context "and the details are not found" do
-      before { mock_establishment_not_found(urn: project.academy_urn) }
-
       scenario "they see the academy urn and a helpful message" do
         visit project_information_path(project)
 
@@ -38,6 +36,8 @@ RSpec.feature "Users can view academy details" do
     end
 
     context "and the details can be found" do
+      let!(:establishment) { create(:gias_establishment, urn: 149061) }
+
       scenario "they see the academy details" do
         visit project_information_path(project)
 

--- a/spec/features/service_support/users_can_navigate_the_application_spec.rb
+++ b/spec/features/service_support/users_can_navigate_the_application_spec.rb
@@ -24,7 +24,17 @@ RSpec.feature "Service support users can navigate the application" do
     expect(page).to have_content(project.urn)
   end
 
-  scenario "they can view the projects that have a record on GIAS" do
+  scenario "they can view the projects that have a GIAS Establishment record" do
+    project = create(:conversion_project, academy_urn: 149061)
+    _establishment = create(:gias_establishment, urn: 149061)
+
+    click_link("URNs added")
+
+    expect(page).to have_content("URNs added")
+    expect(page).to have_content(project.academy_urn)
+  end
+
+  scenario "they can view the projects that have an academy URN but we don't yet have a local GIAS Establishment record for" do
     project = create(:conversion_project, academy_urn: 149061)
 
     click_link("URNs added")

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -128,12 +128,14 @@ RSpec.describe Conversion::Project do
   end
 
   describe "#academy" do
-    it "returns an establishment object when the urn can be found" do
+    it "returns an establishment when there is a matching Gias::Establishment record" do
       mock_successful_api_response_to_create_any_project
+      establishment = create(:gias_establishment, urn: 123456)
 
       project = build(:conversion_project, academy_urn: 123456)
 
-      expect(project.academy).to be_a(Api::AcademiesApi::Establishment)
+      expect(project.academy).to be_a(Gias::Establishment)
+      expect(project.academy).to eq(establishment)
     end
 
     it "returns nil when the urn cannot be found" do
@@ -151,6 +153,7 @@ RSpec.describe Conversion::Project do
 
     it "returns true when the academy can be found" do
       project = build(:conversion_project, academy_urn: 123456)
+      _establishment = create(:gias_establishment, urn: 123456)
 
       expect(project.academy_found?).to eql true
     end

--- a/spec/models/gias/establishment_spec.rb
+++ b/spec/models/gias/establishment_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe Gias::Establishment do
     end
   end
 
+  describe "type" do
+    it "returns the type_name" do
+      establishment = create(:gias_establishment, urn: 123456, type_name: "Community school")
+      expect(establishment.type).to eq("Community school")
+    end
+  end
+
   describe "dfe_number" do
     it "returns the local authority code and establishment number, formatted as a dfe_number" do
       establishment = create(:gias_establishment, urn: 123456, local_authority_code: 123, establishment_number: 456)

--- a/spec/requests/all/projects_controller_spec.rb
+++ b/spec/requests/all/projects_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ServiceSupport::ProjectsController, type: :request do
   let!(:completed_project) { create(:conversion_project, completed_at: Date.today, urn: 165432) }
   let!(:project_without_urn) { create(:conversion_project, academy_urn: nil, urn: 132342) }
   let!(:project_with_urn) { create(:conversion_project, academy_urn: 123456, urn: 154232) }
+  let(:establishment) { create(:gias_establishment, urn: 123456) }
   let(:user) { create(:user) }
 
   describe "without_academy_urn" do


### PR DESCRIPTION
## Changes

To be merged after #1304 and #1300 

Now that we have local Gias::Establishment data uploaded from GIAS by service support, we can use these records to display academy data. The records should include entries for academies which have not yet opened, and are not available on the Academies API.

On the Conversion project information page, show the data for the new academy as retrieved from Gias::Establishment records. Also add some checks to the views to only show academy data if it is present. 

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
