### PR TITLE
Create by month transfers csv export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add new By Month view for non-data-consumer users. This view shows transfers
   transferring in the next (upcoming) month only, and the table has the same
   columns as the date range view described above.
+- Create a By Month CSV export for Conversions
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   transferring in the next (upcoming) month only, and the table has the same
   columns as the date range view described above.
 - Create a By Month CSV export for Conversions
+- Create a By Month CSV export for Transfers
 
 ### Changed
 

--- a/app/presenters/export/csv/academy_presenter_module.rb
+++ b/app/presenters/export/csv/academy_presenter_module.rb
@@ -70,4 +70,16 @@ module Export::Csv::AcademyPresenterModule
 
     @project.academy.address_postcode
   end
+
+  def academy_contact_name
+    return if @project.contacts.where(category: "school_or_academy").blank?
+
+    @project.contacts.where(category: "school_or_academy").pluck(:name).join(", ")
+  end
+
+  def academy_contact_email
+    return if @project.contacts.where(category: "school_or_academy").blank?
+
+    @project.contacts.where(category: "school_or_academy").pluck(:email).join(", ")
+  end
 end

--- a/app/presenters/export/csv/incoming_trust_presenter_module.rb
+++ b/app/presenters/export/csv/incoming_trust_presenter_module.rb
@@ -58,4 +58,24 @@ module Export::Csv::IncomingTrustPresenterModule
 
     @project.incoming_trust.address_postcode
   end
+
+  def incoming_trust_main_contact_name
+    contact = @project.incoming_trust_main_contact_id
+    return unless @project.incoming_trust_main_contact_id.present?
+
+    Contact::Project.find_by(id: contact)&.name
+  end
+
+  def incoming_trust_main_contact_email
+    contact = @project.incoming_trust_main_contact_id
+    return unless @project.incoming_trust_main_contact_id.present?
+
+    Contact::Project.find_by(id: contact)&.email
+  end
+
+  def incoming_trust_sharepoint_link
+    return unless @project.incoming_trust_sharepoint_link.present?
+
+    @project.incoming_trust_sharepoint_link
+  end
 end

--- a/app/presenters/export/csv/local_authority_presenter_module.rb
+++ b/app/presenters/export/csv/local_authority_presenter_module.rb
@@ -11,6 +11,18 @@ module Export::Csv::LocalAuthorityPresenterModule
     @project.local_authority.name
   end
 
+  def local_authority_contact_name
+    return if @project.contacts.where(category: "local_authority").blank?
+
+    @project.contacts.where(category: "local_authority").pluck(:name).join(", ")
+  end
+
+  def local_authority_contact_email
+    return if @project.contacts.where(category: "local_authority").blank?
+
+    @project.contacts.where(category: "local_authority").pluck(:email).join(", ")
+  end
+
   def local_authority_address_1
     return unless @project.local_authority.present?
 

--- a/app/presenters/export/csv/outgoing_trust_presenter_module.rb
+++ b/app/presenters/export/csv/outgoing_trust_presenter_module.rb
@@ -70,4 +70,10 @@ module Export::Csv::OutgoingTrustPresenterModule
 
     @project.outgoing_trust.address_postcode
   end
+
+  def outgoing_trust_sharepoint_link
+    return unless @project.outgoing_trust_sharepoint_link.present?
+
+    @project.outgoing_trust_sharepoint_link
+  end
 end

--- a/app/presenters/export/csv/outgoing_trust_presenter_module.rb
+++ b/app/presenters/export/csv/outgoing_trust_presenter_module.rb
@@ -34,4 +34,40 @@ module Export::Csv::OutgoingTrustPresenterModule
   def outgoing_trust_identifier
     @project.outgoing_trust.group_identifier.to_s
   end
+
+  def outgoing_trust_address_1
+    return unless @project.outgoing_trust.present?
+
+    @project.outgoing_trust.address_street
+  end
+
+  def outgoing_trust_address_2
+    return unless @project.outgoing_trust.present?
+
+    @project.outgoing_trust.address_locality
+  end
+
+  def outgoing_trust_address_3
+    return unless @project.outgoing_trust.present?
+
+    @project.outgoing_trust.address_additional
+  end
+
+  def outgoing_trust_address_town
+    return unless @project.outgoing_trust.present?
+
+    @project.outgoing_trust.address_town
+  end
+
+  def outgoing_trust_address_county
+    return unless @project.outgoing_trust.present?
+
+    @project.outgoing_trust.address_county
+  end
+
+  def outgoing_trust_address_postcode
+    return unless @project.outgoing_trust.present?
+
+    @project.outgoing_trust.address_postcode
+  end
 end

--- a/app/presenters/export/csv/outgoing_trust_presenter_module.rb
+++ b/app/presenters/export/csv/outgoing_trust_presenter_module.rb
@@ -16,4 +16,18 @@ module Export::Csv::OutgoingTrustPresenterModule
 
     @project.outgoing_trust.name
   end
+
+  def outgoing_trust_main_contact_name
+    contact = @project.outgoing_trust_main_contact_id
+    return unless @project.outgoing_trust_main_contact_id.present?
+
+    Contact::Project.find_by(id: contact)&.name
+  end
+
+  def outgoing_trust_main_contact_email
+    contact = @project.outgoing_trust_main_contact_id
+    return unless @project.outgoing_trust_main_contact_id.present?
+
+    Contact::Project.find_by(id: contact)&.email
+  end
 end

