### PR TITLE
(154582) By Month view for data consumers - Conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   age range, main contact details, school type
 - Add Academy UKPRN, School LAESTAB (DfE number) and Academy LAESTAB (DfE
   number) to the Funding agreement letters export
+- Add a new By Month view for export/data consumer users. When a user with this
+  role clicks on "By Month", they will see a new view with the ability to pick a
+  range of dates and see Conversion projects due to convert in that date range
+
+### Changed
+
+- The "By Month" view for data consumers is now a tabbed view of Conversions &
+  Transfers (currently only showing Conversions), with different columns in the
+  table. There is also a date picker to allow users to choose a date range to
+  view.
 
 ## [Release-52][release-52]
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,6 +31,7 @@ $govuk-button-background-colour: $dfe-blue;
 @import "components/task_list/check-box-action-component";
 @import "components/notification-banner";
 @import "components/app-content";
+@import "components/date-range";
 
 @import "patterns/project-summary";
 

--- a/app/assets/stylesheets/components/date-range.scss
+++ b/app/assets/stylesheets/components/date-range.scss
@@ -1,0 +1,24 @@
+.date-range {
+  background-color: #f0f4f5;
+  border: 1px solid #505a5f;
+  padding: govuk-spacing(4) govuk-spacing(4) 0;
+  margin-bottom: govuk-spacing(4);
+}
+
+.date-range fieldset * {
+  display: inline;
+  float: left;
+  margin-right: govuk-spacing(2);
+}
+
+.date-range label,
+.date-range legend {
+  padding-top: govuk-spacing(1);
+}
+
+.date-range .govuk-button {
+  margin-bottom: 0;
+  @media (max-width: 40.0625em) {
+    margin-top: govuk-spacing(2);
+  }
+}

--- a/app/controllers/all/by_month/conversions/projects_controller.rb
+++ b/app/controllers/all/by_month/conversions/projects_controller.rb
@@ -1,0 +1,65 @@
+class All::ByMonth::Conversions::ProjectsController < ApplicationController
+  def date_range
+    authorize Project, :index?
+
+    @from_date = "#{from_year}-#{from_month}-1"
+    @to_date = "#{to_year}-#{to_month}-1"
+    return redirect_if_dates_incorrect if Date.parse(@to_date) < Date.parse(@from_date)
+
+    @from_month = from_month
+    @from_year = from_year
+    @to_month = to_month
+    @to_year = to_year
+
+    @pager, @projects = pagy_array(ByMonthProjectFetcherService.new.conversion_projects_by_date_range(@from_date, @to_date))
+  end
+
+  def date_range_select
+    authorize Project, :index?
+
+    return redirect_if_dates_incorrect if Date.parse(to_date) < Date.parse(from_date)
+
+    from_year, from_month = from_date.split("-")
+    to_year, to_month = to_date.split("-")
+
+    redirect_to action: "date_range", from_month: from_month, from_year: from_year, to_month: to_month, to_year: to_year
+  end
+
+  def date_range_this_month
+    authorize Project, :index?
+
+    from_month = Date.today.month
+    from_year = Date.today.year
+    to_month = Date.today.month
+    to_year = Date.today.year
+    redirect_to action: "date_range", from_month: from_month, from_year: from_year, to_month: to_month, to_year: to_year
+  end
+
+  private def redirect_if_dates_incorrect
+    redirect_to date_range_this_month_all_by_month_conversions_projects_path, alert: I18n.t("project.date_range.date_form.from_date_before_to_date")
+  end
+
+  private def from_month
+    params[:from_month]
+  end
+
+  private def from_year
+    params[:from_year]
+  end
+
+  private def to_month
+    params[:to_month]
+  end
+
+  private def to_year
+    params[:to_year]
+  end
+
+  private def from_date
+    params[:from_date].to_s
+  end
+
+  private def to_date
+    params[:to_date].to_s
+  end
+end

--- a/app/helpers/project_helper.rb
+++ b/app/helpers/project_helper.rb
@@ -69,4 +69,13 @@ module ProjectHelper
 
     project.tasks_data.academy_details_name
   end
+
+  def confirmed_date_original_date(project)
+    return if project.significant_date_provisional
+    return project.significant_date.to_fs(:govuk_short_month) if project.significant_dates.empty?
+
+    confirmed_date = project.significant_dates.order(:created_at).first.revised_date
+    original_date = project.significant_date
+    "#{confirmed_date.to_fs(:govuk_short_month)} (#{original_date.to_fs(:govuk_short_month)})"
+  end
 end

