### PR TITLE
(Fix) Correct Changelog entry for Funding agreement letters PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   conversion task list.
 - A new confirm the date the academy transferred task has been added to the
   transfer task list.
+- Add more contact details to the Funding agreement letters export: School
+  contact, Incoming trust contact and "Other" contact
 
 ## [Release-56][release-56]
 
@@ -37,11 +39,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Guard against incomplete MP details from the Members API (bugfix from
   production)
-
-### Added
-
-- Add more contact details to the Funding agreement letters export: School
-  contact, Incoming trust contact and "Other" contact
 
 ## [Release-55][release-55]
 


### PR DESCRIPTION
Due to a merge error, the Changelog entry for PR
https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/1400 has ended up in the wrong spot.
