### PR TITLE
(Chore) Rename EditProjectSharepointLinkForm -> EditProjectForm

### DIFF
--- a/app/controllers/conversions/projects_controller.rb
+++ b/app/controllers/conversions/projects_controller.rb
@@ -44,12 +44,12 @@ class Conversions::ProjectsController < ProjectsController
 
   def edit
     authorize project
-    @project_form = Conversion::EditProjectSharepointLinkForm.new(project: project)
+    @project_form = Conversion::EditProjectForm.new(project: project)
   end
 
   def update
     authorize project
-    @project_form = Conversion::EditProjectSharepointLinkForm.new(project: project, args: sharepoint_link_params)
+    @project_form = Conversion::EditProjectForm.new(project: project, args: sharepoint_link_params)
 
     if @project_form.save
       redirect_to project_information_path(project), notice: I18n.t("project.update.success")
@@ -63,7 +63,7 @@ class Conversions::ProjectsController < ProjectsController
   end
 
   private def sharepoint_link_params
-    params.require(:conversion_edit_project_sharepoint_link_form).permit(
+    params.require(:conversion_edit_project_form).permit(
       :establishment_sharepoint_link,
       :incoming_trust_sharepoint_link
     )

--- a/app/controllers/transfers/projects_controller.rb
+++ b/app/controllers/transfers/projects_controller.rb
@@ -34,12 +34,12 @@ class Transfers::ProjectsController < ApplicationController
 
   def edit
     authorize project
-    @project_form = Transfer::EditProjectSharepointLinkForm.new(project: project)
+    @project_form = Transfer::EditProjectForm.new(project: project)
   end
 
   def update
     authorize project
-    @project_form = Transfer::EditProjectSharepointLinkForm.new(project: project, args: sharepoint_link_params)
+    @project_form = Transfer::EditProjectForm.new(project: project, args: sharepoint_link_params)
 
     if @project_form.save
       redirect_to project_information_path(project), notice: I18n.t("project.update.success")
@@ -53,7 +53,7 @@ class Transfers::ProjectsController < ApplicationController
   end
 
   private def sharepoint_link_params
-    params.require(:transfer_edit_project_sharepoint_link_form).permit(
+    params.require(:transfer_edit_project_form).permit(
       :establishment_sharepoint_link,
       :incoming_trust_sharepoint_link,
       :outgoing_trust_sharepoint_link

--- a/app/forms/conversion/edit_project_form.rb
+++ b/app/forms/conversion/edit_project_form.rb
@@ -1,4 +1,4 @@
-class Conversion::EditProjectSharepointLinkForm
+class Conversion::EditProjectForm
   include ActiveModel::Model
   include ActiveModel::Attributes
   include ActiveRecord::AttributeAssignment

--- a/app/forms/transfer/edit_project_form.rb
+++ b/app/forms/transfer/edit_project_form.rb
@@ -1,4 +1,4 @@
-class Transfer::EditProjectSharepointLinkForm
+class Transfer::EditProjectForm
   include ActiveModel::Model
   include ActiveModel::Attributes
   include ActiveRecord::AttributeAssignment

--- a/spec/forms/conversion/edit_project_form_spec.rb
+++ b/spec/forms/conversion/edit_project_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.describe Transfer::EditProjectSharepointLinkForm, type: :model do
-  let(:project) { build(:transfer_project, assigned_to: user) }
+RSpec.describe Conversion::EditProjectForm, type: :model do
+  let(:project) { build(:conversion_project, assigned_to: user) }
   let(:user) { build(:user, :caseworker) }
 
   before do
@@ -11,7 +11,7 @@ RSpec.describe Transfer::EditProjectSharepointLinkForm, type: :model do
   describe "#save" do
     context "when the form is valid" do
       it "updates an exsiting sharepoint link" do
-        sharepoint_link_form = Transfer::EditProjectSharepointLinkForm.new(project: project, args: {establishment_sharepoint_link: "https://educationgovuk-my.sharepoint.com/establishment-folder", incoming_trust_sharepoint_link: "https://educationgovuk-my.sharepoint.com/incoming-trust-folder"})
+        sharepoint_link_form = Conversion::EditProjectForm.new(project: project, args: { establishment_sharepoint_link: "https://educationgovuk-my.sharepoint.com/establishment-folder", incoming_trust_sharepoint_link: "https://educationgovuk-my.sharepoint.com/incoming-trust-folder"})
         sharepoint_link_form.establishment_sharepoint_link = "https://educationgovuk-my.sharepoint.com/establishment-folder-updated-link"
         sharepoint_link_form.incoming_trust_sharepoint_link = "https://educationgovuk-my.sharepoint.com/incoming-trust-folder-updated-link"
         sharepoint_link_form.save

--- a/spec/forms/transfer/edit_project_form_spec.rb
+++ b/spec/forms/transfer/edit_project_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.describe Conversion::EditProjectSharepointLinkForm, type: :model do
-  let(:project) { build(:conversion_project, assigned_to: user) }
+RSpec.describe Transfer::EditProjectForm, type: :model do
+  let(:project) { build(:transfer_project, assigned_to: user) }
   let(:user) { build(:user, :caseworker) }
 
   before do
@@ -11,7 +11,7 @@ RSpec.describe Conversion::EditProjectSharepointLinkForm, type: :model do
   describe "#save" do
     context "when the form is valid" do
       it "updates an exsiting sharepoint link" do
-        sharepoint_link_form = Conversion::EditProjectSharepointLinkForm.new(project: project, args: {establishment_sharepoint_link: "https://educationgovuk-my.sharepoint.com/establishment-folder", incoming_trust_sharepoint_link: "https://educationgovuk-my.sharepoint.com/incoming-trust-folder"})
+        sharepoint_link_form = Transfer::EditProjectForm.new(project: project, args: { establishment_sharepoint_link: "https://educationgovuk-my.sharepoint.com/establishment-folder", incoming_trust_sharepoint_link: "https://educationgovuk-my.sharepoint.com/incoming-trust-folder"})
         sharepoint_link_form.establishment_sharepoint_link = "https://educationgovuk-my.sharepoint.com/establishment-folder-updated-link"
         sharepoint_link_form.incoming_trust_sharepoint_link = "https://educationgovuk-my.sharepoint.com/incoming-trust-folder-updated-link"
         sharepoint_link_form.save


### PR DESCRIPTION
## Changes

We are going to add some more editable attributes to projects. We should use the existing form object pattern to do this. So, rename the edit project form object to show it will be for editing more than just sharepoint links.

