### PR TITLE
(157556) Grant managment export include provisional projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add a Yes/No column in the "In progress" listing pages to show if a project is
   "Form a MAT" or not.
 
+### Changed
+
+- the Grant management and finance unit csv exports now include both provisional
+  and confirmed projects
+
 ## [Release-53][release-53]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add new Conversion "Form a MAT" creation form, as a first pass
 - Add a Yes/No column in the "In progress" listing pages to show if a project is
   "Form a MAT" or not.
+- the provisional date column is now included in the Grant management and
+  finance unit csv export
 
 ### Changed
 

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -31,6 +31,10 @@ class Export::Csv::ProjectPresenter
     I18n.t("export.csv.project.values.project_type.transfer") if @project.is_a?(Transfer::Project)
   end
 
+  def provisional_date
+    @project.provisional_date.to_fs(:csv)
+  end
+
   def conversion_date
     return I18n.t("export.csv.project.values.unconfirmed") if @project.conversion_date_provisional?
 

--- a/app/services/export/conversions/grant_management_and_finance_unit_csv_export_service.rb
+++ b/app/services/export/conversions/grant_management_and_finance_unit_csv_export_service.rb
@@ -9,6 +9,7 @@ class Export::Conversions::GrantManagementAndFinanceUnitCsvExportService < Expor
     incoming_trust_name
     incoming_trust_identifier
     advisory_board_date
+    provisional_date
     conversion_date
     academy_order_type
     two_requires_improvement

--- a/app/services/export/transfers/grant_management_and_finance_unit_csv_export_service.rb
+++ b/app/services/export/transfers/grant_management_and_finance_unit_csv_export_service.rb
@@ -13,6 +13,7 @@ class Export::Transfers::GrantManagementAndFinanceUnitCsvExportService < Export:
     academy_surplus_deficit
     trust_surplus_deficit
     advisory_board_date
+    provisional_date
     transfer_date
     added_by_email
     assigned_to_email

--- a/app/services/projects_for_export_service.rb
+++ b/app/services/projects_for_export_service.rb
@@ -33,10 +33,10 @@ class ProjectsForExportService
   end
 
   private def conversion_projects_by_advisory_board_date(month, year)
-    Conversion::Project.confirmed.filtered_by_advisory_board_date(month, year)
+    Conversion::Project.filtered_by_advisory_board_date(month, year)
   end
 
   private def transfer_projects_by_advisory_board_date(month, year)
-    Transfer::Project.confirmed.filtered_by_advisory_board_date(month, year)
+    Transfer::Project.filtered_by_advisory_board_date(month, year)
   end
 end

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -4,6 +4,7 @@ en:
       project:
         headers:
           project_type: Project type
+          provisional_date: Provisional date
           conversion_date: Conversion date
           all_conditions_met: All conditions met
           risk_protection_arrangement: Risk protection arrangement

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -183,6 +183,14 @@ RSpec.describe Export::Csv::ProjectPresenter do
     not_applicable_for_a_transfer
   end
 
+  it "presents the provisional date" do
+    conversion_project = double(Conversion::Project, provisional_date: Date.parse("2024-1-1"), conversion_date_provisional?: true)
+
+    conversion_presenter = described_class.new(conversion_project)
+
+    expect(conversion_presenter.provisional_date).to eql "2024-01-01"
+  end
+
   it "presents the conversion date" do
     project = double(Conversion::Project, conversion_date: Date.parse("2023-1-1"), conversion_date_provisional?: false)
 

--- a/spec/services/projects_for_export_service_spec.rb
+++ b/spec/services/projects_for_export_service_spec.rb
@@ -62,6 +62,18 @@ RSpec.describe ProjectsForExportService do
       expect(projects_for_export).to include(matching_project)
       expect(projects_for_export).not_to include(mismatching_project)
     end
+
+    it "includes both provisional and confirmed projects" do
+      mock_academies_api_client_get_establishments_and_trusts
+
+      confirmed_project = create(:conversion_project, conversion_date_provisional: false, advisory_board_date: Date.parse("2023-1-1"))
+      provisional_project = create(:conversion_project, conversion_date_provisional: true, advisory_board_date: Date.parse("2023-1-1"))
+
+      projects_for_export = described_class.new.grant_management_and_finance_unit_conversion_projects(month: 1, year: 2023)
+
+      expect(projects_for_export).to include(confirmed_project)
+      expect(projects_for_export).to include(provisional_project)
+    end
   end
 
   describe "#grant_management_and_finance_unit_transfer_projects" do
@@ -76,6 +88,18 @@ RSpec.describe ProjectsForExportService do
 
       expect(projects_for_export).to include(matching_project)
       expect(projects_for_export).not_to include(mismatching_project_1, mismatching_project_2)
+    end
+
+    it "includes both provisional and confirmed projects" do
+      mock_academies_api_client_get_establishments_and_trusts
+
+      confirmed_project = create(:transfer_project, transfer_date_provisional: false, advisory_board_date: Date.parse("2023-1-1"))
+      provisional_project = create(:transfer_project, transfer_date_provisional: true, advisory_board_date: Date.parse("2023-1-1"))
+
+      projects_for_export = described_class.new.grant_management_and_finance_unit_transfer_projects(month: 1, year: 2023)
+
+      expect(projects_for_export).to include(confirmed_project)
+      expect(projects_for_export).to include(provisional_project)
     end
   end
 


### PR DESCRIPTION
## Changes

The Grant management and finance unit want their csv export to include both
confirmed and provisional projects. They also want to see the provisional date
regardless - this helps them manage their work.

This work takes the steps to make this happen:

- alter the scopes to include both confirmed and provisional projects
- allow the csv presenter to show the provisional date
- include the provisonal date in the csv export for conversions and transfers

I don't think this export is currently exposed in the UI, but you can get to it at:

`/projects/all/export/grant-management-and-finance-unit/conversions/`
