### PR TITLE
Refactor ContactsFetcherService for performance

### DIFF
--- a/app/controllers/external_contacts_controller.rb
+++ b/app/controllers/external_contacts_controller.rb
@@ -2,7 +2,7 @@ class ExternalContactsController < ApplicationController
   include Projectable
 
   def index
-    @grouped_contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    @grouped_contacts = ContactsFetcherService.new(@project).all_project_contacts
   end
 
   def new

--- a/app/presenters/export/csv/academy_presenter_module.rb
+++ b/app/presenters/export/csv/academy_presenter_module.rb
@@ -72,14 +72,14 @@ module Export::Csv::AcademyPresenterModule
   end
 
   def academy_contact_name
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    contacts = @contacts_fetcher.all_project_contacts
     return if contacts["school_or_academy"].blank?
 
     contacts["school_or_academy"].pluck(:name).join(",")
   end
 
   def academy_contact_email
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    contacts = @contacts_fetcher.all_project_contacts
     return if contacts["school_or_academy"].blank?
 
     contacts["school_or_academy"].pluck(:email).join(",")

--- a/app/presenters/export/csv/incoming_trust_presenter_module.rb
+++ b/app/presenters/export/csv/incoming_trust_presenter_module.rb
@@ -78,6 +78,6 @@ module Export::Csv::IncomingTrustPresenterModule
   end
 
   private def incoming_trust_contact
-    @incoming_trust_contact || ContactsFetcherService.new.incoming_trust_contact(@project)
+    @contacts_fetcher.incoming_trust_contact
   end
 end

--- a/app/presenters/export/csv/local_authority_presenter_module.rb
+++ b/app/presenters/export/csv/local_authority_presenter_module.rb
@@ -12,14 +12,14 @@ module Export::Csv::LocalAuthorityPresenterModule
   end
 
   def local_authority_contact_name
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    contacts = @contacts_fetcher.all_project_contacts
     return if contacts["local_authority"].blank?
 
     contacts["local_authority"].pluck(:name).join(",")
   end
 
   def local_authority_contact_email
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    contacts = @contacts_fetcher.all_project_contacts
     return if contacts["local_authority"].blank?
 
     contacts["local_authority"].pluck(:email).join(",")

--- a/app/presenters/export/csv/outgoing_trust_presenter_module.rb
+++ b/app/presenters/export/csv/outgoing_trust_presenter_module.rb
@@ -72,6 +72,6 @@ module Export::Csv::OutgoingTrustPresenterModule
   end
 
   private def outgoing_trust_contact
-    @outgoing_trust_contact || ContactsFetcherService.new.outgoing_trust_contact(@project)
+    @contacts_fetcher.outgoing_trust_contact
   end
 end

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -9,6 +9,7 @@ class Export::Csv::ProjectPresenter
 
   def initialize(project)
     @project = project
+    @contacts_fetcher = ContactsFetcherService.new(@project)
   end
 
   def reception_to_six_years
@@ -218,14 +219,14 @@ class Export::Csv::ProjectPresenter
   end
 
   def diocese_contact_name
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    contacts = @contacts_fetcher.all_project_contacts
     return if contacts["diocese"].blank?
 
     contacts["diocese"].pluck(:name).join(",")
   end
 
   def diocese_contact_email
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    contacts = @contacts_fetcher.all_project_contacts
     return if contacts["diocese"].blank?
 
     contacts["diocese"].pluck(:email).join(",")
@@ -244,14 +245,14 @@ class Export::Csv::ProjectPresenter
   end
 
   def solicitor_contact_name
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    contacts = @contacts_fetcher.all_project_contacts
     return if contacts["solicitor"].blank?
 
     contacts["solicitor"].pluck(:name).join(",")
   end
 
   def solicitor_contact_email
-    contacts = ContactsFetcherService.new.all_project_contacts(@project)
+    contacts = @contacts_fetcher.all_project_contacts
     return if contacts["solicitor"].blank?
 
     contacts["solicitor"].pluck(:email).join(",")
