### PR TITLE
(154339) Change "All conditions met" header to "Authority to proceed" for Transfer project exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Extend validation on Advisory board date to make sure the date is not too far
   in the past
+- Change "All conditions met" header to "Authority to proceed" for Transfer
+  project exports
 
 ## [Release-51][release-51]
 

--- a/app/services/export/conversions/education_and_skills_funding_agency_csv_export_service.rb
+++ b/app/services/export/conversions/education_and_skills_funding_agency_csv_export_service.rb
@@ -30,5 +30,6 @@ class Export::Conversions::EducationAndSkillsFundingAgencyCsvExportService < Exp
 
   def initialize(projects)
     @projects = projects
+    @project_type = :conversion
   end
 end

--- a/app/services/export/conversions/funding_agreement_letters_csv_exporter_service.rb
+++ b/app/services/export/conversions/funding_agreement_letters_csv_exporter_service.rb
@@ -60,5 +60,6 @@ class Export::Conversions::FundingAgreementLettersCsvExporterService < Export::C
 
   def initialize(projects)
     @projects = projects
+    @project_type = :conversion
   end
 end

--- a/app/services/export/conversions/grant_management_and_finance_unit_csv_export_service.rb
+++ b/app/services/export/conversions/grant_management_and_finance_unit_csv_export_service.rb
@@ -20,5 +20,6 @@ class Export::Conversions::GrantManagementAndFinanceUnitCsvExportService < Expor
 
   def initialize(projects)
     @projects = projects
+    @project_type = :conversion
   end
 end

--- a/app/services/export/csv_export_service.rb
+++ b/app/services/export/csv_export_service.rb
@@ -18,7 +18,7 @@ class Export::CsvExportService
 
   private def headers
     self.class::COLUMN_HEADERS.map do |column|
-      I18n.t("export.csv.project.headers.#{column}")
+      I18n.t("export.csv.project.headers.#{@project_type}.#{column}")
     end
   end
 

--- a/app/services/export/transfers/academies_due_to_transfer_csv_export_service.rb
+++ b/app/services/export/transfers/academies_due_to_transfer_csv_export_service.rb
@@ -23,5 +23,6 @@ class Export::Transfers::AcademiesDueToTransferCsvExportService < Export::CsvExp
 
   def initialize(projects)
     @projects = projects
+    @project_type = :transfer
   end
 end

--- a/app/services/export/transfers/grant_management_and_finance_unit_csv_export_service.rb
+++ b/app/services/export/transfers/grant_management_and_finance_unit_csv_export_service.rb
@@ -21,5 +21,6 @@ class Export::Transfers::GrantManagementAndFinanceUnitCsvExportService < Export:
 
   def initialize(projects)
     @projects = projects
+    @project_type = :transfer
   end
 end

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -78,13 +78,11 @@ en:
             outgoing_trust_to_close: Outgoing trust to close
             request_new_urn_and_record: New URN/record requested
             bank_details_changing: Bank details changing
-            transfer_date: Transfer date
             added_by_email: Added by email
             academy_surplus_deficit: Is the academy in surplus or deficit?
             trust_surplus_deficit: Is the incoming trust in surplus or deficit?
           transfer:
             project_type: Project type
-            conversion_date: Conversion date
             all_conditions_met: Authority to proceed
             risk_protection_arrangement: Risk protection arrangement
             advisory_board_date: Advisory board date
@@ -167,7 +165,7 @@ en:
             transfer: Transfer
           sponsored_grant_type:
             fast_track: fast track
-            intermidiate: intermidiate
+            intermediate: intermediate
             sponsored: sponsored
           unconfirmed: unconfirmed
           confirmed: confirmed

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -3,84 +3,164 @@ en:
     csv:
       project:
         headers:
