### PR TITLE
(157961) Fix unassigned project can render to csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - the Confirmed/Original date column values are now displayed correctly, with
   the currently confirmed date and the original provisional date shown as
   available
+- unassigned projects can now be rendered as csv
 
 ## [Release-53][release-53]
 

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -134,10 +134,14 @@ class Export::Csv::ProjectPresenter
   end
 
   def assigned_to_name
+    return I18n.t("export.csv.project.values.unassigned") unless @project.assigned_to.present?
+
     @project.assigned_to.full_name
   end
 
   def assigned_to_email
+    return I18n.t("export.csv.project.values.unassigned") unless @project.assigned_to.present?
+
     @project.assigned_to.email
   end
 

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -136,6 +136,7 @@ en:
             sponsored: sponsored
           unconfirmed: unconfirmed
           confirmed: confirmed
+          unassigned: unassigned
           not_applicable: not applicable
           "yes": "yes"
           "no": "no"

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -291,6 +291,50 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.risk_protection_arrangement).to eql "unconfirmed"
   end
 
+  describe "#assigned_to_name" do
+    context "when the project is assigned to a user" do
+      it "returns the name of the user the project is assigned to" do
+        user = double(User, full_name: "Assigned User")
+        project = double(Conversion::Project, assigned_to: user)
+
+        presenter = described_class.new(project)
+
+        expect(presenter.assigned_to_name).to eql "Assigned User"
+      end
+    end
+    context "when the project is unassigned" do
+      it "returns 'unassigned'" do
+        project = double(Conversion::Project, assigned_to: nil)
+
+        presenter = described_class.new(project)
+
+        expect(presenter.assigned_to_name).to eql "unassigned"
+      end
+    end
+  end
+
+  describe "#assigned_to_email" do
+    context "when the project is assigned to a user" do
+      it "returns the email address of the user the project is assigned to" do
+        user = double(User, email: "assigned.user@education.gov.uk")
+        project = double(Conversion::Project, assigned_to: user)
+
+        presenter = described_class.new(project)
+
+        expect(presenter.assigned_to_email).to eql "assigned.user@education.gov.uk"
+      end
+    end
+    context "when the project is unassigned" do
+      it "returns 'unassigned'" do
+        project = double(Conversion::Project, assigned_to: nil)
+
+        presenter = described_class.new(project)
+
+        expect(presenter.assigned_to_email).to eql "unassigned"
+      end
+    end
+  end
+
   it "presents the assigned to name" do
     user = double(User, full_name: "Assigned User")
     project = double(Conversion::Project, assigned_to: user)


### PR DESCRIPTION
The assigned_to_name and assigned_to_email assumed that projects are
always assigend to a user, which is not technically the case.

We discovered this whilst testing one of the csv exports where we have
added a new column of data.

Adding a guard resolves this, outputting 'unassigned' as a more useful
indictator than a empty cell.