### PR TITLE
(159930) Add declaration of expenditure certificate task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   management and finance exports
 - Add the new "declaration of expenditure certificate task" to the transfers
   task list
+- The "declaration of expenditure certificate date received" is included in the
+  "Grant management and finance unit" csv export
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add UI for "schools due to convert" export, which is replacing ESFA & Grant
   management and finance exports
+- Add the new "declaration of expenditure certificate task" to the transfers
+  task list
 
 ### Changed
 

--- a/app/forms/transfer/task/declaration_of_expenditure_certificate_task_form.rb
+++ b/app/forms/transfer/task/declaration_of_expenditure_certificate_task_form.rb
@@ -1,0 +1,70 @@
+class Transfer::Task::DeclarationOfExpenditureCertificateTaskForm < BaseOptionalTaskForm
+  attribute :date_received, :date
+  attribute :correct, :boolean
+  attribute :saved, :boolean
+  attribute "date_received(1i)"
+  attribute "date_received(2i)"
+  attribute "date_received(3i)"
+
+  validate :govuk_three_field_date_format
+
+  def initialize(tasks_data, user)
+    @tasks_data = tasks_data
+    @user = user
+    @project = tasks_data.project
+    super(@tasks_data, @user)
+
+    self.date_received = @project.tasks_data.declaration_of_expenditure_certificate_date_received
+  end
+
+  def save
+    if valid?
+      @tasks_data.assign_attributes(
+        declaration_of_expenditure_certificate_date_received: formatted_date,
+        declaration_of_expenditure_certificate_not_applicable: not_applicable,
+        declaration_of_expenditure_certificate_correct: correct,
+        declaration_of_expenditure_certificate_saved: saved
+      )
+      @tasks_data.save!
+    end
+  end
+
+  def formatted_date
+    return nil if month.blank? || year.blank? || day.blank?
+    Date.new(year, month, day)
+  end
+
+  private def govuk_three_field_date_format
+    return if month.blank? && year.blank? && day.blank?
+
+    Date.new(year, month, day)
+  rescue TypeError, Date::Error
+    errors.add(:date_received, I18n.t("transfer.task.confirm_date_academy_transferred.errors.format"))
+  end
+
+  private def day
+    day = attributes["date_received(3i)"]
+    return if day.blank?
+
+    day.to_i
+  end
+
+  private def month
+    month = attributes["date_received(2i)"]
+    return if month.blank?
+
+    month.to_i
+  end
+
+  private def year
+    year = attributes["date_received(1i)"]
+    return false unless ("1900".."3000").to_a.include?(year)
+    return if year.blank?
+
+    year.to_i
+  end
+
+  def completed?
+    date_received.present? && correct.present? && saved.present?
+  end
+end

--- a/app/models/transfer/task_list.rb
+++ b/app/models/transfer/task_list.rb
@@ -42,7 +42,8 @@ class Transfer::TaskList < ::BaseTaskList
         identifier: :after_transfer,
         tasks: [
           Transfer::Task::ConfirmDateAcademyTransferredTaskForm,
-          Transfer::Task::RedactAndSendDocumentsTaskForm
+          Transfer::Task::RedactAndSendDocumentsTaskForm,
+          Transfer::Task::DeclarationOfExpenditureCertificateTaskForm
         ]
       }
     ]

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -309,6 +309,13 @@ class Export::Csv::ProjectPresenter
     other_contact&.title
   end
 
+  def declaration_of_expenditure_certificate_date_received
+    return I18n.t("export.csv.project.values.not_applicable") if @project.is_a?(Conversion::Project)
+    return I18n.t("export.csv.project.values.unconfirmed") unless @project.tasks_data.declaration_of_expenditure_certificate_date_received.present?
+
+    @project.tasks_data.declaration_of_expenditure_certificate_date_received.to_fs(:csv)
+  end
+
   private def other_contact
     @contacts_fetcher.other_contact
   end

