### PR TITLE
Allow database timeout to be set

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -7,6 +7,7 @@ default: &default
   username: <%= ENV["DATABASE_USER"] %>
   password: <%= ENV["DATABASE_PASSWORD"] %>
   host: <%= ENV["DATABASE_HOST"] %>
+  timeout: <%= ENV["DATABASE_TIMEOUT"] || 5000 %>
 
 development:
   <<: *default


### PR DESCRIPTION
We have some BIG, unoptimised queries that are taking too long so we see
timeouts. We want to increase the time the application will wait for a
query to see if we can improved things in the short term.

The default for TinyTDS and so SQLServer is 5 seconds:

https://github.com/rails-sqlserver/tiny_tds?tab=readme-ov-file#tinytdsclient-usage

Although the value is supplied in milliseconds in the Rails
database.yml:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/c0088ce4193a6b70d89ed4d4123bf8b388e92cc0/lib/active_record/connection_adapters/sqlserver_adapter.rb#L106

