### PR TITLE
(154885) By month view for Caseworkers & other non-data consumer users - Conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   range of dates and see Conversion projects due to convert in that date range
 - Add Transfers to the new By Month view for export/data consumer users. This
   view shares the date picker functionality in the change above.
+- Add new By Month view for non-data-consumer users. This view shows the next
+  (upcoming) month only, and the table has the same columns as the date range
+  view described above.
 
 ### Changed
 

--- a/app/controllers/all/by_month/conversions/projects_controller.rb
+++ b/app/controllers/all/by_month/conversions/projects_controller.rb
@@ -35,6 +35,22 @@ class All::ByMonth::Conversions::ProjectsController < ApplicationController
     redirect_to action: "date_range", from_month: from_month, from_year: from_year, to_month: to_month, to_year: to_year
   end
 
+  def next_month
+    authorize Project, :index?
+
+    redirect_to action: "single_month", month: (Date.today + 1.month).month, year: (Date.today + 1.month).year
+  end
+
+  def single_month
+    authorize Project, :index?
+
+    @month = month
+    @year = year
+    @date = "#{year}-#{month}-1"
+
+    @pager, @projects = pagy_array(ByMonthProjectFetcherService.new.conversion_projects_by_date(month, year))
+  end
+
   private def redirect_if_dates_incorrect
     redirect_to date_range_this_month_all_by_month_conversions_projects_path, alert: I18n.t("project.date_range.date_form.from_date_before_to_date")
   end
@@ -61,5 +77,13 @@ class All::ByMonth::Conversions::ProjectsController < ApplicationController
 
   private def to_date
     params[:to_date].to_s
+  end
+
+  private def month
+    params[:month]
+  end
+
+  private def year
+    params[:year]
   end
 end

--- a/app/services/by_month_project_fetcher_service.rb
+++ b/app/services/by_month_project_fetcher_service.rb
@@ -51,6 +51,13 @@ class ByMonthProjectFetcherService
     AcademiesApiPreFetcherService.new.call!(projects) if @pre_fetch_academies_api
   end
 
+  def conversion_projects_by_date(month, year)
+    projects = Project.conversions.confirmed.filtered_by_significant_date(month, year)
+
+    AcademiesApiPreFetcherService.new.call!(projects) if @pre_fetch_academies_api
+    sort_by_conditions_met_and_name(projects)
+  end
+
   private def sort_by_conditions_met_and_name(projects)
     projects.sort_by { |p| [p.all_conditions_met? ? 0 : 1, p.establishment.name] }
   end

--- a/app/views/all/by_month/conversions/projects/_by_month_table.html.erb
+++ b/app/views/all/by_month/conversions/projects/_by_month_table.html.erb
@@ -1,5 +1,9 @@
 <% if projects.empty? %>
-  <%= govuk_inset_text(text: t("project.table.by_month.date_range.conversions.empty", from_date: Date.parse(from_date).to_fs(:govuk_month), to_date: Date.parse(to_date).to_fs(:govuk_month))) %>
+  <% if @from_date && @to_date %>
+    <%= govuk_inset_text(text: t("project.table.by_month.date_range.conversions.empty", from_date: Date.parse(@from_date).to_fs(:govuk_month), to_date: Date.parse(@to_date).to_fs(:govuk_month))) %>
+  <% else %>
+    <%= govuk_inset_text(text: t("project.table.by_month.single_month.conversions.empty", date: Date.parse(@date).to_fs(:govuk_month))) %>
+  <% end %>
 <% else %>
   <table class="govuk-table" name="projects_table" aria-label="Projects table">
     <thead class="govuk-table__head">

--- a/app/views/all/by_month/conversions/projects/single_month.html.erb
+++ b/app/views/all/by_month/conversions/projects/single_month.html.erb
@@ -1,0 +1,30 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("project.single_month.page_title", date: Date.parse(@date).to_fs(:govuk_month))) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <span class="govuk-caption-l"><%= t("project.single_month.subtitle") %></span>
+    <h1 class="govuk-heading-l">
+      <%= t("project.single_month.title", date: Date.parse(@date).to_fs(:govuk_month)) %>
+    </h1>
+    <%= t("project.single_month.body_html") %>
+
+    <nav class="moj-sub-navigation" aria-label="Project index sub-navigation">
+      <ul class="moj-sub-navigation__list">
+        <%= render partial: "shared/sub_navigation_item",
+              locals: {name: t("project.single_month.tabs.conversions"),
+                       path: "/projects/all/by-month/conversions/#{@month}/#{@year}"} %>
+        <%= render partial: "shared/sub_navigation_item",
+              locals: {name: t("project.single_month.tabs.transfers"),
+                       path: "/projects/all/by-month/transfers/#{@month}/#{@year}"} %>
+      </ul>
+    </nav>
+
+    <%= render partial: "by_month_table", locals: {projects: @projects, pager: @pager} %>
+  </div>
+</div>

--- a/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
@@ -13,7 +13,7 @@
           <% if policy(:export).index? %>
             <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_month"), path: date_range_this_month_all_by_month_conversions_projects_path, namespace: "/projects/all/by-month"} %>
           <% else %>
-            <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_month"), path: confirmed_all_by_month_projects_path, namespace: "/projects/all/by-month"} %>
+            <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_month"), path: next_month_all_by_month_conversions_projects_path, namespace: "/projects/all/by-month"} %>
           <% end %>
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_region"), path: all_regions_projects_path, namespace: "/projects/all/regions"} %>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -248,7 +248,10 @@ en:
         caption: Table of users who have in-progress projects
       by_month:
         single_month:
