### PR TITLE
(157876) Include ESFA notes in export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - ESFA csv export now includes a provisional date column
 - when the grant payment certificate has not been received, 'unconfirmed' is
   shown in the csv exports that include it, rather than a empty cell
+- The ESFA csv export now includes the 'Add notes for ESFA' notes.
 
 ### Changed
 

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -254,4 +254,14 @@ class Export::Csv::ProjectPresenter
     return I18n.t("export.csv.project.values.form_a_mat") if @project.form_a_mat?
     I18n.t("export.csv.project.values.single_converter")
   end
+
+  def esfa_notes
+    notes = @project.notes.select do |note|
+      note.task_identifier.eql?("update_esfa")
+    end
+
+    return I18n.t("export.csv.project.values.none") unless notes.any?
+
+    notes.map(&:body).join("\n\n")
+  end
 end

--- a/app/services/export/conversions/education_and_skills_funding_agency_csv_export_service.rb
+++ b/app/services/export/conversions/education_and_skills_funding_agency_csv_export_service.rb
@@ -31,6 +31,7 @@ class Export::Conversions::EducationAndSkillsFundingAgencyCsvExportService < Exp
     main_contact_name
     main_contact_email
     main_contact_title
+    esfa_notes
   ]
 
   def initialize(projects)

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -126,6 +126,7 @@ en:
           school_address_postcode_with_academy_label: Academy postcode
           school_name_with_academy_label: Academy name
           conversion_type: Conversion type
+          esfa_notes: ESFA notes
         values:
           project_type:
             conversion: Conversion
@@ -150,3 +151,4 @@ en:
           commercial: commercial
           single_converter: single converter
           form_a_mat: form a MAT
+          none: none

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -646,4 +646,49 @@ RSpec.describe Export::Csv::ProjectPresenter do
 
     expect(presenter.academy_order_type).to eql "not applicable"
   end
+
+  describe "#esfa_notes" do
+    context "when there are no notes" do
+      it "returns 'none'" do
+        project = build(:conversion_project)
+        project_note = build(:note, body: "This is a project note")
+        allow(project).to receive(:notes).and_return([project_note])
+
+        presenter = described_class.new(project)
+
+        expect(presenter.esfa_notes).to eql("none")
+      end
+    end
+
+    context "when there is one note" do
+      it "returns the note body" do
+        project = build(:conversion_project)
+        project_note = build(:note, body: "This is a project note")
+        note = build(:note, task_identifier: "update_esfa")
+
+        allow(project).to receive(:notes).and_return([project_note, note])
+
+        presenter = described_class.new(project)
+
+        expect(presenter.esfa_notes).to eql(note.body)
+      end
+    end
+
+    context "when there is more than one note" do
+      it "returns the bodies of the notes in a single value" do
+        project = build(:conversion_project)
+        project_note = build(:note, body: "This is a project note")
+        note = build(:note, task_identifier: "update_esfa")
+        another_note = build(:note, body: "This is a note to give to the ESFA", task_identifier: "update_esfa")
+
+        allow(project).to receive(:notes).and_return([note, project_note, another_note])
+
+        presenter = described_class.new(project)
+
+        expect(presenter.esfa_notes).to include(note.body)
+        expect(presenter.esfa_notes).to include(another_note.body)
+        expect(presenter.esfa_notes).not_to include(project_note.body)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This work includes the 'Add notes for ESFA' notes in the appropriate csv export.

<img width="1171" alt="Screenshot 2024-03-04 at 14 10 56" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/81986abe-95d3-4103-912a-f87d73a1e79b">

Based on #1393 
