### PR TITLE
(156240) Enable business support users to view exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Transfers (currently only showing Conversions), with different columns in the
   table. There is also a date picker to allow users to choose a date range to
   view.
+- Give business support users the ability to view export pages
 
 ## [Release-52][release-52]
 

--- a/app/policies/export_policy.rb
+++ b/app/policies/export_policy.rb
@@ -16,6 +16,7 @@ class ExportPolicy
   def csv?
     return true if @user.education_and_skills_funding_agency_team?
     return true if @user.academies_operational_practice_unit_team?
+    return true if @user.business_support_team?
 
     false
   end

--- a/spec/features/all_projects/export/export_users_can_see_an_export_landing_page_spec.rb
+++ b/spec/features/all_projects/export/export_users_can_see_an_export_landing_page_spec.rb
@@ -31,4 +31,15 @@ RSpec.feature "Export users can see the exports landing page" do
     expect(page).to have_content("You can check details about schools' risk protection arrangements and start-up grant funding.")
     expect(page).to have_content("You can get information pre-opening grants for schools becoming academies.")
   end
+
+  scenario "a business support user can see the exports landing page" do
+    user = create(:user, team: :business_support)
+
+    sign_in_with_user(user)
+    click_on "Exports"
+
+    expect(page).to have_content("You can find out who should be sent the funding agreement letters.")
+    expect(page).to have_content("You can check details about schools' risk protection arrangements and start-up grant funding.")
+    expect(page).to have_content("You can get information pre-opening grants for schools becoming academies.")
+  end
 end

--- a/spec/policies/export_policy_spec.rb
+++ b/spec/policies/export_policy_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe ExportPolicy do
   let(:rdo_user) { build(:regional_delivery_officer_user) }
   let(:rcs_user) { build(:regional_casework_services_user) }
   let(:service_support_user) { build(:service_support_user) }
+  let(:business_support_user) { build(:user, team: :business_support) }
 
   permissions :index? do
     it "grants access if the user is in one of the correct teams" do
       expect(described_class).to permit(esfa_user)
       expect(described_class).to permit(aopu_user)
+      expect(described_class).to permit(business_support_user)
       expect(described_class).not_to permit(rdo_user)
       expect(described_class).not_to permit(rcs_user)
       expect(described_class).not_to permit(service_support_user)
@@ -21,6 +23,7 @@ RSpec.describe ExportPolicy do
     it "grants access if the user is in one of the correct teams" do
       expect(described_class).to permit(esfa_user)
       expect(described_class).to permit(aopu_user)
+      expect(described_class).to permit(business_support_user)
       expect(described_class).not_to permit(rdo_user)
       expect(described_class).not_to permit(rcs_user)
       expect(described_class).not_to permit(service_support_user)
@@ -31,6 +34,7 @@ RSpec.describe ExportPolicy do
     it "grants access if the user is in one of the correct teams" do
       expect(described_class).to permit(esfa_user)
       expect(described_class).to permit(aopu_user)
+      expect(described_class).to permit(business_support_user)
       expect(described_class).not_to permit(rdo_user)
       expect(described_class).not_to permit(rcs_user)
       expect(described_class).not_to permit(service_support_user)


### PR DESCRIPTION
We added the business support team a while ago, but never actually granted any rights to users in that team. Add them to the "can export" team group via the ExportPolicy. Check they can see the export pages.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