--- a/app/views/all/by_month/conversions/projects/_by_month_table.html.erb
+++ b/app/views/all/by_month/conversions/projects/_by_month_table.html.erb
@@ -1,0 +1,33 @@
+<% if projects.empty? %>
+  <%= govuk_inset_text(text: t("project.table.by_month.date_range.conversions.empty", from_date: Date.parse(from_date).to_fs(:govuk_month), to_date: Date.parse(to_date).to_fs(:govuk_month))) %>
+<% else %>
+  <table class="govuk-table" name="projects_table" aria-label="Projects table">
+    <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_and_urn") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.region") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.local_authority_name") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.incoming_trust") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.all_conditions_met") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.confirmed_date_original_date") %></th>
+    </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% projects.each do |project| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__header govuk-table__cell">
+          <%= link_to project.establishment.name, project_path(project), class: "govuk-link govuk-link--no-visited-state" %>
+          <%= project.urn %>
+        </td>
+        <td class="govuk-table__cell"><%= t("project.region.#{project.region}") %></td>
+        <td class="govuk-table__cell"><%= project.establishment.local_authority_name %></td>
+        <td class="govuk-table__cell"><%= project.incoming_trust.name %></td>
+        <td class="govuk-table__cell"><%= all_conditions_met_value(project) %></td>
+        <td class="govuk-table__cell"><%= confirmed_date_original_date(project) %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<%= govuk_pagination(pagy: pager) %>

--- a/app/views/all/by_month/conversions/projects/date_range.html.erb
+++ b/app/views/all/by_month/conversions/projects/date_range.html.erb
@@ -1,0 +1,32 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("project.date_range.page_title", date_from: Date.parse(@from_date).to_fs(:govuk_month), date_to: Date.parse(@to_date).to_fs(:govuk_month))) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <span class="govuk-caption-l"><%= t("project.date_range.subtitle") %></span>
+    <h1 class="govuk-heading-l">
+      <%= t("project.date_range.title", date_from: Date.parse(@from_date).to_fs(:govuk_month), date_to: Date.parse(@to_date).to_fs(:govuk_month)) %>
+    </h1>
+    <%= t("project.date_range.body_html") %>
+
+    <%= render partial: "shared/date_range", locals: {from_date: @from_date, to_date: @to_date, action: date_range_select_all_by_month_conversions_projects_path} %>
+
+    <nav class="moj-sub-navigation" aria-label="Project index sub-navigation">
+      <ul class="moj-sub-navigation__list">
+        <%= render partial: "shared/sub_navigation_item",
+              locals: {name: t("project.date_range.tabs.conversions"),
+                       path: "/projects/all/by-month/conversions/from/#{@from_month}/#{@from_year}/to/#{@to_month}/#{@to_year}"} %>
+        <%= render partial: "shared/sub_navigation_item",
+              locals: {name: t("project.date_range.tabs.transfers"),
+                       path: "/projects/all/by-month/transfers/from/#{@from_month}/#{@from_year}/to/#{@to_month}/#{@to_year}"} %>
+      </ul>
+    </nav>
+
+    <%= render partial: "by_month_table", locals: {projects: @projects, from_date: @from_date, to_date: @to_date, pager: @pager} %>
+  </div>
+</div>

--- a/app/views/shared/_date_range.html.erb
+++ b/app/views/shared/_date_range.html.erb
@@ -1,0 +1,24 @@
+<div class="date-range">
+  <%= form_tag(action, method: :post) do %>
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--s"><%= t("project.date_range.date_form.label") %></legend>
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="from_date"><%= t("project.date_range.date_form.from") %></label>
+        <select class="govuk-select" id="from_date" name="from_date">
+          <% (Date.new(2022, 1, 1)..Date.new(2026, 12, 1)).map { |d| [d.year, d.month, 1] }.uniq.each do |date| %>
+            <% date_str = date.join("-") %>
+            <option value="<%= date_str %>" <% if date_str == from_date %> selected="selected"<% end %>><%= Date.parse(date_str).to_fs(:govuk_short_month) %></option>
+          <% end %>
+        </select>
+        <label class="govuk-label" for="to_date"><%= t("project.date_range.date_form.to") %></label>
+        <select class="govuk-select" id="to_date" name="to_date">
+          <% (Date.new(2022, 1, 1)..Date.new(2026, 12, 1)).map { |d| [d.year, d.month, 1] }.uniq.each do |date| %>
+            <% date_str = date.join("-") %>
+            <option value="<%= date_str %>" <% if date_str == to_date %> selected="selected"<% end %>><%= Date.parse(date_str).to_fs(:govuk_short_month) %></option>
+          <% end %>
+        </select>
+        <button type="submit" class="govuk-button" data-module="govuk-button"><%= t("project.date_range.date_form.apply") %></button>
+      </div>
+    </fieldset>
+  <% end %>
+</div>

