### PR TITLE
(158810) Add a form to create Form a MAT transfer projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add button to allow users to create form a MAT projects
+- Add a new Form a MAT Transfer create project form
 
 ## [Release-56][release-56]
 

--- a/app/controllers/transfers/projects_controller.rb
+++ b/app/controllers/transfers/projects_controller.rb
@@ -4,6 +4,8 @@ class Transfers::ProjectsController < ApplicationController
     @project = Transfer::CreateProjectForm.new
   end
 
+  alias_method :new_mat, :new
+
   def create
     authorize Transfer::Project
     @project = Transfer::CreateProjectForm.new(**project_params, user: current_user)
@@ -14,6 +16,19 @@ class Transfers::ProjectsController < ApplicationController
       redirect_to project_path(@created_project), notice: I18n.t("transfer_project.created.success")
     else
       render :new
+    end
+  end
+
+  def create_mat
+    authorize Transfer::Project
+    @project = Transfer::CreateProjectForm.new(**project_params, user: current_user)
+
+    if @project.valid?
+      @created_project = @project.save
+
+      redirect_to project_path(@created_project), notice: I18n.t("transfer_project.form_a_mat.created.success")
+    else
+      render :new_mat
     end
   end
 
@@ -61,7 +76,9 @@ class Transfers::ProjectsController < ApplicationController
       :two_requires_improvement,
       :inadequate_ofsted,
       :financial_safeguarding_governance_issues,
-      :outgoing_trust_to_close
+      :outgoing_trust_to_close,
+      :new_trust_name,
+      :new_trust_reference_number
     )
   end
 end

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -45,7 +45,9 @@ class Transfer::CreateProjectForm < CreateProjectForm
       assigned_to: user,
       assigned_at: DateTime.now,
       region: region,
-      tasks_data: Transfer::TasksData.new
+      tasks_data: Transfer::TasksData.new,
+      new_trust_reference_number: new_trust_reference_number,
+      new_trust_name: new_trust_name
     )
 
     return nil unless valid?

