### PR TITLE
Enable service support users to be able to update all projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Service support users can navigate to the GIAS data upload page
 - Add additional columns to the ESFA report
+- Service support users can now update projects which are assigned to other
+  users
 
 ### Changed
 

--- a/app/helpers/project_helper.rb
+++ b/app/helpers/project_helper.rb
@@ -58,7 +58,7 @@ module ProjectHelper
     if project.completed?
       render NotificationBanner
         .new(message: t("project.notifications.completed_html", date: project.completed_at.to_formatted_s(:govuk_date_time_date_only)))
-    elsif project.assigned_to != user || project.assigned_to.nil?
+    elsif (project.assigned_to != user && !user.is_service_support?) || project.assigned_to.nil?
       render NotificationBanner
         .new(message: t("project.notifications.not_assigned_html"))
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,10 @@ class User < ApplicationRecord
     false
   end
 
+  def is_service_support?
+    team == "service_support"
+  end
+
   def is_regional_caseworker?
     team == "regional_casework_services" && manage_team == false
   end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -89,7 +89,7 @@ class ProjectPolicy
   end
 
   private def project_assigned_to_user?
-    @record.assigned_to == @user
+    @record.assigned_to == @user || @user.is_service_support?
   end
 
   private def edit_project_closed?

--- a/app/policies/task_list_policy.rb
+++ b/app/policies/task_list_policy.rb
@@ -14,6 +14,6 @@ class TaskListPolicy
   def update?
     return false if @project.completed?
 
-    @task_list.project.assigned_to == @user
+    @task_list.project.assigned_to == @user || @user.is_service_support?
   end
 end

--- a/spec/helpers/project_helper_spec.rb
+++ b/spec/helpers/project_helper_spec.rb
@@ -210,7 +210,17 @@ RSpec.describe ProjectHelper, type: :helper do
         end
       end
 
-      context "when the project is not assigned to the user" do
+      context "when the project is not assigned to the user but the user is service support" do
+        it "does nothing" do
+          user = build(:user)
+          service_support_user = build(:user, :service_support)
+          project = build(:conversion_project, completed_at: nil, assigned_to: user)
+
+          expect(project_notification_banner(project, service_support_user)).to be_nil
+        end
+      end
+
+      context "when the project is not assigned to the user and the user is not service support" do
         it "renders a notification banner" do
           user = build(:user)
           other_user = build(:user, email: "other.user@education.gov.uk")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -295,6 +295,14 @@ RSpec.describe User do
     end
   end
 
+  describe "#is_service_support?" do
+    it "returns true when the user is in the service support team" do
+      user = create(:user, team: "service_support")
+
+      expect(user.is_service_support?).to be true
+    end
+  end
+
   describe "#team" do
     it "uses the enum suffix as expected" do
       user = create(:user, team: "london")

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -5,10 +5,15 @@ RSpec.describe ProjectPolicy do
   before { mock_successful_api_response_to_create_any_project }
 
   let(:application_user) { build(:user, :caseworker, email: "application.user@education.gov.uk") }
+  let(:service_support_user) { build(:user, :service_support) }
 
   permissions :update? do
     it "grants access if project is assigned to the same user" do
       expect(subject).to permit(application_user, build(:conversion_project, assigned_to: application_user, conversion_date_provisional: false))
+    end
+
+    it "grants access if the user is service support but assigned to a different user" do
+      expect(subject).to permit(service_support_user, build(:conversion_project, assigned_to: application_user, conversion_date_provisional: false))
     end
 
     it "denies access if the project is assigned to another user" do

--- a/spec/policies/task_list_policy_spec.rb
+++ b/spec/policies/task_list_policy_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe TaskListPolicy do
   before { mock_successful_api_response_to_create_any_project }
 
   let(:application_user) { build(:user, email: "application.user@education.gov.uk") }
+  let(:service_support_user) { build(:user, :service_support) }
 
   permissions :edit? do
     it "grants access if project is assigned to the same user" do
@@ -28,6 +29,11 @@ RSpec.describe TaskListPolicy do
       it "grants access if project is assigned to the same user" do
         task_list = create(:conversion_project, assigned_to: application_user).tasks_data
         expect(subject).to permit(application_user, task_list)
+      end
+
+      it "grants access if the user is service support and the project is assigned to a different user" do
+        task_list = create(:conversion_project, assigned_to: application_user).tasks_data
+        expect(subject).to permit(service_support_user, task_list)
       end
 
       it "denies access if project is assigned to a different user" do


### PR DESCRIPTION
## Changes

The service support user does a lot of data quality work in KIM and updates projects within this service on behalf of regional delivery officers when there is an error. This change will allow this process to happen without needing the assigned user to be present and make the process a lot simplier.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
