### PR TITLE
(157550) Fix: Confirmed/Original date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - the Grant management and finance unit csv exports now include both provisional
   and confirmed projects
 
+### Fixed
+
+- the Confirmed/Original date column values are now displayed correctly, with
+  the currently confirmed date and the original provisional date shown as
+  available
+
 ## [Release-53][release-53]
 
 ### Fixed

--- a/app/helpers/project_helper.rb
+++ b/app/helpers/project_helper.rb
@@ -72,10 +72,9 @@ module ProjectHelper
 
   def confirmed_date_original_date(project)
     return if project.significant_date_provisional
-    return project.significant_date.to_fs(:govuk_short_month) if project.significant_dates.empty?
 
-    confirmed_date = project.significant_dates.order(:created_at).first.revised_date
-    original_date = project.significant_date
+    confirmed_date = project.significant_date
+    original_date = project.provisional_date
     "#{confirmed_date.to_fs(:govuk_short_month)} (#{original_date.to_fs(:govuk_short_month)})"
   end
 end


### PR DESCRIPTION
We can think of these two dates as:

- Confirmed: The most current significant date for the project
- Original: The provisional date i.e. the first significant date whent
  the project was created

We want the behaviour here to be:

- when the date is provisional: show nothing
- when the date is confirmed: show the current confirmed date with the
  provisional date as the 'original' in brackets

Because project dates can move forwards and back there is no 'order' to
how the dates appear.