--- a/app/presenters/export/csv/outgoing_trust_presenter_module.rb
+++ b/app/presenters/export/csv/outgoing_trust_presenter_module.rb
@@ -30,4 +30,8 @@ module Export::Csv::OutgoingTrustPresenterModule
 
     Contact::Project.find_by(id: contact)&.email
   end
+
+  def outgoing_trust_identifier
+    @project.outgoing_trust.group_identifier.to_s
+  end
 end

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -198,4 +198,10 @@ class Export::Csv::ProjectPresenter
 
     @project.contacts.where(category: "diocese").pluck(:email).join(", ")
   end
+
+  def advisory_board_conditions
+    return if @project.advisory_board_conditions.blank?
+
+    @project.advisory_board_conditions
+  end
 end

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -208,4 +208,16 @@ class Export::Csv::ProjectPresenter
   def completed_grant_payment_certificate_received
     @project.tasks_data.receive_grant_payment_certificate_date_received if @project.tasks_data.receive_grant_payment_certificate_date_received.present?
   end
+
+  def solicitor_contact_name
+    return if @project.contacts.where(category: "solicitor").blank?
+
+    @project.contacts.where(category: "solicitor").pluck(:name).join(", ")
+  end
+
+  def solicitor_contact_email
+    return if @project.contacts.where(category: "solicitor").blank?
+
+    @project.contacts.where(category: "solicitor").pluck(:email).join(", ")
+  end
 end

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -220,4 +220,14 @@ class Export::Csv::ProjectPresenter
 
     @project.contacts.where(category: "solicitor").pluck(:email).join(", ")
   end
+
+  def project_created_by_name
+    user_id = @project.regional_delivery_officer_id
+    User.find_by(id: user_id)&.full_name
+  end
+
+  def project_created_by_email
+    user_id = @project.regional_delivery_officer_id
+    User.find_by(id: user_id)&.email
+  end
 end

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -182,4 +182,20 @@ class Export::Csv::ProjectPresenter
     return I18n.t("export.csv.project.values.not_applicable") if @project.tasks_data.check_and_confirm_financial_information_not_applicable?
     @project.tasks_data.check_and_confirm_financial_information_trust_surplus_deficit
   end
+
+  def diocese_name
+    @project.establishment.diocese_name
+  end
+
+  def diocese_contact_name
+    return if @project.contacts.where(category: "diocese").blank?
+
+    @project.contacts.where(category: "diocese").pluck(:name).join(", ")
+  end
+
+  def diocese_contact_email
+    return if @project.contacts.where(category: "diocese").blank?
+
+    @project.contacts.where(category: "diocese").pluck(:email).join(", ")
+  end
 end

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -230,4 +230,8 @@ class Export::Csv::ProjectPresenter
     user_id = @project.regional_delivery_officer_id
     User.find_by(id: user_id)&.email
   end
+
+  def team_managing_the_project
+    I18n.t("teams.#{@project.team}")
+  end
 end

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -204,4 +204,8 @@ class Export::Csv::ProjectPresenter
 
     @project.advisory_board_conditions
   end
+
+  def completed_grant_payment_certificate_received
+    @project.tasks_data.receive_grant_payment_certificate_date_received if @project.tasks_data.receive_grant_payment_certificate_date_received.present?
+  end
 end

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -3,6 +3,8 @@ module Export::Csv::SchoolPresenterModule
     @project.urn.to_s
   end
 
+  alias_method :school_urn_with_academy_label, :school_urn
+
   def school_name
     return unless @project.establishment.present?
 

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -76,4 +76,6 @@ module Export::Csv::SchoolPresenterModule
 
     @project.establishment_sharepoint_link
   end
+
+  alias_method :school_sharepoint_link_with_academy_label, :school_sharepoint_folder
 end

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -11,6 +11,8 @@ module Export::Csv::SchoolPresenterModule
     @project.establishment.name
   end
 
+  alias_method :school_name_with_academy_label, :school_name
+
   def school_type
     return unless @project.establishment.present?
 

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -17,6 +17,8 @@ module Export::Csv::SchoolPresenterModule
     @project.establishment.type
   end
 
+  alias_method :school_type_with_academy_label, :school_type
+
   def school_phase
     return unless @project.establishment.present?
 

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -68,4 +68,10 @@ module Export::Csv::SchoolPresenterModule
 
     "#{@project.establishment.age_range_lower} - #{@project.establishment.age_range_upper}"
   end
+
+  def school_sharepoint_folder
+    return unless @project.establishment_sharepoint_link.present?
+
+    @project.establishment_sharepoint_link
+  end
 end

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -37,11 +37,15 @@ module Export::Csv::SchoolPresenterModule
     @project.establishment.address_street
   end
 
+  alias_method :school_address_1_with_academy_label, :school_address_1
+
   def school_address_2
     return unless @project.establishment.present?
 
     @project.establishment.address_locality
   end
+
+  alias_method :school_address_2_with_academy_label, :school_address_2
 
   def school_address_3
     return unless @project.establishment.present?
@@ -49,11 +53,15 @@ module Export::Csv::SchoolPresenterModule
     @project.establishment.address_additional
   end
 