@@ -306,6 +307,6 @@ class Export::Csv::ProjectPresenter
   end
 
   private def other_contact
-    @other_contact || ContactsFetcherService.new.other_contact(@project)
+    @contacts_fetcher.other_contact
   end
 end

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -108,6 +108,6 @@ module Export::Csv::SchoolPresenterModule
   end
 
   private def school_or_academy_contact
-    @school_or_academy_contact || ContactsFetcherService.new.school_or_academy_contact(@project)
+    @contacts_fetcher.school_or_academy_contact
   end
 end

--- a/app/services/contacts_fetcher_service.rb
+++ b/app/services/contacts_fetcher_service.rb
@@ -1,12 +1,18 @@
 class ContactsFetcherService
-  def all_project_contacts(project)
-    project_contacts = project.contacts
-    all_contacts = project_contacts.to_a
+  def initialize(project)
+    @project = project
+    @project_contacts = @project.contacts
+    @establishment_contacts = Contact::Establishment.find_by(establishment_urn: @project.urn)
+    @all_contacts = all_project_contacts
+  end
 
-    director_of_child_services = project.director_of_child_services
+  def all_project_contacts
+    all_contacts = @project_contacts.to_a
+
+    director_of_child_services = @project.director_of_child_services
     all_contacts << director_of_child_services unless director_of_child_services.nil?
 
-    establishment_contacts = Contact::Establishment.find_by(establishment_urn: project.urn)
+    establishment_contacts = @establishment_contacts
     all_contacts << establishment_contacts unless establishment_contacts.nil?
 
     return {} unless all_contacts.any?
@@ -14,43 +20,39 @@ class ContactsFetcherService
     all_contacts.sort_by(&:name).group_by(&:category)
   end
 
-  def school_or_academy_contact(project)
-    contacts = ContactsFetcherService.new.all_project_contacts(project)
-    return if contacts["school_or_academy"].blank?
+  def school_or_academy_contact
+    return if @all_contacts["school_or_academy"].nil?
 
-    if project.establishment_main_contact_id.present?
-      contacts["school_or_academy"].find { |c| c.id == project.establishment_main_contact_id }
+    if @project.establishment_main_contact_id.present?
+      @all_contacts["school_or_academy"].find { |c| c.id == @project.establishment_main_contact_id }
     else
-      contacts["school_or_academy"].first
+      @all_contacts["school_or_academy"].first
     end
   end
 
-  def outgoing_trust_contact(project)
-    contacts = ContactsFetcherService.new.all_project_contacts(project)
-    return if contacts["outgoing_trust"].blank?
+  def outgoing_trust_contact
+    return if @all_contacts["outgoing_trust"].nil?
 
-    if project.outgoing_trust_main_contact_id.present?
-      contacts["outgoing_trust"].find { |c| c.id == project.outgoing_trust_main_contact_id }
+    if @project.outgoing_trust_main_contact_id.present?
+      @all_contacts["outgoing_trust"].find { |c| c.id == @project.outgoing_trust_main_contact_id }
     else
-      contacts["outgoing_trust"].first
+      @all_contacts["outgoing_trust"].first
     end
   end
 
-  def incoming_trust_contact(project)
-    contacts = ContactsFetcherService.new.all_project_contacts(project)
-    return if contacts["incoming_trust"].blank?
+  def incoming_trust_contact
+    return if @all_contacts["incoming_trust"].nil?
 
-    if project.incoming_trust_main_contact_id.present?
-      contacts["incoming_trust"].find { |c| c.id == project.incoming_trust_main_contact_id }
+    if @project.incoming_trust_main_contact_id.present?
+      @all_contacts["incoming_trust"].find { |c| c.id == @project.incoming_trust_main_contact_id }
     else
-      contacts["incoming_trust"].first
+      @all_contacts["incoming_trust"].first
     end
   end
 
