### PR TITLE
Use globs in the Sonarcloud exclusions

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,7 @@ sonar.tests=spec
 # the dfe frontend is vendored and we should not be modifying it, but it has lots of bugs, ideally
 # we would move it to the vendor directory and exclude it or even better, be able to use the npm package
 # but this is a simple first step
-sonar.exclusions = /**/dfefrontend.*,/config/,/db/,/lib/generators/
+sonar.exclusions = /**/dfefrontend.*,/config/**/*,/db/**/*,/lib/generators/**/*
 
 # configure the location of the Simplecov coverage report
 sonar.ruby.coverage.reportPaths = coverage/coverage.json


### PR DESCRIPTION
When we excluded these locations they should have been globs.
