### PR TITLE
(159810) Temporarily remove future date validation for confirmed project dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - link to TRN spreadsheet in add Form a MAT converversion form opens in new tab
 - link to TRN spreadsheet in add Form a MAT transfer form opens in new tab
+- Temporarily remove the future date validation for confirmed significant dates
 
 ### Fixed
 

--- a/app/forms/concerns/conversion_datable.rb
+++ b/app/forms/concerns/conversion_datable.rb
@@ -7,7 +7,6 @@ module ConversionDatable
     attribute "confirmed_conversion_date(3i)"
 
     validate :conversion_date_format
-    validate :conversion_date_in_the_future, if: -> { valid_month? && valid_year? }
   end
 
   def confirmed_conversion_date
@@ -22,11 +21,6 @@ module ConversionDatable
     errors.add(:confirmed_conversion_date, format_error) if month.blank? || year.blank?
     errors.add(:confirmed_conversion_date, format_error) unless valid_month?
     errors.add(:confirmed_conversion_date, format_error) unless valid_year?
-  end
-
-  private def conversion_date_in_the_future
-    in_the_future_error = I18n.t("conversion.task.stakeholder_kick_off.confirmed_conversion_date.errors.in_the_future")
-    errors.add(:confirmed_conversion_date, in_the_future_error) unless Date.new(year, month, 1).future?
   end
 
   private def month

--- a/app/forms/concerns/transfer_datable.rb
+++ b/app/forms/concerns/transfer_datable.rb
@@ -7,7 +7,6 @@ module TransferDatable
     attribute "confirmed_transfer_date(3i)"
 
     validate :transfer_date_format
-    validate :transfer_date_in_the_future, if: -> { valid_month? && valid_year? }
   end
 
   def confirmed_transfer_date
@@ -22,11 +21,6 @@ module TransferDatable
     errors.add(:confirmed_transfer_date, format_error) if month.blank? || year.blank?
     errors.add(:confirmed_transfer_date, format_error) unless valid_month?
     errors.add(:confirmed_transfer_date, format_error) unless valid_year?
-  end
-
-  private def transfer_date_in_the_future
-    in_the_future_error = I18n.t("transfer.task.stakeholder_kick_off.confirmed_transfer_date.errors.in_the_future")
-    errors.add(:confirmed_transfer_date, in_the_future_error) unless Date.new(year, month, 1).future?
   end
 
   private def month

--- a/spec/forms/conversion/tasks/stakeholder_kick_off_task_form_spec.rb
+++ b/spec/forms/conversion/tasks/stakeholder_kick_off_task_form_spec.rb
@@ -33,21 +33,6 @@ RSpec.describe Conversion::Task::StakeholderKickOffTaskForm do
         end
       end
 
-      context "when the date is in the past" do
-        it "is invalid with the appropriate error message" do
-          task_form = described_class.new(Conversion::TasksData.new, user)
-          task_form.assign_attributes(
-            "confirmed_conversion_date(3i)": "1",
-            "confirmed_conversion_date(2i)": "1",
-            "confirmed_conversion_date(1i)": "2022"
-          )
-
-          expect(task_form).to be_invalid
-          expect(task_form.errors.messages[:confirmed_conversion_date])
-            .to include(I18n.t("conversion.task.stakeholder_kick_off.confirmed_conversion_date.errors.in_the_future"))
-        end
-      end
-
       context "when the date is not provided" do
         it "is valid" do
           task_form = described_class.new(Conversion::TasksData.new, user)

--- a/spec/forms/transfer/tasks/stakeholder_kick_off_task_form_spec.rb
+++ b/spec/forms/transfer/tasks/stakeholder_kick_off_task_form_spec.rb
@@ -33,21 +33,6 @@ RSpec.describe Transfer::Task::StakeholderKickOffTaskForm do
         end
       end
 
-      context "when the date is in the past" do
-        it "is invalid with the appropriate error message" do
-          task_form = described_class.new(Transfer::TasksData.new, user)
-          task_form.assign_attributes(
-            "confirmed_transfer_date(3i)": "1",
-            "confirmed_transfer_date(2i)": "1",
-            "confirmed_transfer_date(1i)": "2022"
-          )
-
-          expect(task_form).to be_invalid
-          expect(task_form.errors.messages[:confirmed_transfer_date])
-            .to include(I18n.t("transfer.task.stakeholder_kick_off.confirmed_transfer_date.errors.in_the_future"))
-        end
-      end
-
       context "when the date is not provided" do
         it "is valid" do
           task_form = described_class.new(Transfer::TasksData.new, user)


### PR DESCRIPTION
We need to temporarily remove the future date validation for confirmed significant dates. People are backfilling the application with projects already completed, and the confirmed dates will be in the past for some of these projects.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
