### PR TITLE
(158871) Temporarily remove the future date validation on project creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Remove maintenance banner for Wednesday 6th March 2024 maintenance
+- Temporarily remove the future date validation for the provisional conversion/
+  transfer date on project creation
 
 ### Fixed
 

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -6,7 +6,7 @@ class Conversion::CreateProjectForm < CreateProjectForm
   attr_reader :provisional_conversion_date
 
   validates :provisional_conversion_date, presence: true
-  validates :provisional_conversion_date, date_in_the_future: true, first_day_of_month: true
+  validates :provisional_conversion_date, first_day_of_month: true
 
   validates :urn, presence: true, existing_academy: true
   validate :urn_unique_for_in_progress_conversions, if: -> { urn.present? }

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -9,7 +9,7 @@ class Transfer::CreateProjectForm < CreateProjectForm
 
   validates :outgoing_trust_ukprn, presence: true, ukprn: true
   validates :provisional_transfer_date, presence: true
-  validates :provisional_transfer_date, date_in_the_future: true, first_day_of_month: true
+  validates :provisional_transfer_date, first_day_of_month: true
   validates :assigned_to_regional_caseworker_team, inclusion: {in: [true, false]}
   validates :two_requires_improvement, inclusion: {in: [true, false], message: I18n.t("errors.transfer_project.attributes.two_requires_improvement.inclusion")}
   validates :inadequate_ofsted, inclusion: {in: [true, false], message: I18n.t("errors.transfer_project.attributes.inadequate_ofsted.inclusion")}

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -108,28 +108,6 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
     describe "provisional_conversion_date" do
       it { is_expected.to validate_presence_of(:provisional_conversion_date) }
 
-      it "must be in the future" do
-        form = build(
-          form_factory.to_sym,
-          provisional_conversion_date: {3 => 1, 2 => 1, 1 => 2030}
-        )
-        expect(form).to be_valid
-
-        form.provisional_conversion_date = {3 => 1, 2 => 1, 1 => 2020}
-        expect(form).to be_invalid
-      end
-
-      it "cannot be in the past" do
-        form = build(
-          form_factory.to_sym,
-          provisional_conversion_date: {3 => 1, 2 => 1, 1 => 2030}
-        )
-        expect(form).to be_valid
-
-        form.provisional_conversion_date = {3 => 1, 2 => 1, 1 => 2020}
-        expect(form).to be_invalid
-      end
-
       context "when the date params are partially complete" do
         it "treats the date as invalid" do
           form = build(form_factory.to_sym, provisional_conversion_date: {3 => 1, 2 => 10, 1 => nil})

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -82,14 +82,6 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
 
     describe "#provisional_transfer_date" do
       it { is_expected.to validate_presence_of(:provisional_transfer_date) }
-
-      it "must be in the future" do
-        form = build(:create_transfer_project_form, provisional_transfer_date: {3 => 1, 2 => 1, 1 => 2030})
-        expect(form).to be_valid
-
-        form.provisional_transfer_date = {3 => 1, 2 => 1, 1 => 2020}
-        expect(form).to be_invalid
-      end
     end
 
     describe "#check_incoming_trust_and_outgoing_trust" do


### PR DESCRIPTION
We usually validate the provisional conversion/transfer date on a project to always be in the future. However, as we are asking users to input historical projects into Complete ahead of KIM shutting down, we need to loosen this validation rule to allow projects with conversion/transfer dates in the past to be added to the system.

We can re-introduce this validation at a later date.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