+  alias_method :school_address_3_with_academy_label, :school_address_3
+
   def school_address_town
     return unless @project.establishment.present?
 
     @project.establishment.address_town
   end
+
+  alias_method :school_address_town_with_academy_label, :school_address_town
 
   def school_address_county
     return unless @project.establishment.present?
@@ -61,11 +69,15 @@ module Export::Csv::SchoolPresenterModule
     @project.establishment.address_county
   end
 
+  alias_method :school_address_county_with_academy_label, :school_address_county
+
   def school_address_postcode
     return unless @project.establishment.present?
 
     @project.establishment.address_postcode
   end
+
+  alias_method :school_address_postcode_with_academy_label, :school_address_postcode
 
   def school_age_range
     return unless @project.establishment.present?

--- a/app/services/export/conversions/by_month_csv_export_service.rb
+++ b/app/services/export/conversions/by_month_csv_export_service.rb
@@ -1,0 +1,72 @@
+class Export::Conversions::ByMonthCsvExportService < Export::CsvExportService
+  COLUMN_HEADERS = %i[
+    school_name
+    school_urn
+    project_type
+    academy_name
+    incoming_trust_name
+    local_authority_name
+    region
+    diocese_name
+    conversion_date
+    academy_order_type
+    two_requires_improvement
+    advisory_board_date
+    advisory_board_conditions
+    risk_protection_arrangement
+    all_conditions_met
+    completed_grant_payment_certificate_received
+    school_type
+    school_age_range
+    school_phase
+    reception_to_six_years
+    seven_to_eleven_years
+    twelve_or_above_years
+    school_address_1
+    school_address_2
+    school_address_3
+    school_address_town
+    school_address_county
+    school_address_postcode
+    school_sharepoint_folder
+    incoming_trust_ukprn
+    incoming_trust_identifier
+    incoming_trust_companies_house_number
+    incoming_trust_address_1
+    incoming_trust_address_2
+    incoming_trust_address_3
+    incoming_trust_address_town
+    incoming_trust_address_county
+    incoming_trust_address_postcode
+    incoming_trust_sharepoint_link
+    project_created_by_name
+    project_created_by_email
+    assigned_to_name
+    team_managing_the_project
+    main_contact_name
+    local_authority_contact_name
+    local_authority_contact_email
+    incoming_trust_main_contact_name
+    incoming_trust_main_contact_email
+    outgoing_trust_main_contact_name
+    outgoing_trust_main_contact_email
+    solicitor_contact_name
+    solicitor_contact_email
+    diocese_contact_name
+    diocese_contact_email
+    mp_name
+    mp_constituency
+    mp_email
+    mp_address_1
+    mp_address_2
+    mp_address_3
+    mp_address_postcode
+    director_of_child_services_name
+    director_of_child_services_email
+    director_of_child_services_role
+  ]
+
+  def initialize(projects)
+    @projects = projects
+  end
+end

--- a/app/services/export/transfers/by_month_csv_export_service.rb
+++ b/app/services/export/transfers/by_month_csv_export_service.rb
@@ -1,0 +1,74 @@
+class Export::Transfers::ByMonthCsvExportService < Export::CsvExportService
+  COLUMN_HEADERS = %i[
+    school_name
+    school_urn_with_academy_label
+    project_type
+    incoming_trust_name
+    outgoing_trust_name
+    local_authority_name
+    region
+    diocese_name
+    transfer_date
+    two_requires_improvement
+    inadequate_ofsted
+    financial_safeguarding_governance_issues
+    outgoing_trust_to_close
+    advisory_board_date
+    advisory_board_conditions
+    authority_to_proceed
+    school_type
+    school_age_range
+    school_phase
+    school_address_1
+    school_address_2
+    school_address_3
+    school_address_town
+    school_address_county
+    school_address_postcode
+    school_sharepoint_folder
+    incoming_trust_ukprn
+    incoming_trust_identifier
+    incoming_trust_companies_house_number
+    incoming_trust_address_1
+    incoming_trust_address_2
+    incoming_trust_address_3
+    incoming_trust_address_town
+    incoming_trust_address_county
+    incoming_trust_address_postcode
+    incoming_trust_sharepoint_link
+    outgoing_trust_ukprn
+    outgoing_trust_identifier
+    outgoing_trust_companies_house_number
+    outgoing_trust_address_1
+    outgoing_trust_address_2
+    outgoing_trust_address_3
+    outgoing_trust_address_town
+    outgoing_trust_address_county
+    outgoing_trust_address_postcode
+    outgoing_trust_sharepoint_link
+    project_created_by_name
+    project_created_by_email
+    assigned_to_name
+    assigned_to_email
+    team_managing_the_project
+    academy_contact_name
+    academy_contact_email
+    local_authority_contact_name
+    local_authority_contact_email
+    incoming_trust_main_contact_name
+    incoming_trust_main_contact_email
+    outgoing_trust_main_contact_name
+    outgoing_trust_main_contact_email
+    solicitor_contact_name
+    solicitor_contact_email
+    diocese_contact_name
+    diocese_contact_email
+    director_of_child_services_name
+    director_of_child_services_email
+    director_of_child_services_role
+  ]
+
+  def initialize(projects)
+    @projects = projects
+  end
+end

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -97,6 +97,7 @@ en:
           diocese_contact_email: Diocese contact email
           advisory_board_conditions: Advisory board conditions
           completed_grant_payment_certificate_received: Completed grant payment certificate received
