### PR TITLE
(158464) Add School, Incoming trust and "Other" contacts to Funding agreement letters export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Guard against incomplete MP details from the Members API (bugfix from
   production)
 
+### Added
+
+- Add more contact details to the Funding agreement letters export: School
+  contact, Incoming trust contact and "Other" contact
+
 ## [Release-55][release-55]
 
 ### Added

--- a/app/presenters/export/csv/incoming_trust_presenter_module.rb
+++ b/app/presenters/export/csv/incoming_trust_presenter_module.rb
@@ -71,6 +71,18 @@ module Export::Csv::IncomingTrustPresenterModule
     contact&.name
   end
 
+  def incoming_trust_main_contact_role
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["incoming_trust"].blank?
+
+    contact = if @project.incoming_trust_main_contact_id.present?
+      contacts["incoming_trust"].find { |c| c.id == @project.incoming_trust_main_contact_id }
+    else
+      contacts["incoming_trust"].first
+    end
+    contact&.title
+  end
+
   def incoming_trust_main_contact_email
     contacts = ContactsFetcherService.new.all_project_contacts(@project)
     return if contacts["incoming_trust"].blank?

--- a/app/presenters/export/csv/incoming_trust_presenter_module.rb
+++ b/app/presenters/export/csv/incoming_trust_presenter_module.rb
@@ -60,44 +60,24 @@ module Export::Csv::IncomingTrustPresenterModule
   end
 
   def incoming_trust_main_contact_name
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
-    return if contacts["incoming_trust"].blank?
-
-    contact = if @project.incoming_trust_main_contact_id.present?
-      contacts["incoming_trust"].find { |c| c.id == @project.incoming_trust_main_contact_id }
-    else
-      contacts["incoming_trust"].first
-    end
-    contact&.name
+    incoming_trust_contact&.name
   end
 
   def incoming_trust_main_contact_role
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
-    return if contacts["incoming_trust"].blank?
-
-    contact = if @project.incoming_trust_main_contact_id.present?
-      contacts["incoming_trust"].find { |c| c.id == @project.incoming_trust_main_contact_id }
-    else
-      contacts["incoming_trust"].first
-    end
-    contact&.title
+    incoming_trust_contact&.title
   end
 
   def incoming_trust_main_contact_email
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
-    return if contacts["incoming_trust"].blank?
-
-    contact = if @project.incoming_trust_main_contact_id.present?
-      contacts["incoming_trust"].find { |c| c.id == @project.incoming_trust_main_contact_id }
-    else
-      contacts["incoming_trust"].first
-    end
-    contact&.email
+    incoming_trust_contact&.email
   end
 
   def incoming_trust_sharepoint_link
     return unless @project.incoming_trust_sharepoint_link.present?
 
     @project.incoming_trust_sharepoint_link
+  end
+
+  private def incoming_trust_contact
+    @incoming_trust_contact || ContactsFetcherService.new.incoming_trust_contact(@project)
   end
 end

--- a/app/presenters/export/csv/outgoing_trust_presenter_module.rb
+++ b/app/presenters/export/csv/outgoing_trust_presenter_module.rb
@@ -18,27 +18,11 @@ module Export::Csv::OutgoingTrustPresenterModule
   end
 
   def outgoing_trust_main_contact_name
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
-    return if contacts["outgoing_trust"].blank?
-
-    contact = if @project.outgoing_trust_main_contact_id.present?
-      contacts["outgoing_trust"].find { |c| c.id == @project.outgoing_trust_main_contact_id }
-    else
-      contacts["outgoing_trust"].first
-    end
-    contact&.name
+    outgoing_trust_contact&.name
   end
 
   def outgoing_trust_main_contact_email
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
-    return if contacts["outgoing_trust"].blank?
-
-    contact = if @project.outgoing_trust_main_contact_id.present?
-      contacts["outgoing_trust"].find { |c| c.id == @project.outgoing_trust_main_contact_id }
-    else
-      contacts["outgoing_trust"].first
-    end
-    contact&.email
+    outgoing_trust_contact&.email
   end
 
   def outgoing_trust_identifier
@@ -85,5 +69,9 @@ module Export::Csv::OutgoingTrustPresenterModule
     return unless @project.outgoing_trust_sharepoint_link.present?
 
     @project.outgoing_trust_sharepoint_link
+  end
+
+  private def outgoing_trust_contact
+    @outgoing_trust_contact || ContactsFetcherService.new.outgoing_trust_contact(@project)
   end
 end

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -266,26 +266,18 @@ class Export::Csv::ProjectPresenter
   end
 
   def other_contact_name
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
-    return if contacts["other"].blank?
-
-    contact = contacts["other"].first
-    contact&.name
+    other_contact&.name
   end
 
   def other_contact_email
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
-    return if contacts["other"].blank?
-
-    contact = contacts["other"].first
-    contact&.email
+    other_contact&.email
   end
 
   def other_contact_role
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
-    return if contacts["other"].blank?
+    other_contact&.title
+  end
 
