### PR TITLE
(159431) Reconfigure the exports page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- link to TRN spreadsheet in add Form a MAT converversion form opens in new tab
+- link to TRN spreadsheet in add Form a MAT conversion form opens in new tab
 - link to TRN spreadsheet in add Form a MAT transfer form opens in new tab
 - Temporarily remove the future date validation for confirmed significant dates
+- Change the export landing page to only show 4 expots (2 each for Conversions
+  and Transfers)
 
 ### Fixed
 

--- a/app/views/all/export/projects/index.html.erb
+++ b/app/views/all/export/projects/index.html.erb
@@ -17,9 +17,10 @@
   <div class="govuk-grid-column-two-thirds">
     <h4 class="govuk-heading-m"><%= t("export.landing_page.conversions.title") %></h4>
     <p class="govuk-body"><%= t("export.landing_page.conversions.body") %></p>
-    <p class="govuk-body"><%= t("export.landing_page.conversions.funding_agreement_letters_html", link: all_export_funding_agreement_letters_conversions_projects_path) %></p>
-    <p class="govuk-body"><%= t("export.landing_page.conversions.risk_protection_arrangements_html", link: all_export_education_and_skills_funding_agency_conversions_projects_path) %></p>
-    <p class="govuk-body"><%= t("export.landing_page.conversions.grant_management_html", link: all_export_grant_management_and_finance_unit_conversions_projects_path) %></p>
+    <ul>
+      <li><%= link_to t("export.landing_page.conversions.schools_due_to_convert"), all_export_by_month_conversions_projects_path %></li>
+      <li><%= link_to t("export.landing_page.conversions.grant_management"), all_export_grant_management_and_finance_unit_conversions_projects_path %></li>
+    </ul>
   </div>
 </div>
 
@@ -27,7 +28,9 @@
   <div class="govuk-grid-column-two-thirds">
     <h4 class="govuk-heading-m"><%= t("export.landing_page.transfers.title") %></h4>
     <p class="govuk-body"><%= t("export.landing_page.transfers.body") %></p>
-    <p class="govuk-body"><%= t("export.landing_page.transfers.academies_due_to_transfer_html", link: all_export_by_month_transfers_projects_path) %></p>
-    <p class="govuk-body"><%= t("export.landing_page.transfers.grant_management_html", link: all_export_grant_management_and_finance_unit_transfers_projects_path) %></p>
+    <ul>
+      <li><%= link_to t("export.landing_page.transfers.academies_due_to_transfer"), all_export_by_month_transfers_projects_path %></li>
+      <li><%= link_to t("export.landing_page.transfers.grant_management"), all_export_grant_management_and_finance_unit_transfers_projects_path %></li>
+    </ul>
   </div>
 </div>

--- a/config/locales/export/landing_page.en.yml
+++ b/config/locales/export/landing_page.en.yml
@@ -4,13 +4,12 @@ en:
       title: Exports
       body: Check tables that show the progress of projects that will convert or transfer soon. You can also download CSV file spreadsheets of the data.
       conversions:
-        title: Conversion project data
-        body: View tables and download spreadsheets that show information about conversions.
-        funding_agreement_letters_html: You can <a href="%{link}">find out who should be sent the funding agreement letters</a>.
-        risk_protection_arrangements_html: You can <a href="%{link}">check details about schools' risk protection arrangements and start-up grant funding</a>.
-        grant_management_html: You can <a href="%{link}">get information pre-opening grants for schools becoming academies</a>.
+        title: Conversions
+        body: View tables and download CSV files that show information about conversions.
+        grant_management: pre-opening grants for schools becoming academies
+        schools_due_to_convert: funding agreement letter contacts, RPA and start-up grants
       transfers:
-        title: Transfer project data
-        body: View tables and download spreadsheets that show information about transfers.
-        academies_due_to_transfer_html: You can <a href="%{link}">check which academies are due to transfer in an particular month</a>.
-        grant_management_html: You can <a href="%{link}">get information pre-opening grants for transferring academies</a>.
+        title: Transfers
+        body: View tables and download CSV files that show information about transfers.
+        academies_due_to_transfer: academies due to transfer over the next 6 months
+        grant_management: pre-transfer grants for academies joining a different trust