-          project_type: Project type
-          conversion_date: Conversion date
-          all_conditions_met: All conditions met
-          risk_protection_arrangement: Risk protection arrangement
-          advisory_board_date: Advisory board date
-          academy_order_type: Academy order type
-          reception_to_six_years: Proposed capacity for pupils in reception to year 6
-          seven_to_eleven_years: Proposed capacity for pupils in years 7 to 11
-          twelve_or_above_years: Proposed capacity for students in year 12 or above
-          two_requires_improvement: 2RI (Two Requires Improvement)
-          sponsored_grant_type: Sponsored Grant Type
-          assigned_to_name: Assigned to name
-          assigned_to_email: Assigned to email
-          school_urn: School URN
-          school_dfe_number: DfE number
-          school_name: School name
-          school_type: School type
-          school_address_1: School address 1
-          school_address_2: School address 2
-          school_address_3: School address 3
-          school_address_town: School town
-          school_address_county: School county
-          school_address_postcode: School postcode
-          academy_urn: Academy URN
-          academy_name: Academy name
-          academy_address_1: Academy address 1
-          academy_address_2: Academy address 2
-          academy_address_3: Academy address 3
-          academy_address_town: Academy town
-          academy_address_county: Academy county
-          academy_address_postcode: Academy postcode
-          director_of_child_services_name: Director of child services name
-          director_of_child_services_role: Director of child services role
-          director_of_child_services_email: Director of child services email
-          director_of_child_services_phone: Director of child services phone
-          incoming_trust_identifier: Incoming trust group identifier
-          incoming_trust_companies_house_number: Incoming trust companies house number
-          incoming_trust_name: Incoming trust name
-          incoming_trust_address_1: Incoming trust address 1
-          incoming_trust_address_2: Incoming trust address 2
-          incoming_trust_address_3: Incoming trust address 3
-          incoming_trust_address_town: Incoming trust address town
-          incoming_trust_address_county: Incoming trust address county
-          incoming_trust_address_postcode: Incoming trust address postcode
-          local_authority_code: Local authority code
-          local_authority_name: Local authority
-          local_authority_address_1: Local authority address 1
-          local_authority_address_2: Local authority address 2
-          local_authority_address_3: Local authority address 3
-          local_authority_address_town: Local authority address town
-          local_authority_address_county: Local authority address county
-          local_authority_address_postcode: Local authority address postcode
-          mp_name: MP name
-          mp_email: MP email
-          mp_constituency: Constituency
-          mp_address_1: MP address 1
-          mp_address_2: MP address 2
-          mp_address_3: MP address 3
-          mp_address_postcode: MP postcode
-          main_contact_name: Main contact name
-          main_contact_email: Main contact email
-          main_contact_title: Main contact role
-          school_phase: School phase
-          link_to_project: Link to project
-          region: Region
-          outgoing_trust_name: Outgoing trust name
-          outgoing_trust_companies_house_number: Outgoing trust companies house number
-          outgoing_trust_ukprn: Outgoing trust UKPRN
-          incoming_trust_ukprn: Incoming trust UKPRN
-          inadequate_ofsted: Transfer due to inadequate
-          financial_safeguarding_governance_issues: Transfer due to financial, safeguarding or governance
-          outgoing_trust_to_close: Outgoing trust to close
-          request_new_urn_and_record: New URN/record requested
-          bank_details_changing: Bank details changing
-          transfer_date: Transfer date
-          added_by_email: Added by email
-          academy_surplus_deficit: Is the academy in surplus or deficit?
-          trust_surplus_deficit: Is the incoming trust in surplus or deficit?
+          conversion:
+            project_type: Project type
+            conversion_date: Conversion date
+            all_conditions_met: All conditions met
+            risk_protection_arrangement: Risk protection arrangement
+            advisory_board_date: Advisory board date
+            academy_order_type: Academy order type
+            reception_to_six_years: Proposed capacity for pupils in reception to year 6
+            seven_to_eleven_years: Proposed capacity for pupils in years 7 to 11
+            twelve_or_above_years: Proposed capacity for students in year 12 or above
+            two_requires_improvement: 2RI (Two Requires Improvement)
+            sponsored_grant_type: Sponsored Grant Type
+            assigned_to_name: Assigned to name
+            assigned_to_email: Assigned to email
+            school_urn: School URN
+            school_dfe_number: DfE number
+            school_name: School name
+            school_type: School type
+            school_address_1: School address 1
+            school_address_2: School address 2
+            school_address_3: School address 3
+            school_address_town: School town
+            school_address_county: School county
+            school_address_postcode: School postcode
+            academy_urn: Academy URN
+            academy_name: Academy name
+            academy_address_1: Academy address 1
+            academy_address_2: Academy address 2
+            academy_address_3: Academy address 3
+            academy_address_town: Academy town
+            academy_address_county: Academy county
+            academy_address_postcode: Academy postcode
+            director_of_child_services_name: Director of child services name
+            director_of_child_services_role: Director of child services role
+            director_of_child_services_email: Director of child services email
+            director_of_child_services_phone: Director of child services phone
+            incoming_trust_identifier: Incoming trust group identifier
+            incoming_trust_companies_house_number: Incoming trust companies house number
+            incoming_trust_name: Incoming trust name
+            incoming_trust_address_1: Incoming trust address 1
+            incoming_trust_address_2: Incoming trust address 2
+            incoming_trust_address_3: Incoming trust address 3
+            incoming_trust_address_town: Incoming trust address town
+            incoming_trust_address_county: Incoming trust address county
+            incoming_trust_address_postcode: Incoming trust address postcode
+            local_authority_code: Local authority code
+            local_authority_name: Local authority
+            local_authority_address_1: Local authority address 1
+            local_authority_address_2: Local authority address 2
+            local_authority_address_3: Local authority address 3
+            local_authority_address_town: Local authority address town
+            local_authority_address_county: Local authority address county
+            local_authority_address_postcode: Local authority address postcode
+            mp_name: MP name
+            mp_email: MP email
+            mp_constituency: Constituency
+            mp_address_1: MP address 1
+            mp_address_2: MP address 2
+            mp_address_3: MP address 3
+            mp_address_postcode: MP postcode
+            main_contact_name: Main contact name
+            main_contact_email: Main contact email
+            main_contact_title: Main contact role
+            school_phase: School phase
+            link_to_project: Link to project
+            region: Region
+            outgoing_trust_name: Outgoing trust name
+            outgoing_trust_companies_house_number: Outgoing trust companies house number
+            outgoing_trust_ukprn: Outgoing trust UKPRN
+            incoming_trust_ukprn: Incoming trust UKPRN
+            inadequate_ofsted: Transfer due to inadequate
+            financial_safeguarding_governance_issues: Transfer due to financial, safeguarding or governance
+            outgoing_trust_to_close: Outgoing trust to close
+            request_new_urn_and_record: New URN/record requested
+            bank_details_changing: Bank details changing
+            transfer_date: Transfer date
+            added_by_email: Added by email
+            academy_surplus_deficit: Is the academy in surplus or deficit?
+            trust_surplus_deficit: Is the incoming trust in surplus or deficit?
+          transfer:
+            project_type: Project type
+            conversion_date: Conversion date
+            all_conditions_met: All conditions met
+            risk_protection_arrangement: Risk protection arrangement
+            advisory_board_date: Advisory board date
+            academy_order_type: Academy order type
+            reception_to_six_years: Proposed capacity for pupils in reception to year 6
+            seven_to_eleven_years: Proposed capacity for pupils in years 7 to 11
+            twelve_or_above_years: Proposed capacity for students in year 12 or above
+            two_requires_improvement: 2RI (Two Requires Improvement)
+            sponsored_grant_type: Sponsored Grant Type
+            assigned_to_name: Assigned to name
+            assigned_to_email: Assigned to email
+            school_urn: School URN
+            school_dfe_number: DfE number
+            school_name: School name
+            school_type: School type
+            school_address_1: School address 1
+            school_address_2: School address 2
+            school_address_3: School address 3
+            school_address_town: School town
+            school_address_county: School county
+            school_address_postcode: School postcode
+            academy_urn: Academy URN
+            academy_name: Academy name
+            academy_address_1: Academy address 1
+            academy_address_2: Academy address 2
+            academy_address_3: Academy address 3
+            academy_address_town: Academy town
+            academy_address_county: Academy county
+            academy_address_postcode: Academy postcode
+            director_of_child_services_name: Director of child services name
+            director_of_child_services_role: Director of child services role
+            director_of_child_services_email: Director of child services email
+            director_of_child_services_phone: Director of child services phone
+            incoming_trust_identifier: Incoming trust group identifier
+            incoming_trust_companies_house_number: Incoming trust companies house number
+            incoming_trust_name: Incoming trust name
+            incoming_trust_address_1: Incoming trust address 1
+            incoming_trust_address_2: Incoming trust address 2
+            incoming_trust_address_3: Incoming trust address 3
+            incoming_trust_address_town: Incoming trust address town
+            incoming_trust_address_county: Incoming trust address county
+            incoming_trust_address_postcode: Incoming trust address postcode
+            local_authority_code: Local authority code
+            local_authority_name: Local authority
+            local_authority_address_1: Local authority address 1
+            local_authority_address_2: Local authority address 2
+            local_authority_address_3: Local authority address 3
+            local_authority_address_town: Local authority address town
+            local_authority_address_county: Local authority address county
+            local_authority_address_postcode: Local authority address postcode
+            mp_name: MP name
+            mp_email: MP email
+            mp_constituency: Constituency
+            mp_address_1: MP address 1
+            mp_address_2: MP address 2
+            mp_address_3: MP address 3
+            mp_address_postcode: MP postcode
+            main_contact_name: Main contact name
+            main_contact_email: Main contact email
+            main_contact_title: Main contact role
+            school_phase: School phase
+            link_to_project: Link to project
+            region: Region
+            outgoing_trust_name: Outgoing trust name
+            outgoing_trust_companies_house_number: Outgoing trust companies house number
+            outgoing_trust_ukprn: Outgoing trust UKPRN
+            incoming_trust_ukprn: Incoming trust UKPRN
+            inadequate_ofsted: Transfer due to inadequate
+            financial_safeguarding_governance_issues: Transfer due to financial, safeguarding or governance
+            outgoing_trust_to_close: Outgoing trust to close
+            request_new_urn_and_record: New URN/record requested
+            bank_details_changing: Bank details changing
+            transfer_date: Transfer date
+            added_by_email: Added by email
+            academy_surplus_deficit: Is the academy in surplus or deficit?
+            trust_surplus_deficit: Is the incoming trust in surplus or deficit?
         values:
           project_type:
             conversion: Conversion

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -85,7 +85,7 @@ en:
           transfer:
             project_type: Project type
             conversion_date: Conversion date
