### PR TITLE
(161623) Do not show "deleted" projects in application

### DIFF
--- a/app/controllers/all/export/grant_management_and_finance_unit/conversions/projects_controller.rb
+++ b/app/controllers/all/export/grant_management_and_finance_unit/conversions/projects_controller.rb
@@ -12,7 +12,7 @@ class All::Export::GrantManagementAndFinanceUnit::Conversions::ProjectsControlle
   end
 
   def show
-    authorize Project, :show?
+    authorize Project, :index?
     @month = Date.new(year, month)
   end
 

--- a/app/controllers/all/export/grant_management_and_finance_unit/transfers/projects_controller.rb
+++ b/app/controllers/all/export/grant_management_and_finance_unit/transfers/projects_controller.rb
@@ -12,7 +12,7 @@ class All::Export::GrantManagementAndFinanceUnit::Transfers::ProjectsController 
   end
 
   def show
-    authorize Project, :show?
+    authorize Project, :index?
     @month = Date.new(year, month)
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -67,6 +67,8 @@ class Project < ApplicationRecord
 
   scope :not_form_a_mat, -> { where.not(incoming_trust_ukprn: nil) }
 
+  default_scope { where.not(state: :deleted) }
+
   enum :region, {
     london: "H",
     south_east: "J",

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -11,6 +11,8 @@ class ProjectPolicy
   end
 
   def show?
+    return false if @record.deleted?
+
     true
   end
 
@@ -20,6 +22,7 @@ class ProjectPolicy
 
   def edit?
     return false if @record.completed?
+    return false if @record.deleted?
 
     true
   end

--- a/spec/features/projects/in_progress/users_can_view_a_list_of_all_projects_spec.rb
+++ b/spec/features/projects/in_progress/users_can_view_a_list_of_all_projects_spec.rb
@@ -62,5 +62,15 @@ RSpec.feature "Viewing all in-progress projects" do
       expect(page).to have_content("Form a MAT project?")
       expect(page).to have_content("Yes")
     end
+
+    scenario "deleted projects are not shown" do
+      deleted_project = create(:conversion_project, :deleted, urn: 121583)
+      in_progress_project = create(:conversion_project, urn: 115652)
+
+      visit all_in_progress_projects_path
+
+      expect(page).to_not have_content(deleted_project.urn.to_s)
+      expect(page).to have_content(in_progress_project.urn.to_s)
+    end
   end
 end

--- a/spec/features/your_projects/users_can_view_their_projects_spec.rb
+++ b/spec/features/your_projects/users_can_view_their_projects_spec.rb
@@ -30,6 +30,15 @@ RSpec.feature "Users can view their projects" do
     expect(page).to have_content(project.outgoing_trust.name)
   end
 
+  scenario "they do not see deleted projects" do
+    project = create(:transfer_project, :deleted, assigned_to: user)
+
+    visit in_progress_your_projects_path
+
+    expect(page).to_not have_content(project.establishment.name)
+    expect(page).to_not have_content(project.urn)
+  end
+
   context "when they are NOT in the Regional casework services team" do
     let(:user) { create(:regional_delivery_officer_user) }
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -470,6 +470,21 @@ RSpec.describe Project, type: :model do
   end
 
   describe "Scopes" do
+    describe "default scope" do
+      before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+
+      it "does not return deleted (state = 2) projects by default" do
+        in_progress_project = create(:conversion_project, state: 0)
+        completed_project = create(:conversion_project, completed_at: Date.today - 1.year, state: 1)
+        deleted_project = create(:conversion_project, state: 2)
+
+        projects = Project.all
+
+        expect(projects).to include(in_progress_project, completed_project)
+        expect(projects).to_not include(deleted_project)
+      end
+    end
+
     describe "conversions" do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 

--- a/spec/models/statistics/project_statistics_spec.rb
+++ b/spec/models/statistics/project_statistics_spec.rb
@@ -61,6 +61,21 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
         expect(subject.total_number_of_completed_transfer_projects).to eql(1)
       end
     end
+
+    context "when there are deleted projects" do
+      before do
+        create(:transfer_project, :deleted)
+        create(:conversion_project, :deleted)
+      end
+
+      it "returns the same number of conversion projects as before" do
+        expect(subject.total_number_of_conversion_projects).to eql(4)
+      end
+
+      it "returns the same number of transfer projects as before" do
+        expect(subject.total_number_of_transfer_projects).to eql(4)
+      end
+    end
   end
 
   describe "Regional casework services projects" do

--- a/spec/services/projects_for_export_service_spec.rb
+++ b/spec/services/projects_for_export_service_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe ProjectsForExportService do
 
       expect(projects_for_export).to include(project)
     end
+
+    it "does not include deleted projects" do
+      project = create(:conversion_project, :deleted, conversion_date_provisional: false, advisory_board_date: Date.parse("2023-1-1"))
+
+      projects_for_export = described_class.new.grant_management_and_finance_unit_conversion_projects(month: 1, year: 2023)
+
+      expect(projects_for_export).to_not include(project)
+    end
   end
 
   describe "#grant_management_and_finance_unit_transfer_projects" do
@@ -65,6 +73,14 @@ RSpec.describe ProjectsForExportService do
       projects_for_export = described_class.new.grant_management_and_finance_unit_transfer_projects(month: 1, year: 2023)
 
       expect(projects_for_export).to include(project)
+    end
+
+    it "does not include deleted projects" do
+      project = create(:transfer_project, :deleted, significant_date_provisional: false, advisory_board_date: Date.parse("2023-1-1"))
+
+      projects_for_export = described_class.new.grant_management_and_finance_unit_transfer_projects(month: 1, year: 2023)
+
+      expect(projects_for_export).to_not include(project)
     end
   end
 
@@ -98,6 +114,14 @@ RSpec.describe ProjectsForExportService do
 
       expect(projects_for_export).to include(project)
     end
+
+    it "does not include deleted projects" do
+      project = create(:transfer_project, :deleted, significant_date_provisional: false, significant_date: Date.parse("2023-1-1"))
+
+      projects_for_export = described_class.new.transfer_by_month_projects(month: 1, year: 2023)
+
+      expect(projects_for_export).to_not include(project)
+    end
   end
 
   describe "#conversion_by_month_projects" do
@@ -123,12 +147,20 @@ RSpec.describe ProjectsForExportService do
       expect(projects_for_export).to include(provisional_project)
     end
 
-    it "includes Form a MAT transfers" do
+    it "includes Form a MAT conversions" do
       project = create(:conversion_project, :form_a_mat, significant_date_provisional: false, significant_date: Date.parse("2023-1-1"))
 
       projects_for_export = described_class.new.conversion_by_month_projects(month: 1, year: 2023)
 
       expect(projects_for_export).to include(project)
+    end
+
+    it "does not include deleted projects" do
+      project = create(:conversion_project, :deleted, significant_date_provisional: false, significant_date: Date.parse("2023-1-1"))
+
+      projects_for_export = described_class.new.conversion_by_month_projects(month: 1, year: 2023)
+
+      expect(projects_for_export).to_not include(project)
     end
   end
 


### PR DESCRIPTION
## Changes

Now that we have the concept of "soft deleted" projects (projects which exist in the database but are in a deleted state) we need to ensure they never appear to users.

To ensure this, we have decided to use a `default_scope` for projects. Default scopes can be problematic as they can conceal issues and cause confusion - but the alternative is to add `active` and `completed` scopes to ALL calls to Project in the application. 

This does mean that we lose access to the `Project.deleted` scope, but if we need to call on deleted projects specifically we can unscope the default scope and call `Project.unscoped.where(state: :deleted)`

We then go on to add some Policy changes and extra specs, to make sure deleted projects do not appear in listing pages, and cannot be shown/edited.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
