### PR TITLE
Fix main contact associations

### DIFF
--- a/app/models/contact/project.rb
+++ b/app/models/contact/project.rb
@@ -6,6 +6,7 @@ class Contact::Project < Contact
   belongs_to :project, class_name: "::Project"
   has_one :main_contact_for_project, class_name: "::Project", inverse_of: :main_contact
   has_one :main_contact_for_establishment, class_name: "::Project", inverse_of: :establishment_main_contact
+  has_one :main_contact_for_incoming_trust, class_name: "::Project", inverse_of: :incoming_trust_main_contact
 
   def establishment_main_contact
     project.establishment_main_contact_id == id

--- a/app/models/contact/project.rb
+++ b/app/models/contact/project.rb
@@ -8,6 +8,7 @@ class Contact::Project < Contact
   has_one :main_contact_for_establishment, class_name: "::Project", inverse_of: :establishment_main_contact
   has_one :main_contact_for_incoming_trust, class_name: "::Project", inverse_of: :incoming_trust_main_contact
   has_one :main_contact_for_outgoing_trust, class_name: "::Project", inverse_of: :outgoing_trust_main_contact
+  has_one :main_contact_for_funding_agreement, class_name: "::Project", inverse_of: :funding_agreement_contact
 
   def establishment_main_contact
     project.establishment_main_contact_id == id

--- a/app/models/contact/project.rb
+++ b/app/models/contact/project.rb
@@ -5,6 +5,7 @@ class Contact::Project < Contact
 
   belongs_to :project, class_name: "::Project"
   has_one :main_contact_for_project, class_name: "::Project", inverse_of: :main_contact
+  has_one :main_contact_for_establishment, class_name: "::Project", inverse_of: :establishment_main_contact
 
   def establishment_main_contact
     project.establishment_main_contact_id == id

--- a/app/models/contact/project.rb
+++ b/app/models/contact/project.rb
@@ -7,6 +7,7 @@ class Contact::Project < Contact
   has_one :main_contact_for_project, class_name: "::Project", inverse_of: :main_contact
   has_one :main_contact_for_establishment, class_name: "::Project", inverse_of: :establishment_main_contact
   has_one :main_contact_for_incoming_trust, class_name: "::Project", inverse_of: :incoming_trust_main_contact
+  has_one :main_contact_for_outgoing_trust, class_name: "::Project", inverse_of: :outgoing_trust_main_contact
 
   def establishment_main_contact
     project.establishment_main_contact_id == id

--- a/app/models/contact/project.rb
+++ b/app/models/contact/project.rb
@@ -4,6 +4,7 @@ class Contact::Project < Contact
   end
 
   belongs_to :project, class_name: "::Project"
+  has_one :main_contact_for_project, class_name: "::Project", inverse_of: :main_contact
 
   def establishment_main_contact
     project.establishment_main_contact_id == id

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -14,8 +14,9 @@ class Project < ApplicationRecord
   has_many :contacts, class_name: "Contact::Project", inverse_of: :project, dependent: :destroy
 
   belongs_to :main_contact, inverse_of: :main_contact_for_project, dependent: :destroy, class_name: "Contact::Project", optional: true
+  belongs_to :establishment_main_contact, inverse_of: :main_contact_for_establishment, dependent: :destroy, class_name: "Contact::Project", optional: true
+
   has_one :funding_agreement_contact, dependent: :destroy, class_name: "Contact::Project", required: false
-  has_one :establishment_main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
   has_one :incoming_trust_main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
   has_one :outgoing_trust_main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -13,8 +13,8 @@ class Project < ApplicationRecord
   has_many :notes, dependent: :destroy
   has_many :contacts, class_name: "Contact::Project", inverse_of: :project, dependent: :destroy
 
+  belongs_to :main_contact, inverse_of: :main_contact_for_project, dependent: :destroy, class_name: "Contact::Project", optional: true
   has_one :funding_agreement_contact, dependent: :destroy, class_name: "Contact::Project", required: false
