### PR TITLE
Improve export performance: Part II

### DIFF
--- a/app/presenters/export/csv/academy_presenter_module.rb
+++ b/app/presenters/export/csv/academy_presenter_module.rb
@@ -16,59 +16,59 @@ module Export::Csv::AcademyPresenterModule
   end
 
   def academy_name
-    if @project.academy_urn.nil? || @project.academy.name.nil?
+    if @project.academy_urn.nil? || @academy.name.nil?
       return I18n.t("export.csv.project.values.unconfirmed")
     end
 
-    @project.academy.name
+    @academy.name
   end
 
   def academy_type
-    return unless @project.academy.present?
+    return unless @academy.present?
 
-    @project.academy.type
+    @academy.type
   end
 
   def academy_dfe_number
-    return unless @project.academy.present?
+    return unless @academy.present?
 
-    @project.academy.dfe_number
+    @academy.dfe_number
   end
 
   def academy_address_1
-    return unless @project.academy.present?
+    return unless @academy.present?
 
-    @project.academy.address_street
+    @academy.address_street
   end
 
   def academy_address_2
-    return unless @project.academy.present?
+    return unless @academy.present?
 
-    @project.academy.address_locality
+    @academy.address_locality
   end
 
   def academy_address_3
-    return unless @project.academy.present?
+    return unless @academy.present?
 
-    @project.academy.address_additional
+    @academy.address_additional
   end
 
   def academy_address_town
-    return unless @project.academy.present?
+    return unless @academy.present?
 
-    @project.academy.address_town
+    @academy.address_town
   end
 
   def academy_address_county
-    return unless @project.academy.present?
+    return unless @academy.present?
 
-    @project.academy.address_county
+    @academy.address_county
   end
 
   def academy_address_postcode
-    return unless @project.academy.present?
+    return unless @academy.present?
 
-    @project.academy.address_postcode
+    @academy.address_postcode
   end
 
   def academy_contact_name

--- a/app/presenters/export/csv/director_of_child_services_presenter_module.rb
+++ b/app/presenters/export/csv/director_of_child_services_presenter_module.rb
@@ -1,19 +1,19 @@
 module Export::Csv::DirectorOfChildServicesPresenterModule
   def director_of_child_services_name
-    return unless @project.director_of_child_services.present?
+    return unless @director_of_child_services.present?
 
-    @project.director_of_child_services.name
+    @director_of_child_services.name
   end
 
   def director_of_child_services_role
-    return unless @project.director_of_child_services.present?
+    return unless @director_of_child_services.present?
 
-    @project.director_of_child_services.title
+    @director_of_child_services.title
   end
 
   def director_of_child_services_email
-    return unless @project.director_of_child_services.present?
+    return unless @director_of_child_services.present?
 
-    @project.director_of_child_services.email
+    @director_of_child_services.email
   end
 end

--- a/app/presenters/export/csv/local_authority_presenter_module.rb
+++ b/app/presenters/export/csv/local_authority_presenter_module.rb
@@ -1,14 +1,14 @@
 module Export::Csv::LocalAuthorityPresenterModule
   def local_authority_code
-    return unless @project.local_authority.present?
+    return unless @local_authority.present?
 
-    @project.local_authority.code.to_s
+    @local_authority.code.to_s
   end
 
   def local_authority_name
-    return unless @project.local_authority.present?
+    return unless @local_authority.present?
 
-    @project.local_authority.name
+    @local_authority.name
   end
 
   def local_authority_contact_name
@@ -26,38 +26,38 @@ module Export::Csv::LocalAuthorityPresenterModule
   end
 
   def local_authority_address_1
-    return unless @project.local_authority.present?
+    return unless @local_authority.present?
 
-    @project.local_authority.address_1
+    @local_authority.address_1
   end
 
   def local_authority_address_2
-    return unless @project.local_authority.present?
+    return unless @local_authority.present?
 
-    @project.local_authority.address_2
+    @local_authority.address_2
   end
 
   def local_authority_address_3
-    return unless @project.local_authority.present?
+    return unless @local_authority.present?
 
-    @project.local_authority.address_3
+    @local_authority.address_3
   end
 
   def local_authority_address_town
-    return unless @project.local_authority.present?
+    return unless @local_authority.present?
 
-    @project.local_authority.address_town
+    @local_authority.address_town
   end
 
   def local_authority_address_county
-    return unless @project.local_authority.present?
+    return unless @local_authority.present?
 
