### PR TITLE
Update Members API error handling and Application Insights events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Clear any radio button values in the Sponsored support grant type task if the
   task is later saved as "Not applicable"
+- for some projects, an MP name could not be located which caused some views and
+  exports to fail, this has been resolved
 
 ## [Release-61][release-61]
 

--- a/app/models/api/members_api/client.rb
+++ b/app/models/api/members_api/client.rb
@@ -35,7 +35,7 @@ class Api::MembersApi::Client
     member_name = member_name(member_id).object
     contact_details = member_contact_details(member_id).object.find { |details| details.type_id == 1 }
 
-    Api::MembersApi::MemberDetails.new(member_name, contact_details)
+    Result.new(Api::MembersApi::MemberDetails.new(member_name, contact_details), nil)
   rescue NoMethodError
     Result.new(nil, Error.new(I18n.t("members_api.errors.contact_details_not_found", member_id: member_id)))
   end

--- a/app/models/api/members_api/client.rb
+++ b/app/models/api/members_api/client.rb
@@ -1,4 +1,6 @@
 class Api::MembersApi::Client
+  include ApplicationInsightsEventTrackable
+
   class Error < StandardError; end
 
   class MultipleResultsError < StandardError; end
@@ -27,7 +29,7 @@ class Api::MembersApi::Client
     member = member_id(constituency)
 
     if member.error.present?
-      track_error(member.error.message)
+      track_event(member.error.message)
       return nil
     end
 
@@ -116,14 +118,6 @@ class Api::MembersApi::Client
         "Content-Type": "application/json"
       }
     )
-  end
-
-  private def track_error(error_message)
-    if ENV.fetch("APPLICATION_INSIGHTS_KEY", nil)
-      tc = ApplicationInsights::TelemetryClient.new(ENV.fetch("APPLICATION_INSIGHTS_KEY"))
-      tc.track_event(error_message)
-      tc.flush
-    end
   end
 
   class Result

--- a/app/models/api/members_api/client.rb
+++ b/app/models/api/members_api/client.rb
@@ -1,6 +1,4 @@
 class Api::MembersApi::Client
-  include ApplicationInsightsEventTrackable
-
   class Error < StandardError; end
 
   class MultipleResultsError < StandardError; end
@@ -28,10 +26,7 @@ class Api::MembersApi::Client
   def member_for_constituency(constituency)
     member = member_id(constituency)
 
-    if member.error.present?
-      track_event(member.error.message)
-      return nil
-    end
+    return Result.new(nil, member.error) if member.error.present?
 
     member_id = member.object
     member_name = member_name(member_id).object

--- a/app/models/concerns/application_insights_event_trackable.rb
+++ b/app/models/concerns/application_insights_event_trackable.rb
@@ -1,0 +1,11 @@
+module ApplicationInsightsEventTrackable
+  extend ActiveSupport::Concern
+
+  def track_event(message)
+    if ENV.fetch("APPLICATION_INSIGHTS_KEY", nil)
+      tc = ApplicationInsights::TelemetryClient.new(ENV.fetch("APPLICATION_INSIGHTS_KEY"))
+      tc.track_event(message)
+      tc.flush
+    end
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,6 +2,7 @@ class Project < ApplicationRecord
   include Teamable
   include Eventable
   include SignificantDate
+  include ApplicationInsightsEventTrackable
 
   attr_writer :establishment, :incoming_trust, :member_of_parliament
 
@@ -127,9 +128,11 @@ class Project < ApplicationRecord
   private def fetch_member_of_parliament
     result = Api::MembersApi::Client.new.member_for_constituency(establishment.parliamentary_constituency)
 
-    return nil if result.error.present?
-
-    result.object
+    if result.error.present?
+      track_event(result.error.message)
+    else
+      result.object
+    end
   end
 
   private def fetch_establishment(urn)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -125,7 +125,11 @@ class Project < ApplicationRecord
   end
 
   private def fetch_member_of_parliament
