### PR TITLE
User can confirm the date the conversion or transfer happened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project is a form a MAT project
 - A new confirm the date the academy opened task has been added to the
   conversion task list.
+- A new confirm the date the academy transferred task has been added to the
+  transfer task list.
 
 ## [Release-56][release-56]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add a new Form a MAT Transfer create project form
 - Show a pink "Form a MAT" label on the project details page if a transfer
   project is a form a MAT project
+- A new confirm the date the academy opened task has been added to the
+  conversion task list.
 
 ## [Release-56][release-56]
 

--- a/app/forms/conversion/task/confirm_date_academy_opened_task_form.rb
+++ b/app/forms/conversion/task/confirm_date_academy_opened_task_form.rb
@@ -1,0 +1,65 @@
+class Conversion::Task::ConfirmDateAcademyOpenedTaskForm < BaseOptionalTaskForm
+  attribute :date_opened, :date
+  attribute "date_opened(1i)"
+  attribute "date_opened(2i)"
+  attribute "date_opened(3i)"
+
+  validate :govuk_three_field_date_format
+
+  def initialize(tasks_data, user)
+    @tasks_data = tasks_data
+    @user = user
+    @project = tasks_data.project
+    super(@tasks_data, @user)
+
+    self.date_opened = @project.tasks_data.confirm_date_academy_opened_date_opened
+  end
+
+  def save
+    if valid?
+      @tasks_data.assign_attributes(
+        confirm_date_academy_opened_date_opened: formatted_date
+      )
+      @tasks_data.save!
+    end
+  end
+
+  def formatted_date
+    return nil if month.blank? || year.blank? || day.blank?
+    Date.new(year, month, day)
+  end
+
+  private def govuk_three_field_date_format
+    return if month.blank? && year.blank? && day.blank?
+
+    Date.new(year, month, day)
+  rescue TypeError, Date::Error
+    errors.add(:date_opened, I18n.t("conversion.task.confirm_date_academy_opened.errors.format"))
+  end
+
+  private def day
+    day = attributes["date_opened(3i)"]
+    return if day.blank?
+
+    day.to_i
+  end
+
+  private def month
+    month = attributes["date_opened(2i)"]
+    return if month.blank?
+
+    month.to_i
+  end
+
+  private def year
+    year = attributes["date_opened(1i)"]
+    return false unless ("1900".."3000").to_a.include?(year)
+    return if year.blank?
+
+    year.to_i
+  end
+
+  def completed?
+    date_opened.present?
+  end
+end

--- a/app/forms/transfer/task/confirm_date_academy_transferred_task_form.rb
+++ b/app/forms/transfer/task/confirm_date_academy_transferred_task_form.rb
@@ -1,0 +1,65 @@
+class Transfer::Task::ConfirmDateAcademyTransferredTaskForm < BaseOptionalTaskForm
+  attribute :date_transferred, :date
+  attribute "date_transferred(1i)"
+  attribute "date_transferred(2i)"
+  attribute "date_transferred(3i)"
+
+  validate :govuk_three_field_date_format
+
+  def initialize(tasks_data, user)
+    @tasks_data = tasks_data
+    @user = user
+    @project = tasks_data.project
+    super(@tasks_data, @user)
+
+    self.date_transferred = @project.tasks_data.confirm_date_academy_transferred_date_transferred
+  end
+
+  def save
+    if valid?
+      @tasks_data.assign_attributes(
+        confirm_date_academy_transferred_date_transferred: formatted_date
+      )
+      @tasks_data.save!
+    end
+  end
+
+  def formatted_date
+    return nil if month.blank? || year.blank? || day.blank?
+    Date.new(year, month, day)
+  end
+
+  private def govuk_three_field_date_format
+    return if month.blank? && year.blank? && day.blank?
+
+    Date.new(year, month, day)
+  rescue TypeError, Date::Error
+    errors.add(:date_transferred, I18n.t("transfer.task.confirm_date_academy_transferred.errors.format"))
+  end
+
+  private def day
+    day = attributes["date_transferred(3i)"]
+    return if day.blank?
+
+    day.to_i
+  end
+
+  private def month
+    month = attributes["date_transferred(2i)"]
+    return if month.blank?
+
+    month.to_i
+  end
+
+  private def year
+    year = attributes["date_transferred(1i)"]
+    return false unless ("1900".."3000").to_a.include?(year)
+    return if year.blank?
+
+    year.to_i
+  end
+
+  def completed?
+    date_transferred.present?
+  end
+end

