### PR TITLE
(156391 ) Add new trust name & reference number to projects (for Form a MAT)

### DIFF
--- a/db/migrate/20240214120824_add_trn_and_trust_name_to_projects.rb
+++ b/db/migrate/20240214120824_add_trn_and_trust_name_to_projects.rb
@@ -1,0 +1,6 @@
+class AddTrnAndTrustNameToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :new_trust_reference_number, :string
+    add_column :projects, :new_trust_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_11_162641) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_14_120824) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -274,6 +274,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_11_162641) do
     t.uuid "establishment_main_contact_id"
     t.uuid "incoming_trust_main_contact_id"
     t.uuid "outgoing_trust_main_contact_id"
+    t.string "new_trust_reference_number"
+    t.string "new_trust_name"
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["incoming_trust_ukprn"], name: "index_projects_on_incoming_trust_ukprn"


### PR DESCRIPTION
## Changes

We need to add a new project type of "Form a MAT". Due to time constraints, we are adding this in as stripped-back a form as possible. Form a MAT projects are Conversion or Transfer projects which are grouped together under a new Trust. As this Trust does not yet exist in GIAS, we need to store its name and TRN somewhere - so we will store it for now on the projects.

As the Trust doesn't exist in GIAS, we cannot reference it using the UKPRN from GIAS/Academies API.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