--- a/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
@@ -10,7 +10,11 @@
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.in_progress"), path: all_in_progress_projects_path, namespace: "/projects/all/in-progress"} %>
 
-          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_month"), path: confirmed_all_by_month_projects_path, namespace: "/projects/all/by-month"} %>
+          <% if policy(:export).index? %>
+            <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_month"), path: date_range_this_month_all_by_month_conversions_projects_path, namespace: "/projects/all/by-month"} %>
+          <% else %>
+            <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_month"), path: confirmed_all_by_month_projects_path, namespace: "/projects/all/by-month"} %>
+          <% end %>
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_region"), path: all_regions_projects_path, namespace: "/projects/all/regions"} %>
 

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -3,6 +3,7 @@
 Date::DATE_FORMATS[:govuk] = "%-d %B %Y"
 Date::DATE_FORMATS[:govuk_weekday] = "%-d %B %Y, %a"
 Date::DATE_FORMATS[:govuk_month] = "%B %Y"
+Date::DATE_FORMATS[:govuk_short_month] = "%b %Y"
 Date::DATE_FORMATS[:govuk_month_only] = "%B"
 
 # Date format for all significant date (conversion date and transfer date)

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -200,6 +200,9 @@ en:
         all_transfers: All transfers
         number_of_conversions: Number of conversions
         number_of_transfers: Number of transfers
+        school_and_urn: School and URN
+        confirmed_date_original_date: Confirmed date (Original date)
+        all_conditions_met: All conditions met
       body:
         type_name:
           conversion_project: Conversion
@@ -242,6 +245,12 @@ en:
       by_user:
         empty: There are no users with projects
         caption: Table of users who have in-progress projects
+      by_month:
+        single_month:
+          empty: There are no projects due to convert or transfer in %{date}
+        date_range:
+          conversions:
+            empty: There are no projects due to convert between %{from_date} and %{to_date}
     openers:
       title: Academies opening or transferring in %{date}
       subtitle: Schools that will become academies, and academies that will move to a different trust.
@@ -296,6 +305,22 @@ en:
     subnavigation:
       new: URNs to create
       with_academy_urn: URNs added
+    date_range:
+      page_title: Academies opening or transferring, %{date_from} to %{date_to}
+      title: "%{date_from} to %{date_to}"
+      subtitle: Academies opening or transferring
+      body_html:
+        <p>Schools that will become academies, and academies that will move to a different trust.</p>
+        <p>You can also download a more detailed version of the data as a CSV file.</p>
+      date_form:
+        label: Date range
+        from: from
+        to: to
+        apply: Apply
+        from_date_before_to_date: "The 'from' date cannot be after the 'to' date"
+      tabs:
+        conversions: Conversions
+        transfers: Transfers
   member_of_parliament:
     show:
       title: Member of Parliament details

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,11 @@ Rails.application.routes.draw do
             get "confirmed/:month/:year", to: "projects#confirmed", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}
             get "revised/:month/:year", to: "projects#revised", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}
             get "revised/", to: "projects#revised_next_month"
+            namespace :conversions do
+              get "from/to", to: "projects#date_range_this_month", as: :date_range_this_month
+              post "from/to", to: "projects#date_range_select", as: :date_range_select
+              get "from/:from_month/:from_year/to/:to_month/:to_year", to: "projects#date_range", constraints: {from_month: MONTH_1_12_REGEX, from_year: YEAR_2000_2499_REGEX, to_month: MONTH_1_12_REGEX, to_year: YEAR_2000_2499_REGEX}, as: :date_range
+            end
           end
           namespace :statistics do
             get "/", to: "statistics#index"

--- a/spec/features/all_projects/by_month/data_users_can_choose_a_date_range_spec.rb
+++ b/spec/features/all_projects/by_month/data_users_can_choose_a_date_range_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.feature "Data users can view projects over a range of dates" do
+  let(:user) { create(:user, team: "education_and_skills_funding_agency") }
+
+  scenario "A data user sees the current month by default" do
+    sign_in_with_user(user)
+    visit "/projects/all/by-month/conversions/from/to"
+
+    expect(page).to have_content("Academies opening or transferring")
+    expect(page).to have_content("#{Date.today.to_fs(:govuk_month)} to #{Date.today.to_fs(:govuk_month)}")
+  end
+
+  scenario "A data user can choose a range of different dates to view" do
+    sign_in_with_user(user)
+    visit "/projects/all/by-month/conversions/from/to"
+
+    select "Jan 2023", from: "from"
+    select "Aug 2023", from: "to"
+    click_on "Apply"
+
+    expect(page).to have_content("Academies opening or transferring")
+    expect(page).to have_content("January 2023 to August 2023")
+  end
+end

