### PR TITLE
(Fix) Return all other contacts for a project in CSV via ContactsFetcherService

### DIFF
--- a/app/presenters/export/csv/incoming_trust_presenter_module.rb
+++ b/app/presenters/export/csv/incoming_trust_presenter_module.rb
@@ -62,15 +62,21 @@ module Export::Csv::IncomingTrustPresenterModule
   def incoming_trust_main_contact_name
     return unless @project.incoming_trust_main_contact_id.present?
 
-    contact = @project.incoming_trust_main_contact_id
-    Contact::Project.find_by(id: contact)&.name
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["incoming_trust"].blank?
+
+    contact = contacts["incoming_trust"].find { |c| c.id == @project.incoming_trust_main_contact_id }
+    contact&.name
   end
 
   def incoming_trust_main_contact_email
     return unless @project.incoming_trust_main_contact_id.present?
 
-    contact = @project.incoming_trust_main_contact_id
-    Contact::Project.find_by(id: contact)&.email
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["incoming_trust"].blank?
+
+    contact = contacts["incoming_trust"].find { |c| c.id == @project.incoming_trust_main_contact_id }
+    contact&.email
   end
 
   def incoming_trust_sharepoint_link

--- a/app/presenters/export/csv/outgoing_trust_presenter_module.rb
+++ b/app/presenters/export/csv/outgoing_trust_presenter_module.rb
@@ -20,15 +20,21 @@ module Export::Csv::OutgoingTrustPresenterModule
   def outgoing_trust_main_contact_name
     return unless @project.outgoing_trust_main_contact_id.present?
 
-    contact = @project.outgoing_trust_main_contact_id
-    Contact::Project.find_by(id: contact)&.name
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["outgoing_trust"].blank?
+
+    contact = contacts["outgoing_trust"].find { |c| c.id == @project.outgoing_trust_main_contact_id }
+    contact&.name
   end
 
   def outgoing_trust_main_contact_email
     return unless @project.outgoing_trust_main_contact_id.present?
 
-    contact = @project.outgoing_trust_main_contact_id
-    Contact::Project.find_by(id: contact)&.email
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["outgoing_trust"].blank?
+
+    contact = contacts["outgoing_trust"].find { |c| c.id == @project.outgoing_trust_main_contact_id }
+    contact&.email
   end
 
   def outgoing_trust_identifier

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -188,15 +188,17 @@ class Export::Csv::ProjectPresenter
   end
 
   def diocese_contact_name
-    return if @project.contacts.where(category: "diocese").blank?
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["diocese"].blank?
 
-    @project.contacts.where(category: "diocese").pluck(:name).join(", ")
+    contacts["diocese"].pluck(:name).join(",")
   end
 
   def diocese_contact_email
-    return if @project.contacts.where(category: "diocese").blank?
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["diocese"].blank?
 
-    @project.contacts.where(category: "diocese").pluck(:email).join(", ")
+    contacts["diocese"].pluck(:email).join(",")
   end
 
   def advisory_board_conditions
@@ -210,15 +212,17 @@ class Export::Csv::ProjectPresenter
   end
 
   def solicitor_contact_name
-    return if @project.contacts.where(category: "solicitor").blank?
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["solicitor"].blank?
 
-    @project.contacts.where(category: "solicitor").pluck(:name).join(", ")
+    contacts["solicitor"].pluck(:name).join(",")
   end
 
   def solicitor_contact_email
-    return if @project.contacts.where(category: "solicitor").blank?
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["solicitor"].blank?
 
-    @project.contacts.where(category: "solicitor").pluck(:email).join(", ")
+    contacts["solicitor"].pluck(:email).join(",")
   end
 
   def project_created_by_name

--- a/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
@@ -1,19 +1,21 @@
 require "rails_helper"
 
 RSpec.describe Export::Csv::IncomingTrustPresenterModule do
-  let(:incoming_trust_main_contact) do
-    mock_successful_api_response_to_create_any_project
-    create(:project_contact, category: "incoming_trust")
-  end
-  let(:project) { build(:conversion_project, incoming_trust_ukprn: 121813, incoming_trust: known_trust, incoming_trust_main_contact_id: incoming_trust_main_contact.id) }
+  let(:project) { create(:conversion_project, incoming_trust_ukprn: 12345678, incoming_trust: known_trust) }
+  let(:incoming_trust_main_contact) { create(:project_contact, category: "incoming_trust", project: project) }
   subject { IncomingTrustPresenterModuleTestClass.new(project) }
+
+  before do
+    mock_successful_api_response_to_create_any_project
+    allow(project).to receive(:incoming_trust_main_contact_id).and_return(incoming_trust_main_contact.id)
+  end
 
   it "presents the identifier" do
     expect(subject.incoming_trust_identifier).to eql "TR03819"
   end
 
   it "presents the ukprn" do
-    expect(subject.incoming_trust_ukprn).to eql "121813"
+    expect(subject.incoming_trust_ukprn).to eql "12345678"
   end
 
   it "presents the companies house number" do

--- a/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
@@ -1,19 +1,18 @@
 require "rails_helper"
 
 RSpec.describe Export::Csv::OutgoingTrustPresenterModule do
-  let(:outgoing_trust_main_contact) do
-    mock_successful_api_response_to_create_any_project
-    create(:project_contact, category: "outgoing_trust")
-  end
-  let(:project) { build(:transfer_project, outgoing_trust_ukprn: 121813, outgoing_trust_main_contact_id: outgoing_trust_main_contact.id) }
+  let(:project) { create(:transfer_project, outgoing_trust_ukprn: 12345678) }
+  let(:outgoing_trust_main_contact) { create(:project_contact, category: "outgoing_trust", project: project) }
   subject { OutgoingTrustPresenterModuleTestClass.new(project) }
 
   before do
+    mock_successful_api_response_to_create_any_project
+    allow(project).to receive(:outgoing_trust_main_contact_id).and_return(outgoing_trust_main_contact.id)
     allow(project).to receive(:outgoing_trust).and_return(known_trust)
   end
 
   it "presents the ukprn" do
-    expect(subject.outgoing_trust_ukprn).to eql "121813"
+    expect(subject.outgoing_trust_ukprn).to eql "12345678"
   end
 
   it "presents the companies house number" do


### PR DESCRIPTION


In https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/1366 we used the ContactsFetcherService to correctly return all contacts for a project in order to pull out the local authority and school/academy contacts. We now need to duplicate this work for Trust contacts, and for completeness we have used the same method to get the Diocese and Solicitor contacts this way.

This means that if a contact is not a Contact::Project but instead a Contact::Establishment contact, we still get them and put them in the CSV.

