### PR TITLE
Create a by month csv export for Transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   transferring in the next (upcoming) month only, and the table has the same
   columns as the date range view described above.
 - Create a By Month CSV export for Conversions
+- Create a By Month CSV export for Transfers
 
 ### Changed
 

--- a/app/presenters/export/csv/academy_presenter_module.rb
+++ b/app/presenters/export/csv/academy_presenter_module.rb
@@ -70,4 +70,16 @@ module Export::Csv::AcademyPresenterModule
 
     @project.academy.address_postcode
   end
+
+  def academy_contact_name
+    return if @project.contacts.where(category: "school_or_academy").blank?
+
+    @project.contacts.where(category: "school_or_academy").pluck(:name).join(", ")
+  end
+
+  def academy_contact_email
+    return if @project.contacts.where(category: "school_or_academy").blank?
+
+    @project.contacts.where(category: "school_or_academy").pluck(:email).join(", ")
+  end
 end

--- a/app/presenters/export/csv/outgoing_trust_presenter_module.rb
+++ b/app/presenters/export/csv/outgoing_trust_presenter_module.rb
@@ -70,4 +70,10 @@ module Export::Csv::OutgoingTrustPresenterModule
 
     @project.outgoing_trust.address_postcode
   end
+
+  def outgoing_trust_sharepoint_link
+    return unless @project.outgoing_trust_sharepoint_link.present?
+
+    @project.outgoing_trust_sharepoint_link
+  end
 end

--- a/app/presenters/export/csv/outgoing_trust_presenter_module.rb
+++ b/app/presenters/export/csv/outgoing_trust_presenter_module.rb
@@ -30,4 +30,8 @@ module Export::Csv::OutgoingTrustPresenterModule
     contact = @project.outgoing_trust_main_contact_id
     Contact::Project.find_by(id: contact)&.email
   end
+
+  def outgoing_trust_identifier
+    @project.outgoing_trust.group_identifier.to_s
+  end
 end

--- a/app/presenters/export/csv/outgoing_trust_presenter_module.rb
+++ b/app/presenters/export/csv/outgoing_trust_presenter_module.rb
@@ -34,4 +34,40 @@ module Export::Csv::OutgoingTrustPresenterModule
   def outgoing_trust_identifier
     @project.outgoing_trust.group_identifier.to_s
   end
+
+  def outgoing_trust_address_1
+    return unless @project.outgoing_trust.present?
+
+    @project.outgoing_trust.address_street
+  end
+
+  def outgoing_trust_address_2
+    return unless @project.outgoing_trust.present?
+
+    @project.outgoing_trust.address_locality
+  end
+
+  def outgoing_trust_address_3
+    return unless @project.outgoing_trust.present?
+
+    @project.outgoing_trust.address_additional
+  end
+
+  def outgoing_trust_address_town
+    return unless @project.outgoing_trust.present?
+
+    @project.outgoing_trust.address_town
+  end
+
+  def outgoing_trust_address_county
+    return unless @project.outgoing_trust.present?
+
+    @project.outgoing_trust.address_county
+  end
+
+  def outgoing_trust_address_postcode
+    return unless @project.outgoing_trust.present?
+
+    @project.outgoing_trust.address_postcode
+  end
 end

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -3,6 +3,8 @@ module Export::Csv::SchoolPresenterModule
     @project.urn.to_s
   end
 
+  alias_method :school_urn_with_academy_label, :school_urn
+
   def school_name
     return unless @project.establishment.present?
 

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -76,4 +76,6 @@ module Export::Csv::SchoolPresenterModule
 
     @project.establishment_sharepoint_link
   end
+
+  alias_method :school_sharepoint_link_with_academy_label, :school_sharepoint_folder
 end

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -11,6 +11,8 @@ module Export::Csv::SchoolPresenterModule
     @project.establishment.name
   end
 
+  alias_method :school_name_with_academy_label, :school_name
+
   def school_type
     return unless @project.establishment.present?
 

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -17,6 +17,8 @@ module Export::Csv::SchoolPresenterModule
     @project.establishment.type
   end
 