--- a/app/models/conversion/task_list.rb
+++ b/app/models/conversion/task_list.rb
@@ -46,6 +46,7 @@ class Conversion::TaskList < ::BaseTaskList
       {
         identifier: :after_opening,
         tasks: [
+          Conversion::Task::ConfirmDateAcademyOpenedTaskForm,
           Conversion::Task::RedactAndSendTaskForm,
           Conversion::Task::UpdateEsfaTaskForm,
           Conversion::Task::ReceiveGrantPaymentCertificateTaskForm

--- a/app/models/transfer/task_list.rb
+++ b/app/models/transfer/task_list.rb
@@ -40,6 +40,7 @@ class Transfer::TaskList < ::BaseTaskList
       {
         identifier: :after_transfer,
         tasks: [
+          Transfer::Task::ConfirmDateAcademyTransferredTaskForm,
           Transfer::Task::RedactAndSendDocumentsTaskForm
         ]
       }

--- a/app/views/conversions/tasks/confirm_date_academy_opened/edit.html.erb
+++ b/app/views/conversions/tasks/confirm_date_academy_opened/edit.html.erb
@@ -1,0 +1,27 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.confirm_date_academy_opened.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+       <%= form.govuk_date_field :date_opened,
+             legend: {text: t("conversion.task.confirm_date_academy_opened.date.title")},
+             hint: {text: t("conversion.task.confirm_date_academy_opened.date.hint.html")} %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/app/views/transfers/tasks/confirm_date_academy_transferred/edit.html.erb
+++ b/app/views/transfers/tasks/confirm_date_academy_transferred/edit.html.erb
@@ -1,0 +1,27 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.confirm_date_academy_transferred.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+       <%= form.govuk_date_field :date_transferred,
+             legend: {text: t("transfer.task.confirm_date_academy_transferred.date.title")},
+             hint: {text: t("transfer.task.confirm_date_academy_transferred.date.hint.html")} %>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/config/locales/conversion/tasks/confirm_date_academy_opened.en.yml
+++ b/config/locales/conversion/tasks/confirm_date_academy_opened.en.yml
@@ -1,0 +1,13 @@
+en:
+  conversion:
+    task:
+      confirm_date_academy_opened:
+        title: Confirm the date the academy opened
+        hint:
+          html: <p>Funding teams need to know when the academy opened so they can make payments related to any Risk Protection Agreements.</p>
+        date:
+          title: Enter the date the academy opened
+          hint:
+            html: <p>For example, 1 3 2023</p>
+        errors:
+          format: Please enter a valid date

--- a/config/locales/transfer/tasks/confirm_date_academy_transferred.en.yml
+++ b/config/locales/transfer/tasks/confirm_date_academy_transferred.en.yml
@@ -1,0 +1,13 @@
+en:
+  transfer:
+    task:
+      confirm_date_academy_transferred:
+        title: Confirm the date the academy transferred
+        hint:
+          html: <p>Funding teams need to know when the academy transferred so they can make payments and changes related to any Risk Protection Agreement.</p>
+        date:
+          title: Enter the date the academy transferred
+          hint:
+            html: <p>For example, 1 3 2023</p>
+        errors:
+          format: Please enter a valid date

--- a/db/migrate/20240228171427_add_confirm_date_academy_opened_attributes_to_conversion.rb
+++ b/db/migrate/20240228171427_add_confirm_date_academy_opened_attributes_to_conversion.rb
@@ -1,0 +1,5 @@
+class AddConfirmDateAcademyOpenedAttributesToConversion < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_tasks_data, :confirm_date_academy_opened_date_opened, :date
+  end
+end

--- a/db/migrate/20240306112000_add_confirm_date_academy_transferred_attributes_to_transfer.rb
+++ b/db/migrate/20240306112000_add_confirm_date_academy_transferred_attributes_to_transfer.rb
@@ -1,0 +1,5 @@
+class AddConfirmDateAcademyTransferredAttributesToTransfer < ActiveRecord::Migration[7.0]
+  def change
+    add_column :transfer_tasks_data, :confirm_date_academy_transferred_date_transferred, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_28_171427) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_06_112000) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -393,6 +393,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_28_171427) do
     t.boolean "check_and_confirm_financial_information_not_applicable"
     t.string "check_and_confirm_financial_information_academy_surplus_deficit"
     t.string "check_and_confirm_financial_information_trust_surplus_deficit"
