### PR TITLE
(Fix) Handle incomplete member details from the Parliamentary Members API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- GUard against incomplete MP details from the Members API (bugfix from
+  production)
+
 ## [Release-55][release-55]
 
 ### Added

--- a/app/models/api/members_api/member_details.rb
+++ b/app/models/api/members_api/member_details.rb
@@ -5,11 +5,11 @@ class Api::MembersApi::MemberDetails
   end
 
   def name
-    @member_name.name_display_as
+    @member_name&.name_display_as
   end
 
   def email
-    @member_contact_details.email
+    @member_contact_details&.email
   end
 
   def address
@@ -23,17 +23,17 @@ class Api::MembersApi::MemberDetails
 
   private def address_lines
     all_address_lines = [
-      @member_contact_details.line1,
-      @member_contact_details.line2,
-      @member_contact_details.line3,
-      @member_contact_details.line4,
-      @member_contact_details.line5
+      @member_contact_details&.line1,
+      @member_contact_details&.line2,
+      @member_contact_details&.line3,
+      @member_contact_details&.line4,
+      @member_contact_details&.line5
     ]
 
     all_address_lines.compact_blank
   end
 
   private def address_postcode
-    @member_contact_details.postcode
+    @member_contact_details&.postcode
   end
 end

--- a/spec/models/api/members_api/member_details_spec.rb
+++ b/spec/models/api/members_api/member_details_spec.rb
@@ -10,6 +10,17 @@ RSpec.describe Api::MembersApi::MemberDetails do
 
       expect(member_details.name).to eql "Member Parliment"
     end
+
+    context "if the member name is nil" do
+      it "returns nil" do
+        mp_name = nil
+        mp_contact_details = double
+
+        member_details = described_class.new(mp_name, mp_contact_details)
+
+        expect(member_details.name).to be_nil
+      end
+    end
   end
 
   describe "#email" do
@@ -20,6 +31,17 @@ RSpec.describe Api::MembersApi::MemberDetails do
       member_details = described_class.new(mp_name, mp_contact_details)
 
       expect(member_details.email).to eql "member.parliment@parliment.uk"
+    end
+
+    context "if the member contact details is nil" do
+      it "returns nil" do
+        mp_name = double
+        mp_contact_details = nil
+
+        member_details = described_class.new(mp_name, mp_contact_details)
+
+        expect(member_details.email).to be_nil
+      end
     end
   end
 
@@ -63,6 +85,20 @@ RSpec.describe Api::MembersApi::MemberDetails do
         expect(member_details.address.line2).to eql "London"
         expect(member_details.address.line3).to be_nil
         expect(member_details.address.postcode).to eql "SW1A 0AA"
+      end
+    end
+
+    context "if the member contact details is nil" do
+      it "returns an empty struct" do
+        mp_name = double
+        mp_contact_details = nil
+
+        member_details = described_class.new(mp_name, mp_contact_details)
+
+        expect(member_details.address.line1).to be_nil
+        expect(member_details.address.line2).to be_nil
+        expect(member_details.address.line3).to be_nil
+        expect(member_details.address.postcode).to be_nil
       end
     end
   end


### PR DESCRIPTION

We were having an error on production related to an incomplete or missing MP details record from the Parliamentary Members API:

```
undefined method `email' for nil:NilClass @member_contact_details.email
```

It seems the MP details are not totally missing, otherwise the guard on `app/presenters/export/csv/mp_presenter_module.rb:9` `Export::Csv::MpPresenterModule#mp_email`
would have caught it.

This fix should guard against the error reoccurring.