-    contact = contacts["other"].first
-    contact&.title
+  private def other_contact
+    @other_contact || ContactsFetcherService.new.other_contact(@project)
   end
 end

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -264,4 +264,28 @@ class Export::Csv::ProjectPresenter
 
     notes.map(&:body).join("\n\n")
   end
+
+  def other_contact_name
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["other"].blank?
+
+    contact = contacts["other"].first
+    contact&.name
+  end
+
+  def other_contact_email
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["other"].blank?
+
+    contact = contacts["other"].first
+    contact&.email
+  end
+
+  def other_contact_role
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["other"].blank?
+
+    contact = contacts["other"].first
+    contact&.title
+  end
 end

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -96,38 +96,18 @@ module Export::Csv::SchoolPresenterModule
   alias_method :school_sharepoint_link_with_academy_label, :school_sharepoint_folder
 
   def school_main_contact_name
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
-    return if contacts["school_or_academy"].blank?
-
-    contact = if @project.establishment_main_contact_id.present?
-      contacts["school_or_academy"].find { |c| c.id == @project.establishment_main_contact_id }
-    else
-      contacts["school_or_academy"].first
-    end
-    contact&.name
+    school_or_academy_contact&.name
   end
 
   def school_main_contact_email
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
-    return if contacts["school_or_academy"].blank?
-
-    contact = if @project.establishment_main_contact_id.present?
-      contacts["school_or_academy"].find { |c| c.id == @project.establishment_main_contact_id }
-    else
-      contacts["school_or_academy"].first
-    end
-    contact&.email
+    school_or_academy_contact&.email
   end
 
   def school_main_contact_role
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
-    return if contacts["school_or_academy"].blank?
+    school_or_academy_contact&.title
+  end
 
-    contact = if @project.establishment_main_contact_id.present?
-      contacts["school_or_academy"].find { |c| c.id == @project.establishment_main_contact_id }
-    else
-      contacts["school_or_academy"].first
-    end
-    contact&.title
+  private def school_or_academy_contact
+    @school_or_academy_contact || ContactsFetcherService.new.school_or_academy_contact(@project)
   end
 end

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -94,4 +94,40 @@ module Export::Csv::SchoolPresenterModule
   end
 
   alias_method :school_sharepoint_link_with_academy_label, :school_sharepoint_folder
+
+  def school_main_contact_name
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["school_or_academy"].blank?
+
+    contact = if @project.establishment_main_contact_id.present?
+      contacts["school_or_academy"].find { |c| c.id == @project.establishment_main_contact_id }
+    else
+      contacts["school_or_academy"].first
+    end
+    contact&.name
+  end
+
+  def school_main_contact_email
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["school_or_academy"].blank?
+
+    contact = if @project.establishment_main_contact_id.present?
+      contacts["school_or_academy"].find { |c| c.id == @project.establishment_main_contact_id }
+    else
+      contacts["school_or_academy"].first
+    end
+    contact&.email
+  end
+
+  def school_main_contact_role
+    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    return if contacts["school_or_academy"].blank?
+
+    contact = if @project.establishment_main_contact_id.present?
+      contacts["school_or_academy"].find { |c| c.id == @project.establishment_main_contact_id }
+    else
+      contacts["school_or_academy"].first
+    end
+    contact&.title
+  end
 end

--- a/app/services/contacts_fetcher_service.rb
+++ b/app/services/contacts_fetcher_service.rb
@@ -13,4 +13,44 @@ class ContactsFetcherService
 
     all_contacts.sort_by(&:name).group_by(&:category)
   end
+
+  def school_or_academy_contact(project)
+    contacts = ContactsFetcherService.new.all_project_contacts(project)
+    return if contacts["school_or_academy"].blank?
+
+    if project.establishment_main_contact_id.present?
+      contacts["school_or_academy"].find { |c| c.id == project.establishment_main_contact_id }
+    else
+      contacts["school_or_academy"].first
+    end
+  end
+
+  def outgoing_trust_contact(project)
+    contacts = ContactsFetcherService.new.all_project_contacts(project)
+    return if contacts["outgoing_trust"].blank?
+
+    if project.outgoing_trust_main_contact_id.present?
+      contacts["outgoing_trust"].find { |c| c.id == project.outgoing_trust_main_contact_id }
+    else
+      contacts["outgoing_trust"].first
+    end
+  end
+
+  def incoming_trust_contact(project)
+    contacts = ContactsFetcherService.new.all_project_contacts(project)
+    return if contacts["incoming_trust"].blank?
+
+    if project.incoming_trust_main_contact_id.present?
+      contacts["incoming_trust"].find { |c| c.id == project.incoming_trust_main_contact_id }
+    else
+      contacts["incoming_trust"].first
+    end
+  end
+
+  def other_contact(project)
+    contacts = ContactsFetcherService.new.all_project_contacts(project)
+    return if contacts["other"].blank?
+
+    contacts["other"].first
+  end
 end