-    @project.local_authority.address_county
+    @local_authority.address_county
   end
 
   def local_authority_address_postcode
-    return unless @project.local_authority.present?
+    return unless @local_authority.present?
 
-    @project.local_authority.address_postcode
+    @local_authority.address_postcode
   end
 end

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -12,6 +12,7 @@ class Export::Csv::ProjectPresenter
     @contacts_fetcher = ContactsFetcherService.new(@project)
     @local_authority = @project.local_authority
     @academy = @project.academy if @project.academy_urn.present?
+    @director_of_child_services = @contacts_fetcher.director_of_child_services
   end
 
   def reception_to_six_years

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -10,6 +10,7 @@ class Export::Csv::ProjectPresenter
   def initialize(project)
     @project = project
     @contacts_fetcher = ContactsFetcherService.new(@project)
+    @local_authority = @project.local_authority
   end
 
   def reception_to_six_years

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -11,6 +11,7 @@ class Export::Csv::ProjectPresenter
     @project = project
     @contacts_fetcher = ContactsFetcherService.new(@project)
     @local_authority = @project.local_authority
+    @academy = @project.academy if @project.academy_urn.present?
   end
 
   def reception_to_six_years

--- a/app/services/contacts_fetcher_service.rb
+++ b/app/services/contacts_fetcher_service.rb
@@ -1,16 +1,18 @@
 class ContactsFetcherService
+  attr_reader :director_of_child_services
+
   def initialize(project)
     @project = project
     @project_contacts = @project.contacts
     @establishment_contacts = Contact::Establishment.find_by(establishment_urn: @project.urn)
     @all_contacts = all_project_contacts
+    @director_of_child_services = @project.director_of_child_services
   end
 
   def all_project_contacts
     all_contacts = @project_contacts.to_a
 
-    director_of_child_services = @project.director_of_child_services
-    all_contacts << director_of_child_services unless director_of_child_services.nil?
+    all_contacts << @director_of_child_services unless @director_of_child_services.nil?
 
     establishment_contacts = @establishment_contacts
     all_contacts << establishment_contacts unless establishment_contacts.nil?

--- a/spec/presenters/export/csv/academy_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/academy_presenter_module_spec.rb
@@ -97,5 +97,6 @@ class AcademyPresenterModuleTestClass
   def initialize(project)
     @project = project
     @contacts_fetcher = ContactsFetcherService.new(@project)
+    @academy = @project.academy if @project.academy_urn.present?
   end
 end

--- a/spec/presenters/export/csv/director_of_child_services_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/director_of_child_services_presenter_module_spec.rb
@@ -35,5 +35,6 @@ class DirectorOfChildServicesPresenterModuleTestClass
 
   def initialize(project)
     @project = project
+    @director_of_child_services = @project.director_of_child_services
   end
 end

--- a/spec/presenters/export/csv/local_authority_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/local_authority_presenter_module_spec.rb
@@ -70,5 +70,6 @@ class LocalAuthorityPresenterModuleTestClass
   def initialize(project)
     @project = project
     @contacts_fetcher = ContactsFetcherService.new(@project)
+    @local_authority = @project.local_authority
   end
 end

--- a/spec/services/contacts_fetcher_service_spec.rb
+++ b/spec/services/contacts_fetcher_service_spec.rb
@@ -4,6 +4,25 @@ RSpec.describe ContactsFetcherService do
   before { mock_all_academies_api_responses }
   let(:project) { create(:transfer_project) }
 
+  describe "#director_of_child_services" do
+    it "returns the contact when there is one" do
+      director_of_child_services_contact = create(:director_of_child_services)
+      allow(project).to receive(:director_of_child_services).and_return(director_of_child_services_contact)
+
+      result = described_class.new(project)
+
+      expect(result.director_of_child_services).to eql(director_of_child_services_contact)
+    end
+
+    it "returns nil when there is not one" do
+      allow(project).to receive(:director_of_child_services).and_return(nil)
+
+      result = described_class.new(project)
+
+      expect(result.director_of_child_services).to be_nil
+    end
+  end
+
   describe "#all_project_contacts" do
     it "returns the contacts for a given project" do
       project_contact = create(:project_contact, project: project, category: "school_or_academy")


### PR DESCRIPTION
This work builds on #1422 and takes a similar view that we can load objects from the database once per project during the export process and re-use them.

We refactor the some of the presenter modules to expect instance variables that are loaded once by the `ProjectPresenter` class.

Testing locally shows this reduces database calls down to 8 per project, which feels about right.
