### PR TITLE
Introduce a concept of "state" to projects

### DIFF
--- a/app/controllers/all/completed/projects_controller.rb
+++ b/app/controllers/all/completed/projects_controller.rb
@@ -4,7 +4,7 @@ class All::Completed::ProjectsController < ApplicationController
 
   def index
     authorize Project, :index?
-    @pager, @projects = pagy(Project.completed)
+    @pager, @projects = pagy(Project.completed.ordered_by_completed_date)
 
     AcademiesApiPreFetcherService.new.call!(@projects)
   end

--- a/app/controllers/all/regions/projects_controller.rb
+++ b/app/controllers/all/regions/projects_controller.rb
@@ -12,7 +12,7 @@ class All::Regions::ProjectsController < ApplicationController
     return not_found_error unless Project.regions.include?(region)
 
     @region = region
-    @pager, @projects = pagy(Project.not_completed.by_region(region).ordered_by_significant_date.includes(:assigned_to))
+    @pager, @projects = pagy(Project.active.by_region(region).ordered_by_significant_date.includes(:assigned_to))
     AcademiesApiPreFetcherService.new.call!(@projects)
   end
 

--- a/app/controllers/all/trusts/projects_controller.rb
+++ b/app/controllers/all/trusts/projects_controller.rb
@@ -11,7 +11,7 @@ class All::Trusts::ProjectsController < ApplicationController
     authorize Project, :index?
 
     @trust = Api::AcademiesApi::Client.new.get_trust(incoming_trust_ukprn).object
-    @pager, @projects = pagy(Project.not_completed.by_trust_ukprn(@trust.ukprn).ordered_by_significant_date.includes(:assigned_to))
+    @pager, @projects = pagy(Project.active.by_trust_ukprn(@trust.ukprn).ordered_by_significant_date.includes(:assigned_to))
 
     AcademiesApiPreFetcherService.new.call!(@projects)
   end

--- a/app/controllers/all/users/projects_controller.rb
+++ b/app/controllers/all/users/projects_controller.rb
@@ -10,7 +10,7 @@ class All::Users::ProjectsController < ApplicationController
   def show
     authorize Project, :index?
     @user = User.find(user_id)
-    @pager, @projects = pagy(Project.not_completed.assigned_to(@user))
+    @pager, @projects = pagy(Project.active.assigned_to(@user))
   end
 
   private def user_id

--- a/app/controllers/projects_complete_controller.rb
+++ b/app/controllers/projects_complete_controller.rb
@@ -16,7 +16,7 @@ class ProjectsCompleteController < ApplicationController
   private def set_project_completed_at
     return if @project.completed?
 
-    @project.update!(completed_at: DateTime.now)
+    @project.update!(completed_at: DateTime.now, state: 1)
   end
 
   private def project_id

--- a/app/controllers/service_support/projects_controller.rb
+++ b/app/controllers/service_support/projects_controller.rb
@@ -4,14 +4,14 @@ class ServiceSupport::ProjectsController < ApplicationController
 
   def without_academy_urn
     authorize Project, :index?
-    @pager, @projects = pagy(Conversion::Project.not_completed.no_academy_urn.by_conversion_date)
+    @pager, @projects = pagy(Conversion::Project.active.no_academy_urn.by_conversion_date)
 
     AcademiesApiPreFetcherService.new.call!(@projects)
   end
 
   def with_academy_urn
     authorize Project, :index?
-    @pager, @projects = pagy(Conversion::Project.not_completed.with_academy_urn.by_conversion_date)
+    @pager, @projects = pagy(Conversion::Project.active.with_academy_urn.by_conversion_date)
 
     AcademiesApiPreFetcherService.new.call!(@projects)
   end

--- a/app/controllers/team/projects_controller.rb
+++ b/app/controllers/team/projects_controller.rb
@@ -14,7 +14,7 @@ class Team::ProjectsController < ApplicationController
 
   def completed
     authorize Project, :index?
-    @pager, @projects = pagy_array(ByTeamProjectFetcherService.new(current_user.team).completed)
+    @pager, @projects = pagy_array(ByTeamProjectFetcherService.new(current_user.team).completed.ordered_by_completed_date)
   end
 
   def unassigned

--- a/app/controllers/your/projects_controller.rb
+++ b/app/controllers/your/projects_controller.rb
@@ -18,7 +18,7 @@ class Your::ProjectsController < ApplicationController
 
   def completed
     authorize Project, :index?
