### PR TITLE
(161265) Include chair of governors contact in export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - a new Chair of governors task has been added to the conversion project task
   list, this tasks ensures the contact details are collected
+- the chair of governors name and email address are now included in the csv
+  export when available
 
 ## [Release-62][release-62]
 

--- a/app/presenters/export/csv/chair_of_governors_presenter_module.rb
+++ b/app/presenters/export/csv/chair_of_governors_presenter_module.rb
@@ -1,0 +1,13 @@
+module Export::Csv::ChairOfGovernorsPresenterModule
+  def chair_of_governors_name
+    return if @project.chair_of_governors_contact.nil?
+
+    @project.chair_of_governors_contact.name
+  end
+
+  def chair_of_governors_email
+    return if @project.chair_of_governors_contact.nil?
+
+    @project.chair_of_governors_contact.email
+  end
+end

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -6,6 +6,7 @@ class Export::Csv::ProjectPresenter
   include Export::Csv::OutgoingTrustPresenterModule
   include Export::Csv::LocalAuthorityPresenterModule
   include Export::Csv::MpPresenterModule
+  include Export::Csv::ChairOfGovernorsPresenterModule
 
   def initialize(project)
     @project = project

--- a/app/services/export/conversions/schools_due_to_convert_csv_export_service.rb
+++ b/app/services/export/conversions/schools_due_to_convert_csv_export_service.rb
@@ -14,9 +14,8 @@ class Export::Conversions::SchoolsDueToConvertCsvExportService < Export::CsvExpo
     school_main_contact_name
     school_main_contact_role
     school_main_contact_email
-    other_contact_name
-    other_contact_role
-    other_contact_email
+    chair_of_governors_name
+    chair_of_governors_email
     academy_urn
     academy_ukprn
     academy_name

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -58,6 +58,8 @@ en:
           incoming_trust_address_town: Incoming trust address town
           incoming_trust_address_county: Incoming trust address county
           incoming_trust_address_postcode: Incoming trust address postcode
+          chair_of_governors_name: Chair of governors name
+          chair_of_governors_email: Chair of governors email
           local_authority_code: Local authority code
           local_authority_name: Local authority
           local_authority_contact_name: Local authority contact name

--- a/spec/presenters/export/csv/chair_of_governors_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/chair_of_governors_presenter_module_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe Export::Csv::ChairOfGovernorsPresenterModule do
+  before do
+    mock_successful_api_response_to_create_any_project
+  end
+
+  describe "#chair_of_governors_name" do
+    context "when there is a contact" do
+      it "presents the name of the contact" do
+        contact = build(:project_contact)
+        project = build(:conversion_project, chair_of_governors_contact: contact)
+
+        presenter = Export::Csv::ProjectPresenter.new(project)
+
+        expect(presenter.chair_of_governors_name).to eq contact.name
+      end
+    end
+
+    context "when there is no contact" do
+      it "presents nothing" do
+        project = build(:conversion_project)
+
+        presenter = Export::Csv::ProjectPresenter.new(project)
+
+        expect(presenter.chair_of_governors_name).to be_nil
+      end
+    end
+  end
+
+  describe "#chair_of_governors_email" do
+    context "when there is a contact" do
+      it "presents the name of the contact" do
+        contact = build(:project_contact)
+        project = build(:conversion_project, chair_of_governors_contact: contact)
+
+        presenter = Export::Csv::ProjectPresenter.new(project)
+
+        expect(presenter.chair_of_governors_email).to eq contact.email
+      end
+    end
+
+    context "when there is no contact" do
+      it "presents nothing" do
+        project = build(:conversion_project)
+
+        presenter = Export::Csv::ProjectPresenter.new(project)
+
+        expect(presenter.chair_of_governors_name).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Based on #1467 

We recently added the ability to identify the chair of governors for a
school converting into an academy, which can now be included in the
export used for preparing and sending the funding agreement letters.

<img width="807" alt="Screenshot 2024-03-28 at 15 55 13" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/ce1465e1-f8b5-417a-84ed-8229389632f5">