-  def other_contact(project)
-    contacts = ContactsFetcherService.new.all_project_contacts(project)
-    return if contacts["other"].blank?
+  def other_contact
+    return if @all_contacts["other"].nil?
 
-    contacts["other"].first
+    @all_contacts["other"].first
   end
 end

--- a/app/services/export/csv_export_service.rb
+++ b/app/services/export/csv_export_service.rb
@@ -10,6 +10,7 @@ class Export::CsvExportService
       csv << headers
       if @projects.any?
         @projects.each do |project|
+          Rails.logger.debug("--> Creating csv row for project #{project.id}")
           csv << row(project)
         end
       end

--- a/spec/presenters/export/csv/academy_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/academy_presenter_module_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Export::Csv::AcademyPresenterModule do
     let(:project) { build(:conversion_project, academy_urn: 149061, academy: gias_establishment) }
     subject { AcademyPresenterModuleTestClass.new(project) }
 
+    before { mock_successful_api_response_to_create_any_project }
+
     it "presents the academy urn" do
       expect(subject.academy_urn).to eql "149061"
     end
@@ -94,5 +96,6 @@ class AcademyPresenterModuleTestClass
 
   def initialize(project)
     @project = project
+    @contacts_fetcher = ContactsFetcherService.new(@project)
   end
 end

--- a/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
@@ -105,5 +105,6 @@ class IncomingTrustPresenterModuleTestClass
 
   def initialize(project)
     @project = project
+    @contacts_fetcher = ContactsFetcherService.new(@project)
   end
 end

--- a/spec/presenters/export/csv/local_authority_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/local_authority_presenter_module_spec.rb
@@ -69,5 +69,6 @@ class LocalAuthorityPresenterModuleTestClass
 
   def initialize(project)
     @project = project
+    @contacts_fetcher = ContactsFetcherService.new(@project)
   end
 end

--- a/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
@@ -70,5 +70,6 @@ class OutgoingTrustPresenterModuleTestClass
 
   def initialize(project)
     @project = project
+    @contacts_fetcher = ContactsFetcherService.new(@project)
   end
 end

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Export::Csv::ProjectPresenter do
+  before do
+    mock_successful_api_response_to_create_any_project
+  end
+
   it "presents the project type when the project is a conversion" do
     project = build(:conversion_project)
 
@@ -64,78 +68,96 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents inadequate_ofsted value for a transfer" do
-    tasks_data = double(Transfer::TasksData, inadequate_ofsted: true)
-    project = double(Transfer::Project, tasks_data: tasks_data)
+    tasks_data = build(:transfer_tasks_data, inadequate_ofsted: true)
+    project = build(:transfer_project, tasks_data: tasks_data)
+
     presenter = described_class.new(project)
+
     expect(presenter.inadequate_ofsted).to eql "yes"
 
-    tasks_data = double(Transfer::TasksData, inadequate_ofsted: false)
-    project = double(Transfer::Project, tasks_data: tasks_data)
+    tasks_data = build(:transfer_tasks_data, inadequate_ofsted: false)
+    project = build(:transfer_project, tasks_data: tasks_data)
+
     presenter = described_class.new(project)
+
     expect(presenter.inadequate_ofsted).to eql "no"
   end
 
   it "presents financial_safeguarding_governance_issues value for a transfer" do
-    tasks_data = double(Transfer::TasksData, financial_safeguarding_governance_issues: true)
-    project = double(Transfer::Project, tasks_data: tasks_data)
+    tasks_data = build(:transfer_tasks_data, financial_safeguarding_governance_issues: true)
+    project = build(:transfer_project, tasks_data: tasks_data)
+
     presenter = described_class.new(project)
+
     expect(presenter.financial_safeguarding_governance_issues).to eql "yes"
 