+  alias_method :school_type_with_academy_label, :school_type
+
   def school_phase
     return unless @project.establishment.present?
 

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -37,11 +37,15 @@ module Export::Csv::SchoolPresenterModule
     @project.establishment.address_street
   end
 
+  alias_method :school_address_1_with_academy_label, :school_address_1
+
   def school_address_2
     return unless @project.establishment.present?
 
     @project.establishment.address_locality
   end
+
+  alias_method :school_address_2_with_academy_label, :school_address_2
 
   def school_address_3
     return unless @project.establishment.present?
@@ -49,11 +53,15 @@ module Export::Csv::SchoolPresenterModule
     @project.establishment.address_additional
   end
 
+  alias_method :school_address_3_with_academy_label, :school_address_3
+
   def school_address_town
     return unless @project.establishment.present?
 
     @project.establishment.address_town
   end
+
+  alias_method :school_address_town_with_academy_label, :school_address_town
 
   def school_address_county
     return unless @project.establishment.present?
@@ -61,11 +69,15 @@ module Export::Csv::SchoolPresenterModule
     @project.establishment.address_county
   end
 
+  alias_method :school_address_county_with_academy_label, :school_address_county
+
   def school_address_postcode
     return unless @project.establishment.present?
 
     @project.establishment.address_postcode
   end
+
+  alias_method :school_address_postcode_with_academy_label, :school_address_postcode
 
   def school_age_range
     return unless @project.establishment.present?

--- a/app/services/export/transfers/by_month_csv_export_service.rb
+++ b/app/services/export/transfers/by_month_csv_export_service.rb
@@ -1,0 +1,74 @@
+class Export::Transfers::ByMonthCsvExportService < Export::CsvExportService
+  COLUMN_HEADERS = %i[
+    school_name_with_academy_label
+    school_urn_with_academy_label
+    project_type
+    incoming_trust_name
+    outgoing_trust_name
+    local_authority_name
+    region
+    diocese_name
+    transfer_date
+    two_requires_improvement
+    inadequate_ofsted
+    financial_safeguarding_governance_issues
+    outgoing_trust_to_close
+    advisory_board_date
+    advisory_board_conditions
+    authority_to_proceed
+    school_type_with_academy_label
+    school_age_range
+    school_phase
+    school_address_1_with_academy_label
+    school_address_2_with_academy_label
+    school_address_3_with_academy_label
+    school_address_town_with_academy_label
+    school_address_county_with_academy_label
+    school_address_postcode_with_academy_label
+    school_sharepoint_link_with_academy_label
+    incoming_trust_ukprn
+    incoming_trust_identifier
+    incoming_trust_companies_house_number
+    incoming_trust_address_1
+    incoming_trust_address_2
+    incoming_trust_address_3
+    incoming_trust_address_town
+    incoming_trust_address_county
+    incoming_trust_address_postcode
+    incoming_trust_sharepoint_link
+    outgoing_trust_ukprn
+    outgoing_trust_identifier
+    outgoing_trust_companies_house_number
+    outgoing_trust_address_1
+    outgoing_trust_address_2
+    outgoing_trust_address_3
+    outgoing_trust_address_town
+    outgoing_trust_address_county
+    outgoing_trust_address_postcode
+    outgoing_trust_sharepoint_link
+    project_created_by_name
+    project_created_by_email
+    assigned_to_name
+    assigned_to_email
+    team_managing_the_project
+    academy_contact_name
+    academy_contact_email
+    local_authority_contact_name
+    local_authority_contact_email
+    incoming_trust_main_contact_name
+    incoming_trust_main_contact_email
+    outgoing_trust_main_contact_name
+    outgoing_trust_main_contact_email
+    solicitor_contact_name
+    solicitor_contact_email
+    diocese_contact_name
+    diocese_contact_email
+    director_of_child_services_name
+    director_of_child_services_email
+    director_of_child_services_role
+  ]
+
+  def initialize(projects)
+    @projects = projects
+  end
+end

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -113,6 +113,8 @@ en:
           solicitor_contact_name: Solicitor contact name
           solicitor_contact_email: Solicitor contact email
           school_urn_with_academy_label: Academy URN
