### PR TITLE
(159129) Add UI for "all schools converting" mega-export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add UI for "schools due to convert" export, which is replacing ESFA & Grant
+  management and finance exports
+
 ### Changed
 
 - link to TRN spreadsheet in add Form a MAT converversion form opens in new tab

--- a/app/controllers/all/export/by_month/conversions/projects_controller.rb
+++ b/app/controllers/all/export/by_month/conversions/projects_controller.rb
@@ -1,0 +1,40 @@
+class All::Export::ByMonth::Conversions::ProjectsController < ApplicationController
+  def index
+    authorize :export
+    service = ProjectsForExportService.new
+    @data = export_months.map do |month|
+      {
+        month: month,
+        count: service.conversion_by_month_projects(month: month.month, year: month.year).count
+      }
+    end
+  end
+
+  def show
+    authorize :export
+    @month = Date.parse("#{year}-#{month}-1")
+  end
+
+  def csv
+    authorize :export
+
+    projects = ProjectsForExportService.new.conversion_by_month_projects(month: month, year: year)
+    csv = Export::Conversions::SchoolsDueToConvertCsvExportService.new(projects).call
+
+    send_data csv, filename: "#{year}-#{month}_schools_due_to_convert.csv", type: :csv, disposition: "attachment"
+  end
+
+  private def month
+    params[:month]
+  end
+
+  private def year
+    params[:year]
+  end
+
+  private def export_months
+    6.times.map do |index|
+      Date.today.at_beginning_of_month + index.months
+    end
+  end
+end

--- a/app/services/projects_for_export_service.rb
+++ b/app/services/projects_for_export_service.rb
@@ -24,6 +24,11 @@ class ProjectsForExportService
     AcademiesApiPreFetcherService.new.call!(projects)
   end
 
+  def conversion_by_month_projects(month:, year:)
+    projects = conversion_projects_by_month_and_year(month, year)
+    AcademiesApiPreFetcherService.new.call!(projects)
+  end
+
   private def transfer_projects_by_month_and_year(month, year)
     Transfer::Project.filtered_by_significant_date(month, year)
   end

--- a/app/services/projects_for_export_service.rb
+++ b/app/services/projects_for_export_service.rb
@@ -1,14 +1,4 @@
 class ProjectsForExportService
-  def risk_protection_arrangement_projects(month:, year:)
-    projects = conversion_projects_by_month_and_year(month, year)
-    AcademiesApiPreFetcherService.new.call!(projects)
-  end
-
-  def funding_agreement_letters_projects(month:, year:)
-    projects = conversion_projects_by_month_and_year(month, year)
-    AcademiesApiPreFetcherService.new.call!(projects)
-  end
-
   def grant_management_and_finance_unit_conversion_projects(month:, year:)
     projects = conversion_projects_by_advisory_board_date(month, year)
     AcademiesApiPreFetcherService.new.call!(projects)
@@ -28,6 +18,9 @@ class ProjectsForExportService
     projects = conversion_projects_by_month_and_year(month, year)
     AcademiesApiPreFetcherService.new.call!(projects)
   end
+
+  alias_method :risk_protection_arrangement_projects, :conversion_by_month_projects
+  alias_method :funding_agreement_letters_projects, :conversion_by_month_projects
 
   private def transfer_projects_by_month_and_year(month, year)
     Transfer::Project.filtered_by_significant_date(month, year)