--- a/spec/helpers/project_helper_spec.rb
+++ b/spec/helpers/project_helper_spec.rb
@@ -285,4 +285,33 @@ RSpec.describe ProjectHelper, type: :helper do
       expect(helper.academy_name(project)).to include("grey", "Unconfirmed")
     end
   end
+
+  describe "#confirmed_date_original_date" do
+    before { mock_all_academies_api_responses }
+
+    context "when the project's significant date is not confirmed" do
+      it "returns nil" do
+        project = build(:conversion_project, significant_date_provisional: true)
+        expect(helper.confirmed_date_original_date(project)).to eq(nil)
+      end
+    end
+
+    context "when the project's significant date is confirmed" do
+      context "and the project has no date histories (this should not happen!)" do
+        it "returns the significant date only, formatted correctly" do
+          project = build(:conversion_project, significant_date: Date.new(2024, 1, 1), significant_date_provisional: false)
+          expect(helper.confirmed_date_original_date(project)).to eq("Jan 2024")
+        end
+      end
+
+      context "and the project has date histories" do
+        it "returns the significant date and the most recent revised date, formatted correctly" do
+          project = create(:conversion_project, significant_date: Date.new(2024, 1, 1), significant_date_provisional: false)
+          create(:date_history, project: project, previous_date: Date.new(2024, 1, 1), revised_date: Date.new(2024, 4, 1))
+
+          expect(helper.confirmed_date_original_date(project)).to eq("Apr 2024 (Jan 2024)")
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/all/by_month/conversions/projects_controller_spec.rb
+++ b/spec/requests/all/by_month/conversions/projects_controller_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe All::ByMonth::Conversions::ProjectsController, type: :request do
+  let(:user) { create(:user, team: "education_and_skills_funding_agency") }
+
+  before do
+    mock_all_academies_api_responses
+    sign_in_with(user)
+  end
+
+  describe "#date_range_this_month" do
+    it "redirects to the current month and year" do
+      get date_range_this_month_all_by_month_conversions_projects_path
+      follow_redirect!
+
+      expect(response).to have_http_status(:success)
+      expect(request.params.fetch(:from_month)).to eq Date.today.month.to_s
+      expect(request.params.fetch(:from_year)).to eq Date.today.year.to_s
+      expect(request.params.fetch(:to_month)).to eq Date.today.month.to_s
+      expect(request.params.fetch(:to_year)).to eq Date.today.year.to_s
+    end
+  end
+
+  describe "#date_range" do
+    it "shows the date range in the page text" do
+      get "/projects/all/by-month/conversions/from/1/2023/to/10/2023"
+      expect(response.body).to include "January 2023 to October 2023"
+    end
+
+    it "shows details of any matching projects" do
+      project = create(:conversion_project, significant_date_provisional: false, significant_date: Date.new(2023, 2, 1))
+      create(:date_history, project: project, previous_date: Date.new(2023, 2, 1), revised_date: Date.new(2023, 3, 1))
+
+      get "/projects/all/by-month/conversions/from/1/2023/to/3/2023"
+      expect(response.body).to include(project.establishment.name)
+      expect(response.body).to include(project.urn.to_s)
+    end
+
+    context "if the 'to' date is before the 'from' date" do
+      it "redirect to the current month with an information message" do
+        get "/projects/all/by-month/conversions/from/10/2023/to/3/2023"
+        follow_redirect!
+        follow_redirect! # This redirects twice
+
+        expect(response.body).to include("The 'from' date cannot be after the 'to' date")
+      end
+    end
+  end
+end

--- a/spec/requests/conversions/projects_controller_spec.rb
+++ b/spec/requests/conversions/projects_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Conversions::ProjectsController do
+RSpec.describe All::ByMonth::Conversions::ProjectsController do
   let(:user) { create(:user, :caseworker) }
   let(:regional_delivery_officer) { create(:user, :regional_delivery_officer) }
   let(:form_class) { Conversion::CreateProjectForm }


### PR DESCRIPTION
## Changes

Change the By Month view for data consumers (i.e. people who can Export). They now see a date range picker that allows them to view a set of months. By default the page is set to the current month. If they choose a from date that's after the to date, they see an error message.

The table has slightly different columns to before.

There is a place to put the link to download the information as CSV, but this has not been developed yet.

Transfers are TBA.

<img width="1338" alt="Screenshot 2024-02-06 at 11 26 32" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/64fc2f8b-23ee-469d-bbaa-df08c8005bc4">

<img width="1321" alt="Screenshot 2024-02-06 at 11 24 45" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/f9bb36d3-032a-4ad1-9bef-d47613639868">


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