-    Api::MembersApi::Client.new.member_for_constituency(establishment.parliamentary_constituency)
+    result = Api::MembersApi::Client.new.member_for_constituency(establishment.parliamentary_constituency)
+
+    return nil if result.error.present?
+
+    result.object
   end
 
   private def fetch_establishment(urn)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -137,14 +137,22 @@ class Project < ApplicationRecord
 
   private def fetch_establishment(urn)
     result = Api::AcademiesApi::Client.new.get_establishment(urn)
-    raise result.error if result.error.present?
+
+    if result.error.present?
+      track_event(result.error.message)
+      raise result.error
+    end
 
     result.object
   end
 
   private def fetch_trust(ukprn)
     result = Api::AcademiesApi::Client.new.get_trust(ukprn)
-    raise result.error if result.error.present?
+
+    if result.error.present?
+      track_event(result.error.message)
+      raise result.error
+    end
 
     result.object
   end

--- a/config/locales/members_api.en.yml
+++ b/config/locales/members_api.en.yml
@@ -1,10 +1,10 @@
 en:
   members_api:
     errors:
-      other: There was an error connecting to the Members API
-      multiple: "Multiple results found for search term: %{search_term}"
-      search_term_not_found: "Constituency not found: %{constituency}"
-      member_not_found: "Member not found: %{member_id}"
-      contact_details_not_found: "Contact details not found for member %{member_id}"
+      other: "[MEMBERS API] There was an error connecting to the Members API"
+      multiple: "[MEMBERS API] Multiple results found for search term: %{search_term}"
+      search_term_not_found: "[MEMBERS_API] Constituency not found: %{constituency}"
+      member_not_found: "[MEMBERS API] Member not found: %{member_id}"
+      contact_details_not_found: "[MEMBERS API] Contact details not found for member %{member_id}"
     member:
       title: Member of Parliament for %{constituency}

--- a/spec/models/api/members_api/client_spec.rb
+++ b/spec/models/api/members_api/client_spec.rb
@@ -1,12 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Api::MembersApi::Client do
-  let(:telemetry_client) { double(ApplicationInsights::TelemetryClient, track_event: true, flush: true) }
-
-  before do
-    allow(ApplicationInsights::TelemetryClient).to receive(:new).and_return(telemetry_client)
-  end
-
   it "uses the environment variables to build the connection" do
     ClimateControl.modify(
       MEMBERS_API_HOST: "https://members-api.test"
@@ -88,12 +82,11 @@ RSpec.describe Api::MembersApi::Client do
       ) do
         fake_client = Api::MembersApi::Client.new
         allow(fake_client).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::MultipleResultsError.new(I18n.t("members_api.errors.multiple", search_term: "St Albans"))))
-        allow(fake_client).to receive(:member_name).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::Error))
-        allow(fake_client).to receive(:member_contact_details).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::Error))
+        allow(fake_client).to receive(:member_name).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::Error.new))
+        allow(fake_client).to receive(:member_contact_details).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::Error.new))
 
         response = fake_client.member_for_constituency("St Albans")
-        expect(response).to be_nil
-        expect(telemetry_client).to have_received(:track_event).with(I18n.t("members_api.errors.multiple", search_term: "St Albans"))
+        expect(response.object).to be_nil
       end
     end
   end

--- a/spec/models/api/members_api/client_spec.rb
+++ b/spec/models/api/members_api/client_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Api::MembersApi::Client do
       fake_contact_details = double(find: Api::MembersApi::MemberContactDetails.new.from_hash({email: "joe.bloggs@email.com", line1: "Houses of Parliment", postcode: "SW1A 0AA"}))
       allow(fake_client).to receive(:member_contact_details).and_return(Api::MembersApi::Client::Result.new(fake_contact_details, nil))
 