--- a/app/views/all/export/by_month/conversions/projects/index.html.erb
+++ b/app/views/all/export/by_month/conversions/projects/index.html.erb
@@ -1,0 +1,37 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("export.by_month.conversions.index.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h3 class="govuk-heading-l"><%= t("export.by_month.conversions.index.title") %></h3>
+    <%= t("export.by_month.conversions.index.body_html") %>
+  </div>
+</div>
+
+<table class="govuk-table" name="projects_table" aria-label="Conversions by month exports">
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header" scope="col"><%= t("project.table.headers.date") %></th>
+    <th class="govuk-table__header" scope="col"><%= t("project.table.headers.number_of_conversions") %></th>
+    <th class="govuk-table__header" scope="col"><%= t("project.table.headers.export") %></th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% @data.each do |item| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header govuk-table__cell"><%= item[:month].to_fs(:govuk_month) %></td>
+      <td class="govuk-table__cell"><%= t("project.table.body.conversion_project_count_html", count: item[:count], date: item[:month].to_fs(:govuk_month)) %></td>
+      <td class="govuk-table__cell">
+        <%= link_to(t("project.table.body.export_link"),
+              show_all_export_by_month_conversions_projects_path(item[:month].month, item[:month].year),
+              title: t("project.table.body.export_link_title_conversions_html", date: item[:month].to_fs(:govuk_month))) %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/all/export/by_month/conversions/projects/show.html.erb
+++ b/app/views/all/export/by_month/conversions/projects/show.html.erb
@@ -1,0 +1,17 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("export.by_month.conversions.show.title", date: @month.to_fs(:govuk_month))) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h3 class="govuk-heading-l"><%= t("export.by_month.conversions.show.title", date: @month.to_fs(:govuk_month)) %></h3>
+    <%= t("export.by_month.conversions.show.body_html") %>
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_button_link_to t("export.by_month.transfers.show.button"), csv_all_export_by_month_conversions_projects_path(@month.month, @month.year) %>
+  </div>
+</div>

--- a/config/locales/export/by_month_csv_export.en.yml
+++ b/config/locales/export/by_month_csv_export.en.yml
@@ -11,7 +11,7 @@ en:
         show:
           title: Details of academies due to transfer in %{month} %{year}
           body_html:
-            <p class="govuk-body">This .CSV spreadsheet shows you academies that will:</p>
+            <p class="govuk-body">This CSV spreadsheet shows you academies that will:</p>
             <ul>
             <li>transfer in %{month} %{year}</li>
             <li>need a new URN</li>

--- a/config/locales/export/by_month_csv_export.en.yml
+++ b/config/locales/export/by_month_csv_export.en.yml
@@ -19,4 +19,25 @@ en:
             <li>no longer transfer in %{month} %{year}</li>
             </ul>
             <p class="govuk-body">It can take a little time to create these files. Thank you for your patience.</p>
-          button: Download .CSV file
+          button: Download CSV file
+      conversions:
+        index:
+          title: RPA, SUG and FA letters exports
+          body_html:
+            <p class="govuk-body">Download CSV files containing information about a converting school's:</p>
+            <ul>
+            <li>risk protection arrangements (RPA)</li>
+            <li>start-up grant (SUG)</li>
+            <li>contacts for the funding agreement letters</li>
+            </ul>
+        show:
+          title: RPA, SUG and FA letters export for %{date}
+          body_html:
+            <p class="govuk-body">Download CSV files containing information about a converting school's:</p>
+            <ul>
+            <li>risk protection arrangements (RPA)</li>
+            <li>start-up grant (SUG)</li>
+            <li>contacts for the funding agreement letters</li>
+            </ul>
+            <p class="govuk-body">These files can be large and could take a few minutes to download.</p>
+          button: Download CSV file

--- a/config/locales/export/education_and_skills_funding_agency_csv_export.en.yml
+++ b/config/locales/export/education_and_skills_funding_agency_csv_export.en.yml
@@ -12,4 +12,4 @@ en:
             <li>Startup grant funding (SUG)</li>
           </ul>
           <p>Export downloads can take time to prepare, please be patient.</p>
-        button: Download csv file
+        button: Download CSV file

--- a/config/locales/export/funding_agreement_letters_csv_export.yml
+++ b/config/locales/export/funding_agreement_letters_csv_export.yml
@@ -7,4 +7,4 @@ en:
         title: "%{date} funding agreement letter export"
         body_html:
           <p>Export downloads can take time to prepare, please be patient.</p>
-        button: Download csv file
+        button: Download CSV file

--- a/config/locales/export/grant_management_and_finance_unit_csv_export.en.yml
+++ b/config/locales/export/grant_management_and_finance_unit_csv_export.en.yml
@@ -31,4 +31,4 @@ en:
         title: "%{date} grant management and funding unit export"
         body_html:
           <p>Export downloads can take time to prepare, please be patient.</p>
