### PR TITLE
Bugfix: Return the correct main contact details in the project presenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add missing string for "full sponsored" support grant type in the Conversions
   CSV export
+- Return the correct main contact details in the Funding Agreement letters
+  export
 
 ## [Release-52][release-52]
 

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -138,15 +138,21 @@ class Export::Csv::ProjectPresenter
   end
 
   def main_contact_name
-    @project.main_contact&.name
+    return unless @project.main_contact_id
+    contact = Contact::Project.find(@project.main_contact_id)
+    contact&.name
   end
 
   def main_contact_email
-    @project.main_contact&.email
+    return unless @project.main_contact_id
+    contact = Contact::Project.find(@project.main_contact_id)
+    contact&.email
   end
 
   def main_contact_title
-    @project.main_contact&.title
+    return unless @project.main_contact_id
+    contact = Contact::Project.find(@project.main_contact_id)
+    contact&.title
   end
 
   def region

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -302,8 +302,9 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents the main contact email" do
-    user = double(Contact::Project, email: "main.contact@education.gov.uk")
-    project = double(Conversion::Project, main_contact: user)
+    mock_successful_api_response_to_create_any_project
+    user = create(:project_contact, email: "main.contact@education.gov.uk")
+    project = create(:conversion_project, main_contact_id: user.id)
 
     presenter = described_class.new(project)
 
@@ -311,8 +312,9 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents the main contact name" do
-    user = double(Contact::Project, name: "Bob Robertson")
-    project = double(Conversion::Project, main_contact: user)
+    mock_successful_api_response_to_create_any_project
+    user = create(:project_contact, name: "Bob Robertson")
+    project = create(:conversion_project, main_contact_id: user.id)
 
     presenter = described_class.new(project)
 
@@ -320,8 +322,9 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents the main contact title" do
-    user = double(Contact::Project, title: "Very important person")
-    project = double(Conversion::Project, main_contact: user)
+    mock_successful_api_response_to_create_any_project
+    user = create(:project_contact, title: "Very important person")
+    project = create(:conversion_project, main_contact_id: user.id)
 
     presenter = described_class.new(project)
 
@@ -329,7 +332,8 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "handles a project without a main contact" do
-    project = double(Conversion::Project, main_contact: nil)
+    mock_successful_api_response_to_create_any_project
+    project = create(:conversion_project, main_contact: nil)
 
     presenter = described_class.new(project)
 


### PR DESCRIPTION
we had a bug report that the exports did not always contain the correct main contact details for the school. While the `Project.main_contact` association works fine in the UI the project presenter pattern is always returning the first Contact association, and not the one indicated by the `main_contact_id` attribute.

To temporarily fix this, return the main contact details in the project presenter a different way. We will have to circle back to this and figure out why the associations aren't working as expected at a later date.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