-          empty: There are no projects due to convert or transfer in %{date}
+          conversions:
+            empty: There are no projects due to convert in %{date}
+          transfers:
+            empty: There are no projects due to transfer in %{date}
         date_range:
           transfers:
             empty: There are no projects due to transfer between %{from_date} and %{to_date}
@@ -321,6 +324,16 @@ en:
         to: to
         apply: Apply
         from_date_before_to_date: "The 'from' date cannot be after the 'to' date"
+      tabs:
+        conversions: Conversions
+        transfers: Transfers
+    single_month:
+      page_title: Academies opening or transferring, %{date}
+      title: "%{date}"
+      subtitle: Academies opening or transferring
+      body_html:
+        <p>Schools that will become academies, and academies that will move to a different trust.</p>
+        <p>You can also download a more detailed version of the data as a CSV file.</p>
       tabs:
         conversions: Conversions
         transfers: Transfers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,6 +117,8 @@ Rails.application.routes.draw do
               get "from/to", to: "projects#date_range_this_month", as: :date_range_this_month
               post "from/to", to: "projects#date_range_select", as: :date_range_select
               get "from/:from_month/:from_year/to/:to_month/:to_year", to: "projects#date_range", constraints: {from_month: MONTH_1_12_REGEX, from_year: YEAR_2000_2499_REGEX, to_month: MONTH_1_12_REGEX, to_year: YEAR_2000_2499_REGEX}, as: :date_range
+              get ":month/:year", to: "projects#single_month", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :single_month
+              get "/", to: "projects#next_month", as: :next_month
             end
             namespace :transfers do
               get "from/to", to: "projects#date_range_this_month", as: :date_range_this_month

--- a/spec/features/all_projects/by_month/users_can_view_projects_by_month_spec.rb
+++ b/spec/features/all_projects/by_month/users_can_view_projects_by_month_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.feature "Users can view projects by month" do
+  context "a data user (who can export)" do
+    let(:user) { create(:user, team: "education_and_skills_funding_agency") }
+
+    scenario "the user sees the date range option in the By Month view" do
+      sign_in_with_user(user)
+      click_on "By month"
+      expect(page).to have_content("Date range")
+    end
+  end
+
+  context "any other user (who cannot export)" do
+    let(:user) { create(:regional_casework_services_user) }
+
+    scenario "the user sees a single month in the By Month view" do
+      sign_in_with_user(user)
+
+      click_on "All projects"
+      click_on "By month"
+      expect(page).to have_content((Date.today + 1.month).to_fs(:govuk_month))
+      expect(page).to_not have_content("Date range")
+    end
+  end
+end

--- a/spec/requests/all/by_month/conversions/projects_controller_spec.rb
+++ b/spec/requests/all/by_month/conversions/projects_controller_spec.rb
@@ -46,4 +46,30 @@ RSpec.describe All::ByMonth::Conversions::ProjectsController, type: :request do
       end
     end
   end
+
+  describe "#next_month" do
+    it "redirects to the next upcoming month and year" do
+      get next_month_all_by_month_conversions_projects_path
+      follow_redirect!
+
+      expect(response).to have_http_status(:success)
+      expect(request.params.fetch(:month)).to eq (Date.today + 1.month).month.to_s
+      expect(request.params.fetch(:year)).to eq (Date.today + 1.month).year.to_s
+    end
+  end
+
+  describe "#single_month" do
+    it "shows the date in the page text" do
+      get "/projects/all/by-month/conversions/1/2023"
+      expect(response.body).to include "January 2023"
+    end
+
+    it "shows details of any matching projects" do
+      project = create(:conversion_project, significant_date_provisional: false, significant_date: Date.new(2023, 2, 1))
+
+      get "/projects/all/by-month/conversions/2/2023"
+      expect(response.body).to include(project.establishment.name)
+      expect(response.body).to include(project.urn.to_s)
+    end
+  end
 end

--- a/spec/services/by_month_project_fetcher_service_spec.rb
+++ b/spec/services/by_month_project_fetcher_service_spec.rb
@@ -195,4 +195,21 @@ RSpec.describe ByMonthProjectFetcherService do
       end
     end
   end
+
+  describe "#conversion_projects_by_date" do
+    context "with prefetching disabled for this test" do
+      it "returns conversion projects and orders by all conditions met & establishment name" do
+        project_one = double(Conversion::Project, all_conditions_met?: false, establishment: double("Establishment", name: "Y school"))
+        project_two = double(Conversion::Project, all_conditions_met?: false, establishment: double("Establishment", name: "B school"))
+        project_three = double(Conversion::Project, all_conditions_met?: false, establishment: double("Establishment", name: "A school"))
+        project_four = double(Conversion::Project, all_conditions_met?: true, establishment: double("Establishment", name: "Z school"))
+
+        allow(Project).to receive(:filtered_by_significant_date).and_return([project_one, project_two, project_three, project_four])
+
+        projects = described_class.new(pre_fetch_academies_api: false).conversion_projects_by_date(1, 2025)
+
+        expect(projects).to eq [project_four, project_three, project_two, project_one]
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes

To be merged after #1330 and #1338 

Add a new view for non-data consumer users to view a list of Conversion projects
with a significant date in the upcoming month. The table view is identical to
the date range view added in https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/1330

Non-data consumer users do not see the date range picker, and instead only see
the upcoming month. We have built in the ability for a different month to be
viewed by manipulating the URL.

<img width="1262" alt="Screenshot 2024-02-08 at 16 44 10" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/fa3f8e06-81bc-434f-a068-13b241d587bf">


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
