### PR TITLE
Add more columns to the Academies due to transfer export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add missing string for "full sponsored" support grant type in the Conversions
   CSV export
 
+### Added
+
+- Add more columns to the Academies due to transfer export: School phase, school
+  age range, main contact details, school type
+
 ## [Release-52][release-52]
 
 ### Changed

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -15,6 +15,12 @@ module Export::Csv::SchoolPresenterModule
     @project.establishment.type
   end
 
+  def school_phase
+    return unless @project.establishment.present?
+
+    @project.establishment.phase
+  end
+
   def school_dfe_number
     return unless @project.establishment.present?
 
@@ -55,5 +61,11 @@ module Export::Csv::SchoolPresenterModule
     return unless @project.establishment.present?
 
     @project.establishment.address_postcode
+  end
+
+  def school_age_range
+    return unless @project.establishment.present?
+
+    "#{@project.establishment.age_range_lower} - #{@project.establishment.age_range_upper}"
   end
 end

--- a/app/services/export/transfers/academies_due_to_transfer_csv_export_service.rb
+++ b/app/services/export/transfers/academies_due_to_transfer_csv_export_service.rb
@@ -2,6 +2,8 @@ class Export::Transfers::AcademiesDueToTransferCsvExportService < Export::CsvExp
   COLUMN_HEADERS = %i[
     school_name
     school_urn
+    school_phase
+    school_age_range
     local_authority_name
     outgoing_trust_name
     outgoing_trust_companies_house_number
@@ -19,6 +21,9 @@ class Export::Transfers::AcademiesDueToTransferCsvExportService < Export::CsvExp
     assigned_to_email
     transfer_date
     authority_to_proceed
+    main_contact_name
+    main_contact_email
+    main_contact_title
   ]
 
   def initialize(projects)

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -20,6 +20,8 @@ en:
           school_dfe_number: DfE number
           school_name: School name
           school_type: School type
+          school_phase: School phase
+          school_age_range: School age range
           school_address_1: School address 1
           school_address_2: School address 2
           school_address_3: School address 3
@@ -65,7 +67,6 @@ en:
           main_contact_name: Main contact name
           main_contact_email: Main contact email
           main_contact_title: Main contact role
-          school_phase: School phase
           link_to_project: Link to project
           region: Region
           outgoing_trust_name: Outgoing trust name

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
     expect(subject.school_type).to eql "Community school"
   end
 
+  it "presents the school phase" do
+    expect(subject.school_phase).to eql "Secondary"
+  end
+
+  it "presents the school age range" do
+    expect(subject.school_age_range).to eql "5 - 16"
+  end
+
   it "presents the school address" do
     expect(subject.school_address_1).to eql "The Green"
     expect(subject.school_address_2).to eql "Deanshanger"
@@ -34,6 +42,7 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
       Api::AcademiesApi::Establishment,
       urn: 121813,
       name: "Deanshanger Primary School",
+      phase: "Secondary",
       dfe_number: "941/2025",
       type: "Community school",
       address_street: "The Green",
@@ -41,7 +50,9 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
       address_additional: "Deanshanger Primary School, the Green, Deanshanger",
       address_town: "Milton Keynes",
       address_county: "Buckinghamshire",
-      address_postcode: "MK19 6HJ"
+      address_postcode: "MK19 6HJ",
+      age_range_lower: 5,
+      age_range_upper: 16
     )
   end
 end


### PR DESCRIPTION
Add School phase, school age range, school type, and main contact details to the Academies due to transfer export

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