-  has_one :main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
   has_one :establishment_main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
   has_one :incoming_trust_main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
   has_one :outgoing_trust_main_contact, dependent: :destroy, class_name: "Contact::Project", required: false

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -17,8 +17,7 @@ class Project < ApplicationRecord
   belongs_to :establishment_main_contact, inverse_of: :main_contact_for_establishment, dependent: :destroy, class_name: "Contact::Project", optional: true
   belongs_to :incoming_trust_main_contact, inverse_of: :main_contact_for_incoming_trust, dependent: :destroy, class_name: "Contact::Project", optional: true
   belongs_to :outgoing_trust_main_contact, inverse_of: :main_contact_for_outgoing_trust, dependent: :destroy, class_name: "Contact::Project", optional: true
-
-  has_one :funding_agreement_contact, dependent: :destroy, class_name: "Contact::Project", required: false
+  belongs_to :funding_agreement_contact, inverse_of: :main_contact_for_funding_agreement, dependent: :destroy, class_name: "Contact::Project", optional: true
 
   validates :urn, presence: true
   validates :urn, urn: true

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,9 +15,9 @@ class Project < ApplicationRecord
 
   belongs_to :main_contact, inverse_of: :main_contact_for_project, dependent: :destroy, class_name: "Contact::Project", optional: true
   belongs_to :establishment_main_contact, inverse_of: :main_contact_for_establishment, dependent: :destroy, class_name: "Contact::Project", optional: true
+  belongs_to :incoming_trust_main_contact, inverse_of: :main_contact_for_incoming_trust, dependent: :destroy, class_name: "Contact::Project", optional: true
 
   has_one :funding_agreement_contact, dependent: :destroy, class_name: "Contact::Project", required: false
-  has_one :incoming_trust_main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
   has_one :outgoing_trust_main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
 
   validates :urn, presence: true

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -16,9 +16,9 @@ class Project < ApplicationRecord
   belongs_to :main_contact, inverse_of: :main_contact_for_project, dependent: :destroy, class_name: "Contact::Project", optional: true
   belongs_to :establishment_main_contact, inverse_of: :main_contact_for_establishment, dependent: :destroy, class_name: "Contact::Project", optional: true
   belongs_to :incoming_trust_main_contact, inverse_of: :main_contact_for_incoming_trust, dependent: :destroy, class_name: "Contact::Project", optional: true
+  belongs_to :outgoing_trust_main_contact, inverse_of: :main_contact_for_outgoing_trust, dependent: :destroy, class_name: "Contact::Project", optional: true
 
   has_one :funding_agreement_contact, dependent: :destroy, class_name: "Contact::Project", required: false
-  has_one :outgoing_trust_main_contact, dependent: :destroy, class_name: "Contact::Project", required: false
 
   validates :urn, presence: true
   validates :urn, urn: true

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -146,21 +146,21 @@ class Export::Csv::ProjectPresenter
   end
 
   def main_contact_name
-    return unless @project.main_contact_id
-    contact = Contact::Project.find(@project.main_contact_id)
-    contact&.name
+    return unless @project.main_contact.present?
+
+    @project.main_contact.name
   end
 
   def main_contact_email
-    return unless @project.main_contact_id
-    contact = Contact::Project.find(@project.main_contact_id)
-    contact&.email
+    return unless @project.main_contact.present?
+
+    @project.main_contact.email
   end
 
   def main_contact_title
-    return unless @project.main_contact_id
-    contact = Contact::Project.find(@project.main_contact_id)
-    contact&.title
+    return unless @project.main_contact.present?
+
+    @project.main_contact.title
   end
 
   def region

--- a/spec/forms/conversion/tasks/funding_agreement_contact_task_form_spec.rb
+++ b/spec/forms/conversion/tasks/funding_agreement_contact_task_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Conversion::Task::FundingAgreementContactTaskForm do
       form.assign_attributes(funding_agreement_contact_id: contact.id)
       form.save
 
