### PR TITLE
Update Sonarcloud exclusions

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,7 @@ sonar.tests=spec
 # the dfe frontend is vendored and we should not be modifying it, but it has lots of bugs, ideally
 # we would move it to the vendor directory and exclude it or even better, be able to use the npm package
 # but this is a simple first step
-sonar.exclusions = /**/dfefrontend.*
+sonar.exclusions = /**/dfefrontend.*,/config/,/db/,/lib/generators/
 
 # configure the location of the Simplecov coverage report
 sonar.ruby.coverage.reportPaths = coverage/coverage.json


### PR DESCRIPTION
Now we have Sonarcloud able to read our coverage report, we have to
tweak what is thinks is 'testable code', we would not expect to have
test coverage on:

- Rails config
- Migration files
- Database config
- Our generators

So we exclude them.