+    t.date "confirm_date_academy_transferred_date_transferred"
   end
 
   create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_15_114238) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_28_171427) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -147,6 +147,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_15_114238) do
     t.string "proposed_capacity_of_the_academy_twelve_or_above_years"
     t.date "receive_grant_payment_certificate_date_received"
     t.boolean "receive_grant_payment_certificate_check_certificate"
+    t.date "confirm_date_academy_opened_date_opened"
   end
 
   create_table "events", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -34,6 +34,7 @@ RSpec.feature "Users can complete conversion tasks" do
     proposed_capacity_of_the_academy
     receive_grant_payment_certificate
     update_esfa
+    confirm_date_academy_opened
   ]
 
   it "confirms we are checking all tasks" do
@@ -314,6 +315,23 @@ RSpec.feature "Users can complete conversion tasks" do
 
       task_status = find("#add-notes-for-esfa-status")
       expect(task_status).to have_content("Completed")
+    end
+  end
+
+  describe "the confirm date academy opened task" do
+    let(:project) { create(:conversion_project, assigned_to: user) }
+
+    context "when the task does not have a date" do
+      scenario "they can add a date" do
+        visit project_tasks_path(project)
+        click_on "Confirm the date the academy opened"
+        fill_in "Day", with: "1"
+        fill_in "Month", with: "1"
+        fill_in "Year", with: "2024"
+        click_on I18n.t("task_list.continue_button.text")
+
+        expect(project.reload.tasks_data.confirm_date_academy_opened_date_opened).to eq Date.new(2024, 1, 1)
+      end
     end
   end
 

--- a/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
+++ b/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
@@ -39,6 +39,7 @@ RSpec.feature "Users can complete transfer tasks" do
     main_contact
     bank_details_changing
     check_and_confirm_financial_information
+    confirm_date_academy_transferred
   ]
 
   it "confirms that all tasks are tested here" do
@@ -144,6 +145,23 @@ RSpec.feature "Users can complete transfer tasks" do
         table_row = page.find("li.app-task-list__item", text: I18n.t("transfer.task.check_and_confirm_financial_information.title"))
 
         expect(table_row).to have_content("Completed")
+      end
+    end
+  end
+
+  describe "the confirm date academy transferred task" do
+    let(:project) { create(:transfer_project, assigned_to: user) }
+
+    context "when the task does not have a date" do
+      scenario "they can add a date" do
+        visit project_tasks_path(project)
+        click_on "Confirm the date the academy transferred"
+        fill_in "Day", with: "1"
+        fill_in "Month", with: "1"
+        fill_in "Year", with: "2024"
+        click_on I18n.t("task_list.continue_button.text")
+
+        expect(project.reload.tasks_data.confirm_date_academy_transferred_date_transferred).to eq Date.new(2024, 1, 1)
       end
     end
   end

