### PR TITLE
(161543) Projects can have deleted state

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -83,7 +83,8 @@ class Project < ApplicationRecord
 
   enum :state, {
     active: 0,
-    completed: 1
+    completed: 1,
+    deleted: 2
   }
 
   def establishment

--- a/spec/factories/conversion/project_factory.rb
+++ b/spec/factories/conversion/project_factory.rb
@@ -20,6 +20,10 @@ FactoryBot.define do
       state { 1 }
     end
 
+    trait :deleted do
+      state { 2 }
+    end
+
     trait :with_conditions do
       advisory_board_conditions { "The following must be met:\n 1. Must be red\n2. Must be blue\n" }
     end

--- a/spec/factories/transfer/project_factory.rb
+++ b/spec/factories/transfer/project_factory.rb
@@ -21,6 +21,10 @@ FactoryBot.define do
       state { 1 }
     end
 
+    trait :deleted do
+      state { 2 }
+    end
+
     trait :form_a_mat do
       incoming_trust_ukprn { nil }
       new_trust_name { "The New Trust" }


### PR DESCRIPTION
## Changes

In https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/1473 we added the concept of state to projects. Now in addition to "active" and "completed", we have "deleted". This enables us to "soft delete" projects without actually removing their database records.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
