### PR TITLE
(154339) Change "All conditions met" header in exports for Transfer projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Extend validation on Advisory board date to make sure the date is not too far
   in the past
+- Change "All conditions met" header to "Authority to proceed" for Transfer
+  project exports
 
 ## [Release-51][release-51]
 

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -51,6 +51,8 @@ class Export::Csv::ProjectPresenter
     I18n.t("export.csv.project.values.#{@project.all_conditions_met}")
   end
 
+  alias_method :authority_to_proceed, :all_conditions_met
+
   def risk_protection_arrangement
     if @project.tasks_data.risk_protection_arrangement_option.nil?
       return I18n.t("export.csv.project.values.unconfirmed")

--- a/app/services/export/transfers/academies_due_to_transfer_csv_export_service.rb
+++ b/app/services/export/transfers/academies_due_to_transfer_csv_export_service.rb
@@ -18,7 +18,7 @@ class Export::Transfers::AcademiesDueToTransferCsvExportService < Export::CsvExp
     region
     assigned_to_email
     transfer_date
-    all_conditions_met
+    authority_to_proceed
   ]
 
   def initialize(projects)

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -81,6 +81,7 @@ en:
           added_by_email: Added by email
           academy_surplus_deficit: Is the academy in surplus or deficit?
           trust_surplus_deficit: Is the incoming trust in surplus or deficit?
+          authority_to_proceed: Authority to proceed?
         values:
           project_type:
             conversion: Conversion

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -88,7 +88,7 @@ en:
             transfer: Transfer
           sponsored_grant_type:
             fast_track: fast track
-            intermidiate: intermidiate
+            intermediate: intermediate
             sponsored: sponsored
           unconfirmed: unconfirmed
           confirmed: confirmed

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -223,20 +223,28 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.all_conditions_met).to eql "yes"
   end
 
-  it "presents all conditions met when it has not been met (nil)" do
-    project = double(Conversion::Project, all_conditions_met: nil)
+  it "presents authority to proceed, which is the name for 'all conditions met' for Transfer projects" do
+    project = double(Transfer::Project, all_conditions_met: true)
 
     presenter = described_class.new(project)
 
-    expect(presenter.all_conditions_met).to eql "no"
+    expect(presenter.authority_to_proceed).to eql "yes"
   end
 
-  it "presents all conditions met when it has not been met (false)" do
-    project = double(Conversion::Project, all_conditions_met: false)
+  it "presents authority to proceed (all conditions met for Transfer projects) when it has not been met (nil)" do
+    project = double(Transfer::Project, all_conditions_met: nil)
 
     presenter = described_class.new(project)
 
-    expect(presenter.all_conditions_met).to eql "no"
+    expect(presenter.authority_to_proceed).to eql "no"
+  end
+
+  it "presents authority to proceed (all conditions met for Transfer projects) when it has not been met (false)" do
+    project = double(Transfer::Project, all_conditions_met: false)
+
+    presenter = described_class.new(project)
+
+    expect(presenter.authority_to_proceed).to eql "no"
   end
 
   it "presents all risk protection arrangement when it is standard" do

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -155,12 +155,12 @@ RSpec.describe Export::Csv::ProjectPresenter do
 
     expect(presenter.sponsored_grant_type).to eql "fast track"
 
-    tasks_data = double(Conversion::TasksData, sponsored_support_grant_type: :intermidiate, sponsored_support_grant_not_applicable?: false)
+    tasks_data = double(Conversion::TasksData, sponsored_support_grant_type: :intermediate, sponsored_support_grant_not_applicable?: false)
     project = double(Conversion::Project, tasks_data: tasks_data)
 
     presenter = described_class.new(project)
 
-    expect(presenter.sponsored_grant_type).to eql "intermidiate"
+    expect(presenter.sponsored_grant_type).to eql "intermediate"
 
     tasks_data = double(Conversion::TasksData, sponsored_support_grant_type: :sponsored, sponsored_support_grant_not_applicable?: false)
     project = double(Conversion::Project, tasks_data: tasks_data)


### PR DESCRIPTION
## Changes

The header for the "All conditions met" column in the Transfers export should be
"Authority to proceed"

The simplest way to do this is to add a `authority_to_proceed` alias to the
Project Presenter, and use this to return the `all_conditions_met` method. 
Because the name of the method (alias) is `authority_to_proceed`, we
can add a new I18n string to the file with the correct header.

Therefore when we call the column header `authority_to_proceed` in the export,
we get the I18n string for `authority_to_proceed` as the header, and the value
of `all_conditions_met` in the value.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