+          school_sharepoint_folder: School sharepoint folder
           project_created_by_name: Project created by name
           project_created_by_email: Project created by email address
           team_managing_the_project: Team managing the project

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -53,6 +53,8 @@ en:
           incoming_trust_address_postcode: Incoming trust address postcode
           local_authority_code: Local authority code
           local_authority_name: Local authority
+          local_authority_contact_name: Local authority contact name
+          local_authority_contact_email: Local authority contact email
           local_authority_address_1: Local authority address 1
           local_authority_address_2: Local authority address 2
           local_authority_address_3: Local authority address 3

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -92,6 +92,8 @@ en:
           diocese_contact_email: Diocese contact email
           advisory_board_conditions: Advisory board conditions
           completed_grant_payment_certificate_received: Completed grant payment certificate received
+          project_created_by_name: Project created by name
+          project_created_by_email: Project created by email address
           solicitor_contact_name: Solicitor contact name
           solicitor_contact_email: Solicitor contact email
         values:

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -92,6 +92,8 @@ en:
           diocese_contact_email: Diocese contact email
           advisory_board_conditions: Advisory board conditions
           completed_grant_payment_certificate_received: Completed grant payment certificate received
+          solicitor_contact_name: Solicitor contact name
+          solicitor_contact_email: Solicitor contact email
         values:
           project_type:
             conversion: Conversion

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -113,6 +113,8 @@ en:
           solicitor_contact_name: Solicitor contact name
           solicitor_contact_email: Solicitor contact email
           school_urn_with_academy_label: Academy URN
+          academy_contact_name: Academy contact name
+          academy_contact_email: Academt contact email
         values:
           project_type:
             conversion: Conversion

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -79,6 +79,8 @@ en:
           outgoing_trust_name: Outgoing trust name
           outgoing_trust_companies_house_number: Outgoing trust companies house number
           outgoing_trust_ukprn: Outgoing trust UKPRN
+          outgoing_trust_main_contact_name: Outgoing trust main contact name
+          outgoing_trust_main_contact_email: Outgoing trust main contact email
           incoming_trust_ukprn: Incoming trust UKPRN
           inadequate_ofsted: Transfer due to inadequate
           financial_safeguarding_governance_issues: Transfer due to financial, safeguarding or governance

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -115,6 +115,7 @@ en:
           school_urn_with_academy_label: Academy URN
           academy_contact_name: Academy contact name
           academy_contact_email: Academt contact email
+          academy_sharepoint_link: Academy sharepoint link
         values:
           project_type:
             conversion: Conversion

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -80,6 +80,7 @@ en:
           outgoing_trust_identifier: Outgoing trust group identifier
           outgoing_trust_companies_house_number: Outgoing trust companies house number
           outgoing_trust_ukprn: Outgoing trust UKPRN
+          outgoing_trust_sharepoint_link: Outgoing trust sharepoint link
           outgoing_trust_address_1: Outgoing trust address 1
           outgoing_trust_address_2: Outgoing trust address 2
           outgoing_trust_address_3: Outgoing trust address 3

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -45,6 +45,9 @@ en:
           incoming_trust_identifier: Incoming trust group identifier
           incoming_trust_companies_house_number: Incoming trust companies house number
           incoming_trust_name: Incoming trust name
+          incoming_trust_main_contact_name: Incoming trust main contact name
+          incoming_trust_main_contact_email: Incoming trust main contact email
+          incoming_trust_sharepoint_link: Incoming trust sharepoint link
           incoming_trust_address_1: Incoming trust address 1
           incoming_trust_address_2: Incoming trust address 2
           incoming_trust_address_3: Incoming trust address 3

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -77,6 +77,7 @@ en:
           link_to_project: Link to project
           region: Region
           outgoing_trust_name: Outgoing trust name
+          outgoing_trust_identifier: Outgoing trust group identifier
           outgoing_trust_companies_house_number: Outgoing trust companies house number
           outgoing_trust_ukprn: Outgoing trust UKPRN
           outgoing_trust_main_contact_name: Outgoing trust main contact name

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -104,6 +104,7 @@ en:
           team_managing_the_project: Team managing the project
           solicitor_contact_name: Solicitor contact name
           solicitor_contact_email: Solicitor contact email
+          school_urn_with_academy_label: Academy URN
         values:
           project_type:
             conversion: Conversion

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -94,6 +94,7 @@ en:
           completed_grant_payment_certificate_received: Completed grant payment certificate received
           project_created_by_name: Project created by name
           project_created_by_email: Project created by email address
+          team_managing_the_project: Team managing the project
           solicitor_contact_name: Solicitor contact name
           solicitor_contact_email: Solicitor contact email
         values:

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -80,6 +80,12 @@ en:
           outgoing_trust_identifier: Outgoing trust group identifier
           outgoing_trust_companies_house_number: Outgoing trust companies house number
           outgoing_trust_ukprn: Outgoing trust UKPRN
