### PR TITLE
Add Form a MAT project forms open TRN spreadsheet link in new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- link to TRN spreadsheet in add Form a MAT converversion form opens in new tab
+- link to TRN spreadsheet in add Form a MAT transfer form opens in new tab
+
 ### Fixed
 
 ## [Release-58][release-58]

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -87,7 +87,7 @@ en:
         caseworker_id: The caseworker responsible for this project
         new_trust_name: Enter the proposed name for the new trust. This can be changed later on if necessary.
         new_trust_reference_number_html:
-          <p>You can find the TRN in the <a href="https://educationgovuk.sharepoint.com/:x:/s/TrustandAcademyManagementServiceTRAMSPrivateBeta/ETyRXN0eIYxOmCVHTqWxSLYBQvHdfWicu7NybUaDeiz88g">new trusts spreadsheet (opens in new tab)</a>.</p>
+          <p>You can find the TRN in the <a href="https://educationgovuk.sharepoint.com/:x:/s/TrustandAcademyManagementServiceTRAMSPrivateBeta/ETyRXN0eIYxOmCVHTqWxSLYBQvHdfWicu7NybUaDeiz88g" class="govuk-link" rel="noreferrer noopener" target="_blank">new trusts spreadsheet (opens in new tab)</a>.</p>
       conversion_project:
         provisional_conversion_date: You can find this in the advisory board template.
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -81,7 +81,7 @@ en:
       transfer_create_project_form:
         new_trust_name: Enter the proposed name for the new trust. This can be changed later on if necessary.
         new_trust_reference_number_html:
-          <p>You can find the TRN in the <a href="https://educationgovuk.sharepoint.com/:x:/s/TrustandAcademyManagementServiceTRAMSPrivateBeta/ETyRXN0eIYxOmCVHTqWxSLYBQvHdfWicu7NybUaDeiz88g">new trusts spreadsheet (opens in new tab)</a>.</p>
+          <p>You can find the TRN in the <a href="https://educationgovuk.sharepoint.com/:x:/s/TrustandAcademyManagementServiceTRAMSPrivateBeta/ETyRXN0eIYxOmCVHTqWxSLYBQvHdfWicu7NybUaDeiz88g" class="govuk-link" rel="noreferrer noopener" target="_blank">new trusts spreadsheet (opens in new tab)</a>.</p>
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this academy. This is where you save all the relevant academy documents.
         incoming_trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
         outgoing_trust_sharepoint_link: Provide a link to the SharePoint folder for the outgoing trust. This is where you save all the relevant trust documents.


### PR DESCRIPTION
## Changes

Trust TRN field hint text for Form a MAT conversions and transfers points user to a spreadsheet to get the trust reference number so they can add the project to Complete.

The text says open in new tab, but it opens in the same tab. This happens for conversions and transfers.

This work opens those links in new tabs.

![Screenshot 2024-03-14 at 11 37 27 AM](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/57301fca-40c9-42b1-86b4-19c021ef8da6)

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