-    tasks_data = double(Transfer::TasksData, financial_safeguarding_governance_issues: false)
-    project = double(Transfer::Project, tasks_data: tasks_data)
+    tasks_data = build(:transfer_tasks_data, financial_safeguarding_governance_issues: false)
+    project = build(:transfer_project, tasks_data: tasks_data)
+
     presenter = described_class.new(project)
+
     expect(presenter.financial_safeguarding_governance_issues).to eql "no"
   end
 
   it "presents outgoing_trust_to_close value for a transfer" do
-    tasks_data = double(Transfer::TasksData, outgoing_trust_to_close: true)
-    project = double(Transfer::Project, tasks_data: tasks_data)
+    tasks_data = build(:transfer_tasks_data, outgoing_trust_to_close: true)
+    project = build(:transfer_project, tasks_data: tasks_data)
+
     presenter = described_class.new(project)
+
     expect(presenter.outgoing_trust_to_close).to eql "yes"
 
-    tasks_data = double(Transfer::TasksData, outgoing_trust_to_close: false)
-    project = double(Transfer::Project, tasks_data: tasks_data)
+    tasks_data = build(:transfer_tasks_data, outgoing_trust_to_close: false)
+    project = build(:transfer_project, tasks_data: tasks_data)
+
     presenter = described_class.new(project)
+
     expect(presenter.outgoing_trust_to_close).to eql "no"
   end
 
   it "presents request_new_urn_and_record value for a transfer" do
