### PR TITLE
(160892) Add provisional significant date to by month exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Service Support users can now change any of the assignments for a project
 - the by month exports now include the provisional conversion and transfer date
   where applicable
+- all exports now show provisional conversion or transfer date as applicable
+  instead of 'provisional date'
 
 ## [Release-60][release-60]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Service Support users can now change any of the assignments for a project
+- the by month exports now include the provisional conversion and transfer date
+  where applicable
 
 ## [Release-60][release-60]
 

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -38,6 +38,8 @@ class Export::Csv::ProjectPresenter
   def provisional_date
     @project.provisional_date.to_fs(:csv)
   end
+  alias_method :provisional_conversion_date, :provisional_date
+  alias_method :provisional_transfer_date, :provisional_date
 
   def conversion_date
     return I18n.t("export.csv.project.values.unconfirmed") if @project.conversion_date_provisional?

--- a/app/services/export/conversions/by_month_csv_export_service.rb
+++ b/app/services/export/conversions/by_month_csv_export_service.rb
@@ -8,6 +8,7 @@ class Export::Conversions::ByMonthCsvExportService < Export::CsvExportService
     local_authority_name
     region
     diocese_name
+    provisional_conversion_date
     conversion_date
     academy_order_type
     two_requires_improvement

--- a/app/services/export/conversions/grant_management_and_finance_unit_csv_export_service.rb
+++ b/app/services/export/conversions/grant_management_and_finance_unit_csv_export_service.rb
@@ -10,7 +10,7 @@ class Export::Conversions::GrantManagementAndFinanceUnitCsvExportService < Expor
     incoming_trust_name
     incoming_trust_identifier
     advisory_board_date
-    provisional_date
+    provisional_conversion_date
     conversion_date
     academy_order_type
     completed_grant_payment_certificate_received

--- a/app/services/export/conversions/schools_due_to_convert_csv_export_service.rb
+++ b/app/services/export/conversions/schools_due_to_convert_csv_export_service.rb
@@ -67,7 +67,7 @@ class Export::Conversions::SchoolsDueToConvertCsvExportService < Export::CsvExpo
     two_requires_improvement
     sponsored_grant_type
     risk_protection_arrangement
-    provisional_date
+    provisional_conversion_date
     conversion_date
     all_conditions_met
     date_academy_opened

--- a/app/services/export/transfers/academies_due_to_transfer_csv_export_service.rb
+++ b/app/services/export/transfers/academies_due_to_transfer_csv_export_service.rb
@@ -21,7 +21,7 @@ class Export::Transfers::AcademiesDueToTransferCsvExportService < Export::CsvExp
     region
     assigned_to_email
     assigned_to_team
-    provisional_date
+    provisional_transfer_date
     transfer_date
     authority_to_proceed
     main_contact_name

--- a/app/services/export/transfers/by_month_csv_export_service.rb
+++ b/app/services/export/transfers/by_month_csv_export_service.rb
@@ -8,6 +8,7 @@ class Export::Transfers::ByMonthCsvExportService < Export::CsvExportService
     local_authority_name
     region
     diocese_name
+    provisional_transfer_date
     transfer_date
     two_requires_improvement
     inadequate_ofsted

--- a/app/services/export/transfers/grant_management_and_finance_unit_csv_export_service.rb
+++ b/app/services/export/transfers/grant_management_and_finance_unit_csv_export_service.rb
@@ -15,7 +15,7 @@ class Export::Transfers::GrantManagementAndFinanceUnitCsvExportService < Export:
     trust_surplus_deficit
     transfer_grant_level
     advisory_board_date
-    provisional_date
+    provisional_transfer_date
     transfer_date
     date_academy_transferred
     declaration_of_expenditure_certificate_date_received

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -5,6 +5,8 @@ en:
         headers:
           project_type: Project type
           provisional_date: Provisional date
+          provisional_conversion_date: Provisional conversion date
+          provisional_transfer_date: Provisional transfer date
           conversion_date: Confirmed conversion date
           all_conditions_met: All conditions met
           risk_protection_arrangement: Risk protection arrangement

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -4,7 +4,6 @@ en:
       project:
         headers:
           project_type: Project type
-          provisional_date: Provisional date
           provisional_conversion_date: Provisional conversion date
           provisional_transfer_date: Provisional transfer date
           conversion_date: Confirmed conversion date


### PR DESCRIPTION
This work adds provisional conversion and transfer date columns to the 'by month' csv exports.

It also relabels the same columns in other exports instead of showing 'provisional date'.