+          academy_contact_name: Academy contact name
+          academy_contact_email: Academt contact email
         values:
           project_type:
             conversion: Conversion

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -80,6 +80,7 @@ en:
           outgoing_trust_identifier: Outgoing trust group identifier
           outgoing_trust_companies_house_number: Outgoing trust companies house number
           outgoing_trust_ukprn: Outgoing trust UKPRN
+          outgoing_trust_sharepoint_link: Outgoing trust sharepoint link
           outgoing_trust_address_1: Outgoing trust address 1
           outgoing_trust_address_2: Outgoing trust address 2
           outgoing_trust_address_3: Outgoing trust address 3

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -116,6 +116,7 @@ en:
           academy_contact_name: Academy contact name
           academy_contact_email: Academt contact email
           school_sharepoint_link_with_academy_label: Academy sharepoint link
+          school_type_with_academy_label: Academy type
         values:
           project_type:
             conversion: Conversion

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -77,6 +77,7 @@ en:
           link_to_project: Link to project
           region: Region
           outgoing_trust_name: Outgoing trust name
+          outgoing_trust_identifier: Outgoing trust group identifier
           outgoing_trust_companies_house_number: Outgoing trust companies house number
           outgoing_trust_ukprn: Outgoing trust UKPRN
           outgoing_trust_main_contact_name: Outgoing trust main contact name

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -104,6 +104,7 @@ en:
           team_managing_the_project: Team managing the project
           solicitor_contact_name: Solicitor contact name
           solicitor_contact_email: Solicitor contact email
+          school_urn_with_academy_label: Academy URN
         values:
           project_type:
             conversion: Conversion

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -117,6 +117,12 @@ en:
           academy_contact_email: Academt contact email
           school_sharepoint_link_with_academy_label: Academy sharepoint link
           school_type_with_academy_label: Academy type
+          school_address_1_with_academy_label: Academy address 1
+          school_address_2_with_academy_label: Academy address 2
+          school_address_3_with_academy_label: Academy address 3
+          school_address_town_with_academy_label: Academy town
+          school_address_county_with_academy_label: Academy county
+          school_address_postcode_with_academy_label: Academy postcode
         values:
           project_type:
             conversion: Conversion

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -80,6 +80,12 @@ en:
           outgoing_trust_identifier: Outgoing trust group identifier
           outgoing_trust_companies_house_number: Outgoing trust companies house number
           outgoing_trust_ukprn: Outgoing trust UKPRN
+          outgoing_trust_address_1: Outgoing trust address 1
+          outgoing_trust_address_2: Outgoing trust address 2
+          outgoing_trust_address_3: Outgoing trust address 3
+          outgoing_trust_address_town: Outgoing trust address town
+          outgoing_trust_address_county: Outgoing trust address county
+          outgoing_trust_address_postcode: Outgoing trust address postcode
           outgoing_trust_main_contact_name: Outgoing trust main contact name
           outgoing_trust_main_contact_email: Outgoing trust main contact email
           incoming_trust_ukprn: Incoming trust UKPRN

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -123,6 +123,7 @@ en:
           school_address_town_with_academy_label: Academy town
           school_address_county_with_academy_label: Academy county
           school_address_postcode_with_academy_label: Academy postcode
+          school_name_with_academy_label: Academy name
         values:
           project_type:
             conversion: Conversion

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -115,6 +115,7 @@ en:
           school_urn_with_academy_label: Academy URN
           academy_contact_name: Academy contact name
           academy_contact_email: Academt contact email
+          school_sharepoint_link_with_academy_label: Academy sharepoint link
         values:
           project_type:
             conversion: Conversion

--- a/spec/presenters/export/csv/academy_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/academy_presenter_module_spec.rb
@@ -1,36 +1,57 @@
 require "rails_helper"
 
 RSpec.describe Export::Csv::AcademyPresenterModule do
-  let(:project) { build(:conversion_project, academy_urn: 149061, academy: gias_establishment) }
-  subject { AcademyPresenterModuleTestClass.new(project) }
+  context "when a project is a conversion project" do
+    let(:project) { build(:conversion_project, academy_urn: 149061, academy: gias_establishment) }
+    subject { AcademyPresenterModuleTestClass.new(project) }
 
