### PR TITLE
(158338) Add grant payment certificate received to csv export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Academies due to transfer csv export now includes a provisional date column
 - Funding agreement letter csv export now includes a provisional date column
 - ESFA csv export now includes a provisional date column
+- when the grant payment certificate has not been received, 'unconfirmed' is
+ shown in the csv exports that include it, rather than a empty cell
 
 ## [Release-54][release-54]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Show Conversion type (single converter/form a MAT) in the ESFA, Grant
   management and By Month exports, and ensure Form a MAT projects are correctly
   displayed in the export
+- the Grant management and Finance Unit conversion csv export now includes the
+  grant payment certificate has not been received column
 
 ### Changed
 
@@ -23,7 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Funding agreement letter csv export now includes a provisional date column
 - ESFA csv export now includes a provisional date column
 - when the grant payment certificate has not been received, 'unconfirmed' is
- shown in the csv exports that include it, rather than a empty cell
+  shown in the csv exports that include it, rather than a empty cell
 
 ## [Release-54][release-54]
 

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -216,7 +216,9 @@ class Export::Csv::ProjectPresenter
   end
 
   def completed_grant_payment_certificate_received
-    @project.tasks_data.receive_grant_payment_certificate_date_received.to_fs(:csv) if @project.tasks_data.receive_grant_payment_certificate_date_received.present?
+    return I18n.t("export.csv.project.values.unconfirmed") unless @project.tasks_data.receive_grant_payment_certificate_date_received.present?
+
+    @project.tasks_data.receive_grant_payment_certificate_date_received.to_fs(:csv)
   end
 
   def solicitor_contact_name

--- a/app/services/export/conversions/grant_management_and_finance_unit_csv_export_service.rb
+++ b/app/services/export/conversions/grant_management_and_finance_unit_csv_export_service.rb
@@ -13,6 +13,7 @@ class Export::Conversions::GrantManagementAndFinanceUnitCsvExportService < Expor
     provisional_date
     conversion_date
     academy_order_type
+    completed_grant_payment_certificate_received
     two_requires_improvement
     sponsored_grant_type
     assigned_to_name

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -532,14 +532,26 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.advisory_board_conditions).to eql("These are the conditions.")
   end
 
-  it "presents the completed grant payment certificate received" do
-    mock_successful_api_response_to_create_any_project
-    tasks_data = build(:conversion_tasks_data, receive_grant_payment_certificate_date_received: Date.new(2024, 1, 1))
-    project = build(:conversion_project, tasks_data: tasks_data)
+  describe "#completed_grant_payment_certificate_received" do
+    it "presents the completed grant payment certificate received" do
+      mock_successful_api_response_to_create_any_project
+      tasks_data = build(:conversion_tasks_data, receive_grant_payment_certificate_date_received: Date.new(2024, 1, 1))
+      project = build(:conversion_project, tasks_data: tasks_data)
 
-    presenter = described_class.new(project)
+      presenter = described_class.new(project)
 
-    expect(presenter.completed_grant_payment_certificate_received).to eql("2024-01-01")
+      expect(presenter.completed_grant_payment_certificate_received).to eql("2024-01-01")
+    end
+
+    it "presents unconfirmed when there is no date" do
+      mock_successful_api_response_to_create_any_project
+      tasks_data = build(:conversion_tasks_data, receive_grant_payment_certificate_date_received: nil)
+      project = build(:conversion_project, tasks_data: tasks_data)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.completed_grant_payment_certificate_received).to eql("unconfirmed")
+    end
   end
 
   it "presents the solicitor contact name" do


### PR DESCRIPTION
Add date grant payment certificate received date to the Grant managemnet and finance unit conversions csv export.

We already include this in the 'by month' export so we update the nil state to return 'unconfirmed' and added it to the correct export.