-      expect(project.funding_agreement_contact).to eq(contact)
+      expect(project.reload.funding_agreement_contact).to eq(contact)
     end
   end
 end

--- a/spec/forms/transfer/tasks/main_contact_task_form_spec.rb
+++ b/spec/forms/transfer/tasks/main_contact_task_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Transfer::Task::MainContactTaskForm do
       form.assign_attributes(main_contact_id: contact.id)
       form.save
 
-      expect(project.main_contact).to eq(contact)
+      expect(project.reload.main_contact).to eq(contact)
     end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_one(:funding_agreement_contact).required(false) }
     it { is_expected.to belong_to(:establishment_main_contact).optional(true) }
     it { is_expected.to belong_to(:incoming_trust_main_contact).optional(true) }
-    it { is_expected.to have_one(:outgoing_trust_main_contact).required(false) }
+    it { is_expected.to belong_to(:outgoing_trust_main_contact).optional(true) }
 
     describe "delete related entities" do
       context "when the project is deleted" do
@@ -107,6 +107,24 @@ RSpec.describe Project, type: :model do
         project.update(incoming_trust_main_contact: incoming_trust_main_contact)
 
         expect(project.incoming_trust_main_contact).to eql(incoming_trust_main_contact)
+      end
+    end
+
+    describe "#outgoing_trust_main_contact" do
+      it "returns nil when no association exists, but there are project contacts" do
+        project = create(:conversion_project)
+        create_list(:project_contact, 3, project: project)
+
+        expect(project.outgoing_trust_main_contact).to be_nil
+      end
+
+      it "returns the contact when one is set" do
+        project = create(:conversion_project)
+        outgoing_trust_main_contact = create(:project_contact)
+
+        project.update(outgoing_trust_main_contact: outgoing_trust_main_contact)
+
+        expect(project.outgoing_trust_main_contact).to eql(outgoing_trust_main_contact)
       end
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to belong_to(:main_contact).optional(true) }
     it { is_expected.to have_one(:funding_agreement_contact).required(false) }
     it { is_expected.to belong_to(:establishment_main_contact).optional(true) }
-    it { is_expected.to have_one(:incoming_trust_main_contact).required(false) }
+    it { is_expected.to belong_to(:incoming_trust_main_contact).optional(true) }
     it { is_expected.to have_one(:outgoing_trust_main_contact).required(false) }
 
     describe "delete related entities" do
@@ -89,6 +89,24 @@ RSpec.describe Project, type: :model do
         project.update(establishment_main_contact: establishment_main_contact)
 
         expect(project.establishment_main_contact).to eql(establishment_main_contact)
+      end
+    end
+
+    describe "#incoming_trust_main_contact" do
+      it "returns nil when no association exists, but there are project contacts" do
+        project = create(:conversion_project)
+        create_list(:project_contact, 3, project: project)
+
+        expect(project.incoming_trust_main_contact).to be_nil
+      end
+
+      it "returns the contact when one is set" do
+        project = create(:conversion_project)
+        incoming_trust_main_contact = create(:project_contact)
+
+        project.update(incoming_trust_main_contact: incoming_trust_main_contact)
+
+        expect(project.incoming_trust_main_contact).to eql(incoming_trust_main_contact)
       end
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to belong_to(:tasks_data).required(true) }
     it { is_expected.to belong_to(:main_contact).optional(true) }
     it { is_expected.to have_one(:funding_agreement_contact).required(false) }
-    it { is_expected.to have_one(:establishment_main_contact).required(false) }
+    it { is_expected.to belong_to(:establishment_main_contact).optional(true) }
     it { is_expected.to have_one(:incoming_trust_main_contact).required(false) }
     it { is_expected.to have_one(:outgoing_trust_main_contact).required(false) }
 
@@ -70,6 +70,25 @@ RSpec.describe Project, type: :model do
         project.update(main_contact: main_contact)
 
         expect(project.main_contact).to eql(main_contact)
