### PR TITLE
Use locales instead of strings

### DIFF
--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -12,17 +12,17 @@ class Export::Csv::ProjectPresenter
   end
 
   def reception_to_six_years
-    return "Not applicable" if @project.tasks_data.proposed_capacity_of_the_academy_not_applicable
+    return I18n.t("export.csv.project.values.not_applicable") if @project.tasks_data.proposed_capacity_of_the_academy_not_applicable
     @project.tasks_data.proposed_capacity_of_the_academy_reception_to_six_years
   end
 
   def seven_to_eleven_years
-    return "Not applicable" if @project.tasks_data.proposed_capacity_of_the_academy_not_applicable
+    return I18n.t("export.csv.project.values.not_applicable") if @project.tasks_data.proposed_capacity_of_the_academy_not_applicable
     @project.tasks_data.proposed_capacity_of_the_academy_seven_to_eleven_years
   end
 
   def twelve_or_above_years
-    return "Not applicable" if @project.tasks_data.proposed_capacity_of_the_academy_not_applicable
+    return I18n.t("export.csv.project.values.not_applicable") if @project.tasks_data.proposed_capacity_of_the_academy_not_applicable
     @project.tasks_data.proposed_capacity_of_the_academy_twelve_or_above_years
   end
 

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -396,9 +396,9 @@ RSpec.describe Export::Csv::ProjectPresenter do
 
       presenter = described_class.new(project)
 
-      expect(presenter.reception_to_six_years).to eql("Not applicable")
-      expect(presenter.seven_to_eleven_years).to eql("Not applicable")
-      expect(presenter.twelve_or_above_years).to eql("Not applicable")
+      expect(presenter.reception_to_six_years).to eql("not applicable")
+      expect(presenter.seven_to_eleven_years).to eql("not applicable")
+      expect(presenter.twelve_or_above_years).to eql("not applicable")
     end
   end
 


### PR DESCRIPTION
We have a 'not applicable' locale already so it makes sense to use it
here, Sonarcloud is monaing about the repeated string and by moving to
locales we can ignore it.