--- a/app/services/export/conversions/funding_agreement_letters_csv_exporter_service.rb
+++ b/app/services/export/conversions/funding_agreement_letters_csv_exporter_service.rb
@@ -10,6 +10,9 @@ class Export::Conversions::FundingAgreementLettersCsvExporterService < Export::C
     school_address_town
     school_address_county
     school_address_postcode
+    school_main_contact_name
+    school_main_contact_email
+    school_main_contact_role
     academy_urn
     academy_name
     academy_address_1
@@ -21,6 +24,9 @@ class Export::Conversions::FundingAgreementLettersCsvExporterService < Export::C
     incoming_trust_identifier
     incoming_trust_companies_house_number
     incoming_trust_name
+    incoming_trust_main_contact_name
+    incoming_trust_main_contact_email
+    incoming_trust_main_contact_role
     incoming_trust_address_1
     incoming_trust_address_2
     incoming_trust_address_3
@@ -57,6 +63,9 @@ class Export::Conversions::FundingAgreementLettersCsvExporterService < Export::C
     main_contact_name
     main_contact_email
     main_contact_title
+    other_contact_name
+    other_contact_email
+    other_contact_role
   ]
 
   def initialize(projects)

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -48,6 +48,7 @@ en:
           incoming_trust_name: Incoming trust name
           incoming_trust_main_contact_name: Incoming trust main contact name
           incoming_trust_main_contact_email: Incoming trust main contact email
+          incoming_trust_main_contact_role: Incoming trust main contact role
           incoming_trust_sharepoint_link: Incoming trust sharepoint link
           incoming_trust_address_1: Incoming trust address 1
           incoming_trust_address_2: Incoming trust address 2
@@ -127,6 +128,12 @@ en:
           school_name_with_academy_label: Academy name
           conversion_type: Conversion type
           esfa_notes: ESFA notes
+          school_main_contact_email: School contact email
+          school_main_contact_name: School contact name
+          school_main_contact_role: School contact role
+          other_contact_name: Other contact name
+          other_contact_email: Other contact email
+          other_contact_role: Other contact role
         values:
           project_type:
             conversion: Conversion

--- a/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
@@ -79,24 +79,6 @@ RSpec.describe Export::Csv::IncomingTrustPresenterModule do
     expect(subject.incoming_trust_main_contact_role).to eql "CEO of Learning"
   end
 
-  context "when there is no main contact ID" do
-    before do
-      allow(project).to receive(:incoming_trust_main_contact_id).and_return(nil)
-    end
-
-    it "presents the next incoming trust contact name" do
-      expect(subject.incoming_trust_main_contact_name).to eql "Jo Example"
-    end
-
-    it "presents the next incoming trust contact email" do
-      expect(subject.incoming_trust_main_contact_email).to eql "jo@example.com"
-    end
-
-    it "presents the next incoming trust contact role" do
-      expect(subject.incoming_trust_main_contact_role).to eql "CEO of Learning"
-    end
-  end
-
   it "presents the sharepoint link" do
     expect(subject.incoming_trust_sharepoint_link).to eql "https://educationgovuk-my.sharepoint.com/incoming-trust-folder"
   end

--- a/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
@@ -75,6 +75,10 @@ RSpec.describe Export::Csv::IncomingTrustPresenterModule do
     expect(subject.incoming_trust_main_contact_email).to eql "jo@example.com"
   end
 
+  it "presents the main contact role" do
+    expect(subject.incoming_trust_main_contact_role).to eql "CEO of Learning"
+  end
+
   context "when there is no main contact ID" do
     before do
       allow(project).to receive(:incoming_trust_main_contact_id).and_return(nil)
@@ -86,6 +90,10 @@ RSpec.describe Export::Csv::IncomingTrustPresenterModule do
 
     it "presents the next incoming trust contact email" do
       expect(subject.incoming_trust_main_contact_email).to eql "jo@example.com"
+    end
+
+    it "presents the next incoming trust contact role" do
+      expect(subject.incoming_trust_main_contact_role).to eql "CEO of Learning"
     end
   end
 