+          outgoing_trust_address_1: Outgoing trust address 1
+          outgoing_trust_address_2: Outgoing trust address 2
+          outgoing_trust_address_3: Outgoing trust address 3
+          outgoing_trust_address_town: Outgoing trust address town
+          outgoing_trust_address_county: Outgoing trust address county
+          outgoing_trust_address_postcode: Outgoing trust address postcode
           outgoing_trust_main_contact_name: Outgoing trust main contact name
           outgoing_trust_main_contact_email: Outgoing trust main contact email
           incoming_trust_ukprn: Incoming trust UKPRN

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -97,6 +97,7 @@ en:
           diocese_contact_email: Diocese contact email
           advisory_board_conditions: Advisory board conditions
           completed_grant_payment_certificate_received: Completed grant payment certificate received
+          school_age_range: Pupil age range
           school_sharepoint_folder: School sharepoint folder
           project_created_by_name: Project created by name
           project_created_by_email: Project created by email address

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -91,6 +91,7 @@ en:
           diocese_contact_name: Diocese contact name
           diocese_contact_email: Diocese contact email
           advisory_board_conditions: Advisory board conditions
+          completed_grant_payment_certificate_received: Completed grant payment certificate received
         values:
           project_type:
             conversion: Conversion

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -116,6 +116,7 @@ en:
           academy_contact_name: Academy contact name
           academy_contact_email: Academt contact email
           academy_sharepoint_link: Academy sharepoint link
+          academy_type: Academy type
         values:
           project_type:
             conversion: Conversion

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -87,6 +87,9 @@ en:
           academy_surplus_deficit: Is the academy in surplus or deficit?
           trust_surplus_deficit: Is the incoming trust in surplus or deficit?
           authority_to_proceed: Authority to proceed?
+          diocese_name: Diocese
+          diocese_contact_name: Diocese contact name
+          diocese_contact_email: Diocese contact email
         values:
           project_type:
             conversion: Conversion

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -90,6 +90,7 @@ en:
           diocese_name: Diocese
           diocese_contact_name: Diocese contact name
           diocese_contact_email: Diocese contact email
+          advisory_board_conditions: Advisory board conditions
         values:
           project_type:
             conversion: Conversion

--- a/spec/presenters/export/csv/academy_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/academy_presenter_module_spec.rb
@@ -1,36 +1,57 @@
 require "rails_helper"
 
 RSpec.describe Export::Csv::AcademyPresenterModule do
-  let(:project) { build(:conversion_project, academy_urn: 149061, academy: gias_establishment) }
-  subject { AcademyPresenterModuleTestClass.new(project) }
+  context "when a project is a conversion project" do
+    let(:project) { build(:conversion_project, academy_urn: 149061, academy: gias_establishment) }
+    subject { AcademyPresenterModuleTestClass.new(project) }
 
-  it "presents the academy urn" do
-    expect(subject.academy_urn).to eql "149061"
+    it "presents the academy urn" do
+      expect(subject.academy_urn).to eql "149061"
+    end
+
+    it "presents the academy ukprn" do
+      expect(subject.academy_ukprn).to eql "10065250"
+    end
+
+    it "presents the academy DfE number" do
+      expect(subject.academy_dfe_number).to eql "941/2025"
+    end
+
+    it "presents the academy name" do
+      expect(subject.academy_name).to eql "Deanshanger Primary School"
+    end
+
+    it "presents the academy type" do
+      expect(subject.academy_type).to eql "Academy converter"
+    end
+
+    it "presents the academy address" do
+      expect(subject.academy_address_1).to eql "The Green"
+      expect(subject.academy_address_2).to eql "Deanshanger"
+      expect(subject.academy_address_3).to eql "Deanshanger Primary School, the Green, Deanshanger"
+      expect(subject.academy_address_town).to eql "Milton Keynes"
+      expect(subject.academy_address_county).to eql "Buckinghamshire"
+      expect(subject.academy_address_postcode).to eql "MK19 6HJ"
+    end
   end
 
-  it "presents the academy ukprn" do
-    expect(subject.academy_ukprn).to eql "10065250"
-  end
+  context "when a project is a transfer project" do
+    let(:transfer_project) { build(:transfer_project, urn: 123456) }
+    subject { AcademyPresenterModuleTestClass.new(transfer_project) }
 
-  it "presents the academy DfE number" do
-    expect(subject.academy_dfe_number).to eql "941/2025"
-  end
+    it "presents the academy contact name" do
+      mock_successful_api_response_to_create_any_project
+      create(:project_contact, category: "school_or_academy", name: "academy contact name", project: transfer_project)
 
-  it "presents the academy name" do
-    expect(subject.academy_name).to eql "Deanshanger Primary School"
-  end
+      expect(subject.academy_contact_name).to eql("academy contact name")
+    end
 
-  it "presents the academy type" do
-    expect(subject.academy_type).to eql "Academy converter"
-  end
+    it "presents the academy contact email" do
+      mock_successful_api_response_to_create_any_project
+      create(:project_contact, category: "school_or_academy", email: "academy_contact@email.com", project: transfer_project)
 
-  it "presents the academy address" do
-    expect(subject.academy_address_1).to eql "The Green"
-    expect(subject.academy_address_2).to eql "Deanshanger"
-    expect(subject.academy_address_3).to eql "Deanshanger Primary School, the Green, Deanshanger"
-    expect(subject.academy_address_town).to eql "Milton Keynes"
-    expect(subject.academy_address_county).to eql "Buckinghamshire"
-    expect(subject.academy_address_postcode).to eql "MK19 6HJ"
+      expect(subject.academy_contact_email).to eql("academy_contact@email.com")
+    end
   end
 
   def gias_establishment