--- a/app/services/export/transfers/grant_management_and_finance_unit_csv_export_service.rb
+++ b/app/services/export/transfers/grant_management_and_finance_unit_csv_export_service.rb
@@ -18,6 +18,7 @@ class Export::Transfers::GrantManagementAndFinanceUnitCsvExportService < Export:
     provisional_date
     transfer_date
     date_academy_transferred
+    declaration_of_expenditure_certificate_date_received
     added_by_email
     assigned_to_email
     link_to_project

--- a/app/views/transfers/tasks/declaration_of_expenditure_certificate/edit.html.erb
+++ b/app/views/transfers/tasks/declaration_of_expenditure_certificate/edit.html.erb
@@ -1,0 +1,39 @@
+<%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
+
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.declaration_of_expenditure_certificate.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+
+       <%= form.govuk_date_field :date_received,
+             legend: {text: t("transfer.task.declaration_of_expenditure_certificate.date_received.title")},
+             hint: {text: t("transfer.task.declaration_of_expenditure_certificate.date_received.hint.html")} %>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :correct)) %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
+      </div>
+
+      <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -137,6 +137,7 @@ en:
           other_contact_role: Other contact role
           date_academy_transferred: Date the transfer happened
           date_academy_opened: Date the conversion happened
+          declaration_of_expenditure_certificate_date_received: Date the declaration of expenditure certificate was received
         values:
           project_type:
             conversion: Conversion

--- a/config/locales/transfer/tasks/declaration_of_expenditure_certificate.en.yml
+++ b/config/locales/transfer/tasks/declaration_of_expenditure_certificate.en.yml
@@ -1,0 +1,33 @@
+en:
+  transfer:
+    task:
+      declaration_of_expenditure_certificate:
+        title: Receive declaration of expenditure certificate
+        hint:
+          html:
+            <p>Only do this task if the incoming trust got academy transfer grant funding.</p>
+            <p>3 months after the transfer date, remind the trust to complete and return the declaration of expenditure certificate.</p>
+        guidance_link: What to do if you have not received the certificate
+        guidance:
+          html:
+            <p>The incoming trust should send the certificate back to you within 10 days of the first reminder.</p>
+            <p>If they do not, send them another reminder.</p>
+            <p>Remind them every 10 days until they send it back.</p>
+        not_applicable:
+          title: Not applicable
+        date_received:
+          title: Enter the date you received the declaration of expenditure certificate
+          hint:
+            html: For example 27 5 2007
+        correct:
+          title: Check the declaration of expenditure certificate is correct
+          hint:
+            html:
+              <p>Make sure the amounts mentioned are accurate. You also need to make sure the grant has been used for allowable expenses and that there is no missing information.</p>
+              <p>Email <a href="mailto:cfugrantpayments.regionsgroup@education.gov.uk">cfugrantpayments.regionsgroup@education.gov.uk</a> if there are any issues.</p>
+          guidance_link: How to check the declaration of expenditure certificate
+          guidance:
+            html:
+              <p>You can read <a href="https://educationgovuk.sharepoint.com/:w:/r/sites/lvedfe00116/WorkplaceDocuments/ARDG%20Internal%20Guidance/6.%20Taking%20action%20with%20underperforming%20open%20academies%20and%20free%20schools/Academy%20transfer/Academy%20Transfer%20Project/Academy%20Transfer%20Grant%20Funding%20.docx?d=w622ba523f15d429695bc8c2950091ea0&csf=1&web=1&e=oBNhwq" target="_blank">guidance on how to process and check the declaration of expenditure certificate (opens in new tab)</a> on SharePoint.</p>
+        saved:
+          title: Save the declaration of expenditure certificate in the academy's SharePoint folder