-      response = fake_client.member_for_constituency("St Albans")
+      response = fake_client.member_for_constituency("St Albans").object
 
       expect(response.name).to eq("Joe Bloggs")
       expect(response.email).to eq("joe.bloggs@email.com")

--- a/spec/models/concerns/appliation_insights_event_trackable_spec.rb
+++ b/spec/models/concerns/appliation_insights_event_trackable_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+class TestClass
+  include ApplicationInsightsEventTrackable
+end
+
+RSpec.describe ApplicationInsightsEventTrackable do
+  it "makes the track_event instance method available" do
+    expect(TestClass.new).to respond_to :track_event
+  end
+
+  it "tracks the event with Application Insights" do
+    ClimateControl.modify(APPLICATION_INSIGHTS_KEY: "fake-application-insights-key") do
+      telemetry_client = double(ApplicationInsights::TelemetryClient, track_event: true, flush: true)
+      allow(ApplicationInsights::TelemetryClient).to receive(:new).and_return(telemetry_client)
+
+      TestClass.new.track_event("test message")
+
+      expect(telemetry_client).to have_received(:track_event).with("test message")
+    end
+  end
+
+  it "does nothing when there is no Application Insights key" do
+    allow(ApplicationInsights::TelemetryClient).to receive(:new)
+
+    TestClass.new.track_event("test message")
+
+    expect(ApplicationInsights::TelemetryClient).not_to have_received(:new)
+  end
+end

--- a/spec/models/contact/parliament_spec.rb
+++ b/spec/models/contact/parliament_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Contact::Parliament do
   context "when the Member of Parliament is not found" do
     before do
       allow(client).to receive(:new).and_return(client_instance)
-      allow(client_instance).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::NotFoundError))
+      allow(client_instance).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::NotFoundError.new))
     end
 
     it "raises a not found error" do
@@ -53,7 +53,7 @@ RSpec.describe Contact::Parliament do
   context "when the Members API returns multiple results for the constituency" do
     before do
       allow(client).to receive(:new).and_return(client_instance)
-      allow(client_instance).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::MultipleResultsError))
+      allow(client_instance).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::MultipleResultsError.new))
     end
 
     it "raises a a multiple results error" do
@@ -64,7 +64,7 @@ RSpec.describe Contact::Parliament do
   context "when the Members API returns an error response" do
     before do
       allow(client).to receive(:new).and_return(client_instance)
-      allow(client_instance).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::Error))
+      allow(client_instance).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::Error.new))
     end
 
     it "raises a generic error" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -389,6 +389,21 @@ RSpec.describe Project, type: :model do
 
       expect(member_of_parliament).to be nil
     end
+
+    it "sends Applications Instights an event when the API call fails" do
+      ClimateControl.modify(APPLICATION_INSIGHTS_KEY: "fake-application-insights-key") do
+        telemetry_client = double(ApplicationInsights::TelemetryClient, track_event: true, flush: true)
+        allow(ApplicationInsights::TelemetryClient).to receive(:new).and_return(telemetry_client)
+
+        mock_nil_member_for_constituency_response
+
+        project = build(:conversion_project)
+        allow(project).to receive(:establishment).and_return(build(:academies_api_establishment))
+        project.member_of_parliament
+
+        expect(telemetry_client).to have_received(:track_event)
+      end
+    end
   end
 
   describe "#completed?" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -269,6 +269,16 @@ RSpec.describe Project, type: :model do
       it "raises the error" do
         expect { subject.establishment }.to raise_error(Api::AcademiesApi::Client::NotFoundError, error_message)
       end
+
+      it "sends the event to Application Insights" do
+        ClimateControl.modify(APPLICATION_INSIGHTS_KEY: "fake-application-insights-key") do
+          telemetry_client = double(ApplicationInsights::TelemetryClient, track_event: true, flush: true)
+          allow(ApplicationInsights::TelemetryClient).to receive(:new).and_return(telemetry_client)
+
+          expect { subject.establishment }.to raise_error(Api::AcademiesApi::Client::NotFoundError)
+          expect(telemetry_client).to have_received(:track_event)
+        end
+      end
     end
 
     context "when the Academies API client returns a #{Api::AcademiesApi::Client::Error}" do