-            all_conditions_met: All conditions met
+            all_conditions_met: Authority to proceed
             risk_protection_arrangement: Risk protection arrangement
             advisory_board_date: Advisory board date
             academy_order_type: Academy order type

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -155,12 +155,12 @@ RSpec.describe Export::Csv::ProjectPresenter do
 
     expect(presenter.sponsored_grant_type).to eql "fast track"
 
-    tasks_data = double(Conversion::TasksData, sponsored_support_grant_type: :intermidiate, sponsored_support_grant_not_applicable?: false)
+    tasks_data = double(Conversion::TasksData, sponsored_support_grant_type: :intermediate, sponsored_support_grant_not_applicable?: false)
     project = double(Conversion::Project, tasks_data: tasks_data)
 
     presenter = described_class.new(project)
 
-    expect(presenter.sponsored_grant_type).to eql "intermidiate"
+    expect(presenter.sponsored_grant_type).to eql "intermediate"
 
     tasks_data = double(Conversion::TasksData, sponsored_support_grant_type: :sponsored, sponsored_support_grant_not_applicable?: false)
     project = double(Conversion::Project, tasks_data: tasks_data)


### PR DESCRIPTION
## Changes

The header for the "All conditions met" column in the Transfers export should be "Authority to proceed". 

To do this, we first needed to namespace the CSV headers, as they were the same for Conversions and Transfers. This means we can have different headers for Conversions and Transfers.

Then once this is done, change the "All conditions met" header for Transfers.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