--- a/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
@@ -1,7 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Export::Csv::IncomingTrustPresenterModule do
-  let(:project) { build(:conversion_project, incoming_trust_ukprn: 121813, incoming_trust: known_trust) }
+  let(:incoming_trust_main_contact) do
+    mock_successful_api_response_to_create_any_project
+    create(:project_contact, category: "incoming_trust")
+  end
+  let(:project) { build(:conversion_project, incoming_trust_ukprn: 121813, incoming_trust: known_trust, incoming_trust_main_contact_id: incoming_trust_main_contact.id) }
   subject { IncomingTrustPresenterModuleTestClass.new(project) }
 
   it "presents the identifier" do
@@ -43,6 +47,18 @@ RSpec.describe Export::Csv::IncomingTrustPresenterModule do
       address_county: nil,
       address_postcode: "MK13 0BQ"
     )
+  end
+
+  it "presents the main contact name" do
+    expect(subject.incoming_trust_main_contact_name).to eql "Jo Example"
+  end
+
+  it "presents the main contact email" do
+    expect(subject.incoming_trust_main_contact_email).to eql "jo@example.com"
+  end
+
+  it "presents the sharepoint link" do
+    expect(subject.incoming_trust_sharepoint_link).to eql "https://educationgovuk-my.sharepoint.com/incoming-trust-folder"
   end
 end
 

--- a/spec/presenters/export/csv/local_authority_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/local_authority_presenter_module_spec.rb
@@ -1,12 +1,14 @@
 require "rails_helper"
 
 RSpec.describe Export::Csv::LocalAuthorityPresenterModule do
-  let(:project) { build(:conversion_project) }
-  subject { LocalAuthorityPresenterModuleTestClass.new(project) }
-
   before do
+    mock_successful_api_response_to_create_any_project
     allow(project).to receive(:local_authority).and_return known_local_authority
   end
+
+  let(:project) { create(:conversion_project) }
+  let!(:local_authority_main_contact) { create(:project_contact, category: "local_authority", name: "contact name", email: "local_authority_contact@email.com", project: project) }
+  subject { LocalAuthorityPresenterModuleTestClass.new(project) }
 
   it "presents the code" do
     expect(subject.local_authority_code).to eql "100"
@@ -23,6 +25,14 @@ RSpec.describe Export::Csv::LocalAuthorityPresenterModule do
     expect(subject.local_authority_address_town).to eql nil
     expect(subject.local_authority_address_county).to eql "Northampton"
     expect(subject.local_authority_address_postcode).to eql "NN1 1ED"
+  end
+
+  it "presents the local authority contact name" do
+    expect(subject.local_authority_contact_name).to eql "contact name"
+  end
+
+  it "presents the local authority contact email" do
+    expect(subject.local_authority_contact_email).to eql "local_authority_contact@email.com"
   end
 
   def known_local_authority

--- a/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe Export::Csv::OutgoingTrustPresenterModule do
     expect(subject.outgoing_trust_address_postcode).to eql "MK13 0BQ"
   end
 