+      end
+    end
+
+    describe "#establishment_main_contact" do
+      it "returns nil when no association exists, but there are project contacts" do
+        project = create(:conversion_project)
+        create_list(:project_contact, 3, project: project)
+
+        expect(project.establishment_main_contact).to be_nil
+      end
+
+      it "returns the contact when one is set" do
+        project = create(:conversion_project)
+        create(:project_contact, project: project)
+        establishment_main_contact = create(:project_contact)
+
+        project.update(establishment_main_contact: establishment_main_contact)
+
+        expect(project.establishment_main_contact).to eql(establishment_main_contact)
       end
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Project, type: :model do
     it { is_expected.to belong_to(:team_leader).required(false) }
     it { is_expected.to belong_to(:assigned_to).required(false) }
     it { is_expected.to belong_to(:tasks_data).required(true) }
+    it { is_expected.to belong_to(:main_contact).optional(true) }
     it { is_expected.to have_one(:funding_agreement_contact).required(false) }
-    it { is_expected.to have_one(:main_contact).required(false) }
     it { is_expected.to have_one(:establishment_main_contact).required(false) }
     it { is_expected.to have_one(:incoming_trust_main_contact).required(false) }
     it { is_expected.to have_one(:outgoing_trust_main_contact).required(false) }
@@ -51,6 +51,25 @@ RSpec.describe Project, type: :model do
           expect(Contact::Project.count).to be_zero
           expect(Conversion::TasksData.count).to be_zero
         end
+      end
+    end
+
+    describe "#main_contact" do
+      it "returns nil when no main contact associsation exists, but there are project contacts" do
+        project = create(:conversion_project)
+        create_list(:project_contact, 5, project: project)
+
+        expect(project.main_contact).to be_nil
+      end
+
+      it "returns the contact when one is set" do
+        project = create(:conversion_project)
+        create_list(:project_contact, 5, project: project)
+        main_contact = create(:project_contact)
+
+        project.update(main_contact: main_contact)
+
+        expect(project.main_contact).to eql(main_contact)
       end
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to belong_to(:assigned_to).required(false) }
     it { is_expected.to belong_to(:tasks_data).required(true) }
     it { is_expected.to belong_to(:main_contact).optional(true) }
-    it { is_expected.to have_one(:funding_agreement_contact).required(false) }
+    it { is_expected.to belong_to(:funding_agreement_contact).optional(true) }
     it { is_expected.to belong_to(:establishment_main_contact).optional(true) }
     it { is_expected.to belong_to(:incoming_trust_main_contact).optional(true) }
     it { is_expected.to belong_to(:outgoing_trust_main_contact).optional(true) }
@@ -125,6 +125,24 @@ RSpec.describe Project, type: :model do
         project.update(outgoing_trust_main_contact: outgoing_trust_main_contact)
 
         expect(project.outgoing_trust_main_contact).to eql(outgoing_trust_main_contact)
+      end
+    end
+
+    describe "#funding_agreement_contact" do
+      it "returns nil when no association exists, but there are project contacts" do
+        project = create(:conversion_project)
+        create_list(:project_contact, 3, project: project)
+
+        expect(project.funding_agreement_contact).to be_nil
+      end
+
+      it "returns the contact when one is set" do
+        project = create(:conversion_project)
+        funding_agreement_contact = create(:project_contact)
+
+        project.update(funding_agreement_contact: funding_agreement_contact)
+
+        expect(project.funding_agreement_contact).to eql(funding_agreement_contact)
       end
     end
   end


### PR DESCRIPTION
Conceptually all these 'main contact' associations work the same way, when we added them we got the `belongs_to`/`has_one` declarations the wrong way around, they worked, but when other `Project.contacts were` present, these would get returned as the 'main contacts' in error.

This work fixes this by declaring the `belongs_to` on the class that contains the foreign key, `Project` here, see the Rails guide:

https://guides.rubyonrails.org/association_basics.html#choosing-between-belongs-to-and-has-one

We've kept this work focused on fixing the associations and nothing else.