-    @pager, @projects = pagy(Project.assigned_to(current_user).completed)
+    @pager, @projects = pagy(Project.assigned_to(current_user).completed.ordered_by_completed_date)
 
     AcademiesApiPreFetcherService.new.call!(@projects)
   end

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -38,7 +38,7 @@ class Conversion::CreateProjectForm < CreateProjectForm
   end
 
   private def urn_unique_for_in_progress_conversions
-    errors.add(:urn, :duplicate) if Conversion::Project.not_completed.where(urn: urn).any?
+    errors.add(:urn, :duplicate) if Conversion::Project.active.where(urn: urn).any?
   end
 
   def directive_academy_order_responses

--- a/app/forms/create_project_form.rb
+++ b/app/forms/create_project_form.rb
@@ -76,7 +76,7 @@ class CreateProjectForm
   end
 
   private def urn_unique_for_in_progress_transfers
-    errors.add(:urn, :duplicate) if Transfer::Project.not_completed.where(urn: urn).any?
+    errors.add(:urn, :duplicate) if Transfer::Project.active.where(urn: urn).any?
   end
 
   private def value_at_position(hash, position)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -42,9 +42,8 @@ class Project < ApplicationRecord
   scope :conversions, -> { where(type: "Conversion::Project") }
   scope :transfers, -> { where(type: "Transfer::Project") }
 
-  scope :completed, -> { where.not(completed_at: nil).order(completed_at: :desc) }
-  scope :not_completed, -> { where(completed_at: nil) }
-  scope :in_progress, -> { where(completed_at: nil).assigned }
+  scope :ordered_by_completed_date, -> { completed.order(completed_at: :desc) }
+  scope :in_progress, -> { where(state: 0).assigned }
 
   scope :assigned, -> { where.not(assigned_to: nil) }
   scope :assigned_to_caseworker, ->(user) { where(assigned_to: user).or(where(caseworker: user)) }
@@ -81,6 +80,11 @@ class Project < ApplicationRecord
   }, suffix: true
 
   enum :team, PROJECT_TEAMS, suffix: true
+
+  enum :state, {
+    active: 0,
+    completed: 1
+  }
 
   def establishment
     @establishment ||= fetch_establishment(urn)

--- a/app/services/by_local_authority_project_fetcher_service.rb
+++ b/app/services/by_local_authority_project_fetcher_service.rb
@@ -10,14 +10,14 @@ class ByLocalAuthorityProjectFetcherService
   end
 
   def projects_for_local_authority(local_authority_code)
-    all_projects = Project.not_completed.select(:id, :urn, :incoming_trust_ukprn)
+    all_projects = Project.active.select(:id, :urn, :incoming_trust_ukprn)
     projects_for_local_authority = all_projects.select { |p| p.establishment.local_authority_code == local_authority_code }
 
     Project.where(id: projects_for_local_authority.pluck(:id)).includes(:assigned_to).ordered_by_significant_date
   end
 
   private def projects_by_local_authority
-    projects = Project.not_completed.select(:id, :urn, :incoming_trust_ukprn, :type)
+    projects = Project.active.select(:id, :urn, :incoming_trust_ukprn, :type)
 
     AcademiesApiPreFetcherService.new.call!(projects)
 

--- a/app/services/by_region_project_fetcher_service.rb
+++ b/app/services/by_region_project_fetcher_service.rb
@@ -14,7 +14,7 @@ class ByRegionProjectFetcherService
   end
 
   private def projects_by_region
-    projects = Project.not_completed
+    projects = Project.active
     return false unless projects.any?
 
     projects.group_by(&:region)

--- a/db/migrate/20240404101826_add_state_to_projects.rb
+++ b/db/migrate/20240404101826_add_state_to_projects.rb
@@ -1,0 +1,13 @@
+class AddStateToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :state, :integer, default: 0, null: false
+
+    ActiveRecord::Base.transaction do
+      Project.all.each do |project|
+        if !project.completed_at.nil?
+          project.update!(state: 1)
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_28_122736) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_04_101826) do
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false
@@ -279,6 +279,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_28_122736) do
     t.string "new_trust_reference_number"
     t.string "new_trust_name"
     t.uuid "chair_of_governors_contact_id"
+    t.integer "state", default: 0, null: false
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["incoming_trust_ukprn"], name: "index_projects_on_incoming_trust_ukprn"