--- a/db/migrate/20240315085020_add_transfer_declaration_of_expenditure_certificate_task_attributes.rb
+++ b/db/migrate/20240315085020_add_transfer_declaration_of_expenditure_certificate_task_attributes.rb
@@ -1,0 +1,8 @@
+class AddTransferDeclarationOfExpenditureCertificateTaskAttributes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :transfer_tasks_data, :declaration_of_expenditure_certificate_date_received, :date
+    add_column :transfer_tasks_data, :declaration_of_expenditure_certificate_correct, :boolean, default: false
+    add_column :transfer_tasks_data, :declaration_of_expenditure_certificate_saved, :boolean, default: false
+    add_column :transfer_tasks_data, :declaration_of_expenditure_certificate_not_applicable, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_14_083733) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_15_085020) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -400,6 +400,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_14_083733) do
     t.date "confirm_date_academy_transferred_date_transferred"
     t.boolean "sponsored_support_grant_not_applicable", default: false
     t.string "sponsored_support_grant_type"
+    t.date "declaration_of_expenditure_certificate_date_received"
+    t.boolean "declaration_of_expenditure_certificate_correct", default: false
+    t.boolean "declaration_of_expenditure_certificate_saved", default: false
+    t.boolean "declaration_of_expenditure_certificate_not_applicable", default: false
   end
 
   create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
+++ b/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
@@ -41,6 +41,7 @@ RSpec.feature "Users can complete transfer tasks" do
     check_and_confirm_financial_information
     confirm_date_academy_transferred
     sponsored_grant_type
+    declaration_of_expenditure_certificate
   ]
 
   it "confirms that all tasks are tested here" do
@@ -217,6 +218,80 @@ RSpec.feature "Users can complete transfer tasks" do
         click_on I18n.t("task_list.continue_button.text")
 
         expect(project.reload.tasks_data.confirm_date_academy_transferred_date_transferred).to eq Date.new(2024, 1, 1)
+      end
+    end
+
+    describe "the declaration of expenditure certificate task" do
+      scenario "can be not applicable" do
+        visit project_tasks_path(project)
+        click_on "Receive declaration of expenditure certificate"
+        click_not_applicable(page)
+        click_on I18n.t("task_list.continue_button.text")
+
+        table_row = page.find("li.app-task-list__item", text: "Receive declaration of expenditure certificate")
+
+        expect(table_row).to have_content("Not applicable")
+      end
+
+      scenario "can be in progress" do
+        visit project_tasks_path(project)
+        click_on "Receive declaration of expenditure certificate"
+        check "Check the declaration of expenditure certificate is correct"
+        click_on I18n.t("task_list.continue_button.text")
+
+        table_row = page.find("li.app-task-list__item", text: "Receive declaration of expenditure certificate")
+        expect(table_row).to have_content("In progress")
+
+        click_on "Receive declaration of expenditure certificate"
+        check "Save the declaration of expenditure certificate in the academy's SharePoint folder"
+        click_on I18n.t("task_list.continue_button.text")
+
+        table_row = page.find("li.app-task-list__item", text: "Receive declaration of expenditure certificate")
+        expect(table_row).to have_content("In progress")
+
+        click_on "Receive declaration of expenditure certificate"
+        fill_in "Day", with: "1"
+        fill_in "Month", with: "1"
+        fill_in "Year", with: "2024"
+        click_on I18n.t("task_list.continue_button.text")
+
+        table_row = page.find("li.app-task-list__item", text: "Receive declaration of expenditure certificate")
+        expect(table_row).to have_content("Complete")
+      end
+      scenario "can be completed" do
+        visit project_tasks_path(project)
+        click_on "Receive declaration of expenditure certificate"
+        check "Check the declaration of expenditure certificate is correct"
+        check "Save the declaration of expenditure certificate in the academy's SharePoint folder"
+        fill_in "Day", with: "1"
+        fill_in "Month", with: "1"
+        fill_in "Year", with: "2024"
+        click_on I18n.t("task_list.continue_button.text")
+
+        table_row = page.find("li.app-task-list__item", text: "Receive declaration of expenditure certificate")
+        expect(table_row).to have_content("Complete")
+      end
+
+      scenario "records the date" do
+        visit project_tasks_path(project)
+        click_on "Receive declaration of expenditure certificate"
+        fill_in "Day", with: "1"
+        fill_in "Month", with: "1"
+        fill_in "Year", with: "2024"
+        click_on I18n.t("task_list.continue_button.text")
+
+        expect(project.reload.tasks_data.declaration_of_expenditure_certificate_date_received).to eql(Date.new(2024, 1, 1))
+      end
+
+      scenario "shows an error when the date is not valid" do
+        visit project_tasks_path(project)
+        click_on "Receive declaration of expenditure certificate"
+        fill_in "Day", with: "1"
+        fill_in "Month", with: "24"
+        fill_in "Year", with: "2024"
+        click_on I18n.t("task_list.continue_button.text")
+
+        expect(page).to have_content("Please enter a valid date")
       end
     end
   end

