### PR TITLE
(156562) Change the update ESFA task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   management and By Month exports, and ensure Form a MAT projects are correctly
   displayed in the export
 
+### Changed
+
+- the Update ESFA data in KIM task no longer mentions KIM, asking users to add a
+  task note instead.
+
 ## [Release-54][release-54]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - the Update ESFA data in KIM task no longer mentions KIM, asking users to add a
   task note instead.
+- the Add notes for ESFA task can only be completed by providing at least one
+  task note and checking the task off.
 
 ## [Release-54][release-54]
 

--- a/app/forms/conversion/task/update_esfa_task_form.rb
+++ b/app/forms/conversion/task/update_esfa_task_form.rb
@@ -1,3 +1,17 @@
 class Conversion::Task::UpdateEsfaTaskForm < BaseTaskForm
   attribute :update, :boolean
+
+  private def in_progress?
+    update.present? || task_notes.any?
+  end
+
+  private def completed?
+    update.present? && task_notes.any?
+  end
+
+  private def task_notes
+    @tasks_data.project.notes.select do |note|
+      note.task_identifier.eql?(identifier.to_s)
+    end
+  end
 end

--- a/config/locales/conversion/tasks/update_esfa.en.yml
+++ b/config/locales/conversion/tasks/update_esfa.en.yml
@@ -2,12 +2,14 @@ en:
   conversion:
     task:
       update_esfa:
-        title: Update ESFA data in KIM
+        title: Add notes for ESFA
         hint:
           html: <p>Carry out final checks and update project information if necessary so the ESFA (Education and Skills Funding Agency) can issue the funding when the project is handed over.</p>
 
         update:
-          title: Update any ESFA fields in KIM and add notes if necessary
+          title: Add notes to this task
+          hint:
+            html: <p>Notes you add here will appear in the ESFA export.</p>
           guidance_link: Things you may want to write notes about
           guidance:
             html:

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Users can complete conversion tasks" do
     land_questionnaire land_registry
     redact_and_send
     school_completed share_information single_worksheet
-    supplemental_funding_agreement update_esfa
+    supplemental_funding_agreement
   ]
 
   optional_tasks = %w[handover articles_of_association church_supplemental_agreement
@@ -33,6 +33,7 @@ RSpec.feature "Users can complete conversion tasks" do
     main_contact
     proposed_capacity_of_the_academy
     receive_grant_payment_certificate
+    update_esfa
   ]
 
   it "confirms we are checking all tasks" do
@@ -294,6 +295,25 @@ RSpec.feature "Users can complete conversion tasks" do
         expect(page).to have_content("DfE received the grant payment certificate on 1 January 2024.")
         expect(page).to_not have_content("Enter the date you received the grant payment certificate")
       end
+    end
+  end
+
+  describe "the update ESFA task" do
+    let(:project) { create(:conversion_project, assigned_to: user) }
+
+    scenario "they can compelte the task" do
+      visit project_tasks_path(project)
+      click_on "Add notes for ESFA"
+
+      click_on "Add a new task note"
+      fill_in "Enter note", with: "These are my handover notes for the ESFA"
+      click_on "Add note"
+
+      check "Add notes to this task"
+      click_on "Save and return"
+
+      task_status = find("#add-notes-for-esfa-status")
+      expect(task_status).to have_content("Completed")
     end
   end
 

--- a/spec/forms/conversion/tasks/update_esfa_task_form_spec.rb
+++ b/spec/forms/conversion/tasks/update_esfa_task_form_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe Conversion::Task::UpdateEsfaTaskForm do
+  let(:user) { create(:user) }
+
+  describe "#status" do
+    context "when the task is not checked and there is no task note" do
+      it "returns not started" do
+        project = build(:conversion_project)
+        task_form = described_class.new(project.tasks_data, user)
+        allow(project.tasks_data).to receive(:project).and_return(project)
+
+        expect(task_form.status).to eql(:not_started)
+      end
+    end
+
+    context "when the task is not checked and there is a task note" do
+      it "returns in progress" do
+        project = build(:conversion_project)
+        note = build(:note, task_identifier: :update_esfa, project: project)
+        task_form = described_class.new(project.tasks_data, user)
+
+        allow(project).to receive(:notes).and_return([note])
+        allow(project.tasks_data).to receive(:project).and_return(project)
+
+        expect(task_form.status).to eql(:in_progress)
+      end
+    end
+
+    context "when the task is checked but the note is not for the task" do
+      it "returns in progress" do
+        project = build(:conversion_project)
+        note = build(:note, task_identifier: :not_this_task, project: project)
+        task_form = described_class.new(project.tasks_data, user)
+        task_form.assign_attributes(update: true)
+
+        allow(project).to receive(:notes).and_return([note])
+        allow(project.tasks_data).to receive(:project).and_return(project)
+
+        expect(task_form.status).to eql(:in_progress)
+      end
+    end
+
+    context "when the task is checked but there is no task note" do
+      it "returns in progress" do
+        project = build(:conversion_project)
+        task_form = described_class.new(project.tasks_data, user)
+        task_form.assign_attributes(update: true)
+
+        allow(project.tasks_data).to receive(:project).and_return(project)
+
+        expect(task_form.status).to eql(:in_progress)
+      end
+    end
+
+    context "when the task is checked and there is a tasks note" do
+      it "returns completed" do
+        project = build(:conversion_project)
+        note = build(:note, task_identifier: :update_esfa, project: project)
+        task_form = described_class.new(project.tasks_data, user)
+        task_form.assign_attributes(update: true)
+
+        allow(project).to receive(:notes).and_return([note])
+        allow(project.tasks_data).to receive(:project).and_return(project)
+
+        expect(task_form.status).to eql(:completed)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We cannot use KIM so this task has to change. 

We update the content to ask users to add a task note instead.

The task is only compelte when the task is checked AND at least one task note is added.

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/a5ea11fe-bfb4-4e51-8b0b-bab94413544a)
