### PR TITLE
(159072) Transfer confirm support grant task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Show the date a transfer happened in the Grant management export
 - The Confirm transfer grant funding level task has been added to transfer
   project task lists
+- The Confirm transfer grant funding level value is included in the Grant
+  management and finance unit export
 
 ## [Release-56][release-56]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Show `Form a MAT` or `single transfer` in the exports for Transfer projects
 - Add button to allow users to create form a MAT transfer projects
 - Show the date a transfer happened in the Grant management export
+- The Confirm transfer grant funding level task has been added to transfer
+  project task lists
 
 ## [Release-56][release-56]
 

--- a/app/forms/transfer/task/sponsored_support_grant_task_form.rb
+++ b/app/forms/transfer/task/sponsored_support_grant_task_form.rb
@@ -1,0 +1,7 @@
+class Transfer::Task::SponsoredSupportGrantTaskForm < BaseOptionalTaskForm
+  attribute :type, :string
+
+  def type_options
+    Transfer::TasksData.sponsored_support_grant_types.values
+  end
+end

--- a/app/models/transfer/task_list.rb
+++ b/app/models/transfer/task_list.rb
@@ -8,6 +8,7 @@ class Transfer::TaskList < ::BaseTaskList
           Transfer::Task::StakeholderKickOffTaskForm,
           Transfer::Task::MainContactTaskForm,
           Transfer::Task::RequestNewUrnAndRecordTaskForm,
+          Transfer::Task::SponsoredSupportGrantTaskForm,
           Transfer::Task::CheckAndConfirmFinancialInformationTaskForm
         ]
       },

--- a/app/models/transfer/tasks_data.rb
+++ b/app/models/transfer/tasks_data.rb
@@ -6,4 +6,12 @@ class Transfer::TasksData < ActiveRecord::Base
   def self.policy_class
     TaskListPolicy
   end
+
+  enum :sponsored_support_grant_type,
+    {
+      standard: "standard",
+      fast_track: "fast_track",
+      intermediate: "intermediate",
+      full_sponsored: "full_sponsored"
+    }
 end

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -147,6 +147,14 @@ class Export::Csv::ProjectPresenter
     I18n.t("export.csv.project.values.sponsored_grant_type.#{@project.tasks_data.sponsored_support_grant_type}")
   end
 
+  def transfer_grant_level
+    return I18n.t("export.csv.project.values.not_applicable") if @project.is_a?(Conversion::Project)
+    return I18n.t("export.csv.project.values.not_applicable") if @project.tasks_data.sponsored_support_grant_not_applicable?
+    return I18n.t("export.csv.project.values.unconfirmed") if @project.tasks_data.sponsored_support_grant_type.nil?
+
+    I18n.t("export.csv.project.values.sponsored_grant_type.#{@project.tasks_data.sponsored_support_grant_type}")
+  end
+
   def assigned_to_name
     return I18n.t("export.csv.project.values.unassigned") unless @project.assigned_to.present?
 

--- a/app/services/export/transfers/grant_management_and_finance_unit_csv_export_service.rb
+++ b/app/services/export/transfers/grant_management_and_finance_unit_csv_export_service.rb
@@ -13,6 +13,7 @@ class Export::Transfers::GrantManagementAndFinanceUnitCsvExportService < Export:
     outgoing_trust_to_close
     academy_surplus_deficit
     trust_surplus_deficit
+    transfer_grant_level
     advisory_board_date
     provisional_date
     transfer_date