--- a/spec/models/transfer/task_list_spec.rb
+++ b/spec/models/transfer/task_list_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe Transfer::TaskList do
         :confirm_incoming_trust_has_completed_all_actions,
         :conditions_met,
         :confirm_date_academy_transferred,
-        :redact_and_send_documents
+        :redact_and_send_documents,
+        :declaration_of_expenditure_certificate
       ]
 
       expect(described_class.identifiers).to eql transfer_task_list_identifiers
@@ -52,9 +53,9 @@ RSpec.describe Transfer::TaskList do
       project = create(:transfer_project)
       task_list = described_class.new(project, user)
 
-      expect(task_list.tasks.count).to eql 24
+      expect(task_list.tasks.count).to eql 25
       expect(task_list.tasks.first).to be_a Transfer::Task::HandoverTaskForm
-      expect(task_list.tasks.last).to be_a Transfer::Task::RedactAndSendDocumentsTaskForm
+      expect(task_list.tasks.last).to be_a Transfer::Task::DeclarationOfExpenditureCertificateTaskForm
     end
   end
 end

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -862,4 +862,48 @@ RSpec.describe Export::Csv::ProjectPresenter do
       end
     end
   end
+
+  describe "#declaration_of_expenditure_certificate_date_received_date_received" do
+    context "when project is a conversion" do
+      it "presents not applicable" do
+        project = build(:conversion_project)
+
+        presenter = described_class.new(project)
+
+        expect(presenter.declaration_of_expenditure_certificate_date_received).to eql "not applicable"
+      end
+    end
+
+    context "when the project is a transfer" do
+      context "and the date is nil" do
+        it "presents unconfirmed" do
+          project = build(:transfer_project)
+          build(
+            :transfer_tasks_data,
+            declaration_of_expenditure_certificate_date_received: nil,
+            project: project
+          )
+
+          presenter = described_class.new(project)
+
+          expect(presenter.declaration_of_expenditure_certificate_date_received).to eql "unconfirmed"
+        end
+      end
+
+      context "and the date is present" do
+        it "presents the date" do
+          project = build(:transfer_project)
+          build(
+            :transfer_tasks_data,
+            declaration_of_expenditure_certificate_date_received: Date.new(2024, 1, 1),
+            project: project
+          )
+
+          presenter = described_class.new(project)
+
+          expect(presenter.declaration_of_expenditure_certificate_date_received).to eql "2024-01-01"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add the task to the transfers task list and the date value to the appropriate export.

Because the task has a date, we have to duplicate our code that handles this in the form, one day we might make that reusable, but that day is not today! 

Task in the list:
![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/89356bee-d97d-4572-8eba-916c09ecde53)

Task:
![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/16f690db-2144-4b96-9548-4ff2762d14bf)

Included in the export:
<img width="807" alt="Screenshot 2024-03-15 at 15 59 16" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/3919ac3b-51e5-486c-97b8-418347f64188">



