### PR TITLE
Refactor Service Support permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Allow service support users to be able to access all exports
 
+### Changed
+
+- Service Support users can now change any of the assignments for a project
+
 ## [Release-60][release-60]
 
 ### Changed

--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -6,6 +6,8 @@ class AssignmentPolicy
   end
 
   def assign_team_leader?
+    return true if @user.is_service_support?
+
     @user.manage_team?
   end
 
@@ -14,6 +16,8 @@ class AssignmentPolicy
   end
 
   def assign_regional_delivery_officer?
+    return true if @user.is_service_support?
+
     @user.manage_team?
   end
 
@@ -22,6 +26,8 @@ class AssignmentPolicy
   end
 
   def assign_assigned_to?
+    return true if @user.is_service_support?
+
     @user.has_role?
   end
 
@@ -30,10 +36,12 @@ class AssignmentPolicy
   end
 
   def assign_team?
+    return true if @user.is_service_support?
+
     @user.has_role?
   end
 
   def update_team?
-    @user.has_role?
+    assign_team?
   end
 end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -53,6 +53,7 @@ class ProjectPolicy
 
   def change_significant_date?
     return false if @record.significant_date_provisional?
+    return true if @user.is_service_support?
 
     project_assigned_to_user?
   end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -46,6 +46,7 @@ class ProjectPolicy
 
   def update?
     return false if @record.completed?
+    return true if @user.is_service_support?
 
     project_assigned_to_user?
   end
@@ -93,7 +94,7 @@ class ProjectPolicy
   end
 
   private def project_assigned_to_user?
-    @record.assigned_to == @user || @user.is_service_support?
+    @record.assigned_to == @user
   end
 
   private def edit_project_closed?

--- a/spec/policies/assignment_policy_spec.rb
+++ b/spec/policies/assignment_policy_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe AssignmentPolicy do
       expect(subject).to permit(user)
     end
 
+    it "grants access when the user is service support" do
+      user = build(:user, :service_support)
+      expect(subject).to permit(user)
+    end
+
     it "denies access when the user is not a team lead" do
       user = build(:user)
       expect(subject).not_to permit(user)
@@ -21,6 +26,11 @@ RSpec.describe AssignmentPolicy do
       expect(subject).to permit(user)
     end
 
+    it "grants access when the user is service support" do
+      user = build(:user, :service_support)
+      expect(subject).to permit(user)
+    end
+
     it "denies access when the user is not a team lead" do
       user = build(:user)
       expect(subject).not_to permit(user)
@@ -30,6 +40,11 @@ RSpec.describe AssignmentPolicy do
   permissions :assign_assigned_to?, :update_assigned_to? do
     it "grants access when the user is a team lead" do
       user = build(:user, :caseworker)
+      expect(subject).to permit(user)
+    end
+
+    it "grants access when the user is service support" do
+      user = build(:user, :service_support)
       expect(subject).to permit(user)
     end
 

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -55,6 +55,10 @@ RSpec.describe ProjectPolicy do
         expect(subject).to permit(application_user, build(:conversion_project, assigned_to: application_user, conversion_date_provisional: false))
       end
 
+      it "grants access if the user is service support" do
+        expect(subject).to permit(build(:user, :service_support), build(:conversion_project, assigned_to: application_user, conversion_date_provisional: false))
+      end
+
       it "denies access if the project is assigned to another user" do
         expect(subject).not_to permit(application_user, build(:conversion_project, assigned_to: build(:user), conversion_date_provisional: false))
       end


### PR DESCRIPTION
We wanted to allow Service Support to:

- edit any project details
- change the project conversion or transfer date
- change the assignment

It turned out most of this was already possible because we include Service
Support users in the `project_assigned_to_user?` policy method.

I found this really hard to follow, so I've taken it out and hopefully left
things a little simpler to follow.

This work also allows Service Support to change the assignment, something that
was not previously possible.