--- a/spec/accessibility/all_projects_spec.rb
+++ b/spec/accessibility/all_projects_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "All projects", driver: :headless_firefox, accessibility: true do
   end
 
   scenario "> Completed" do
-    project = create(:conversion_project, assigned_to: user, completed_at: Date.yesterday, urn: 123434)
+    project = create(:conversion_project, :completed, assigned_to: user, completed_at: Date.yesterday, urn: 123434)
 
     visit all_completed_projects_path
 

--- a/spec/accessibility/projects_spec.rb
+++ b/spec/accessibility/projects_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Test projects accessibility", driver: :headless_firefox, accessib
   end
 
   scenario "completed projects page" do
-    completed_project = create(:conversion_project, assigned_to: user, completed_at: Date.today)
+    completed_project = create(:conversion_project, :completed, assigned_to: user, completed_at: Date.today)
     visit completed_your_projects_path
 
     expect(page).to have_content(completed_project.urn)

--- a/spec/accessibility/team_projects_spec.rb
+++ b/spec/accessibility/team_projects_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Team projects", driver: :headless_firefox, accessibility: true do
   end
 
   scenario "> Completed" do
-    project = create(:conversion_project, assigned_to: user, completed_at: Date.yesterday, team: "regional_casework_services", urn: 123434)
+    project = create(:conversion_project, :completed, assigned_to: user, completed_at: Date.yesterday, team: "regional_casework_services", urn: 123434)
 
     visit completed_team_projects_path
 

--- a/spec/accessibility/your_projects_spec.rb
+++ b/spec/accessibility/your_projects_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Your projects", driver: :headless_firefox, accessibility: true do
   end
 
   scenario "> Completed" do
-    project = create(:conversion_project, assigned_to: user, completed_at: Date.yesterday, urn: 123434)
+    project = create(:conversion_project, :completed, assigned_to: user, completed_at: Date.yesterday, urn: 123434)
 
     visit completed_your_projects_path
 

--- a/spec/factories/conversion/project_factory.rb
+++ b/spec/factories/conversion/project_factory.rb
@@ -14,6 +14,11 @@ FactoryBot.define do
     tasks_data { association :conversion_tasks_data }
     team { Project.teams["london"] }
     all_conditions_met { nil }
+    state { 0 }
+
+    trait :completed do
+      state { 1 }
+    end
 
     trait :with_conditions do
       advisory_board_conditions { "The following must be met:\n 1. Must be red\n2. Must be blue\n" }

--- a/spec/factories/transfer/project_factory.rb
+++ b/spec/factories/transfer/project_factory.rb
@@ -15,6 +15,11 @@ FactoryBot.define do
     tasks_data { association :transfer_tasks_data }
     outgoing_trust_ukprn { 10059062 }
     two_requires_improvement { false }
+    state { 0 }
+
+    trait :completed do
+      state { 1 }
+    end
 
     trait :form_a_mat do
       incoming_trust_ukprn { nil }

--- a/spec/features/projects/added_by/user_can_view_the_projects_they_have_added_spec.rb
+++ b/spec/features/projects/added_by/user_can_view_the_projects_they_have_added_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Viewing all projects a user has added" do
       mock_all_academies_api_responses
     end
 
-    let!(:completed_project) { create(:conversion_project, urn: 121583, completed_at: Date.yesterday, regional_delivery_officer: user) }
+    let!(:completed_project) { create(:conversion_project, :completed, urn: 121583, completed_at: Date.yesterday, regional_delivery_officer: user) }
     let!(:in_progress_project) { create(:conversion_project, urn: 115652, regional_delivery_officer: user) }
     let!(:sponsored_in_progress_project) { create(:conversion_project, urn: 112209, directive_academy_order: true, regional_delivery_officer: user) }
     let!(:voluntary_in_progress_project) { create(:conversion_project, urn: 103835, directive_academy_order: false, regional_delivery_officer: user) }

--- a/spec/features/projects/completed/users_can_view_a_list_of_all_projects_spec.rb
+++ b/spec/features/projects/completed/users_can_view_a_list_of_all_projects_spec.rb
@@ -16,9 +16,9 @@ RSpec.feature "Viewing all completed projects" do
   end
 
   context "when there are projects" do