@@ -324,6 +334,16 @@ RSpec.describe Project, type: :model do
 
         it "raises the error" do
           expect { subject.incoming_trust }.to raise_error(Api::AcademiesApi::Client::NotFoundError, error_message)
+        end
+
+        it "sends the event to Application Insights" do
+          ClimateControl.modify(APPLICATION_INSIGHTS_KEY: "fake-application-insights-key") do
+            telemetry_client = double(ApplicationInsights::TelemetryClient, track_event: true, flush: true)
+            allow(ApplicationInsights::TelemetryClient).to receive(:new).and_return(telemetry_client)
+
+            expect { subject.incoming_trust }.to raise_error(Api::AcademiesApi::Client::NotFoundError)
+            expect(telemetry_client).to have_received(:track_event)
+          end
         end
       end
 

--- a/spec/support/members_api_helpers.rb
+++ b/spec/support/members_api_helpers.rb
@@ -57,7 +57,9 @@ module MembersApiHelpers
       email: "member.parliament@parliament.uk",
       address: address
     )
-    members_client = double(Api::MembersApi::Client, member_for_constituency: member_details)
+    result = Api::MembersApi::Client::Result.new(member_details, nil)
+
+    members_client = double(Api::MembersApi::Client, member_for_constituency: result)
     allow(Api::MembersApi::Client).to receive(:new).and_return(members_client)
     members_client
   end
@@ -92,7 +94,8 @@ module MembersApiHelpers
 
   def mock_nil_member_for_constituency_response
     test_client = Api::MembersApi::Client.new
-    allow(test_client).to receive(:member_for_constituency).and_return(nil)
+    empty_result = Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::NotFoundError)
+    allow(test_client).to receive(:member_for_constituency).and_return(empty_result)
     allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
   end
 

--- a/spec/support/members_api_helpers.rb
+++ b/spec/support/members_api_helpers.rb
@@ -79,14 +79,14 @@ module MembersApiHelpers
 
   def mock_member_not_found_response
     test_client = Api::MembersApi::Client.new
-    not_found_result = Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::NotFoundError)
+    not_found_result = Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::NotFoundError.new)
     allow(test_client).to receive(:member_name).and_return(not_found_result)
     allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
   end
 
   def mock_contact_details_not_found_response
     test_client = Api::MembersApi::Client.new
-    not_found_result = Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::NotFoundError)
+    not_found_result = Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::NotFoundError.new)
 
     allow(test_client).to receive(:member_contact_details).and_return(not_found_result)
     allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
@@ -94,14 +94,14 @@ module MembersApiHelpers
 
   def mock_nil_member_for_constituency_response
     test_client = Api::MembersApi::Client.new
-    empty_result = Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::NotFoundError)
+    empty_result = Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::NotFoundError.new)
     allow(test_client).to receive(:member_for_constituency).and_return(empty_result)
     allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
   end
 
   def mock_members_api_unavailable_response
     test_client = Api::MembersApi::Client.new
-    error_result = Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::Error)
+    error_result = Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::Error.new)
     allow(test_client).to receive(:constituency).and_return(error_result)
     allow(test_client).to receive(:member_name).and_return(error_result)
     allow(test_client).to receive(:member_contact_details).and_return(error_result)


### PR DESCRIPTION
We are seeing some Members API errrors in production that are stopping some view and exports from completing, this work is mosly focused on resolving that.

We do so by making the Memeber API client always retrun the same `Result` object and dealing with it appropriately.

With that done, we update the Application Insights event tracking so we can better surface errors and add event tracking to the Academies API for good measure.