-  it "presents the academy urn" do
-    expect(subject.academy_urn).to eql "149061"
+    it "presents the academy urn" do
+      expect(subject.academy_urn).to eql "149061"
+    end
+
+    it "presents the academy ukprn" do
+      expect(subject.academy_ukprn).to eql "10065250"
+    end
+
+    it "presents the academy DfE number" do
+      expect(subject.academy_dfe_number).to eql "941/2025"
+    end
+
+    it "presents the academy name" do
+      expect(subject.academy_name).to eql "Deanshanger Primary School"
+    end
+
+    it "presents the academy type" do
+      expect(subject.academy_type).to eql "Academy converter"
+    end
+
+    it "presents the academy address" do
+      expect(subject.academy_address_1).to eql "The Green"
+      expect(subject.academy_address_2).to eql "Deanshanger"
+      expect(subject.academy_address_3).to eql "Deanshanger Primary School, the Green, Deanshanger"
+      expect(subject.academy_address_town).to eql "Milton Keynes"
+      expect(subject.academy_address_county).to eql "Buckinghamshire"
+      expect(subject.academy_address_postcode).to eql "MK19 6HJ"
+    end
   end
 
-  it "presents the academy ukprn" do
-    expect(subject.academy_ukprn).to eql "10065250"
-  end
+  context "when a project is a transfer project" do
+    let(:transfer_project) { build(:transfer_project, urn: 123456) }
+    subject { AcademyPresenterModuleTestClass.new(transfer_project) }
 
-  it "presents the academy DfE number" do
-    expect(subject.academy_dfe_number).to eql "941/2025"
-  end
+    it "presents the academy contact name" do
+      mock_successful_api_response_to_create_any_project
+      create(:project_contact, category: "school_or_academy", name: "academy contact name", project: transfer_project)
 
-  it "presents the academy name" do
-    expect(subject.academy_name).to eql "Deanshanger Primary School"
-  end
+      expect(subject.academy_contact_name).to eql("academy contact name")
+    end
 
-  it "presents the academy type" do
-    expect(subject.academy_type).to eql "Academy converter"
-  end
+    it "presents the academy contact email" do
+      mock_successful_api_response_to_create_any_project
+      create(:project_contact, category: "school_or_academy", email: "academy_contact@email.com", project: transfer_project)
 
-  it "presents the academy address" do
-    expect(subject.academy_address_1).to eql "The Green"
-    expect(subject.academy_address_2).to eql "Deanshanger"
-    expect(subject.academy_address_3).to eql "Deanshanger Primary School, the Green, Deanshanger"
-    expect(subject.academy_address_town).to eql "Milton Keynes"
-    expect(subject.academy_address_county).to eql "Buckinghamshire"
-    expect(subject.academy_address_postcode).to eql "MK19 6HJ"
+      expect(subject.academy_contact_email).to eql("academy_contact@email.com")
+    end
   end
 
   def gias_establishment

--- a/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe Export::Csv::OutgoingTrustPresenterModule do
     expect(subject.outgoing_trust_address_postcode).to eql "MK13 0BQ"
   end
 
