### PR TITLE
(156694) Projects can say if they are Form a MAT

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -112,6 +112,11 @@ class Project < ApplicationRecord
     :not_applicable
   end
 
+  def form_a_mat?
+    return true if (new_trust_reference_number && new_trust_name) && !incoming_trust_ukprn
+    false
+  end
+
   private def fetch_member_of_parliament
     Api::MembersApi::Client.new.member_for_constituency(establishment.parliamentary_constituency)
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -659,6 +659,26 @@ RSpec.describe Project, type: :model do
     end
   end
 
+  describe "#form_a_mat?" do
+    it "returns true if the project has a TRN and new trust name" do
+      project = build(:conversion_project,
+        new_trust_reference_number: "TR12345",
+        new_trust_name: "New Trust Company",
+        incoming_trust_ukprn: nil)
+
+      expect(project.form_a_mat?).to be true
+    end
+
+    it "returns false if the project has not TRN and new trust name, and has an incoming trust UKPRN" do
+      project = build(:conversion_project,
+        new_trust_reference_number: nil,
+        new_trust_name: nil,
+        incoming_trust_ukprn: 12345678)
+
+      expect(project.form_a_mat?).to be false
+    end
+  end
+
   describe "delegation" do
     it "delegates local_authority to establishment" do
       local_authotity = double(code: 100)


### PR DESCRIPTION
## Changes

To be merged after #1353 and #1355 

Add a small helper method to allow projects to be identified as Form a MAT or not. If a project has a Trust reference number and Trust name, and no Incoming Trust UKPRN, we assume it is Form a MAT.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