--- a/app/views/transfers/tasks/sponsored_support_grant/edit.html.erb
+++ b/app/views/transfers/tasks/sponsored_support_grant/edit.html.erb
@@ -1,0 +1,44 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "transfers/tasks/shared/back_link", locals: {project_id: @project.id} %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.sponsored_support_grant.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
+      <div class="govuk-form-group govuk-!-margin-bottom-9">
+        <%= form.govuk_radio_buttons_fieldset(:type, legend: {size: "l", text: t("transfer.task.sponsored_support_grant.type_of_grant.radio_buttons.title")}) do %>
+          <div class="app-task-section__hint">
+            <%= t("transfer.task.sponsored_support_grant.type_of_grant.radio_buttons.hint.html") %>
+          </div>
+          <%= govuk_details(
+                summary_text: t("transfer.task.sponsored_support_grant.type_of_grant.radio_buttons.guidance_link"),
+                text: t("transfer.task.sponsored_support_grant.type_of_grant.radio_buttons.guidance.html")
+              ) %>
+        <% @task.type_options.each do |option| %>
+          <%= form.govuk_radio_button :type,
+                option,
+                label: {text: t("transfer.task.sponsored_support_grant.type_of_grant.radio_buttons.responses.#{option}")} %>
+        <% end %>
+      <% end %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -15,6 +15,7 @@ en:
           twelve_or_above_years: Proposed capacity for students in year 12 or above
           two_requires_improvement: 2RI (Two Requires Improvement)
           sponsored_grant_type: Sponsored Grant Type
+          transfer_grant_level: Transfer grant level
           assigned_to_name: Assigned to name
           assigned_to_email: Assigned to email
           school_urn: School URN
@@ -142,6 +143,7 @@ en:
             conversion: Conversion
             transfer: Transfer
           sponsored_grant_type:
+            standard: standard transfer grant
             full_sponsored: full sponsored
             fast_track: fast track
             intermediate: intermediate

--- a/config/locales/transfer/tasks/sponsored_support_grant.en.yml
+++ b/config/locales/transfer/tasks/sponsored_support_grant.en.yml
@@ -1,0 +1,67 @@
+en:
+  transfer:
+    task:
+      sponsored_support_grant:
+        title: Confirm transfer grant funding level
+        hint:
+          html:
+            <p>Transfer funding grants are only usually available in intervention cases.</p>
+            <p>This includes transfers due to:</p>
+            <ul>
+              <li>an inadequate rating in an Ofsted inspection</li>
+              <li>intervention by DfE following at least 2 requires improvement ratings in Ofsted inspections</li>
+              <li>intervention due to financial, governance or safeguarding concerns</li>
+            </ul>
+            <p>Others transferring for other reasons may also be able to access this funding. This is judged on a case-by-case basis.</p>
+        guidance_link: Grant amounts, eligibility and guidance
+        guidance:
+          html:
+            <p>Each eligible transfer will get £25,000 as a standard level of funding.</p>
+            <p>This is adjusted if the academy transferring has a budget surplus. The incoming trust must use bugdet surplus to pay for transfer costs before using transfer grant funding.</p>
+            <p>In some circumstances, they might be entitled to a larger grant. There are 3 levels of funding money that can be added to the transfer grant:</p>
+            <ul>
+              <li>fast track</li>
+              <li>intermediate</li>
+              <li>full sponsored</li>
+            </ul>
+            <p>The following amounts all include the £25,000 basic level of transfer grant funding.</p>
+            <p>Fast track grant amounts are:</p>
+            <ul>
+              <li>£70,000 for primary and special academies</li>
+              <li>£80,000 for secondary and all through academies</li>
+            </ul>
+            <p>Intermediate grant amounts are:</p>
+            <ul>
+              <li>£90,000 for primary and special academies</li>
+              <li>£115,000 for secondary and all-through academies</li>
+            </ul>
+            <p>Full sponsored grant amounts are:</p>
+            <ul>
+              <li>£110,000 for primary and special academies</li>
+              <li>£150,000 secondary and all-through academies</li>
+            </ul>
+            <p>Any funding up to £100,000 must be approved by the director of the National Directorate.</p>
+            <p>Any funding of £100,000 or more must be approved by the Director General for Regions Group.</p>
+            <p>You can <a href="https://educationgovuk.sharepoint.com/:w:/r/sites/lvedfe00116/WorkplaceDocuments/ARDG%20Internal%20Guidance/6.%20Taking%20action%20with%20underperforming%20open%20academies%20and%20free%20schools/Academy%20transfer/Academy%20Transfer%20Project/Academy%20Transfer%20Grant%20Funding%20.docx?d=w622ba523f15d429695bc8c2950091ea0&csf=1&web=1&e=rENLif" target="_blank">read the transfer grant funding guidance Word document (opens in new tab)</a> for more in-depth advice and support.</p>
+        not_applicable:
+          title: Not applicable
+        type_of_grant:
+          radio_buttons:
+            title: What level of transfer grant funding is required?
+            hint:
+              html:
+                <p>Confirm if the incoming trust will receive the standard transfer grant funding amout, or a higher level of fast track, intermediate or full sponsored grant.</p>
+                <p>This can be changed later on if the trust finds they need more money.</p>
+            guidance_link: Changing the grant amount if the trust needs more funding later
+            guidance:
+              html:
+                <p>Trusts can discover new information that means they might need more funding than they first thought they would.</p>
+                <p>When this happens, speak to your regional director. They will need to approve the new grant amount. You may need to write a business case for the additional funding.</p>
+                <p>When the new funding is agreed and approved, the trust will need to complete a new grant claim form and send it to the grants team.</p>
+                <p>You can then come back to this task and update the grant type information.</p>
+            responses:
+              standard: Standard transfer grant
+              fast_track: Fast track
+              intermediate: Intermediate
+              full_sponsored: Full sponsored
+            guidance_link: Changing the grant amount if the trust needs more funding later