--- a/spec/features/all_projects/export/esfa_users_can_export_download_spec.rb
+++ b/spec/features/all_projects/export/esfa_users_can_export_download_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "ESFA users can export" do
 
     click_on "Exports"
 
-    click_on "check details about schools' risk protection arrangements and start-up grant funding"
+    click_on "funding agreement letter contacts, RPA and start-up grants"
 
     expect(page).to have_link(Date.today.to_fs(:govuk_month))
     expect(page).to have_link(Date.today.next_month.to_fs(:govuk_month))
@@ -41,9 +41,11 @@ RSpec.feature "ESFA users can export" do
 
     click_on "Exports"
 
-    click_on "check details about schools' risk protection arrangements and start-up grant funding"
+    click_on "funding agreement letter contacts, RPA and start-up grants"
 
-    click_on "Export for #{Date.today.to_fs(:govuk_month)}"
+    within("tr.govuk-table__row:contains('#{Date.today.to_fs(:govuk_month)}')") do
+      click_on "Export"
+    end
 
     expect(page).to have_link("Download CSV file")
   end

--- a/spec/features/all_projects/export/export_users_can_see_an_export_landing_page_spec.rb
+++ b/spec/features/all_projects/export/export_users_can_see_an_export_landing_page_spec.rb
@@ -16,9 +16,10 @@ RSpec.feature "Export users can see the exports landing page" do
     sign_in_with_user(user)
     click_on "Exports"
 
-    expect(page).to have_content("You can find out who should be sent the funding agreement letters.")
-    expect(page).to have_content("You can check details about schools' risk protection arrangements and start-up grant funding.")
-    expect(page).to have_content("You can get information pre-opening grants for schools becoming academies.")
+    expect(page).to have_content("funding agreement letter contacts, RPA and start-up grants")
+    expect(page).to have_content("pre-opening grants for schools becoming academies")
+    expect(page).to have_content("academies due to transfer over the next 6 months")
+    expect(page).to have_content("pre-transfer grants for academies joining a different trust")
   end
 
   scenario "an AOPU user can see the exports landing page" do
@@ -27,9 +28,10 @@ RSpec.feature "Export users can see the exports landing page" do
     sign_in_with_user(user)
     click_on "Exports"
 
-    expect(page).to have_content("You can find out who should be sent the funding agreement letters.")
-    expect(page).to have_content("You can check details about schools' risk protection arrangements and start-up grant funding.")
-    expect(page).to have_content("You can get information pre-opening grants for schools becoming academies.")
+    expect(page).to have_content("funding agreement letter contacts, RPA and start-up grants")
+    expect(page).to have_content("pre-opening grants for schools becoming academies")
+    expect(page).to have_content("academies due to transfer over the next 6 months")
+    expect(page).to have_content("pre-transfer grants for academies joining a different trust")
   end
 
   scenario "a business support user can see the exports landing page" do
@@ -38,8 +40,9 @@ RSpec.feature "Export users can see the exports landing page" do
     sign_in_with_user(user)
     click_on "Exports"
 
-    expect(page).to have_content("You can find out who should be sent the funding agreement letters.")
-    expect(page).to have_content("You can check details about schools' risk protection arrangements and start-up grant funding.")
-    expect(page).to have_content("You can get information pre-opening grants for schools becoming academies.")
+    expect(page).to have_content("funding agreement letter contacts, RPA and start-up grants")
+    expect(page).to have_content("pre-opening grants for schools becoming academies")
+    expect(page).to have_content("academies due to transfer over the next 6 months")
+    expect(page).to have_content("pre-transfer grants for academies joining a different trust")
   end
 end


### PR DESCRIPTION
We only want to show 4 exports on the export landing page:

- The grant management & finance exports for Conversions & Transfers
- The "all by month" exports for Conversions and Transfers

<img width="1112" alt="Screenshot 2024-03-18 at 14 37 42" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/539e6aa8-98a7-4625-a247-479c45e22ae2">


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
