### PR TITLE
Update FreeTDS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,14 +56,14 @@ RUN apt-get clean && rm -rf /var/cache/apt/archives && rm -rf /var/cache/apt/lis
 # Install FreeTDS
 # https://github.com/rails-sqlserver/tiny_tds#install
 # default FreeTDS version
-ARG freetds_version=1.1.24
+ARG FREETDS_VERSION=1.4.10
 RUN \
   curl --proto "=https" --tlsv1.2 -sSf \
-    "https://www.freetds.org/files/stable/freetds-${freetds_version}.tar.gz" \
-    --output "freetds-${freetds_version}.tar.gz" && \
-  tar -xvzf "freetds-${freetds_version}.tar.gz" && \
-  rm "freetds-${freetds_version}.tar.gz" && \
-  cd "freetds-${freetds_version}" && \
+    "https://www.freetds.org/files/stable/freetds-${FREETDS_VERSION}.tar.gz" \
+    --output "freetds-${FREETDS_VERSION}.tar.gz" && \
+  tar -xvzf "freetds-${FREETDS_VERSION}.tar.gz" && \
+  rm "freetds-${FREETDS_VERSION}.tar.gz" && \
+  cd "freetds-${FREETDS_VERSION}" && \
   ./configure --prefix=/usr/local --with-tdsver=7.3 && \
   make && make install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get clean && rm -rf /var/cache/apt/archives && rm -rf /var/cache/apt/lis
 # https://github.com/rails-sqlserver/tiny_tds#install
 # default FreeTDS version
 ARG FREETDS_VERSION=1.4.10
+ARG TDS_VERSION=7.3
 RUN \
   curl --proto "=https" --tlsv1.2 -sSf \
     "https://www.freetds.org/files/stable/freetds-${FREETDS_VERSION}.tar.gz" \
@@ -64,7 +65,7 @@ RUN \
   tar -xvzf "freetds-${FREETDS_VERSION}.tar.gz" && \
   rm "freetds-${FREETDS_VERSION}.tar.gz" && \
   cd "freetds-${FREETDS_VERSION}" && \
-  ./configure --prefix=/usr/local --with-tdsver=7.3 && \
+  ./configure --prefix=/usr/local --with-tdsver=${TDS_VERSION} && \
   make && make install
 
 # Install Geckodriver


### PR DESCRIPTION
We are running a pretty old version op FreeTDS which TinyTDS uses (which the Rails SQL Server adaptor uses).

This work updates FreeTDS to the current version and tidys up a little, making the build args more convential.

I very much doubt this will lead to a performance boost, but it can't hurt to update the version.