--- a/db/migrate/20240311084953_add_transfer_sponsored_support_grant_task_attributes.rb
+++ b/db/migrate/20240311084953_add_transfer_sponsored_support_grant_task_attributes.rb
@@ -1,0 +1,6 @@
+class AddTransferSponsoredSupportGrantTaskAttributes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :transfer_tasks_data, :sponsored_support_grant_not_applicable, :boolean, default: false
+    add_column :transfer_tasks_data, :sponsored_support_grant_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_06_112000) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_11_084953) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -394,6 +394,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_06_112000) do
     t.string "check_and_confirm_financial_information_academy_surplus_deficit"
     t.string "check_and_confirm_financial_information_trust_surplus_deficit"
     t.date "confirm_date_academy_transferred_date_transferred"
+    t.boolean "sponsored_support_grant_not_applicable", default: false
+    t.string "sponsored_support_grant_type"
   end
 
   create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
+++ b/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
@@ -40,6 +40,7 @@ RSpec.feature "Users can complete transfer tasks" do
     bank_details_changing
     check_and_confirm_financial_information
     confirm_date_academy_transferred
+    sponsored_grant_type
   ]
 
   it "confirms that all tasks are tested here" do
@@ -90,6 +91,60 @@ RSpec.feature "Users can complete transfer tasks" do
   end
 
   describe "tasks with collected data" do
+    describe "the sponsored support grant task" do
+      before do
+        visit project_tasks_path(project)
+        click_on "Confirm transfer grant funding level"
+      end
+
+      scenario "the response can be standard" do
+        choose "Standard transfer grant"
+        click_on I18n.t("task_list.continue_button.text")
+
+        expect(project.reload.tasks_data.sponsored_support_grant_type).to eq "standard"
+      end
+
+      scenario "the response can be fast track" do
+        choose "Fast track"
+        click_on I18n.t("task_list.continue_button.text")
+
+        expect(project.reload.tasks_data.sponsored_support_grant_type).to eq "fast_track"
+      end
+
+      scenario "the response can be intermediate" do
+        choose "Intermediate"
+        click_on I18n.t("task_list.continue_button.text")
+
+        expect(project.reload.tasks_data.sponsored_support_grant_type).to eq "intermediate"
+      end
+
+      scenario "the response can be full sponsored" do
+        choose "Full sponsored"
+        click_on I18n.t("task_list.continue_button.text")
+
+        expect(project.reload.tasks_data.sponsored_support_grant_type).to eq "full_sponsored"
+      end
+
+      scenario "the task can be completed" do
+        choose "Full sponsored"
+        page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
+        # uncheck the Not applicable box
+        page.find(".govuk-checkboxes__label", text: "Not applicable").click
+        click_on I18n.t("task_list.continue_button.text")
+
+        table_row = page.find("li.app-task-list__item", text: I18n.t("transfer.task.sponsored_support_grant.title"))
+        expect(table_row).to have_content("Completed")
+      end
+
+      scenario "the task can be marked as Not applicable" do
+        page.find(".govuk-checkboxes__label", text: "Not applicable").click
+        click_on I18n.t("task_list.continue_button.text")
+
+        table_row = page.find("li.app-task-list__item", text: I18n.t("transfer.task.sponsored_support_grant.title"))
+        expect(table_row).to have_content("Not applicable")
+      end
+    end
+
     describe "the check_and_confirm_financial_information task" do
       before do
         visit project_tasks_path(project)

