### PR TITLE
(158812) Add a button to allow users to create a new Form a MAT Transfer project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Add button to allow users to create form a MAT projects
+- Add button to allow users to create form a MAT conversion projects
 - Add a new Form a MAT Transfer create project form
 - Show a pink "Form a MAT" label on the project details page if a transfer
   project is a form a MAT project
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add more contact details to the Funding agreement letters export: School
   contact, Incoming trust contact and "Other" contact
 - Show `Form a MAT` or `single transfer` in the exports for Transfer projects
+- Add button to allow users to create form a MAT transfer projects
 
 ## [Release-56][release-56]
 

--- a/app/views/projects/shared/_new_projects.html.erb
+++ b/app/views/projects/shared/_new_projects.html.erb
@@ -12,5 +12,9 @@
           transfers_new_path,
           class: "govuk-button",
           data: {module: "govuk-button"} %>
+    <%= link_to t("transfer_project.form_a_mat.new.title"),
+          transfers_new_mat_path,
+          class: "govuk-button",
+          data: {module: "govuk-button"} %>
   </div>
 <% end %>

--- a/spec/requests/project_management_spec.rb
+++ b/spec/requests/project_management_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Project management" do
         expect(response.body).to include(I18n.t("conversion_project.new.title"))
         expect(response.body).to include(I18n.t("conversion_project.form_a_mat.new.title"))
         expect(response.body).to include(I18n.t("transfer_project.new.title"))
+        expect(response.body).to include(I18n.t("transfer_project.form_a_mat.new.title"))
       end
     end
 
@@ -35,6 +36,7 @@ RSpec.describe "Project management" do
         expect(response.body).to include(I18n.t("conversion_project.new.title"))
         expect(response.body).to include(I18n.t("conversion_project.form_a_mat.new.title"))
         expect(response.body).to include(I18n.t("transfer_project.new.title"))
+        expect(response.body).to include(I18n.t("transfer_project.form_a_mat.new.title"))
       end
     end
 
@@ -54,6 +56,7 @@ RSpec.describe "Project management" do
         expect(response.body).not_to include(I18n.t("conversion_project.new.title"))
         expect(response.body).not_to include(I18n.t("conversion_project.form_a_mat.new.title"))
         expect(response.body).not_to include(I18n.t("transfer_project.new.title"))
+        expect(response.body).not_to include(I18n.t("transfer_project.form_a_mat.new.title"))
       end
     end
   end


### PR DESCRIPTION

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
