### PR TITLE
Adding more guidance to Redact and send documents tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Allow service support users to be able to access all exports
+- Added guidance to action to send redacts documents to GOV.UK in Redact and
+  send documents task for conversions and transfers
 
 ## [Release-60][release-60]
 

--- a/config/locales/conversion/tasks/redact_and_send.en.yml
+++ b/config/locales/conversion/tasks/redact_and_send.en.yml
@@ -31,11 +31,20 @@ en:
             title: Save relevant documents in the school's SharePoint folder
 
           send_redaction:
-            title: Send the redacted documents to the funding team to be published on GOV.UK
+            title: Send the redacted documents to the funding agreements mailbox to be published on GOV.UK
             guidance_link: Help sending documents
             guidance:
               html:
                 <p>Email the documents to <a href="mailto:fundingagreements.converters@education.gov.uk" target="_blank">fundingagreements.converters@education.gov.uk</a>.</p>
+                <p>You must use the correct file name format when you save the files.</p>
+                <p>The file name must include the:</p>
+                <ul>
+                  <li>academy URN</li>
+                  <li>academy name</li>
+                  <li>local authority name</li>
+                  <li>document name</li>
+                </ul>
+                <p>It must be written as AcademyURN_AcademyName_LA_DocumentName_Redacted</p>
 
           send_solicitors:
             title: Send the redacted and unredacted versions of documents to the solicitors

--- a/config/locales/transfer/tasks/redact_and_send_documents.en.yml
+++ b/config/locales/transfer/tasks/redact_and_send_documents.en.yml
@@ -37,10 +37,20 @@ en:
         saved:
           title: Save documents in the relevant academy, incoming trust or outgoing trust SharePoint folders
         send_to_funding_team:
-          title: Send the redacted documents to the funding team to be published on GOV.UK
-          hint:
+          title: Send the redacted documents to the funding agreements mailbox to be published on GOV.UK
+          guidance_link: Help sending documents
+          guidance:
             html:
-              <p>Email the documents to <a href="mailto:fundingagreements.converters@education.gov.uk">fundingagreements.converters@education.gov.uk</a>.</p>
+              <p>Email the documents to <a href="mailto:fundingagreements.converters@education.gov.uk" target="_blank">fundingagreements.converters@education.gov.uk</a>.</p>
+              <p>You must use the correct file name format when you save the files.</p>
+              <p>The file name must include the:</p>
+              <ul>
+                <li>academy URN</li>
+                <li>academy name</li>
+                <li>local authority name</li>
+                <li>document name</li>
+              </ul>
+              <p>It must be written as AcademyURN_AcademyName_LA_DocumentName_Redacted</p>
         send_to_solicitors:
           title: Send the redacted and unredacted versions of documents to the solicitors
           hint:


### PR DESCRIPTION
## Changes

This work adds new guidance to an action in the Redact and send documents tasks in both conversions and transfers.

The guidance explain how to name the files the user must send to the funding agreements mailbox.

## Before

### Conversions

![Screenshot 2024-03-22 at 12 04 43 PM](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/5d7c50ad-3482-4048-b24a-d75a2d1378a7)

### Transfers 

![Screenshot 2024-03-22 at 12 03 18 PM](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/830fe1ff-ed66-4461-ad96-272fd4d17388)

## After

### Conversions

![Screenshot 2024-03-22 at 12 05 44 PM](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/66f12157-b8cf-400c-a249-6c3adb319aec)

### Transfers

![Screenshot 2024-03-22 at 12 06 16 PM](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/772f2e3b-819b-4fd2-a346-10eb88f044d1)

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