--- a/spec/models/transfer/task_list_spec.rb
+++ b/spec/models/transfer/task_list_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Transfer::TaskList do
         :stakeholder_kick_off,
         :main_contact,
         :request_new_urn_and_record,
+        :sponsored_support_grant,
         :check_and_confirm_financial_information,
         :form_m,
         :land_consent_letter,
@@ -51,7 +52,7 @@ RSpec.describe Transfer::TaskList do
       project = create(:transfer_project)
       task_list = described_class.new(project, user)
 
-      expect(task_list.tasks.count).to eql 23
+      expect(task_list.tasks.count).to eql 24
       expect(task_list.tasks.first).to be_a Transfer::Task::HandoverTaskForm
       expect(task_list.tasks.last).to be_a Transfer::Task::RedactAndSendDocumentsTaskForm
     end

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -140,43 +140,125 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.bank_details_changing).to eql "no"
   end
 
-  it "presents the sponsored grant type" do
-    tasks_data = double(Conversion::TasksData, sponsored_support_grant_type: nil, sponsored_support_grant_not_applicable?: false)
-    project = double(Conversion::Project, tasks_data: tasks_data)
+  describe "#sponsored_grant_type" do
+    it "handles a transfer" do
+      tasks_data = build(:transfer_tasks_data, sponsored_support_grant_type: :fast_track, sponsored_support_grant_not_applicable: false)
+      project = build(:transfer_project, tasks_data: tasks_data)
 
-    presenter = described_class.new(project)
+      presenter = described_class.new(project)
 
-    expect(presenter.sponsored_grant_type).to eql "unconfirmed"
+      expect(presenter.sponsored_grant_type).to eql "not applicable"
+    end
 
-    tasks_data = double(Conversion::TasksData, sponsored_support_grant_type: :fast_track, sponsored_support_grant_not_applicable?: false)
-    project = double(Conversion::Project, tasks_data: tasks_data)
+    it "presnets nil values as unconfirmed" do
+      tasks_data = build(:conversion_tasks_data, sponsored_support_grant_type: nil, sponsored_support_grant_not_applicable: false)
+      project = build(:conversion_project, tasks_data: tasks_data)
 
-    presenter = described_class.new(project)
+      presenter = described_class.new(project)
 
-    expect(presenter.sponsored_grant_type).to eql "fast track"
+      expect(presenter.sponsored_grant_type).to eql "unconfirmed"
+    end
 
-    tasks_data = double(Conversion::TasksData, sponsored_support_grant_type: :intermediate, sponsored_support_grant_not_applicable?: false)
-    project = double(Conversion::Project, tasks_data: tasks_data)
+    it "presents fast track" do
+      tasks_data = build(:conversion_tasks_data, sponsored_support_grant_type: :fast_track, sponsored_support_grant_not_applicable: false)
+      project = build(:conversion_project, tasks_data: tasks_data)
 
-    presenter = described_class.new(project)
+      presenter = described_class.new(project)
 
-    expect(presenter.sponsored_grant_type).to eql "intermediate"
+      expect(presenter.sponsored_grant_type).to eql "fast track"
+    end
 
-    tasks_data = double(Conversion::TasksData, sponsored_support_grant_type: :sponsored, sponsored_support_grant_not_applicable?: false)
-    project = double(Conversion::Project, tasks_data: tasks_data)
+    it "presents intermediate" do
+      tasks_data = build(:conversion_tasks_data, sponsored_support_grant_type: :intermediate, sponsored_support_grant_not_applicable: false)
+      project = build(:conversion_project, tasks_data: tasks_data)
 