-    let!(:completed_project) { create(:conversion_project, urn: 121583, completed_at: Date.yesterday) }
-    let!(:sponsored_completed_project) { create(:conversion_project, urn: 121102, completed_at: Date.yesterday, directive_academy_order: true) }
-    let!(:voluntary_completed_project) { create(:conversion_project, urn: 114067, completed_at: Date.yesterday, directive_academy_order: false) }
+    let!(:completed_project) { create(:conversion_project, :completed, urn: 121583, completed_at: Date.yesterday) }
+    let!(:sponsored_completed_project) { create(:conversion_project, :completed, urn: 121102, completed_at: Date.yesterday, directive_academy_order: true) }
+    let!(:voluntary_completed_project) { create(:conversion_project, :completed, urn: 114067, completed_at: Date.yesterday, directive_academy_order: false) }
     let!(:in_progress_project) { create(:conversion_project, urn: 115652) }
 
     scenario "they can view all completed projects" do
@@ -35,7 +35,7 @@ RSpec.feature "Viewing all completed projects" do
 
     scenario "when there are enough projects to page they see a pager" do
       21.times do
-        create(:conversion_project, completed_at: Date.today)
+        create(:conversion_project, :completed, completed_at: Date.today)
       end
 
       visit all_completed_projects_path

--- a/spec/features/projects/in_progress/users_can_view_a_list_of_all_projects_spec.rb
+++ b/spec/features/projects/in_progress/users_can_view_a_list_of_all_projects_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Viewing all in-progress projects" do
 
   context "when there are projects in progress" do
     scenario "they can view all in progress projects" do
-      completed_project = create(:conversion_project, urn: 121583, completed_at: Date.yesterday)
+      completed_project = create(:conversion_project, :completed, urn: 121583, completed_at: Date.yesterday)
       in_progress_project = create(:conversion_project, urn: 115652)
 
       visit all_in_progress_projects_path

--- a/spec/features/projects/regions/users_can_view_a_list_of_projects_for_a_given_region_spec.rb
+++ b/spec/features/projects/regions/users_can_view_a_list_of_projects_for_a_given_region_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Users can view a list of projects for a given region" do
   context "when a region has a project" do
     scenario "they see the project listed" do
       project = create(:conversion_project, region: "london", urn: 103835)
-      completed_project = create(:conversion_project, completed_at: Date.today, region: "london", urn: 121813)
+      completed_project = create(:conversion_project, :completed, completed_at: Date.today, region: "london", urn: 121813)
 
       visit by_region_all_regions_projects_path("london")
 
@@ -43,7 +43,7 @@ RSpec.feature "Users can view a list of projects for a given region" do
 
   context "when there are no projects for the region" do
     scenario "they see an helpful message" do
-      create(:conversion_project, completed_at: Date.today, region: "london", urn: 121813)
+      create(:conversion_project, :completed, completed_at: Date.today, region: "london", urn: 121813)
 
       visit by_region_all_regions_projects_path("london")
 

--- a/spec/features/projects/trusts/users_can_view_a_list_of_projects_for_a_given_trust_spec.rb
+++ b/spec/features/projects/trusts/users_can_view_a_list_of_projects_for_a_given_trust_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Users can view a list of projects for a given trust" do
   context "when a trust has a project" do
     scenario "they see the project listed" do
       project = create(:conversion_project, incoming_trust_ukprn: 10010010, urn: 123456)
-      completed_project = create(:conversion_project, completed_at: Date.today, incoming_trust_ukprn: 10010010, urn: 165432)
+      completed_project = create(:conversion_project, :completed, completed_at: Date.today, incoming_trust_ukprn: 10010010, urn: 165432)
 
       visit by_trust_all_trusts_projects_path(10010010)
 

--- a/spec/features/projects/users_can_view_a_list_of_assigned_projects_spec.rb
+++ b/spec/features/projects/users_can_view_a_list_of_assigned_projects_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Viewing assigned projects" do
   context "when there are projects" do
     let!(:in_progress_assigned_project) { create(:conversion_project, urn: 103835, assigned_to: user, conversion_date: (Date.today + 1.month).at_beginning_of_month) }
     let!(:in_progress_assigned_project_next_year) { create(:conversion_project, urn: 103835, assigned_to: user, conversion_date: (Date.today + 1.year).at_beginning_of_month) }