+  it "presents the sharepoint link" do
+    expect(subject.outgoing_trust_sharepoint_link).to eql "https://educationgovuk-my.sharepoint.com/outgoing-trust-folder"
+  end
+
   def known_trust
     double(
       Api::AcademiesApi::Trust,

--- a/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
@@ -1,7 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Export::Csv::OutgoingTrustPresenterModule do
-  let(:project) { build(:transfer_project, outgoing_trust_ukprn: 121813) }
+  let(:outgoing_trust_main_contact) do
+    mock_successful_api_response_to_create_any_project
+    create(:project_contact, category: "outgoing_trust")
+  end
+  let(:project) { build(:transfer_project, outgoing_trust_ukprn: 121813, outgoing_trust_main_contact_id: outgoing_trust_main_contact.id) }
   subject { OutgoingTrustPresenterModuleTestClass.new(project) }
 
   before do
@@ -18,6 +22,14 @@ RSpec.describe Export::Csv::OutgoingTrustPresenterModule do
 
   it "presents the name" do
     expect(subject.outgoing_trust_name).to eql "The Grand Union Partnership"
+  end
+
+  it "presents the main contact name" do
+    expect(subject.outgoing_trust_main_contact_name).to eql "Jo Example"
+  end
+
+  it "presents the main contact email" do
+    expect(subject.outgoing_trust_main_contact_email).to eql "jo@example.com"
   end
 
   def known_trust

--- a/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe Export::Csv::OutgoingTrustPresenterModule do
     expect(subject.outgoing_trust_main_contact_email).to eql "jo@example.com"
   end
 
+  it "presents the outgoing trust identifier" do
+    expect(subject.outgoing_trust_identifier).to eql "TR03819"
+  end
+
   def known_trust
     double(
       Api::AcademiesApi::Trust,

--- a/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe Export::Csv::OutgoingTrustPresenterModule do
     expect(subject.outgoing_trust_identifier).to eql "TR03819"
   end
 
+  it "presents the outgoing trusts address" do
+    expect(subject.outgoing_trust_address_1).to eql "New Bradwell County Combined School"
+    expect(subject.outgoing_trust_address_2).to eql "Bounty Street"
+    expect(subject.outgoing_trust_address_3).to be_nil
+    expect(subject.outgoing_trust_address_town).to eql "Milton Keynes"
+    expect(subject.outgoing_trust_address_county).to be_nil
+    expect(subject.outgoing_trust_address_postcode).to eql "MK13 0BQ"
+  end
+
   def known_trust
     double(
       Api::AcademiesApi::Trust,

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -480,6 +480,16 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.advisory_board_conditions).to eql("These are the conditions.")
   end
 
+  it "presents the completed grant payment certificate received" do
+    mock_successful_api_response_to_create_any_project
+    tasks_data = build(:conversion_tasks_data, receive_grant_payment_certificate_date_received: Date.new(2024, 1, 1))
+    project = create(:conversion_project, tasks_data: tasks_data)
+
+    presenter = described_class.new(project)
+
+    expect(presenter.completed_grant_payment_certificate_received).to eql(tasks_data.receive_grant_payment_certificate_date_received)
+  end
+
   def not_applicable_for_a_transfer
     project = build(:transfer_project)
 

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -431,6 +431,46 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.academy_surplus_deficit).to eq("not applicable")
   end
 
+  it "presents the diocese name" do
+    mock_successful_api_response_to_create_any_project
+    project = build(:conversion_project)
+
+    presenter = described_class.new(project)
+
+    expect(presenter.diocese_name).to eql("Diocese of West Placefield")
+  end
+
+  it "presents the diocese contact name" do
+    mock_successful_api_response_to_create_any_project
+    project = create(:conversion_project)
+    create(:project_contact, category: "diocese", name: "contact name", project: project)
+
+    presenter = described_class.new(project)
+
+    expect(presenter.diocese_contact_name).to eql("contact name")
+  end
+
+  it "presents the diocese contact email" do
+    mock_successful_api_response_to_create_any_project
+    project = create(:conversion_project)
+    create(:project_contact, category: "diocese", email: "diocese_contact@email.com", project: project)
+
+    presenter = described_class.new(project)
+
+    expect(presenter.diocese_contact_email).to eql("diocese_contact@email.com")
+  end
+
+  context "when there is no diocese contact" do
+    it "returns nil" do
+      mock_successful_api_response_to_create_any_project
+      project = create(:conversion_project)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.diocese_contact_name).to be_nil
+    end
+  end
+
   def not_applicable_for_a_transfer
     project = build(:transfer_project)
 

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -521,6 +521,26 @@ RSpec.describe Export::Csv::ProjectPresenter do
     end
   end
 
+  it "presents the project created by name" do
+    mock_successful_api_response_to_create_any_project
+    user = create(:regional_delivery_officer_user, first_name: "Joe", last_name: "Bloggs")
+    project = create(:conversion_project, regional_delivery_officer: user)
+
+    presenter = described_class.new(project)
+
+    expect(presenter.project_created_by_name).to eql("Joe Bloggs")
+  end
+
+  it "presents the project created by email" do
+    mock_successful_api_response_to_create_any_project
+    user = create(:regional_delivery_officer_user, email: "joe.bloggs@education.gov.uk")
+    project = create(:conversion_project, regional_delivery_officer: user)
+
+    presenter = described_class.new(project)
+
+    expect(presenter.project_created_by_email).to eql("joe.bloggs@education.gov.uk")
+  end
+
   def not_applicable_for_a_transfer
     project = build(:transfer_project)
 

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -471,6 +471,15 @@ RSpec.describe Export::Csv::ProjectPresenter do
     end
   end
 
+  it "presents the advisory board conditions" do
+    mock_successful_api_response_to_create_any_project
+    project = build(:conversion_project, advisory_board_conditions: "These are the conditions.")
+
+    presenter = described_class.new(project)
+
+    expect(presenter.advisory_board_conditions).to eql("These are the conditions.")
+  end
+
   def not_applicable_for_a_transfer
     project = build(:transfer_project)
 

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -541,6 +541,16 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.project_created_by_email).to eql("joe.bloggs@education.gov.uk")
   end
 
+  it "presents the team managing the project" do
+    mock_successful_api_response_to_create_any_project
+    user = create(:user, team: "london")
+    project = create(:conversion_project, assigned_to_id: user)
+
+    presenter = described_class.new(project)
+
+    expect(presenter.team_managing_the_project).to eql("London")
+  end
+
   def not_applicable_for_a_transfer
     project = build(:transfer_project)
 

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -490,6 +490,37 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.completed_grant_payment_certificate_received).to eql(tasks_data.receive_grant_payment_certificate_date_received)
   end
 
+  it "presents the solicitor contact name" do
+    mock_successful_api_response_to_create_any_project
+    project = create(:conversion_project)
+    create(:project_contact, category: "solicitor", name: "solicitor contact name", project: project)
+
+    presenter = described_class.new(project)
+
+    expect(presenter.solicitor_contact_name).to eql("solicitor contact name")
+  end
+
+  it "presents the solicitor contact email" do
+    mock_successful_api_response_to_create_any_project
+    project = create(:conversion_project)
+    create(:project_contact, category: "solicitor", email: "solicitor_contact@email.com", project: project)
+
+    presenter = described_class.new(project)
+
+    expect(presenter.solicitor_contact_email).to eql("solicitor_contact@email.com")
+  end
+
+  context "when there is no solicitor contact" do
+    it "returns nil" do
+      mock_successful_api_response_to_create_any_project
+      project = create(:conversion_project)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.solicitor_contact_name).to be_nil
+    end
+  end
+
   def not_applicable_for_a_transfer
     project = build(:transfer_project)
 

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
     it "presents the project URN" do
       expect(subject.school_urn_with_academy_label).to eql "121813"
     end
