### PR TITLE
(161543) Projects have a "deleted" attribute

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -68,6 +68,9 @@ class Project < ApplicationRecord
 
   scope :not_form_a_mat, -> { where.not(incoming_trust_ukprn: nil) }
 
+  default_scope { where.not(deleted: true) }
+  scope :deleted, -> { unscope(where: :deleted).where(deleted: true) }
+
   enum :region, {
     london: "H",
     south_east: "J",

--- a/db/migrate/20240403093252_add_deleted_to_projects.rb
+++ b/db/migrate/20240403093252_add_deleted_to_projects.rb
@@ -1,0 +1,5 @@
+class AddDeletedToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :deleted, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_28_122736) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_03_093252) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -279,6 +279,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_28_122736) do
     t.string "new_trust_reference_number"
     t.string "new_trust_name"
     t.uuid "chair_of_governors_contact_id"
+    t.boolean "deleted", default: false, null: false
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["incoming_trust_ukprn"], name: "index_projects_on_incoming_trust_ukprn"

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -359,7 +359,7 @@ RSpec.feature "Users can complete conversion tasks" do
     end
 
     scenario "updates an existing chair of governors contact" do
-      chair_of_governors = create(:project_contact)
+      chair_of_governors = create(:project_contact, project: project)
       project.update(chair_of_governors_contact: chair_of_governors)
 
       visit project_tasks_path(project)
@@ -380,6 +380,8 @@ RSpec.feature "Users can complete conversion tasks" do
       expect(page).to have_content "jane.chair@school.com"
       expect(page).to have_content "01234 567879"
       expect(page).to have_content project.establishment.name
+
+      expect(chair_of_governors.reload.name).to eq("Jane Chair")
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -736,6 +736,27 @@ RSpec.describe Project, type: :model do
         expect(Project.not_form_a_mat).to include(single_converter_project)
       end
     end
+
+    describe "deleted scope" do
+      it "returns projects where `deleted` is true" do
+        mock_successful_api_responses(urn: any_args, ukprn: any_args)
+        _project_1 = create(:conversion_project, deleted: false)
+        project_2 = create(:conversion_project, deleted: true)
+
+        expect(Project.deleted).to eq([project_2])
+      end
+    end
+
+    describe "default_scope" do
+      it "always returns non-deleted projects by default" do
+        mock_successful_api_responses(urn: any_args, ukprn: any_args)
+        project_1 = create(:conversion_project, deleted: false)
+        project_2 = create(:conversion_project, deleted: true)
+
+        expect(Project.all).to_not include(project_2)
+        expect(Project.all).to include(project_1)
+      end
+    end
   end
 
   describe "region" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_db_column(:academy_urn).of_type :integer }
     it { is_expected.to have_db_column(:team).of_type :string }
     it { is_expected.to have_db_column(:all_conditions_met).of_type :boolean }
+    it { is_expected.to have_db_column(:deleted).of_type :boolean }
   end
 
   describe "Relationships" do


### PR DESCRIPTION
## Changes

Note: this is not a user-facing change.

Add a "deleted" attribute to Projects, to allow them to be "soft deleted". That is, removed from the application views but not fully deleted from the system. "Deleted" projects are not shown to users in the UI, exports or statistics.

To save us from explicitly requesting "non-deleted" projects in the application, add a `default_scope` to Projects, to only return non-deleted projects whenever Projects are requested.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
