### PR TITLE
(159705) Add additional database indicies

### DIFF
--- a/db/migrate/20240314083733_add_additional_indicies.rb
+++ b/db/migrate/20240314083733_add_additional_indicies.rb
@@ -1,0 +1,8 @@
+class AddAdditionalIndicies < ActiveRecord::Migration[7.0]
+  def change
+    add_index :local_authorities, :code
+    add_index :projects, :tasks_data_id
+    add_index :projects, :tasks_data_type
+    add_index :significant_date_histories, :project_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_11_084953) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_14_083733) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -228,6 +228,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_11_084953) do
     t.string "address_postcode", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_local_authorities_on_code"
   end
 
   create_table "notes", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
@@ -282,6 +283,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_11_084953) do
     t.index ["incoming_trust_ukprn"], name: "index_projects_on_incoming_trust_ukprn"
     t.index ["outgoing_trust_ukprn"], name: "index_projects_on_outgoing_trust_ukprn"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"
+    t.index ["tasks_data_id"], name: "index_projects_on_tasks_data_id"
+    t.index ["tasks_data_type"], name: "index_projects_on_tasks_data_type"
     t.index ["team_leader_id"], name: "index_projects_on_team_leader_id"
     t.index ["urn"], name: "index_projects_on_urn"
   end
@@ -292,6 +295,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_11_084953) do
     t.uuid "project_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["project_id"], name: "index_significant_date_histories_on_project_id"
   end
 
   create_table "transfer_tasks_data", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|


### PR DESCRIPTION
This is a bit speculative as I have no way to test this locally (not
enough seed data), but it seems reasonable that anything that is
referenced from one table to another would benefit from an index - these
all look to meet that criteria, so I've added one.

For the record:

Testing in production with the 'Conversion funding agreement letters
export' from April 2024 which contains 116 projects.

```
Benchmark.measure do
  projects = ProjectsForExportService.new.funding_agreement_letters_projects(month: 4, year: 2024)
end
```

~2 seconds to fetch the projects and get their details from the
Academies API

```
Benchmark.measure do
  Export::Conversions::FundingAgreementLettersCsvExporterService.new(projects).call
end
```

~38 seconds to generate the csv (Rails caches after this and we drop to
~6 seconds)