--- a/app/views/transfers/projects/new_mat.html.erb
+++ b/app/views/transfers/projects/new_mat.html.erb
@@ -1,0 +1,87 @@
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: root_path} %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("transfer_project.form_a_mat.new.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @project, url: transfers_new_mat_path do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl"><%= t("transfer_project.form_a_mat.new.title") %></h1>
+      <%= t("transfer_project.form_a_mat.new.hint_html") %>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_text_field :urn, label: {size: "m", text: t("helpers.label.transfer_project.urn")}, hint: {text: t("helpers.hint.transfer_project.urn").html_safe}, width: 10 %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_text_field :outgoing_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.outgoing_trust_ukprn").html_safe}, width: 10 %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_text_field :new_trust_reference_number, label: {size: "m"}, width: 10 %>
+        <%= form.govuk_text_field :new_trust_name, label: {size: "m"} %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.establishment_sharepoint_link")} %>
+        <%= form.govuk_text_field :incoming_trust_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.incoming_trust_sharepoint_link")} %>
+        <%= form.govuk_text_field :outgoing_trust_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_sharepoint_link")} %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_date_field :advisory_board_date, legend: {text: t("helpers.legend.transfer_project.advisory_board_date")}, form_group: {id: "advisory-board-date"}, hint: {text: t("helpers.hint.project.advisory_board_date").html_safe} %>
+        <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m", text: t("helpers.label.transfer_project.advisory_board_conditions")} %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_date_field :provisional_transfer_date, legend: {text: t("helpers.legend.transfer_project.provisional_transfer_date")}, omit_day: true, form_group: {id: "provisional-transfer-date"}, hint: {text: t("helpers.hint.transfer_project.provisional_transfer_date")} %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_collection_radio_buttons :two_requires_improvement,
+              @project.yes_no_responses,
+              :id,
+              :name,
+              form_group: {id: "two-requires-improvement"},
+              hint: {text: t("helpers.hint.transfer_project.two_requires_improvement")} %>
+
+        <%= form.govuk_collection_radio_buttons :inadequate_ofsted,
+              @project.yes_no_responses,
+              :id,
+              :name,
+              form_group: {id: "inadequate-ofsted"} %>
+
+        <%= form.govuk_collection_radio_buttons :financial_safeguarding_governance_issues,
+              @project.yes_no_responses,
+              :id,
+              :name,
+              form_group: {id: "financial-safeguarding-governance-issues"} %>
+
+        <%= form.govuk_collection_radio_buttons :outgoing_trust_to_close,
+              @project.yes_no_responses,
+              :id,
+              :name,
+              form_group: {id: "outgoing-trust-to-close"} %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team,
+              @project.yes_no_responses,
+              :id,
+              :name,
+              form_group: {id: "assigned-to-regional-caseworker-team"},
+              legend: {text: t("helpers.legend.transfer_project.assigned_to_regional_caseworker_team")} %>
+        <%= form.govuk_text_area :handover_note_body,
+              label: {text: t("helpers.label.transfer_project.handover_note_body"), size: "m"},
+              hint: {text: t("helpers.hint.transfer_project.handover_note_body_html")} %>
+      </div>
+
+      <%= form.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -21,6 +21,12 @@ en:
       outgoing_trust: Outgoing trust
       transfer_date: Transfer date
       region: Region
+    form_a_mat:
+      new:
+        title: Add a form a MAT transfer
+        hint_html: <p class="govuk-body">Enter information about the academy, the new MAT (multi-academy trust) and the advisory board's decision about this academy's transfer.</p><p class="govuk-body">This will create a new transfer project.</p>
+      created:
+        success: Form a MAT transfer project successfully created
   helpers:
     label:
       transfer_project:
@@ -34,6 +40,9 @@ en:
         incoming_trust_sharepoint_link: Incoming trust SharePoint link
         outgoing_trust_sharepoint_link: Outgoing trust SharePoint link
         handover_note_body: Handover comments
+      transfer_create_project_form:
+        new_trust_reference_number: Trust reference number (TRN)
+        new_trust_name: Trust name
     legend:
       transfer_project:
         advisory_board_date: Date of advisory board
@@ -69,6 +78,23 @@ en:
             <li>any finanical package that has been finalised and agreed</li>
           </ul>
         two_requires_improvement: If an academy receives 2 or more requires improvement ratings (2RI) from Ofsted, it can be transferred to a different trust to improve performance.
+      transfer_create_project_form:
+        new_trust_name: Enter the proposed name for the new trust. This can be changed later on if necessary.
+        new_trust_reference_number_html:
+          <p>You can find the TRN in the <a href="https://educationgovuk.sharepoint.com/:x:/s/TrustandAcademyManagementServiceTRAMSPrivateBeta/ETyRXN0eIYxOmCVHTqWxSLYBQvHdfWicu7NybUaDeiz88g">new trusts spreadsheet (opens in new tab)</a>.</p>
+        establishment_sharepoint_link: Provide a link to the SharePoint folder for this academy. This is where you save all the relevant academy documents.
+        incoming_trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
+        outgoing_trust_sharepoint_link: Provide a link to the SharePoint folder for the outgoing trust. This is where you save all the relevant trust documents.
+        advisory_board_conditions: Enter details of conditions that must be met before the school or academy can transfer.
+        handover_note_body_html:
+          <p>You must describe how the project has progressed so far and highlight any issues or concerns.</p>
+          <p>Include information about:</p>
+          <ul>
+          <li>which version of the master funding agreement the incoming trust uses</li>
+          <li>if the introduction and next steps email been sent to the trusts</li>
+          <li>who the Schools Financial Support and Oversight lead is</li>
+          <li>any finanical package that has been finalised and agreed</li>
+          </ul>
   errors:
     attributes:
       provisional_transfer_date:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,7 +93,9 @@ Rails.application.routes.draw do
     end
     namespace :transfers do
       get "new", to: "projects#new"
+      get "new_mat", to: "projects#new_mat"
       post "/", to: "projects#create"
+      post "new_mat", to: "projects#create_mat", as: :create_mat
       get ":id", to: "projects#edit", as: :edit
       post ":id", to: "projects#update", as: :update
     end

--- a/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
+++ b/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
@@ -1,43 +1,83 @@
 require "rails_helper"
 
-RSpec.feature "Users can create new conversion projects" do
+RSpec.feature "Users can create new transfer projects" do
   let(:regional_delivery_officer) { create(:user, :regional_delivery_officer) }
 
-  before do
-    sign_in_with_user(regional_delivery_officer)
-    visit transfers_new_path
-  end
+  context "single transferer projects" do
+    before do
+      sign_in_with_user(regional_delivery_officer)
+      visit transfers_new_path
+    end
 
-  context "when the URN and UKPRN are valid" do
-    let(:urn) { 123456 }
-    let(:incoming_ukprn) { 10061021 }
-    let(:outgoing_ukprn) { 10090252 }
-    let(:two_weeks_ago) { Date.today - 2.weeks }
-    let(:two_months_time) { Date.today + 2.months }
+    context "when the URN and UKPRN are valid" do
+      let(:urn) { 123456 }
+      let(:incoming_ukprn) { 10061021 }
+      let(:outgoing_ukprn) { 10090252 }
+      let(:new_trust_reference_number) { nil }
+      let(:two_weeks_ago) { Date.today - 2.weeks }
+      let(:two_months_time) { Date.today + 2.months }
 
-    before { mock_all_academies_api_responses }
+      before { mock_all_academies_api_responses }
 
-    scenario "a new project is created" do
-      fill_in_form
+      scenario "a new project is created" do
+        fill_in_form
 
-      click_button("Continue")
+        click_button("Continue")
 
-      expect(page).to have_content(I18n.t("transfer_project.created.success"))
-      expect(Transfer::Project.count).to eq(1)
+        expect(page).to have_content(I18n.t("transfer_project.created.success"))
+        expect(Transfer::Project.count).to eq(1)
+      end
+    end
+
+    context "when required values are not supplied" do
+      scenario "error messages are shown to the user" do
+        click_button("Continue")
+
+        expect(page).to have_content("There is a problem")
+      end
     end
   end
 
-  context "when required values are not supplied" do
-    scenario "error messages are shown to the user" do
-      click_button("Continue")
+  context "form a MAT transfer projects" do
+    before do
+      sign_in_with_user(regional_delivery_officer)
+      visit transfers_new_mat_path
+    end
 
-      expect(page).to have_content("There is a problem")
+    context "when the URN, UKPRN and new Trust reference number are valid" do
+      let(:urn) { 123456 }
+      let(:outgoing_ukprn) { 10090252 }
+      let(:incoming_ukprn) { nil }
+      let(:new_trust_reference_number) { "TR12345" }
+      let(:two_weeks_ago) { Date.today - 2.weeks }
+      let(:two_months_time) { Date.today + 2.months }
+
+      before { mock_all_academies_api_responses }
+
+      scenario "a new project is created" do
+        fill_in_form
+
+        click_button("Continue")
+
+        expect(page).to have_content(I18n.t("transfer_project.form_a_mat.created.success"))
+        expect(Transfer::Project.count).to eq(1)
+      end
+    end
+
+    context "when required values are not supplied" do
+      scenario "error messages are shown to the user" do
+        click_button("Continue")
+
+        expect(page).to have_content("There is a problem")
+      end
     end
   end
 
   def fill_in_form
     fill_in "Academy URN", with: urn
-    fill_in "Incoming trust UKPRN", with: incoming_ukprn
+    fill_in "Incoming trust UKPRN", with: incoming_ukprn if incoming_ukprn
+    fill_in "Trust reference number (TRN)", with: new_trust_reference_number if new_trust_reference_number
+    fill_in "Trust name", with: "New Trust" if new_trust_reference_number
     fill_in "Outgoing trust UKPRN (UK Provider Reference Number)", with: outgoing_ukprn
 
     fill_in "Academy SharePoint link", with: "https://educationgovuk-my.sharepoint.com/school-folder"


### PR DESCRIPTION


## Changes

This form is available at `/projects/transfers/new_mat` and will create a new "Form a MAT" transfer project. This is much like the form created for "Form a MAT" conversions in https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/1355

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