--- a/spec/forms/conversion/tasks/confirm_date_academy_opened_task_form_spec.rb
+++ b/spec/forms/conversion/tasks/confirm_date_academy_opened_task_form_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe Conversion::Task::ConfirmDateAcademyOpenedTaskForm do
+  let(:user) { create(:user) }
+  let(:project) { create(:conversion_project) }
+  let(:form) { described_class.new(project.tasks_data, user) }
+
+  before { mock_successful_api_response_to_create_any_project }
+
+  describe "validations" do
+    describe "day" do
+      it "when the value is 3rd, it is invalid" do
+        form.assign_attributes("date_opened(1i)": "2024", "date_opened(2i)": "1", "date_opened(3i)": "3rd")
+
+        expect(form).to be_valid
+      end
+
+      it "when the value is not in the range of 1..31, it is invalid" do
+        form.assign_attributes("date_opened(1i)": "2024", "date_opened(2i)": "1", "date_opened(3i)": "40")
+
+        expect(form).to be_invalid
+      end
+
+      it "when the value is not a number, it is invalid" do
+        form.assign_attributes("date_opened(1i)": "2024", "date_opened(2i)": "1", "date_opened(3i)": "not a number")
+
+        expect(form).to be_invalid
+      end
+    end
+
+    describe "month" do
+      it "when the value is not in the range of 1..12, it is invalid" do
+        form.assign_attributes("date_opened(1i)": "2024", "date_opened(2i)": "20", "date_opened(3i)": "20")
+
+        expect(form).to be_invalid
+      end
+
+      it "when the value is not a number, it is invalid" do
+        form.assign_attributes("date_opened(1i)": "2024", "date_opened(2i)": "January", "date_opened(3i)": "20")
+
+        expect(form).to be_invalid
+      end
+    end
+
+    describe "year" do
+      it "when the value is not in the range of 1900..3000, it is invalid" do
+        form.assign_attributes("date_opened(1i)": "800", "date_opened(2i)": "2", "date_opened(3i)": "20")
+
+        expect(form).to be_invalid
+      end
+
+      it "when the value is not a number, it is invalid" do
+        form.assign_attributes("date_opened(1i)": "Nineteen hundred", "date_opened(2i)": "1", "date_opened(3i)": "20")
+
+        expect(form).to be_invalid
+      end
+    end
+
+    describe "the conversion to a date" do
+      context "when the values form a date that is incorrect" do
+        it "is invalid" do
+          form.assign_attributes("date_opened(1i)": "30", "date_opened(2i)": "2", "date_opened(3i)": "2024")
+
+          expect(form).to be_invalid
+        end
+      end
+    end
+
+    describe "submitting nothing" do
+      it "when a user submits nothing, its valid" do
+        form.assign_attributes("date_opened(1i)": "", "date_opened(2i)": "", "date_opened(3i)": "")
+
+        expect(form).to be_valid
+      end
+
+      it "when a user submits spaces, its valid" do
+        form.assign_attributes("date_opened(1i)": "  ", "date_opened(2i)": "  ", "date_opened(3i)": "   ")
+
+        expect(form).to be_valid
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when the form is valid" do
+      it "saves the task" do
+        form.assign_attributes("date_opened(1i)": "2024", "date_opened(2i)": "1", "date_opened(3i)": "1")
+
+        form.save
+
+        expect(project.tasks_data.reload.confirm_date_academy_opened_date_opened).to eq(Date.new(2024, 1, 1))
+      end
+    end
+
+    context "when the form is invalid" do
+      it "shows the error" do
+        form.assign_attributes("date_opened(1i)": "2024", "date_opened(2i)": "January", "date_opened(3i)": "4")
+
+        form.save
+
+        expect(form.errors.messages[:date_opened])
+          .to include(I18n.t("conversion.task.confirm_date_academy_opened.errors.format"))
+      end
+    end
+  end
+end

--- a/spec/forms/transfer/tasks/confirm_date_academy_transferred_task_form_spec.rb
+++ b/spec/forms/transfer/tasks/confirm_date_academy_transferred_task_form_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe Transfer::Task::ConfirmDateAcademyTransferredTaskForm do
+  let(:user) { create(:user) }
+  let(:project) { create(:transfer_project) }
+  let(:form) { described_class.new(project.tasks_data, user) }
+
+  before { mock_successful_api_response_to_create_any_project }
+
+  describe "validations" do
+    describe "day" do
+      it "when the value is 3rd, it is invalid" do
+        form.assign_attributes("date_transferred(1i)": "2024", "date_transferred(2i)": "1", "date_transferred(3i)": "3rd")
+
+        expect(form).to be_valid
+      end
+
+      it "when the value is not in the range of 1..31, it is invalid" do
+        form.assign_attributes("date_transferred(1i)": "2024", "date_transferred(2i)": "1", "date_transferred(3i)": "40")
+
+        expect(form).to be_invalid
+      end
+
+      it "when the value is not a number, it is invalid" do
+        form.assign_attributes("date_transferred(1i)": "2024", "date_transferred(2i)": "1", "date_transferred(3i)": "not a number")
+
+        expect(form).to be_invalid
+      end
+    end
+
+    describe "month" do
+      it "when the value is not in the range of 1..12, it is invalid" do
+        form.assign_attributes("date_transferred(1i)": "2024", "date_transferred(2i)": "20", "date_transferred(3i)": "20")
+
+        expect(form).to be_invalid
+      end
+
+      it "when the value is not a number, it is invalid" do
+        form.assign_attributes("date_transferred(1i)": "2024", "date_transferred(2i)": "January", "date_transferred(3i)": "20")
+
+        expect(form).to be_invalid
+      end
+    end
+
+    describe "year" do
+      it "when the value is not in the range of 1900..3000, it is invalid" do
+        form.assign_attributes("date_transferred(1i)": "800", "date_transferred(2i)": "2", "date_transferred(3i)": "20")
+
+        expect(form).to be_invalid
+      end
+
+      it "when the value is not a number, it is invalid" do
+        form.assign_attributes("date_transferred(1i)": "Nineteen hundred", "date_transferred(2i)": "1", "date_transferred(3i)": "20")
+
+        expect(form).to be_invalid
+      end
+    end
+
+    describe "the transfer to a date" do
+      context "when the values form a date that is incorrect" do
+        it "is invalid" do
+          form.assign_attributes("date_transferred(1i)": "30", "date_transferred(2i)": "2", "date_transferred(3i)": "2024")
+
+          expect(form).to be_invalid
+        end
+      end
+    end
+
+    describe "submitting nothing" do
+      it "when a user submits nothing, its valid" do
+        form.assign_attributes("date_transferred(1i)": "", "date_transferred(2i)": "", "date_transferred(3i)": "")
+
+        expect(form).to be_valid
+      end
+
+      it "when a user submits spaces, its valid" do
+        form.assign_attributes("date_transferred(1i)": "  ", "date_transferred(2i)": "  ", "date_transferred(3i)": "   ")
+
+        expect(form).to be_valid
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when the form is valid" do
+      it "saves the task" do
+        form.assign_attributes("date_transferred(1i)": "2024", "date_transferred(2i)": "1", "date_transferred(3i)": "1")
+
+        form.save
+
+        expect(project.tasks_data.reload.confirm_date_academy_transferred_date_transferred).to eq(Date.new(2024, 1, 1))
+      end
+    end
+
+    context "when the form is invalid" do
+      it "shows the error" do
+        form.assign_attributes("date_transferred(1i)": "2024", "date_transferred(2i)": "January", "date_transferred(3i)": "4")
+
+        form.save
+
+        expect(form.errors.messages[:date_transferred])
+          .to include(I18n.t("transfer.task.confirm_date_academy_transferred.errors.format"))
+      end
+    end
+  end
+end

