### PR TITLE
(158463) Fall back to next trust contact if a project doesn't have a main trust contact

### DIFF
--- a/app/presenters/export/csv/incoming_trust_presenter_module.rb
+++ b/app/presenters/export/csv/incoming_trust_presenter_module.rb
@@ -60,22 +60,26 @@ module Export::Csv::IncomingTrustPresenterModule
   end
 
   def incoming_trust_main_contact_name
-    return unless @project.incoming_trust_main_contact_id.present?
-
     contacts = ContactsFetcherService.new.all_project_contacts(@project)
     return if contacts["incoming_trust"].blank?
 
-    contact = contacts["incoming_trust"].find { |c| c.id == @project.incoming_trust_main_contact_id }
+    contact = if @project.incoming_trust_main_contact_id.present?
+      contacts["incoming_trust"].find { |c| c.id == @project.incoming_trust_main_contact_id }
+    else
+      contacts["incoming_trust"].first
+    end
     contact&.name
   end
 
   def incoming_trust_main_contact_email
-    return unless @project.incoming_trust_main_contact_id.present?
-
     contacts = ContactsFetcherService.new.all_project_contacts(@project)
     return if contacts["incoming_trust"].blank?
 
-    contact = contacts["incoming_trust"].find { |c| c.id == @project.incoming_trust_main_contact_id }
+    contact = if @project.incoming_trust_main_contact_id.present?
+      contacts["incoming_trust"].find { |c| c.id == @project.incoming_trust_main_contact_id }
+    else
+      contacts["incoming_trust"].first
+    end
     contact&.email
   end
 

--- a/app/presenters/export/csv/outgoing_trust_presenter_module.rb
+++ b/app/presenters/export/csv/outgoing_trust_presenter_module.rb
@@ -18,22 +18,26 @@ module Export::Csv::OutgoingTrustPresenterModule
   end
 
   def outgoing_trust_main_contact_name
-    return unless @project.outgoing_trust_main_contact_id.present?
-
     contacts = ContactsFetcherService.new.all_project_contacts(@project)
     return if contacts["outgoing_trust"].blank?
 
-    contact = contacts["outgoing_trust"].find { |c| c.id == @project.outgoing_trust_main_contact_id }
+    contact = if @project.outgoing_trust_main_contact_id.present?
+      contacts["outgoing_trust"].find { |c| c.id == @project.outgoing_trust_main_contact_id }
+    else
+      contacts["outgoing_trust"].first
+    end
     contact&.name
   end
 
   def outgoing_trust_main_contact_email
-    return unless @project.outgoing_trust_main_contact_id.present?
-
     contacts = ContactsFetcherService.new.all_project_contacts(@project)
     return if contacts["outgoing_trust"].blank?
 
-    contact = contacts["outgoing_trust"].find { |c| c.id == @project.outgoing_trust_main_contact_id }
+    contact = if @project.outgoing_trust_main_contact_id.present?
+      contacts["outgoing_trust"].find { |c| c.id == @project.outgoing_trust_main_contact_id }
+    else
+      contacts["outgoing_trust"].first
+    end
     contact&.email
   end
 

--- a/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
@@ -67,6 +67,32 @@ RSpec.describe Export::Csv::IncomingTrustPresenterModule do
     expect(subject.incoming_trust_address_postcode).to eql "MK13 0BQ"
   end
 
+  it "presents the main contact name" do
+    expect(subject.incoming_trust_main_contact_name).to eql "Jo Example"
+  end
+
+  it "presents the main contact email" do
+    expect(subject.incoming_trust_main_contact_email).to eql "jo@example.com"
+  end
+
+  context "when there is no main contact ID" do
+    before do
+      allow(project).to receive(:incoming_trust_main_contact_id).and_return(nil)
+    end
+
+    it "presents the next incoming trust contact name" do
+      expect(subject.incoming_trust_main_contact_name).to eql "Jo Example"
+    end
+
+    it "presents the next incoming trust contact email" do
+      expect(subject.incoming_trust_main_contact_email).to eql "jo@example.com"
+    end
+  end
+
+  it "presents the sharepoint link" do
+    expect(subject.incoming_trust_sharepoint_link).to eql "https://educationgovuk-my.sharepoint.com/incoming-trust-folder"
+  end
+
   def known_trust
     double(
       Api::AcademiesApi::Trust,
@@ -81,18 +107,6 @@ RSpec.describe Export::Csv::IncomingTrustPresenterModule do
       address_county: nil,
       address_postcode: "MK13 0BQ"
     )
-  end
-
-  it "presents the main contact name" do
-    expect(subject.incoming_trust_main_contact_name).to eql "Jo Example"
-  end
-
-  it "presents the main contact email" do
-    expect(subject.incoming_trust_main_contact_email).to eql "jo@example.com"
-  end
-
-  it "presents the sharepoint link" do
-    expect(subject.incoming_trust_sharepoint_link).to eql "https://educationgovuk-my.sharepoint.com/incoming-trust-folder"
   end
 end
 

--- a/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
@@ -31,6 +31,20 @@ RSpec.describe Export::Csv::OutgoingTrustPresenterModule do
     expect(subject.outgoing_trust_main_contact_email).to eql "jo@example.com"
   end
 
+  context "when there is no main contact ID" do
+    before do
+      allow(project).to receive(:outgoing_trust_main_contact_id).and_return(nil)
+    end
+
+    it "presents the next outgoing trust contact name" do
+      expect(subject.outgoing_trust_main_contact_name).to eql "Jo Example"
+    end
+
+    it "presents the next outgoing trust contact email" do
+      expect(subject.outgoing_trust_main_contact_email).to eql "jo@example.com"
+    end
+  end
+
   it "presents the outgoing trust identifier" do
     expect(subject.outgoing_trust_identifier).to eql "TR03819"
   end


### PR DESCRIPTION
While a user can select a main outgoing/incoming trust contact ID, not all projects have one selected. If this is the case, we can try to fall back onto the next trust contact, instead of presenting an empty column.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