+
+    it "presents the academy sharepoint link" do
+      expect(subject.school_sharepoint_link_with_academy_label).to eql "https://educationgovuk-my.sharepoint.com/establishment-folder"
+    end
   end
 
 

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -49,8 +49,11 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
     it "presents the academy sharepoint link" do
       expect(subject.school_sharepoint_link_with_academy_label).to eql "https://educationgovuk-my.sharepoint.com/establishment-folder"
     end
-  end
 
+    it "presents the academy type" do
+      expect(subject.school_type_with_academy_label).to eql "Community school"
+    end
+  end
 
   def known_establishment
     double(

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
     expect(subject.school_sharepoint_folder).to eql "https://educationgovuk-my.sharepoint.com/establishment-folder"
   end
 
+  context "when a school method has an alternative label" do
+    it "presents the project URN" do
+      expect(subject.school_urn_with_academy_label).to eql "121813"
+    end
+  end
+
+
   def known_establishment
     double(
       Api::AcademiesApi::Establishment,

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -62,6 +62,10 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
       expect(subject.school_address_county_with_academy_label).to eql "Buckinghamshire"
       expect(subject.school_address_postcode_with_academy_label).to eql "MK19 6HJ"
     end
+
+    it "presents the academy name" do
+      expect(subject.school_name_with_academy_label).to eql "Deanshanger Primary School"
+    end
   end
 
   def known_establishment

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -53,6 +53,15 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
     it "presents the academy type" do
       expect(subject.school_type_with_academy_label).to eql "Community school"
     end
+
+    it "presents the academy address" do
+      expect(subject.school_address_1_with_academy_label).to eql "The Green"
+      expect(subject.school_address_2_with_academy_label).to eql "Deanshanger"
+      expect(subject.school_address_3_with_academy_label).to eql "Deanshanger Primary School, the Green, Deanshanger"
+      expect(subject.school_address_town_with_academy_label).to eql "Milton Keynes"
+      expect(subject.school_address_county_with_academy_label).to eql "Buckinghamshire"
+      expect(subject.school_address_postcode_with_academy_label).to eql "MK19 6HJ"
+    end
   end
 
   def known_establishment

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
     expect(subject.school_address_postcode).to eql "MK19 6HJ"
   end
 
+  it "presents the school sharepoint folder link" do
+    expect(subject.school_sharepoint_folder).to eql "https://educationgovuk-my.sharepoint.com/establishment-folder"
+  end
+
   def known_establishment
     double(
       Api::AcademiesApi::Establishment,

--- a/spec/services/export/conversions/by_month_csv_export_service_spec.rb
+++ b/spec/services/export/conversions/by_month_csv_export_service_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Export::Conversions::ByMonthCsvExportService do
+  describe "#call" do
+    before do
+      mock_all_academies_api_responses
+      mock_successful_member_details
+    end
+
+    it "returns a csv with headers and values" do
+      user = build(:user, first_name: "Joe", last_name: "Bloggs")
+      project = build(:conversion_project, team: "south_east", assigned_to: user)
+      projects = [project]
+
+      csv_export = described_class.new(projects).call
+
+      expect(csv_export).to include("Project created by")
+      expect(csv_export).to include("Team managing the project")
+
+      expect(csv_export).to include("Joe Bloggs")
+      expect(csv_export).to include("South East")
+    end
+  end
+end

--- a/spec/services/export/transfers/by_month_csv_export_services_spec.rb
+++ b/spec/services/export/transfers/by_month_csv_export_services_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Export::Transfers::ByMonthCsvExportService do
+  describe "#call" do
+    before do
+      mock_all_academies_api_responses
+      mock_successful_member_details
+    end
+
+    it "returns a csv with headers and values" do
+      project = build(:transfer_project)
+      projects = [project]
+
+      csv_export = described_class.new(projects).call
+
+      expect(csv_export).to include("Project type")
+      expect(csv_export).to include("Outgoing trust UKPRN")
+
+      expect(csv_export).to include("Transfer")
+      expect(csv_export).to include("10059062")
+    end
+  end
+end


### PR DESCRIPTION
## Changes

This has been built on top of #1326

Create a `by month` CSV export for Transfers. 

We have added alias methods to extract the establishment information for a Transfer from the `project.establishment` association but with different Column labels from the original `school_name`, `school_urn` (etc) implementations. Because Conversions get their data for their new academies from the `project.academy` association, we were unable to use the `academy_name`, `academy_urn` (etc) implementations for extracting Academy information in Transfers, because Transfers do not use the `project.academy` association. The required "Academy" information is on the `project.establishment` association. By creating alias methods, we can use the same methods to extract `project.establishment` data, but use labels more suited to Transfer projects (e.g. Academy name instead
of School name)

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