--- a/spec/models/conversion/task_list_spec.rb
+++ b/spec/models/conversion/task_list_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Conversion::TaskList do
         :school_completed,
         :conditions_met,
         :share_information,
+        :confirm_date_academy_opened,
         :redact_and_send,
         :update_esfa,
         :receive_grant_payment_certificate
@@ -92,6 +93,7 @@ RSpec.describe Conversion::TaskList do
           {
             identifier: :after_opening,
             tasks: [
+              Conversion::Task::ConfirmDateAcademyOpenedTaskForm,
               Conversion::Task::RedactAndSendTaskForm,
               Conversion::Task::UpdateEsfaTaskForm,
               Conversion::Task::ReceiveGrantPaymentCertificateTaskForm
@@ -118,7 +120,7 @@ RSpec.describe Conversion::TaskList do
       project = create(:conversion_project)
       task_list = described_class.new(project, user)
 
-      expect(task_list.tasks.count).to eql 30
+      expect(task_list.tasks.count).to eql 31
       expect(task_list.tasks.first).to be_a Conversion::Task::HandoverTaskForm
       expect(task_list.tasks.last).to be_a Conversion::Task::ReceiveGrantPaymentCertificateTaskForm
     end

--- a/spec/models/transfer/task_list_spec.rb
+++ b/spec/models/transfer/task_list_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Transfer::TaskList do
         :bank_details_changing,
         :confirm_incoming_trust_has_completed_all_actions,
         :conditions_met,
+        :confirm_date_academy_transferred,
         :redact_and_send_documents
       ]
 
@@ -50,7 +51,7 @@ RSpec.describe Transfer::TaskList do
       project = create(:transfer_project)
       task_list = described_class.new(project, user)
 
-      expect(task_list.tasks.count).to eql 22
+      expect(task_list.tasks.count).to eql 23
       expect(task_list.tasks.first).to be_a Transfer::Task::HandoverTaskForm
       expect(task_list.tasks.last).to be_a Transfer::Task::RedactAndSendDocumentsTaskForm
     end


### PR DESCRIPTION
## Changes

A user can now confirm the date the conversion of transfer happened.

We lean on the existing receive grant payment certificate task to
validate the three parameter date, our use case is slightly different as
the date can be updated once set.

We also added some range validation on the year to help catch errors.

We did look to extract some of the validation to share among the form
objects, but on balance decided the duplication was better than the
miss-direction.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
