### PR TITLE
Update significant_date_in_range scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   where applicable
 - all exports now show provisional conversion or transfer date as applicable
   instead of 'provisional date'
+- the projects shown in the 'by month' views and exports no longer contain those
+  that were due to convert or transfer in the date range, but are no longer
+  going to
 
 ## [Release-60][release-60]
 

--- a/app/models/concerns/significant_date.rb
+++ b/app/models/concerns/significant_date.rb
@@ -41,18 +41,9 @@ module SignificantDate
     end
 
     def significant_date_in_range(from_date, to_date)
-      projects = in_progress.confirmed
-
-      latest_date_histories = SignificantDateHistory.group(:project_id).maximum(:created_at)
-
-      matching_date_histories = SignificantDateHistory
-        .where(project_id: latest_date_histories.keys)
-        .where(created_at: latest_date_histories.values)
-        .to_sql
-
-      projects.joins("INNER JOIN (#{matching_date_histories}) AS date_history ON date_history.project_id = projects.id")
-        .where("date_history.revised_date >= ?", Date.parse(from_date).at_beginning_of_month)
-        .where("date_history.revised_date <= ?", Date.parse(to_date).at_end_of_month)
+      in_progress.confirmed
+        .where("significant_date >= ?", Date.parse(from_date).at_beginning_of_month)
+        .where("significant_date <= ?", Date.parse(to_date).at_end_of_month)
         .ordered_by_significant_date
     end
   end


### PR DESCRIPTION
The 'by month' views show only confirmed projects i.e. those with a
significant date that is NOT provisional.

There is no reasons to deal with the SignificantDateHistory here as we
have already filtered out any project that does not have a confirmed
significant date and we only want confirmed projects anyway.

The `significant_date` field holds this date and we can query it.

We only need to deal with SignificantDateHistory when we want projects
that were due to convert or transfer but have 'slipped' or 'slid' to
another month.

As we are looking for performance improvements, I will record the
current approx time for a request/response in production now, so that we
can compare the effect:

Date Range: Jan 2024 to Dec 2024
Date run: 25 Mar 2024
Time: ~13163ms
