### PR TITLE
Replace conversion/transfer type wording to be more descriptive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Replace conversion/transfer type wording to be `join a MAT`.
+
 ### Fixed
 
 - Clear any radio button values in the Sponsored support grant type task if the

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -286,13 +286,13 @@ class Export::Csv::ProjectPresenter
   def conversion_type
     return if @project.type == "Transfer::Project"
     return I18n.t("export.csv.project.values.form_a_mat") if @project.form_a_mat?
-    I18n.t("export.csv.project.values.single_converter")
+    I18n.t("export.csv.project.values.join_a_mat")
   end
 
   def transfer_type
     return if @project.type == "Conversion::Project"
     return I18n.t("export.csv.project.values.form_a_mat") if @project.form_a_mat?
-    I18n.t("export.csv.project.values.single_transfer")
+    I18n.t("export.csv.project.values.join_a_mat")
   end
 
   def esfa_notes

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -163,8 +163,7 @@ en:
           standard: standard
           church_or_trust: church or trust
           commercial: commercial
-          single_converter: single converter
-          single_transfer: single transfer
+          join_a_mat: join a MAT
           form_a_mat: form a MAT
           none: none
           team:

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -768,11 +768,11 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.team_managing_the_project).to eql("London")
   end
 
-  it "presents the single converter conversion type" do
+  it "presents the join a MAT conversion type" do
     project = build(:conversion_project)
 
     presenter = described_class.new(project)
-    expect(presenter.conversion_type).to eq("single converter")
+    expect(presenter.conversion_type).to eq("join a MAT")
   end
 
   it "presents the form a MAT conversion type" do
@@ -782,11 +782,11 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.conversion_type).to eq("form a MAT")
   end
 
-  it "presents the single transfer transfer type" do
+  it "presents the join a MAT transfer type" do
     project = build(:transfer_project)
 
     presenter = described_class.new(project)
-    expect(presenter.transfer_type).to eq("single transfer")
+    expect(presenter.transfer_type).to eq("join a MAT")
   end
 
   it "presents the form a MAT transfer type" do


### PR DESCRIPTION
## Changes

Feedback from ESFA is that the terms `single converter` and `single transfer` are not clear.
`join a MAT` has been used to help make this clearer and will also match the `form a MAT` convention too.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