-    presenter = described_class.new(project)
+      presenter = described_class.new(project)
 
-    expect(presenter.sponsored_grant_type).to eql "sponsored"
+      expect(presenter.sponsored_grant_type).to eql "intermediate"
+    end
+
+    it "presents full sponsored" do
+      tasks_data = build(:conversion_tasks_data, sponsored_support_grant_type: :full_sponsored, sponsored_support_grant_not_applicable: false)
+      project = build(:conversion_project, tasks_data: tasks_data)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.sponsored_grant_type).to eql "full sponsored"
+    end
+
+    it "presents not applicable" do
+      tasks_data = build(:conversion_tasks_data, sponsored_support_grant_type: nil, sponsored_support_grant_not_applicable: true)
+      project = build(:conversion_project, tasks_data: tasks_data)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.sponsored_grant_type).to eql "not applicable"
+    end
   end
 
-  it "presents the sponsored grant type value when it does not apply" do
-    tasks_data = double(Conversion::TasksData, sponsored_support_grant_not_applicable?: true)
-    project = double(Conversion::Project, tasks_data: tasks_data)
+  describe "#transfer_grant_level" do
+    it "handles a transfer" do
+      tasks_data = build(:conversion_tasks_data, sponsored_support_grant_type: :fast_track, sponsored_support_grant_not_applicable: false)
+      project = build(:conversion_project, tasks_data: tasks_data)
 
-    presenter = described_class.new(project)
+      presenter = described_class.new(project)
 
-    expect(presenter.sponsored_grant_type).to eql "not applicable"
+      expect(presenter.transfer_grant_level).to eql "not applicable"
+    end
+
+    it "presents nil values as unconfirmed" do
+      tasks_data = build(:transfer_tasks_data, sponsored_support_grant_type: nil, sponsored_support_grant_not_applicable: false)
+      project = build(:transfer_project, tasks_data: tasks_data)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.transfer_grant_level).to eql "unconfirmed"
+    end
+
+    it "presents stanadard values" do
+      tasks_data = build(:transfer_tasks_data, sponsored_support_grant_type: :standard, sponsored_support_grant_not_applicable: false)
+      project = build(:transfer_project, tasks_data: tasks_data)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.transfer_grant_level).to eql "standard transfer grant"
+    end
+
+    it "presents fast track" do
+      tasks_data = build(:transfer_tasks_data, sponsored_support_grant_type: :fast_track, sponsored_support_grant_not_applicable: false)
+      project = build(:transfer_project, tasks_data: tasks_data)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.transfer_grant_level).to eql "fast track"
+    end
+
+    it "presents intermediate" do
+      tasks_data = build(:transfer_tasks_data, sponsored_support_grant_type: :intermediate, sponsored_support_grant_not_applicable: false)
+      project = build(:transfer_project, tasks_data: tasks_data)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.transfer_grant_level).to eql "intermediate"
+    end
+
+    it "presents full sponsored" do
+      tasks_data = build(:transfer_tasks_data, sponsored_support_grant_type: :full_sponsored, sponsored_support_grant_not_applicable: false)
+      project = build(:transfer_project, tasks_data: tasks_data)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.transfer_grant_level).to eql "full sponsored"
+    end
+
+    it "presents not applicable" do
+      tasks_data = build(:transfer_tasks_data, sponsored_support_grant_type: nil, sponsored_support_grant_not_applicable: true)
+      project = build(:transfer_project, tasks_data: tasks_data)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.transfer_grant_level).to eql "not applicable"
+    end
   end
 
   it "presents the sponsored grant type value for a transfer" do


### PR DESCRIPTION
Add a new task to the transfer task list that is basically a copy of the 'Confirm and process the sponsored support grant' with minor changes, it acually has less values to capture at this point.

We've kept the database attributes the same name as the conversion project version, as it is functionally the same, but as the value has to be exported with a different 'column header' we have to duplicate in the export presenter to allow for this.