-        button: Download csv file
+        button: Download CSV file

--- a/config/locales/export/landing_page.en.yml
+++ b/config/locales/export/landing_page.en.yml
@@ -2,7 +2,7 @@ en:
   export:
     landing_page:
       title: Exports
-      body: Check tables that show the progress of projects that will convert or transfer soon. You can also download .CSV file spreadsheets of the data.
+      body: Check tables that show the progress of projects that will convert or transfer soon. You can also download CSV file spreadsheets of the data.
       conversions:
         title: Conversion project data
         body: View tables and download spreadsheets that show information about conversions.

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -220,6 +220,9 @@ en:
         view_confirmed_transfer_projects_for: View %{date}'s confirmed transfers
         view_revised_transfer_projects_for: View %{date}'s revised transfers
         download_transfer_projects_for: Download %{date}'s transfers
+        export_link: Export
+        export_link_title_conversions_html: Download the funding export for %{date} conversions
+        conversion_project_count_html: "%{count} <span class='govuk-visually-hidden'>school(s) converting in %{date}</span>"
       empty:
         projects: There are no projects
       in_progress:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -189,6 +189,11 @@ Rails.application.routes.draw do
                 get ":month/:year", to: "projects#show", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :show
                 get ":month/:year/csv", to: "projects#csv", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :csv
               end
+              namespace :conversions do
+                get "/", to: "projects#index"
+                get ":month/:year", to: "projects#show", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :show
+                get ":month/:year/csv", to: "projects#csv", constraints: {month: MONTH_1_12_REGEX, year: YEAR_2000_2499_REGEX}, as: :csv
+              end
             end
           end
         end

--- a/spec/features/all_projects/export/esfa_users_can_export_download_spec.rb
+++ b/spec/features/all_projects/export/esfa_users_can_export_download_spec.rb
@@ -45,6 +45,6 @@ RSpec.feature "ESFA users can export" do
 
     click_on "Export for #{Date.today.to_fs(:govuk_month)}"
 
-    expect(page).to have_link("Download csv file")
+    expect(page).to have_link("Download CSV file")
   end
 end

--- a/spec/features/all_projects/export/grant_management_and_finance_users_can_export_download_spec.rb
+++ b/spec/features/all_projects/export/grant_management_and_finance_users_can_export_download_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Grant management and finance unit users can export projects by Ad
       click_on "Export for #{Date.today.to_fs(:govuk_month)}"
       expect(page).to have_content("#{Date.today.to_fs(:govuk_month)} Grants Management and Finance Unit export")
 
-      click_on "Download csv file"
+      click_on "Download CSV file"
       expect(page.response_headers["Content-Disposition"]).to include("#{Date.today.year}-#{Date.today.month}_grant_management_and_finance_unit_conversions_export.csv")
     end
   end
@@ -88,7 +88,7 @@ RSpec.feature "Grant management and finance unit users can export projects by Ad
       click_on "Export for #{Date.today.to_fs(:govuk_month)}"
       expect(page).to have_content("#{Date.today.to_fs(:govuk_month)} Grants Management and Finance Unit export")
 
-      click_on "Download csv file"
+      click_on "Download CSV file"
       expect(page.response_headers["Content-Disposition"]).to include("#{Date.today.year}-#{Date.today.month}_grant_management_and_finance_unit_transfers_export.csv")
     end
   end

