### PR TITLE
(Fix) Correct typo in the Academy contact email column header

### DIFF
--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -114,7 +114,7 @@ en:
           solicitor_contact_email: Solicitor contact email
           school_urn_with_academy_label: Academy URN
           academy_contact_name: Academy contact name
-          academy_contact_email: Academt contact email
+          academy_contact_email: Academy contact email
           school_sharepoint_link_with_academy_label: Academy sharepoint link
           school_type_with_academy_label: Academy type
           school_address_1_with_academy_label: Academy address 1


### PR DESCRIPTION

Academt -> Academy