### PR TITLE
(Fix) Return all local authority and establishment contacts for a project in CSV

### DIFF
--- a/app/presenters/export/csv/academy_presenter_module.rb
+++ b/app/presenters/export/csv/academy_presenter_module.rb
@@ -72,14 +72,16 @@ module Export::Csv::AcademyPresenterModule
   end
 
   def academy_contact_name
-    return if @project.contacts.where(category: "school_or_academy").blank?
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["school_or_academy"].blank?
 
-    @project.contacts.where(category: "school_or_academy").pluck(:name).join(", ")
+    contacts["school_or_academy"].pluck(:name).join(",")
   end
 
   def academy_contact_email
-    return if @project.contacts.where(category: "school_or_academy").blank?
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["school_or_academy"].blank?
 
-    @project.contacts.where(category: "school_or_academy").pluck(:email).join(", ")
+    contacts["school_or_academy"].pluck(:email).join(",")
   end
 end

--- a/app/presenters/export/csv/local_authority_presenter_module.rb
+++ b/app/presenters/export/csv/local_authority_presenter_module.rb
@@ -12,15 +12,17 @@ module Export::Csv::LocalAuthorityPresenterModule
   end
 
   def local_authority_contact_name
-    return if @project.contacts.where(category: "local_authority").blank?
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["local_authority"].blank?
 
-    @project.contacts.where(category: "local_authority").pluck(:name).join(", ")
+    contacts["local_authority"].pluck(:name).join(",")
   end
 
   def local_authority_contact_email
-    return if @project.contacts.where(category: "local_authority").blank?
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["local_authority"].blank?
 
-    @project.contacts.where(category: "local_authority").pluck(:email).join(", ")
+    contacts["local_authority"].pluck(:email).join(",")
   end
 
   def local_authority_address_1

--- a/spec/presenters/export/csv/academy_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/academy_presenter_module_spec.rb
@@ -33,6 +33,24 @@ RSpec.describe Export::Csv::AcademyPresenterModule do
       expect(subject.academy_address_county).to eql "Buckinghamshire"
       expect(subject.academy_address_postcode).to eql "MK19 6HJ"
     end
+
+    context "when the project has more than one school or academy contact" do
+      it "presents the academy contact names" do
+        mock_successful_api_response_to_create_any_project
+        create(:project_contact, category: "school_or_academy", name: "academy contact name", project: project)
+        create(:establishment_contact, establishment_urn: project.urn, name: "establishment contact name")
+
+        expect(subject.academy_contact_name).to eql("academy contact name,establishment contact name")
+      end
+
+      it "presents the academy contact emails" do
+        mock_successful_api_response_to_create_any_project
+        create(:project_contact, category: "school_or_academy", email: "academy_contact@email.com", project: project)
+        create(:establishment_contact, establishment_urn: project.urn, email: "establishment_contact@email.com")
+
+        expect(subject.academy_contact_email).to eql("academy_contact@email.com,establishment_contact@email.com")
+      end
+    end
   end
 
   context "when a project is a transfer project" do

--- a/spec/presenters/export/csv/local_authority_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/local_authority_presenter_module_spec.rb
@@ -4,10 +4,12 @@ RSpec.describe Export::Csv::LocalAuthorityPresenterModule do
   before do
     mock_successful_api_response_to_create_any_project
     allow(project).to receive(:local_authority).and_return known_local_authority
+    allow(project).to receive(:director_of_child_services).and_return(director_of_child_services_contact)
   end
 
   let(:project) { create(:conversion_project) }
-  let!(:local_authority_main_contact) { create(:project_contact, category: "local_authority", name: "contact name", email: "local_authority_contact@email.com", project: project) }
+  let(:director_of_child_services_contact) { create(:director_of_child_services, name: "Jake Example") }
+
   subject { LocalAuthorityPresenterModuleTestClass.new(project) }
 
   it "presents the code" do
@@ -28,11 +30,23 @@ RSpec.describe Export::Csv::LocalAuthorityPresenterModule do
   end
 
   it "presents the local authority contact name" do
-    expect(subject.local_authority_contact_name).to eql "contact name"
+    expect(subject.local_authority_contact_name).to eql "Jake Example"
   end
 
   it "presents the local authority contact email" do
-    expect(subject.local_authority_contact_email).to eql "local_authority_contact@email.com"
+    expect(subject.local_authority_contact_email).to eql "jake@example.com"
+  end
+
+  context "when there is more than one local authority contact" do
+    let!(:local_authority_main_contact) { create(:project_contact, category: "local_authority", name: "Bob Contact", email: "local_authority_contact@email.com", project: project) }
+
+    it "presents the local authority contact names" do
+      expect(subject.local_authority_contact_name).to eql "Bob Contact,Jake Example"
+    end
+
+    it "presents the local authority contact emails" do
+      expect(subject.local_authority_contact_email).to eql "local_authority_contact@email.com,jake@example.com"
+    end
   end
 
   def known_local_authority


### PR DESCRIPTION


When testing the CSV exports for Conversions and Transfers, we noticed that the Local Authority and School/Academy contacts in the CSVs did not match the contacts in the UI.

Upon investigation, we realised the UI uses the ContactsFetcherService to get *all* contacts for a project, not just the Contact::Project ones, and display them on the UI grouped by category type. Some of the contacts in the UI are Contact::EStablishment contact types, which are linked to the projects via the `urn` of the project.

To fix, we are now calling ContactsFetcherService in the CSV presenters, and picking out the desired contacts by their category type. This means the contacts can be a mix of Contact::Project and Contact::Establishment. This also means that some CSVs will have multiple contacts in the same column, but this will have to be remedied later.

For context on the ContactsFetcherService see https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/blob/main/app/controllers/external_contacts_controller.rb#L5