### PR TITLE
(156033) Add provisional dates to more exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   management and By Month exports, and ensure Form a MAT projects are correctly
   displayed in the export
 
+### Changed
+
+- Academies due to transfer csv export now includes both provisional and
+  confirmed projects
+- Funding agreement letter csv export now includes both provisional and
+  confirmed projects
+- ESFA csv export now includes both the provisional and confirmed projects
+
 ## [Release-54][release-54]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Funding agreement letter csv export now includes both provisional and
   confirmed projects
 - ESFA csv export now includes both the provisional and confirmed projects
+- Academies due to transfer csv export now includes a provisional date column
+- Funding agreement letter csv export now includes a provisional date column
+- ESFA csv export now includes a provisional date column
 
 ## [Release-54][release-54]
 

--- a/app/services/export/conversions/education_and_skills_funding_agency_csv_export_service.rb
+++ b/app/services/export/conversions/education_and_skills_funding_agency_csv_export_service.rb
@@ -19,6 +19,7 @@ class Export::Conversions::EducationAndSkillsFundingAgencyCsvExportService < Exp
     incoming_trust_identifier
     incoming_trust_companies_house_number
     incoming_trust_name
+    provisional_date
     conversion_date
     all_conditions_met
     risk_protection_arrangement

--- a/app/services/export/conversions/funding_agreement_letters_csv_exporter_service.rb
+++ b/app/services/export/conversions/funding_agreement_letters_csv_exporter_service.rb
@@ -50,6 +50,7 @@ class Export::Conversions::FundingAgreementLettersCsvExporterService < Export::C
     academy_order_type
     two_requires_improvement
     sponsored_grant_type
+    provisional_date
     conversion_date
     assigned_to_name
     assigned_to_email

--- a/app/services/export/transfers/academies_due_to_transfer_csv_export_service.rb
+++ b/app/services/export/transfers/academies_due_to_transfer_csv_export_service.rb
@@ -19,6 +19,7 @@ class Export::Transfers::AcademiesDueToTransferCsvExportService < Export::CsvExp
     bank_details_changing
     region
     assigned_to_email
+    provisional_date
     transfer_date
     authority_to_proceed
     main_contact_name

--- a/app/services/projects_for_export_service.rb
+++ b/app/services/projects_for_export_service.rb
@@ -25,11 +25,11 @@ class ProjectsForExportService
   end
 
   private def transfer_projects_by_month_and_year(month, year)
-    Transfer::Project.confirmed.filtered_by_significant_date(month, year)
+    Transfer::Project.filtered_by_significant_date(month, year)
   end
 
   private def conversion_projects_by_month_and_year(month, year)
-    Conversion::Project.confirmed.filtered_by_significant_date(month, year)
+    Conversion::Project.filtered_by_significant_date(month, year)
   end
 
   private def conversion_projects_by_advisory_board_date(month, year)


### PR DESCRIPTION
The follow csv exports now include both provisional and confirmed projects and include the provisional date in the exported columns:

- Academies due to transfer csv export
- Funding agreement letter csv export
- ESFA csv export

This brings them inline with the two pre-opening grant exports, leaving only the 'by-month' export without the provisonal date.