### PR TITLE
Remove the maintenance banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Remove maintenance banner for Wednesday 6th March 2024 maintenance
+
 ### Fixed
 
-- GUard against incomplete MP details from the Members API (bugfix from
+- Guard against incomplete MP details from the Members API (bugfix from
   production)
 
 ## [Release-55][release-55]

--- a/app/views/all/in_progress/projects/index.html.erb
+++ b/app/views/all/in_progress/projects/index.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "shared/maintenance_banner" %>
-
 <% content_for :primary_navigation do %>
   <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
 <% end %>

--- a/app/views/service_support/projects/without_academy_urn.html.erb
+++ b/app/views/service_support/projects/without_academy_urn.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "shared/maintenance_banner" %>
-
 <% content_for :primary_navigation do %>
   <%= render partial: "shared/navigation/service_support_primary_navigation" %>
 <% end %>

--- a/app/views/your/projects/in_progress.html.erb
+++ b/app/views/your/projects/in_progress.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: "shared/maintenance_banner" %>
-
 <% content_for :primary_navigation do %>
   <%= render partial: "shared/navigation/your_projects_primary_navigation" %>
 <% end %>


### PR DESCRIPTION
We'll keep the banner for future use and remove the places it was
rendered.
