### PR TITLE
(Fix) Add missing I18n string for Conversion data export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Add missing string for "full sponsored" support grant type in the Conversions
+  CSV export
+
 ## [Release-52][release-52]
 
 ### Changed

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -87,6 +87,7 @@ en:
             conversion: Conversion
             transfer: Transfer
           sponsored_grant_type:
+            full_sponsored: full sponsored
             fast_track: fast track
             intermediate: intermediate
             sponsored: sponsored


### PR DESCRIPTION
We received a bug report that the strings for `full_sponsored` and `intermediate` values were missing from the CSV reports. We added/corrected the string for intermediate in a previous commit (ba9244254ad1d63f361b9535081133c89cec92df)

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