-    tasks_data = double(Transfer::TasksData,
+    tasks_data = build(:transfer_tasks_data,
       request_new_urn_and_record_complete: true,
       request_new_urn_and_record_receive: true,
       request_new_urn_and_record_give: true,
       request_new_urn_and_record_not_applicable: false)
-    project = double(Transfer::Project, tasks_data: tasks_data)
+    project = build(:transfer_project, tasks_data: tasks_data)
+
     presenter = described_class.new(project)
+
     expect(presenter.request_new_urn_and_record).to eql "confirmed"
 
-    tasks_data = double(Transfer::TasksData,
+    tasks_data = build(:transfer_tasks_data,
       request_new_urn_and_record_complete: false,
       request_new_urn_and_record_receive: false,
       request_new_urn_and_record_give: false,
       request_new_urn_and_record_not_applicable: false)
-    project = double(Transfer::Project, tasks_data: tasks_data)
+    project = build(:transfer_project, tasks_data: tasks_data)
+
     presenter = described_class.new(project)
+
     expect(presenter.request_new_urn_and_record).to eql "unconfirmed"
 
-    tasks_data = double(Transfer::TasksData,
+    tasks_data = build(:transfer_tasks_data,
       request_new_urn_and_record_complete: false,
       request_new_urn_and_record_receive: false,
       request_new_urn_and_record_give: false,
       request_new_urn_and_record_not_applicable: true)
-    project = double(Transfer::Project, tasks_data: tasks_data)
+    project = build(:transfer_project, tasks_data: tasks_data)
+
     presenter = described_class.new(project)
+
     expect(presenter.request_new_urn_and_record).to eql "not applicable"
   end
 
   it "presents bank_details_changing value for a transfer" do
-    tasks_data = double(Transfer::TasksData, bank_details_changing_yes_no: true)
-    project = double(Transfer::Project, tasks_data: tasks_data)
+    tasks_data = build(:transfer_tasks_data, bank_details_changing_yes_no: true)
+    project = build(:transfer_project, tasks_data: tasks_data)
     presenter = described_class.new(project)
     expect(presenter.bank_details_changing).to eql "yes"
 
-    tasks_data = double(Transfer::TasksData, bank_details_changing_yes_no: false)
-    project = double(Transfer::Project, tasks_data: tasks_data)
+    tasks_data = build(:transfer_tasks_data, bank_details_changing_yes_no: false)
+    project = build(:transfer_project, tasks_data: tasks_data)
     presenter = described_class.new(project)
     expect(presenter.bank_details_changing).to eql "no"
   end
@@ -197,7 +219,7 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   describe "#transfer_grant_level" do
-    it "handles a transfer" do
+    it "handles a conversion" do
       tasks_data = build(:conversion_tasks_data, sponsored_support_grant_type: :fast_track, sponsored_support_grant_not_applicable: false)
       project = build(:conversion_project, tasks_data: tasks_data)
 
@@ -266,7 +288,7 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents the provisional date" do
-    conversion_project = double(Conversion::Project, provisional_date: Date.parse("2024-1-1"), conversion_date_provisional?: true)
+    conversion_project = build(:conversion_project, conversion_date: Date.parse("2024-1-1"), conversion_date_provisional: true)
 
     conversion_presenter = described_class.new(conversion_project)
 
@@ -274,7 +296,7 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents the conversion date" do
-    project = double(Conversion::Project, conversion_date: Date.parse("2023-1-1"), conversion_date_provisional?: false)
+    project = build(:conversion_project, conversion_date: Date.parse("2023-1-1"), conversion_date_provisional: false)
 
     presenter = described_class.new(project)
 
@@ -282,7 +304,7 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents unconfirmed when the conversion date is provisional" do
-    project = double(Conversion::Project, conversion_date: Date.parse("2023-1-1"), conversion_date_provisional?: true)
+    project = build(:conversion_project, conversion_date: Date.parse("2023-1-1"), conversion_date_provisional: true)
 
     presenter = described_class.new(project)
 
@@ -290,7 +312,7 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents the significant date (as transfer date)" do
-    project = double(Transfer::Project, significant_date: Date.parse("2023-1-1"), significant_date_provisional?: false)
+    project = build(:conversion_project, significant_date: Date.parse("2023-1-1"), significant_date_provisional: false)
 
     presenter = described_class.new(project)
 
@@ -298,7 +320,7 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents unconfirmed when the significant date is provisional" do
-    project = double(Transfer::Project, significant_date: Date.parse("2023-1-1"), significant_date_provisional?: true)
+    project = build(:transfer_project, significant_date: Date.parse("2023-1-1"), significant_date_provisional: true)
 
     presenter = described_class.new(project)
 
@@ -306,39 +328,39 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents the actual transfer date" do
-    tasks_data = double(Transfer::TasksData, confirm_date_academy_transferred_date_transferred: Date.parse("2023-1-1"))
-    project = double(Transfer::Project, tasks_data: tasks_data)
+    tasks_data = build(:transfer_tasks_data, confirm_date_academy_transferred_date_transferred: Date.parse("2023-1-1"))
+    project = build(:transfer_project, tasks_data: tasks_data)
     presenter = described_class.new(project)
 
     expect(presenter.date_academy_transferred).to eq("2023-01-01")
   end
 
   it "presents unconfirmed when the project doesn't have an actual transfer date" do
-    tasks_data = double(Transfer::TasksData, confirm_date_academy_transferred_date_transferred: nil)
-    project = double(Transfer::Project, tasks_data: tasks_data)
+    tasks_data = build(:transfer_tasks_data, confirm_date_academy_transferred_date_transferred: nil)
+    project = build(:transfer_project, tasks_data: tasks_data)
     presenter = described_class.new(project)
 
     expect(presenter.date_academy_transferred).to eq(I18n.t("export.csv.project.values.unconfirmed"))
   end
 
   it "presents the actual conversion date" do
-    tasks_data = double(Conversion::TasksData, confirm_date_academy_opened_date_opened: Date.parse("2024-1-1"))
-    project = double(Conversion::Project, tasks_data: tasks_data)
+    tasks_data = build(:conversion_tasks_data, confirm_date_academy_opened_date_opened: Date.parse("2024-1-1"))
+    project = build(:conversion_project, tasks_data: tasks_data)
     presenter = described_class.new(project)
 
     expect(presenter.date_academy_opened).to eq("2024-01-01")
   end
 
   it "presents unconfirmed when the project doesn't have an actual conversion date" do
-    tasks_data = double(Conversion::TasksData, confirm_date_academy_opened_date_opened: nil)
-    project = double(Conversion::Project, tasks_data: tasks_data)
+    tasks_data = build(:conversion_tasks_data, confirm_date_academy_opened_date_opened: nil)
+    project = build(:conversion_project, tasks_data: tasks_data)
     presenter = described_class.new(project)
 
     expect(presenter.date_academy_opened).to eq(I18n.t("export.csv.project.values.unconfirmed"))
   end
 
   it "presents all conditions met" do
-    project = double(Conversion::Project, all_conditions_met: true)
+    project = build(:conversion_project, all_conditions_met: true)
 
     presenter = described_class.new(project)
 
@@ -346,7 +368,7 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents authority to proceed, which is the name for 'all conditions met' for Transfer projects" do
-    project = double(Transfer::Project, all_conditions_met: true)
+    project = build(:transfer_project, all_conditions_met: true)
 
     presenter = described_class.new(project)
 
@@ -354,7 +376,7 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents authority to proceed (all conditions met for Transfer projects) when it has not been met (nil)" do
-    project = double(Transfer::Project, all_conditions_met: nil)
+    project = build(:transfer_project, all_conditions_met: nil)
 
     presenter = described_class.new(project)
 
@@ -362,7 +384,7 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents authority to proceed (all conditions met for Transfer projects) when it has not been met (false)" do
-    project = double(Transfer::Project, all_conditions_met: false)
+    project = build(:transfer_project, all_conditions_met: false)
 
     presenter = described_class.new(project)
 
@@ -370,8 +392,8 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents all risk protection arrangement when it is standard" do
-    tasks_data = double(Conversion::TasksData, risk_protection_arrangement_option: :standard)
-    project = double(Conversion::Project, tasks_data: tasks_data)
+    tasks_data = build(:conversion_tasks_data, risk_protection_arrangement_option: :standard)
+    project = build(:conversion_project, tasks_data: tasks_data)
 
     presenter = described_class.new(project)
 
@@ -379,8 +401,8 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents all risk protection arrangement when it is church/trust" do
-    tasks_data = double(Conversion::TasksData, risk_protection_arrangement_option: :church_or_trust)
-    project = double(Conversion::Project, tasks_data: tasks_data)
+    tasks_data = build(:conversion_tasks_data, risk_protection_arrangement_option: :church_or_trust)
+    project = build(:conversion_project, tasks_data: tasks_data)
 
     presenter = described_class.new(project)
 
@@ -388,8 +410,8 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents all risk protection arrangement when it is commercial" do
-    tasks_data = double(Conversion::TasksData, risk_protection_arrangement_option: :commercial)
-    project = double(Conversion::Project, tasks_data: tasks_data)
+    tasks_data = build(:conversion_tasks_data, risk_protection_arrangement_option: :commercial)
+    project = build(:conversion_project, tasks_data: tasks_data)
 
     presenter = described_class.new(project)
 
@@ -397,8 +419,8 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents all risk protection arrangement when it is not yet confirmed" do
-    tasks_data = double(Conversion::TasksData, risk_protection_arrangement_option: nil)
-    project = double(Conversion::Project, tasks_data: tasks_data)
+    tasks_data = build(:conversion_tasks_data, risk_protection_arrangement_option: nil)
+    project = build(:conversion_project, tasks_data: tasks_data)
 
     presenter = described_class.new(project)
 
@@ -408,8 +430,8 @@ RSpec.describe Export::Csv::ProjectPresenter do
   describe "#assigned_to_name" do
     context "when the project is assigned to a user" do
       it "returns the name of the user the project is assigned to" do
-        user = double(User, full_name: "Assigned User")
-        project = double(Conversion::Project, assigned_to: user)
+        user = build(:user, first_name: "Assigned", last_name: "User")
+        project = build(:conversion_project, assigned_to: user)
 
         presenter = described_class.new(project)
 
@@ -418,7 +440,7 @@ RSpec.describe Export::Csv::ProjectPresenter do
     end
     context "when the project is unassigned" do
       it "returns 'unassigned'" do
-        project = double(Conversion::Project, assigned_to: nil)
+        project = build(:conversion_project, assigned_to: nil)
 
         presenter = described_class.new(project)
 
@@ -430,8 +452,8 @@ RSpec.describe Export::Csv::ProjectPresenter do
   describe "#assigned_to_email" do
     context "when the project is assigned to a user" do
       it "returns the email address of the user the project is assigned to" do
-        user = double(User, email: "assigned.user@education.gov.uk")
-        project = double(Conversion::Project, assigned_to: user)
+        user = build(:user, email: "assigned.user@education.gov.uk")
+        project = build(:conversion_project, assigned_to: user)
 
         presenter = described_class.new(project)
 
@@ -440,7 +462,7 @@ RSpec.describe Export::Csv::ProjectPresenter do
     end
     context "when the project is unassigned" do
       it "returns 'unassigned'" do
-        project = double(Conversion::Project, assigned_to: nil)
+        project = build(:conversion_project, assigned_to: nil)
 
         presenter = described_class.new(project)
 
@@ -450,8 +472,8 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents the assigned to name" do
-    user = double(User, full_name: "Assigned User")
-    project = double(Conversion::Project, assigned_to: user)
+    user = build(:user, first_name: "Assigned", last_name: "User")
+    project = build(:conversion_project, assigned_to: user)
 
     presenter = described_class.new(project)
 
@@ -459,8 +481,8 @@ RSpec.describe Export::Csv::ProjectPresenter do
   end
 
   it "presents the assigned to email" do
-    user = double(User, email: "assigned.user@education.gov.uk")
-    project = double(Conversion::Project, assigned_to: user)
+    user = build(:user, email: "assigned.user@education.gov.uk")
+    project = build(:conversion_project, assigned_to: user)
 
     presenter = described_class.new(project)
 

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -113,5 +113,6 @@ class SchoolPresenterModuleTestClass
 
   def initialize(project)
     @project = project
+    @contacts_fetcher = ContactsFetcherService.new(@project)
   end
 end

--- a/spec/services/contacts_fetcher_service_spec.rb
+++ b/spec/services/contacts_fetcher_service_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe ContactsFetcherService do
   before { mock_all_academies_api_responses }
   let(:project) { create(:transfer_project) }
-  subject { described_class.new }
 
   describe "#all_project_contacts" do
     it "returns the contacts for a given project" do
@@ -14,7 +13,7 @@ RSpec.describe ContactsFetcherService do
 
       establishment_contact = create(:establishment_contact, establishment_urn: project.urn)
 
-      result = subject.all_project_contacts(project)
+      result = described_class.new(project).all_project_contacts
 
       expect(result.count).to eql(2)
       expect(result["school_or_academy"].count).to eql(2)
@@ -30,8 +29,7 @@ RSpec.describe ContactsFetcherService do
           director_of_child_services = create(:director_of_child_services)
           allow(project).to receive(:director_of_child_services).and_return(director_of_child_services)
 
-          service = described_class.new
-          result = service.all_project_contacts(project)
+          result = described_class.new(project).all_project_contacts
 
           expect(result.values.flatten.count).to eql(1)
           expect(result.values.flatten.first).to be(director_of_child_services)
@@ -43,8 +41,7 @@ RSpec.describe ContactsFetcherService do
           project = create(:transfer_project)
           establishment_contact = create(:establishment_contact, establishment_urn: project.urn)
 
-          service = described_class.new
-          result = service.all_project_contacts(project)
+          result = described_class.new(project).all_project_contacts
 
           expect(result.values.flatten.count).to eql(1)
           expect(result.values.flatten.first).to eq(establishment_contact)
@@ -56,8 +53,7 @@ RSpec.describe ContactsFetcherService do
           project = create(:transfer_project)
           allow(project).to receive(:director_of_child_services).and_return(nil)
 
-          service = described_class.new
-          result = service.all_project_contacts(project)
+          result = described_class.new(project).all_project_contacts
 
           expect(result).to be_empty
         end
@@ -72,7 +68,7 @@ RSpec.describe ContactsFetcherService do
       before { allow(project).to receive(:establishment_main_contact_id).and_return(contact.id) }
 
       it "returns the contact with that id" do
-        expect(subject.school_or_academy_contact(project)).to eq(contact)
+        expect(described_class.new(project).school_or_academy_contact).to eq(contact)
       end
     end
 
@@ -80,7 +76,7 @@ RSpec.describe ContactsFetcherService do
       before { allow(project).to receive(:establishment_main_contact_id).and_return(nil) }
 
       it "returns the next matching contact" do
-        expect(subject.school_or_academy_contact(project)).to eq(contact)
+        expect(described_class.new(project).school_or_academy_contact).to eq(contact)
       end
     end
   end
@@ -92,7 +88,7 @@ RSpec.describe ContactsFetcherService do
       before { allow(project).to receive(:outgoing_trust_main_contact_id).and_return(contact.id) }
 
       it "returns the contact with that id" do
-        expect(subject.outgoing_trust_contact(project)).to eq(contact)
+        expect(described_class.new(project).outgoing_trust_contact).to eq(contact)
       end
     end
 
@@ -100,7 +96,7 @@ RSpec.describe ContactsFetcherService do
       before { allow(project).to receive(:outgoing_trust_main_contact_id).and_return(nil) }
 
       it "returns the next matching contact" do
-        expect(subject.outgoing_trust_contact(project)).to eq(contact)
+        expect(described_class.new(project).outgoing_trust_contact).to eq(contact)
       end
     end
   end
@@ -112,7 +108,7 @@ RSpec.describe ContactsFetcherService do
       before { allow(project).to receive(:incoming_trust_main_contact_id).and_return(contact.id) }
 
       it "returns the contact with that id" do
-        expect(subject.incoming_trust_contact(project)).to eq(contact)
+        expect(described_class.new(project).incoming_trust_contact).to eq(contact)
       end
     end
 
@@ -120,7 +116,7 @@ RSpec.describe ContactsFetcherService do
       before { allow(project).to receive(:incoming_trust_main_contact_id).and_return(nil) }
 
       it "returns the next matching contact" do
-        expect(subject.incoming_trust_contact(project)).to eq(contact)
+        expect(described_class.new(project).incoming_trust_contact).to eq(contact)
       end
     end
   end
@@ -129,7 +125,7 @@ RSpec.describe ContactsFetcherService do
     let!(:contact) { create(:project_contact, project: project, category: "other") }
 
     it "returns the first 'other' contact" do
-      expect(subject.other_contact(project)).to eq(contact)
+      expect(described_class.new(project).other_contact).to eq(contact)
     end
   end
 end


### PR DESCRIPTION
We do a lot of fetching contacts and this service is pretty happy to hit
the database a lot. In production with ~120 projects, exports are taking
a full minute to run and so the app is timing out.

We want to start by optimising our queries and this is the first
candidate (with more to follow).

The principles here are:

- there can generally be one ContactsFetcherService for one Project as
  it references the project internally
- our exports presenters are actually modules that all get mixed in to
  `project_presenter` so we make one instance of ContactsFetcherService
  available to all rather than instantiating (and so new db calls) new
  ones

This change has a big impact on the presenter specs as we have to stub
extra methods or (as we chose) switch to factories.

The result of this is, for a single conversion:

- 39 database queries per project/row in export before change
- 23 database queries per project/row in export after change

We'll have to see if this makes enough of a difference and we have
identified more optimisations we can make.