+  it "presents the sharepoint link" do
+    expect(subject.outgoing_trust_sharepoint_link).to eql "https://educationgovuk-my.sharepoint.com/outgoing-trust-folder"
+  end
+
   def known_trust
     double(
       Api::AcademiesApi::Trust,

--- a/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe Export::Csv::OutgoingTrustPresenterModule do
     expect(subject.outgoing_trust_main_contact_email).to eql "jo@example.com"
   end
 
+  it "presents the outgoing trust identifier" do
+    expect(subject.outgoing_trust_identifier).to eql "TR03819"
+  end
+
   def known_trust
     double(
       Api::AcademiesApi::Trust,

--- a/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe Export::Csv::OutgoingTrustPresenterModule do
     expect(subject.outgoing_trust_identifier).to eql "TR03819"
   end
 
+  it "presents the outgoing trusts address" do
+    expect(subject.outgoing_trust_address_1).to eql "New Bradwell County Combined School"
+    expect(subject.outgoing_trust_address_2).to eql "Bounty Street"
+    expect(subject.outgoing_trust_address_3).to be_nil
+    expect(subject.outgoing_trust_address_town).to eql "Milton Keynes"
+    expect(subject.outgoing_trust_address_county).to be_nil
+    expect(subject.outgoing_trust_address_postcode).to eql "MK13 0BQ"
+  end
+
   def known_trust
     double(
       Api::AcademiesApi::Trust,

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
     it "presents the project URN" do
       expect(subject.school_urn_with_academy_label).to eql "121813"
     end
+
+    it "presents the academy sharepoint link" do
+      expect(subject.school_sharepoint_link_with_academy_label).to eql "https://educationgovuk-my.sharepoint.com/establishment-folder"
+    end
   end
 
 

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -49,8 +49,11 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
     it "presents the academy sharepoint link" do
       expect(subject.school_sharepoint_link_with_academy_label).to eql "https://educationgovuk-my.sharepoint.com/establishment-folder"
     end
-  end
 
+    it "presents the academy type" do
+      expect(subject.school_type_with_academy_label).to eql "Community school"
+    end
+  end
 
   def known_establishment
     double(

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
     expect(subject.school_sharepoint_folder).to eql "https://educationgovuk-my.sharepoint.com/establishment-folder"
   end
 
+  context "when a school method has an alternative label" do
+    it "presents the project URN" do
+      expect(subject.school_urn_with_academy_label).to eql "121813"
+    end
+  end
+
+
   def known_establishment
     double(
       Api::AcademiesApi::Establishment,

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -62,6 +62,10 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
       expect(subject.school_address_county_with_academy_label).to eql "Buckinghamshire"
       expect(subject.school_address_postcode_with_academy_label).to eql "MK19 6HJ"
     end
+
+    it "presents the academy name" do
+      expect(subject.school_name_with_academy_label).to eql "Deanshanger Primary School"
+    end
   end
 
   def known_establishment

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -53,6 +53,15 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
     it "presents the academy type" do
       expect(subject.school_type_with_academy_label).to eql "Community school"
     end
+
+    it "presents the academy address" do
+      expect(subject.school_address_1_with_academy_label).to eql "The Green"
+      expect(subject.school_address_2_with_academy_label).to eql "Deanshanger"
+      expect(subject.school_address_3_with_academy_label).to eql "Deanshanger Primary School, the Green, Deanshanger"
+      expect(subject.school_address_town_with_academy_label).to eql "Milton Keynes"
+      expect(subject.school_address_county_with_academy_label).to eql "Buckinghamshire"
+      expect(subject.school_address_postcode_with_academy_label).to eql "MK19 6HJ"
+    end
   end
 
   def known_establishment

--- a/spec/services/export/transfers/by_month_csv_export_services_spec.rb
+++ b/spec/services/export/transfers/by_month_csv_export_services_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Export::Transfers::ByMonthCsvExportService do
+  describe "#call" do
+    before do
+      mock_all_academies_api_responses
+      mock_successful_member_details
+    end
+
+    it "returns a csv with headers and values" do
+      project = build(:transfer_project)
+      projects = [project]
+
+      csv_export = described_class.new(projects).call
+
+      expect(csv_export).to include("Project type")
+      expect(csv_export).to include("Outgoing trust UKPRN")
+
+      expect(csv_export).to include("Transfer")
+      expect(csv_export).to include("10059062")
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Create a `by month` CSV export for Transfers. 

We have added alias methods to extract the establishment information for a Transfer from the `project.establishment` association but with different Column labels from the original `school_name`, `school_urn` (etc) implementations. Because Conversions get their data for their new academies from the `project.academy` association, we were unable to use the `academy_name`, `academy_urn` (etc) implementations for extracting Academy information in Transfers, because Transfers do not use the `project.academy` association. The required "Academy" information is on the `project.establishment` association. By creating alias methods, we can use the same methods to extract `project.establishment` data, but use labels more suited to Transfer projects (e.g. Academy name instead
of School name)

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