-    let!(:completed_assigned_project) { create(:conversion_project, urn: 114067, assigned_to: user, completed_at: Date.yesterday) }
+    let!(:completed_assigned_project) { create(:conversion_project, :completed, urn: 114067, assigned_to: user, completed_at: Date.yesterday) }
 
     context "when signed in as a Regional caseworker" do
       let(:user) { create(:regional_casework_services_user) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -531,7 +531,7 @@ RSpec.describe Project, type: :model do
       end
     end
 
-    describe "not_completed scope" do
+    describe "active scope" do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 
       it "only returns projects where state = 0" do
@@ -539,7 +539,7 @@ RSpec.describe Project, type: :model do
         in_progress_project_1 = create(:conversion_project, completed_at: nil, state: 0)
         in_progress_project_2 = create(:conversion_project, completed_at: nil, state: 0)
 
-        projects = Project.not_completed
+        projects = Project.active
 
         expect(projects).to include(in_progress_project_1, in_progress_project_2)
         expect(projects).to_not include(completed_project)

--- a/spec/models/statistics/project_statistics_spec.rb
+++ b/spec/models/statistics/project_statistics_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
     before do
       create_list(:conversion_project, 2, assigned_to: nil)
       create(:conversion_project)
-      create(:conversion_project, completed_at: Date.today)
+      create(:conversion_project, :completed, completed_at: Date.today)
       create_list(:transfer_project, 2, assigned_to: nil)
       create(:transfer_project)
-      create(:transfer_project, completed_at: Date.today)
+      create(:transfer_project, :completed, completed_at: Date.today)
     end
 
     describe "#total_number_of_conversion_projects" do
@@ -66,12 +66,12 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
   describe "Regional casework services projects" do
     before do
       create(:conversion_project, team: :regional_casework_services, completed_at: nil)
-      create(:conversion_project, team: :regional_casework_services, completed_at: Date.today + 2.years)
+      create(:conversion_project, :completed, team: :regional_casework_services, completed_at: Date.today + 2.years)
       create(:conversion_project, team: :regional_casework_services, assigned_to: nil)
       create(:conversion_project, team: :north_west, assigned_to: nil)
 
       create(:transfer_project, team: :regional_casework_services, completed_at: nil)
-      create(:transfer_project, team: :regional_casework_services, completed_at: Date.today + 2.years)
+      create(:transfer_project, :completed, team: :regional_casework_services, completed_at: Date.today + 2.years)
       create(:transfer_project, team: :regional_casework_services, assigned_to: nil)
       create(:transfer_project, team: :north_west, assigned_to: nil)
     end
@@ -128,15 +128,15 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
   describe "Regional projects that are not with regional casework services" do
     before do
       create(:conversion_project, team: "london", completed_at: nil)
-      create(:conversion_project, team: "london", completed_at: Date.today + 2.years)
+      create(:conversion_project, :completed, team: "london", completed_at: Date.today + 2.years)
       create(:conversion_project, team: "london", completed_at: nil, directive_academy_order: true)
-      create(:conversion_project, team: "london", completed_at: Date.today + 2.years, directive_academy_order: true)
+      create(:conversion_project, :completed, team: "london", completed_at: Date.today + 2.years, directive_academy_order: true)
       create(:conversion_project, team: "london", assigned_to: nil)
 
       create(:transfer_project, team: "london", completed_at: nil)
-      create(:transfer_project, team: "london", completed_at: Date.today + 2.years)
+      create(:transfer_project, :completed, team: "london", completed_at: Date.today + 2.years)
       create(:transfer_project, team: "london", completed_at: nil, directive_academy_order: true)
-      create(:transfer_project, team: "london", completed_at: Date.today + 2.years, directive_academy_order: true)
+      create(:transfer_project, :completed, team: "london", completed_at: Date.today + 2.years, directive_academy_order: true)
       create(:transfer_project, team: "london", assigned_to: nil)
     end
 
@@ -186,16 +186,16 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
   describe "projects per region" do
     before do
       create(:conversion_project, region: :london, completed_at: nil)
-      create(:conversion_project, region: :london, completed_at: Date.today + 2.years)
+      create(:conversion_project, :completed, region: :london, completed_at: Date.today + 2.years)
       create(:conversion_project, region: :south_east)
-      create(:conversion_project, region: :london, completed_at: Date.today + 2.years, directive_academy_order: true)
+      create(:conversion_project, :completed, region: :london, completed_at: Date.today + 2.years, directive_academy_order: true)
       create(:conversion_project, region: :london, completed_at: nil, directive_academy_order: true)
       create(:conversion_project, region: :london, assigned_to: nil)
 
       create(:transfer_project, region: :london, completed_at: nil)
-      create(:transfer_project, region: :london, completed_at: Date.today + 2.years)
+      create(:transfer_project, :completed, region: :london, completed_at: Date.today + 2.years)
       create(:transfer_project, region: :west_midlands)
-      create(:transfer_project, region: :london, completed_at: Date.today + 2.years, directive_academy_order: true)
+      create(:transfer_project, :completed, region: :london, completed_at: Date.today + 2.years, directive_academy_order: true)
       create(:transfer_project, region: :london, completed_at: nil, directive_academy_order: true)
       create(:transfer_project, region: :london, assigned_to: nil)
     end

--- a/spec/requests/all/projects_controller_spec.rb
+++ b/spec/requests/all/projects_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ServiceSupport::ProjectsController, type: :request do
     mock_all_academies_api_responses
   end
 
-  let!(:completed_project) { create(:conversion_project, completed_at: Date.today, urn: 165432) }
+  let!(:completed_project) { create(:conversion_project, :completed, completed_at: Date.today, urn: 165432) }
   let!(:project_without_urn) { create(:conversion_project, academy_urn: nil, urn: 132342) }
   let!(:project_with_urn) { create(:conversion_project, academy_urn: 123456, urn: 154232) }
   let(:establishment) { create(:gias_establishment, urn: 123456) }

--- a/spec/services/by_team_project_fetcher_service_spec.rb
+++ b/spec/services/by_team_project_fetcher_service_spec.rb
@@ -108,10 +108,10 @@ RSpec.describe ByTeamProjectFetcherService do
   describe "#completed" do
     before { mock_all_academies_api_responses }
 
-    let!(:conversion_project_rcs) { create(:conversion_project, team: "regional_casework_services", region: "north_east", completed_at: Date.yesterday) }
-    let!(:conversion_project_london) { create(:conversion_project, team: "regional_casework_services", region: "london", completed_at: Date.yesterday) }
-    let!(:transfer_project_rcs) { create(:transfer_project, team: "regional_casework_services", region: "north_east", completed_at: Date.yesterday) }
-    let!(:transfer_project_london) { create(:transfer_project, team: "regional_casework_services", region: "london", completed_at: Date.yesterday) }
+    let!(:conversion_project_rcs) { create(:conversion_project, :completed, team: "regional_casework_services", region: "north_east", completed_at: Date.yesterday) }
+    let!(:conversion_project_london) { create(:conversion_project, :completed, team: "regional_casework_services", region: "london", completed_at: Date.yesterday) }
+    let!(:transfer_project_rcs) { create(:transfer_project, :completed, team: "regional_casework_services", region: "north_east", completed_at: Date.yesterday) }
+    let!(:transfer_project_london) { create(:transfer_project, :completed, team: "regional_casework_services", region: "london", completed_at: Date.yesterday) }
 
     context "when the user is in the 'regional_casework_services' team" do
       it "returns all completed projects where the project's team is regional_casework_services" do
@@ -204,7 +204,7 @@ RSpec.describe ByTeamProjectFetcherService do
     it "only returns in_progress projects" do
       user = create(:user, :caseworker, team: "regional_casework_services", first_name: "Abbie")
       _project_1 = create(:conversion_project, assigned_to: user)
-      _project_2 = create(:conversion_project, assigned_to: user, completed_at: Date.yesterday)
+      _project_2 = create(:conversion_project, :completed, assigned_to: user, completed_at: Date.yesterday)
 
       result = described_class.new(user.team).users
       expect(result[0].name).to eq("Abbie Doe")


### PR DESCRIPTION
We want to be able to mark projects as "deleted", but not actually delete the record from the database. We intend to add a deleted state to projects .

Ahead of this, we have decided to add a `state` to projects, and enumerate it for the various different states a project can be in. For now, this is "active" and "completed"

Add an enumerator to projects - 0 for active (default) and 1 for completed.

As the state is an enumerator, we get the scope Project.completed for free now. Due to Rails magic, we also get Project.not_completed - anything not in the completed state. In the first commit, we keep Project.not_completed as is; in the second, we replace Project.not_completed with the more semantic Project.active.

As the original Project.completed scope had an order (ordering by completed_at date) we have had to split this ordering out and add it as a new scope.

We have added the new state to the project factories, and updated the relevant tests.

Unfortunately this was the smallest single commit we could make for this change.

(No user-facing changes in this commit)