### PR TITLE
(157070) Show the date a transfer happened (if available) in the Grant management export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   contact, Incoming trust contact and "Other" contact
 - Show `Form a MAT` or `single transfer` in the exports for Transfer projects
 - Add button to allow users to create form a MAT transfer projects
+- Show the date a transfer happened in the Grant management export
 
 ## [Release-56][release-56]
 

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -47,6 +47,13 @@ class Export::Csv::ProjectPresenter
     @project.significant_date.to_fs(:csv)
   end
 
+  def date_academy_transferred
+    return nil if @project.is_a?(Conversion::Project)
+    return I18n.t("export.csv.project.values.unconfirmed") if @project.tasks_data.confirm_date_academy_transferred_date_transferred.nil?
+
+    @project.tasks_data.confirm_date_academy_transferred_date_transferred.to_fs(:csv)
+  end
+
   def all_conditions_met
     if @project.all_conditions_met.nil?
       return I18n.t("export.csv.project.values.no")

--- a/app/services/export/transfers/grant_management_and_finance_unit_csv_export_service.rb
+++ b/app/services/export/transfers/grant_management_and_finance_unit_csv_export_service.rb
@@ -16,6 +16,7 @@ class Export::Transfers::GrantManagementAndFinanceUnitCsvExportService < Export:
     advisory_board_date
     provisional_date
     transfer_date
+    date_academy_transferred
     added_by_email
     assigned_to_email
     link_to_project

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -135,6 +135,7 @@ en:
           other_contact_name: Other contact name
           other_contact_email: Other contact email
           other_contact_role: Other contact role
+          date_academy_transferred: Date the transfer happened
         values:
           project_type:
             conversion: Conversion

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -223,6 +223,22 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.transfer_date).to eql "unconfirmed"
   end
 
+  it "presents the actual transfer date" do
+    tasks_data = double(Transfer::TasksData, confirm_date_academy_transferred_date_transferred: Date.parse("2023-1-1"))
+    project = double(Transfer::Project, tasks_data: tasks_data)
+    presenter = described_class.new(project)
+
+    expect(presenter.date_academy_transferred).to eq("2023-01-01")
+  end
+
+  it "presents unconfirmed when the project doesn't have an actual transfer date" do
+    tasks_data = double(Transfer::TasksData, confirm_date_academy_transferred_date_transferred: nil)
+    project = double(Transfer::Project, tasks_data: tasks_data)
+    presenter = described_class.new(project)
+
+    expect(presenter.date_academy_transferred).to eq(I18n.t("export.csv.project.values.unconfirmed"))
+  end
+
   it "presents all conditions met" do
     project = double(Conversion::Project, all_conditions_met: true)
 


### PR DESCRIPTION
## Changes

Show the date a transfer actually happened in the Grant management and finance unit export. Show "unconfirmed" if the value has not yet been entered.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
