### PR TITLE
Add more columns to the ESFA funding agreement letters export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add more columns to the Academies due to transfer export: School phase, school
   age range, main contact details, school type
+- Add Academy UKPRN, School LAESTAB (DfE number) and Academy LAESTAB (DfE
+  number) to the Funding agreement letters export
 
 ## [Release-52][release-52]
 

--- a/app/presenters/export/csv/academy_presenter_module.rb
+++ b/app/presenters/export/csv/academy_presenter_module.rb
@@ -7,6 +7,14 @@ module Export::Csv::AcademyPresenterModule
     @project.academy_urn.to_s
   end
 
+  def academy_ukprn
+    if @project.academy_urn.nil?
+      return I18n.t("export.csv.project.values.unconfirmed")
+    end
+
+    @project.academy.ukprn.to_s
+  end
+
   def academy_name
     if @project.academy_urn.nil? || @project.academy.name.nil?
       return I18n.t("export.csv.project.values.unconfirmed")

--- a/app/services/export/conversions/education_and_skills_funding_agency_csv_export_service.rb
+++ b/app/services/export/conversions/education_and_skills_funding_agency_csv_export_service.rb
@@ -4,11 +4,14 @@ class Export::Conversions::EducationAndSkillsFundingAgencyCsvExportService < Exp
     school_name
     school_type
     school_phase
+    school_dfe_number
     local_authority_name
     region
     advisory_board_date
     academy_urn
+    academy_ukprn
     academy_name
+    academy_dfe_number
     reception_to_six_years
     seven_to_eleven_years
     twelve_or_above_years

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -17,7 +17,7 @@ en:
           assigned_to_name: Assigned to name
           assigned_to_email: Assigned to email
           school_urn: School URN
-          school_dfe_number: DfE number
+          school_dfe_number: DfE number/LAESTAB
           school_name: School name
           school_type: School type
           school_phase: School phase
@@ -36,6 +36,8 @@ en:
           academy_address_town: Academy town
           academy_address_county: Academy county
           academy_address_postcode: Academy postcode
+          academy_dfe_number: Academy DfE number/LAESTAB
+          academy_ukprn: Academy UKPRN
           director_of_child_services_name: Director of child services name
           director_of_child_services_role: Director of child services role
           director_of_child_services_email: Director of child services email

--- a/spec/presenters/export/csv/academy_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/academy_presenter_module_spec.rb
@@ -1,11 +1,15 @@
 require "rails_helper"
 
 RSpec.describe Export::Csv::AcademyPresenterModule do
-  let(:project) { build(:conversion_project, academy_urn: 149061, academy: known_establishment) }
+  let(:project) { build(:conversion_project, academy_urn: 149061, academy: gias_establishment) }
   subject { AcademyPresenterModuleTestClass.new(project) }
 
   it "presents the academy urn" do
     expect(subject.academy_urn).to eql "149061"
+  end
+
+  it "presents the academy ukprn" do
+    expect(subject.academy_ukprn).to eql "10065250"
   end
 
   it "presents the academy DfE number" do
@@ -29,20 +33,20 @@ RSpec.describe Export::Csv::AcademyPresenterModule do
     expect(subject.academy_address_postcode).to eql "MK19 6HJ"
   end
 
-  def known_establishment
-    double(
-      Api::AcademiesApi::Establishment,
+  def gias_establishment
+    build(:gias_establishment,
       urn: 149061,
+      ukprn: 10065250,
       name: "Deanshanger Primary School",
-      dfe_number: "941/2025",
+      establishment_number: "2025",
+      local_authority_code: "941",
       type: "Academy converter",
       address_street: "The Green",
       address_locality: "Deanshanger",
       address_additional: "Deanshanger Primary School, the Green, Deanshanger",
       address_town: "Milton Keynes",
       address_county: "Buckinghamshire",
-      address_postcode: "MK19 6HJ"
-    )
+      address_postcode: "MK19 6HJ")
   end
 end
 


### PR DESCRIPTION
We need to add to the funding agreement letters export:

- Academy UKPRN. This can be retrieved from the GIAS::Establishment record associated with the project. In a previous commit we changed the academy associated with the project from an AcademiesApi::Establishment to GIAS::Establishment, so alter the academy presenter test to use the correct association, and retrieve the Academy UKPRN from the GIAS::EStablishment

- School DfE number. We already have a presenter for this.

- Academy DfE number. Add a new presenter for this.

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