--- a/spec/requests/all/export/by_month/conversions/projects_controller_spec.rb
+++ b/spec/requests/all/export/by_month/conversions/projects_controller_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe All::Export::ByMonth::Conversions::ProjectsController, type: :request do
+  let(:user) { create(:user, team: :education_and_skills_funding_agency) }
+
+  before do
+    mock_all_academies_api_responses
+    mock_successful_members_api_responses(member_name: build(:members_api_name), member_contact_details: [build(:members_api_contact_details)])
+    sign_in_with(user)
+  end
+
+  describe "#index" do
+    it "shows the next 6 months" do
+      travel_to Date.new(2023, 1, 1) do
+        get all_export_by_month_conversions_projects_path
+        expect(response.body).to include(
+          "January 2023",
+          "February 2023",
+          "March 2023",
+          "April 2023",
+          "May 2023",
+          "June 2023"
+        )
+      end
+    end
+
+    it "shows the counts of schools converting in the next 6 months" do
+      _february_project = create(:conversion_project, significant_date: Date.new(2023, 2, 1))
+
+      travel_to Date.new(2023, 1, 1) do
+        get all_export_by_month_conversions_projects_path
+        expect(response.body).to include("1 <span class='govuk-visually-hidden'>school(s) converting in February 2023</span>")
+      end
+    end
+  end
+
+  describe "#show" do
+    it "shows the info page for the CSV download" do
+      get show_all_export_by_month_conversions_projects_path(5, 2025)
+      expect(response.body).to include("RPA, SUG and FA letters export for May 2025")
+    end
+  end
+
+  describe "#csv" do
+    let!(:project) { create(:conversion_project, significant_date: Date.new(2025, 5, 1), significant_date_provisional: false) }
+
+    it "returns the csv with a successful response" do
+      get csv_all_export_by_month_conversions_projects_path(5, 2025)
+      expect(response.body).to include(project.urn.to_s)
+      expect(response).to have_http_status(:success)
+    end
+
+    it "formats the csv filename with the month & year" do
+      get csv_all_export_by_month_conversions_projects_path(5, 2025)
+      expect(response.header["Content-Disposition"]).to include("2025-5_schools_due_to_convert.csv")
+    end
+  end
+end

--- a/spec/services/projects_for_export_service_spec.rb
+++ b/spec/services/projects_for_export_service_spec.rb
@@ -141,6 +141,38 @@ RSpec.describe ProjectsForExportService do
     end
   end
 
+  describe "#conversion_by_month_projects" do
+    it "returns only conversion projects converting in the supplied month & year" do
+      matching_project_1 = create(:conversion_project, significant_date_provisional: false, significant_date: Date.parse("2023-1-1"))
+      matching_project_2 = create(:conversion_project, significant_date_provisional: false, significant_date: Date.parse("2023-1-1"))
+      mismatching_project_1 = create(:conversion_project, significant_date_provisional: false, significant_date: Date.parse("2023-2-1"))
+      mismatching_project_2 = create(:transfer_project, significant_date_provisional: false, significant_date: Date.parse("2023-1-1"))
+
+      projects_for_export = described_class.new.conversion_by_month_projects(month: 1, year: 2023)
+
+      expect(projects_for_export).to include(matching_project_1, matching_project_2)
+      expect(projects_for_export).not_to include(mismatching_project_1, mismatching_project_2)
+    end
+
+    it "includes both provisional and confirmed projects" do
+      confirmed_project = create(:conversion_project, conversion_date_provisional: false, significant_date: Date.parse("2023-1-1"))
+      provisional_project = create(:conversion_project, conversion_date_provisional: true, significant_date: Date.parse("2023-1-1"))
+
+      projects_for_export = described_class.new.conversion_by_month_projects(month: 1, year: 2023)
+
+      expect(projects_for_export).to include(confirmed_project)
+      expect(projects_for_export).to include(provisional_project)
+    end
+
+    it "includes Form a MAT transfers" do
+      project = create(:conversion_project, :form_a_mat, significant_date_provisional: false, significant_date: Date.parse("2023-1-1"))
+
+      projects_for_export = described_class.new.conversion_by_month_projects(month: 1, year: 2023)
+
+      expect(projects_for_export).to include(project)
+    end
+  end
+
   describe "#funding_agreement_letters_projects" do
     it "returns only conversion projects" do
       transfer_project = create(:transfer_project, transfer_date_provisional: false, transfer_date: Date.parse("2025-1-1"))


### PR DESCRIPTION
## Changes

Build out the UI for the new "mega" Conversions export. This is at `/projects/all/export/by-month/conversions` but not currently linked from the Exports page.

<img width="1320" alt="Screenshot 2024-03-15 at 10 59 50" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/0da869fd-cd8a-4480-9a82-f3216dd990eb">


<img width="1188" alt="Screenshot 2024-03-15 at 11 00 37" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/c6019a83-3297-44ff-9f84-ddfdf29ea004">

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
