### PR TITLE
(Fix) A contact must be assigned to a project before it is added as chair of governors

### DIFF
--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -359,7 +359,7 @@ RSpec.feature "Users can complete conversion tasks" do
     end
 
     scenario "updates an existing chair of governors contact" do
-      chair_of_governors = create(:project_contact)
+      chair_of_governors = create(:project_contact, project: project)
       project.update(chair_of_governors_contact: chair_of_governors)
 
       visit project_tasks_path(project)


### PR DESCRIPTION

While writing code elsewhere we uncovered a small anomaly in this test - the contact which is created to be the Chair of Governors contact for a project must actually belong to that project before it is assigned. In not linking the contact to the project, the test is actually reassigning the contact from one project to another, as well as updating its attributes.

This anomaly was showing up as a bug in other branches (specifically when working on soft deleting projects).

