### PR TITLE
Release 61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release-61][release-61]
+
 ### Added
 
 - Allow service support users to be able to access all exports
@@ -1727,7 +1729,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-60...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-61...HEAD
+[release-61]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-60...release-61
 [release-60]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-59...release-60
 [release-59]:


### PR DESCRIPTION
## Added

- Allow service support users to be able to access all exports
- Added guidance to action to send redacts documents to GOV.UK in Redact and
  send documents task for conversions and transfers

## Changed

- Service Support users can now change any of the assignments for a project
- the by month exports now include the provisional conversion and transfer date
  where applicable
- all exports now show provisional conversion or transfer date as applicable
  instead of 'provisional date'
- the projects shown in the 'by month' views and exports no longer contain those
  that were due to convert or transfer in the date range, but are no longer
  going to