--- a/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
@@ -31,20 +31,6 @@ RSpec.describe Export::Csv::OutgoingTrustPresenterModule do
     expect(subject.outgoing_trust_main_contact_email).to eql "jo@example.com"
   end
 
-  context "when there is no main contact ID" do
-    before do
-      allow(project).to receive(:outgoing_trust_main_contact_id).and_return(nil)
-    end
-
-    it "presents the next outgoing trust contact name" do
-      expect(subject.outgoing_trust_main_contact_name).to eql "Jo Example"
-    end
-
-    it "presents the next outgoing trust contact email" do
-      expect(subject.outgoing_trust_main_contact_email).to eql "jo@example.com"
-    end
-  end
-
   it "presents the outgoing trust identifier" do
     expect(subject.outgoing_trust_identifier).to eql "TR03819"
   end

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -639,6 +639,33 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.conversion_type).to be_nil
   end
 
+  it "presents the first 'other' contact name" do
+    mock_successful_api_response_to_create_any_project
+    project = create(:conversion_project)
+    _contact = create(:project_contact, category: "other", project: project)
+
+    presenter = described_class.new(project)
+    expect(presenter.other_contact_name).to eq("Jo Example")
+  end
+
+  it "presents the first 'other' contact email" do
+    mock_successful_api_response_to_create_any_project
+    project = create(:conversion_project)
+    _contact = create(:project_contact, category: "other", project: project)
+
+    presenter = described_class.new(project)
+    expect(presenter.other_contact_email).to eq("jo@example.com")
+  end
+
+  it "presents the first 'other' contact role" do
+    mock_successful_api_response_to_create_any_project
+    project = create(:conversion_project)
+    _contact = create(:project_contact, category: "other", project: project)
+
+    presenter = described_class.new(project)
+    expect(presenter.other_contact_role).to eq("CEO of Learning")
+  end
+
   def not_applicable_for_a_transfer
     project = build(:transfer_project)
 

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -88,22 +88,6 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
     expect(subject.school_main_contact_role).to eq("CEO of Learning")
   end
 
-  context "when there is no main contact selected" do
-    before { allow(project).to receive(:establishment_main_contact_id).and_return(nil) }
-
-    it "presents the next school contact name" do
-      expect(subject.school_main_contact_name).to eq("Jo Example")
-    end
-
-    it "presents the next school contact email" do
-      expect(subject.school_main_contact_email).to eq("jo@example.com")
-    end
-
-    it "presents the next school contact role" do
-      expect(subject.school_main_contact_role).to eq("CEO of Learning")
-    end
-  end
-
   def known_establishment
     double(
       Api::AcademiesApi::Establishment,

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -1,8 +1,16 @@
 require "rails_helper"
 
 RSpec.describe Export::Csv::SchoolPresenterModule do
-  let(:project) { build(:conversion_project, urn: 121813, establishment: known_establishment) }
+  let(:project) { create(:conversion_project, urn: 121813, establishment: known_establishment) }
+  let(:contact) { create(:project_contact, category: "school_or_academy", project: project) }
+  let(:director_of_child_services) { build(:director_of_child_services) }
   subject { SchoolPresenterModuleTestClass.new(project) }
+
+  before do
+    mock_successful_api_response_to_create_any_project
+    allow(project).to receive(:establishment_main_contact_id).and_return(contact.id)
+    allow(project).to receive(:director_of_child_services).and_return(director_of_child_services)
+  end
 
   it "presents the school urn" do
     expect(subject.school_urn).to eql "121813"
@@ -65,6 +73,34 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
 
     it "presents the academy name" do
       expect(subject.school_name_with_academy_label).to eql "Deanshanger Primary School"
+    end
+  end
+
+  it "presents the school main contact name" do
+    expect(subject.school_main_contact_name).to eq("Jo Example")
+  end
+
+  it "presents the school main contact email" do
+    expect(subject.school_main_contact_email).to eq("jo@example.com")
+  end
+
+  it "presents the school main contact role" do
+    expect(subject.school_main_contact_role).to eq("CEO of Learning")
+  end
+
+  context "when there is no main contact selected" do
+    before { allow(project).to receive(:establishment_main_contact_id).and_return(nil) }
+
+    it "presents the next school contact name" do
+      expect(subject.school_main_contact_name).to eq("Jo Example")
+    end
+
+    it "presents the next school contact email" do
+      expect(subject.school_main_contact_email).to eq("jo@example.com")
+    end
+
+    it "presents the next school contact role" do
+      expect(subject.school_main_contact_role).to eq("CEO of Learning")
     end
   end
 


### PR DESCRIPTION
## Changes

Add more columns to the Funding agreement letters export: School contact details, Incoming trust contact details and "Other" contact details.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
