### PR TITLE
(159343) Export the team a project is assigned to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   task list
 - The "declaration of expenditure certificate date received" is included in the
   "Grant management and finance unit" csv export
+- The team a project is assigned to is now included in the 'academies due to
+  transfer over the next 6 months' export
 
 ### Changed
 

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -171,6 +171,12 @@ class Export::Csv::ProjectPresenter
     @project.assigned_to.email
   end
 
+  def assigned_to_team
+    return I18n.t("export.csv.project.values.unassigned") unless @project.team.present?
+
+    I18n.t("export.csv.project.values.team.#{@project.team}")
+  end
+
   def main_contact_name
     return unless @project.main_contact.present?
 

--- a/app/services/export/transfers/academies_due_to_transfer_csv_export_service.rb
+++ b/app/services/export/transfers/academies_due_to_transfer_csv_export_service.rb
@@ -20,6 +20,7 @@ class Export::Transfers::AcademiesDueToTransferCsvExportService < Export::CsvExp
     bank_details_changing
     region
     assigned_to_email
+    assigned_to_team
     provisional_date
     transfer_date
     authority_to_proceed

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -138,6 +138,7 @@ en:
           date_academy_transferred: Date the transfer happened
           date_academy_opened: Date the conversion happened
           declaration_of_expenditure_certificate_date_received: Date the declaration of expenditure certificate was received
+          assigned_to_team: Team managing the project
         values:
           project_type:
             conversion: Conversion
@@ -165,3 +166,14 @@ en:
           single_transfer: single transfer
           form_a_mat: form a MAT
           none: none
+          team:
+            london: London
+            south_east: South East
+            yorkshire_and_the_humber: Yorkshire and the Humber
+            north_west: North West
+            east_of_england: East of England
+            west_midlands: West Midlands
+            north_east: North East
+            south_west: South West
+            east_midlands: East Midlands
+            regional_casework_services: Regional Casework Services

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -489,6 +489,32 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.assigned_to_email).to eql "assigned.user@education.gov.uk"
   end
 
+  describe "#assigned_to_team" do
+    it "presents unassigned when there is no team" do
+      project = build(:conversion_project, team: nil)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.assigned_to_team).to eql "unassigned"
+    end
+
+    it "presents the region of the regional team when assigned" do
+      project = build(:conversion_project, team: :london)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.assigned_to_team).to eql "London"
+    end
+
+    it "presents RCS when assigned" do
+      project = build(:conversion_project, team: :regional_casework_services)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.assigned_to_team).to eql "Regional Casework Services"
+    end
+  end
+
   it "presents the main contact email" do
     mock_successful_api_response_to_create_any_project
     user = create(:project_contact, email: "main.contact@education.gov.uk")


### PR DESCRIPTION
The AOPU want to continue to 'baseline' projects and want to know which
team a project is with, either:

- Regional Casework Services
- Regional group

We can include the `team` attribute in the appropriate export to meet
this need.

<img width="807" alt="Screenshot 2024-03-18 at 14 35 20" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/b4739d73-150e-4e12-970e-e7a0b89112a4">
