### PR TITLE
(Fix) Clear the value of sponsored_support_grant_type if "Not applicable" ticked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Clear any radio button values in the Sponsored support grant type task if the
+  task is later saved as "Not applicable"
+
 ## [Release-61][release-61]
 
 ### Added

--- a/app/forms/conversion/task/sponsored_support_grant_task_form.rb
+++ b/app/forms/conversion/task/sponsored_support_grant_task_form.rb
@@ -8,4 +8,14 @@ class Conversion::Task::SponsoredSupportGrantTaskForm < BaseOptionalTaskForm
   def type_options
     Conversion::TasksData.sponsored_support_grant_types.values
   end
+
+  def save
+    if not_applicable
+      @tasks_data.sponsored_support_grant_type = nil
+      @tasks_data.assign_attributes prefixed_attributes.except("sponsored_support_grant_type")
+    else
+      @tasks_data.assign_attributes prefixed_attributes
+    end
+    @tasks_data.save!
+  end
 end

--- a/app/forms/transfer/task/sponsored_support_grant_task_form.rb
+++ b/app/forms/transfer/task/sponsored_support_grant_task_form.rb
@@ -4,4 +4,14 @@ class Transfer::Task::SponsoredSupportGrantTaskForm < BaseOptionalTaskForm
   def type_options
     Transfer::TasksData.sponsored_support_grant_types.values
   end
+
+  def save
+    if not_applicable
+      @tasks_data.sponsored_support_grant_type = nil
+      @tasks_data.assign_attributes prefixed_attributes.except("sponsored_support_grant_type")
+    else
+      @tasks_data.assign_attributes prefixed_attributes
+    end
+    @tasks_data.save!
+  end
 end

--- a/spec/forms/conversion/tasks/sponsored_support_grant_task_form_spec.rb
+++ b/spec/forms/conversion/tasks/sponsored_support_grant_task_form_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Conversion::Task::SponsoredSupportGrantTaskForm do
+  let(:user) { create(:user) }
+  let(:project) { create(:conversion_project) }
+
+  describe "#save" do
+    before { mock_successful_api_response_to_create_any_project }
+
+    it "clears the value of 'type' if 'Not applicable' is ticked" do
+      form = described_class.new(project.tasks_data, user)
+      form.assign_attributes(type: "fast_track")
+      form.save
+
+      expect(project.tasks_data.sponsored_support_grant_type).to eq("fast_track")
+
+      form.assign_attributes(not_applicable: true)
+      form.save
+
+      expect(project.tasks_data.sponsored_support_grant_type).to be_nil
+    end
+  end
+end

--- a/spec/forms/transfer/tasks/sponsored_support_grant_task_form_spec.rb
+++ b/spec/forms/transfer/tasks/sponsored_support_grant_task_form_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Transfer::Task::SponsoredSupportGrantTaskForm do
+  let(:user) { create(:user) }
+  let(:project) { create(:transfer_project) }
+
+  describe "#save" do
+    before { mock_successful_api_response_to_create_any_project }
+
+    it "clears the value of 'type' if 'Not applicable' is ticked" do
+      form = described_class.new(project.tasks_data, user)
+      form.assign_attributes(type: "fast_track")
+      form.save
+
+      expect(project.tasks_data.sponsored_support_grant_type).to eq("fast_track")
+
+      form.assign_attributes(not_applicable: true)
+      form.save
+
+      expect(project.tasks_data.sponsored_support_grant_type).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
We had a bug (more a UI anomaly) on the Sponsored Support Grant task: a user had previously selected a support grant type but now wanted the task to be "Not applicable". However because the support grant types are in radio buttons, they were unable to clear the value.

This confused the user, as although the task was now correctly logged as "not applicable" the UI showed the type still selected.

Override the `save` method on these two tasks, so that if the Not applicable box is checked, any value in sponsored_support_grant_type is removed.

![image (8)](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/58cac351-a6bb-4fd8-b002-cf6ec066370a)


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
