### PR TITLE
(160908) Users can change directive academy order and two requires improvement responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   allows mistakes to be corrected.
 - users can now change the advisory board date and any conditions on a
   conversion project.
+- users can now change the academy order type for a conversion project.
 
 ## [Release-62][release-62]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - users can now change the advisory board date and any conditions on a
   conversion project.
 - users can now change the academy order type for a conversion project.
+- users can now change the conversion due to intervention following 2RI response
+  for a conversion project.
 
 ## [Release-62][release-62]
 

--- a/app/controllers/conversions/projects_controller.rb
+++ b/app/controllers/conversions/projects_controller.rb
@@ -68,7 +68,8 @@ class Conversions::ProjectsController < ProjectsController
       :incoming_trust_sharepoint_link,
       :incoming_trust_ukprn,
       :advisory_board_date,
-      :advisory_board_conditions
+      :advisory_board_conditions,
+      :directive_academy_order
     )
   end
 

--- a/app/controllers/conversions/projects_controller.rb
+++ b/app/controllers/conversions/projects_controller.rb
@@ -69,7 +69,8 @@ class Conversions::ProjectsController < ProjectsController
       :incoming_trust_ukprn,
       :advisory_board_date,
       :advisory_board_conditions,
-      :directive_academy_order
+      :directive_academy_order,
+      :two_requires_improvement
     )
   end
 

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -41,13 +41,6 @@ class Conversion::CreateProjectForm < CreateProjectForm
     errors.add(:urn, :duplicate) if Conversion::Project.active.where(urn: urn).any?
   end
 
-  def directive_academy_order_responses
-    @directive_academy_order_responses ||= [
-      OpenStruct.new(id: true, name: I18n.t("helpers.responses.conversion_project.directive_academy_order.yes")),
-      OpenStruct.new(id: false, name: I18n.t("helpers.responses.conversion_project.directive_academy_order.no"))
-    ]
-  end
-
   def save
     assigned_to = assigned_to_regional_caseworker_team ? nil : user
     assigned_at = assigned_to_regional_caseworker_team ? nil : DateTime.now

--- a/app/forms/conversion/edit_project_form.rb
+++ b/app/forms/conversion/edit_project_form.rb
@@ -10,6 +10,7 @@ class Conversion::EditProjectForm
   attribute :incoming_trust_ukprn
   attribute :advisory_board_date, :date
   attribute :advisory_board_conditions
+  attribute :directive_academy_order, :boolean
 
   validates :establishment_sharepoint_link, presence: true, sharepoint_url: true
   validates :incoming_trust_sharepoint_link, presence: true, sharepoint_url: true
@@ -20,6 +21,8 @@ class Conversion::EditProjectForm
   validates :advisory_board_date, presence: true
   validates :advisory_board_date, date_in_the_past: true
 
+  validates :directive_academy_order, inclusion: {in: [true, false]}
+
   def self.new_from_project(project)
     new(
       project: project,
@@ -27,7 +30,8 @@ class Conversion::EditProjectForm
       incoming_trust_sharepoint_link: project.incoming_trust_sharepoint_link,
       incoming_trust_ukprn: project.incoming_trust_ukprn,
       advisory_board_date: project.advisory_board_date,
-      advisory_board_conditions: project.advisory_board_conditions
+      advisory_board_conditions: project.advisory_board_conditions,
+      directive_academy_order: project.directive_academy_order
     )
   end
 
@@ -46,7 +50,8 @@ class Conversion::EditProjectForm
       incoming_trust_sharepoint_link: incoming_trust_sharepoint_link,
       incoming_trust_ukprn: incoming_trust_ukprn,
       advisory_board_date: advisory_board_date,
-      advisory_board_conditions: advisory_board_conditions
+      advisory_board_conditions: advisory_board_conditions,
+      directive_academy_order: directive_academy_order
     )
 
     project.save!

--- a/app/forms/conversion/edit_project_form.rb
+++ b/app/forms/conversion/edit_project_form.rb
@@ -11,6 +11,7 @@ class Conversion::EditProjectForm
   attribute :advisory_board_date, :date
   attribute :advisory_board_conditions
   attribute :directive_academy_order, :boolean
+  attribute :two_requires_improvement, :boolean
 
   validates :establishment_sharepoint_link, presence: true, sharepoint_url: true
   validates :incoming_trust_sharepoint_link, presence: true, sharepoint_url: true
@@ -23,6 +24,8 @@ class Conversion::EditProjectForm
 
   validates :directive_academy_order, inclusion: {in: [true, false]}
 
+  validates :two_requires_improvement, inclusion: {in: [true, false], message: I18n.t("errors.conversion_project.attributes.two_requires_improvement.inclusion")}
+
   def self.new_from_project(project)
     new(
       project: project,
@@ -31,7 +34,8 @@ class Conversion::EditProjectForm
       incoming_trust_ukprn: project.incoming_trust_ukprn,
       advisory_board_date: project.advisory_board_date,
       advisory_board_conditions: project.advisory_board_conditions,
-      directive_academy_order: project.directive_academy_order
+      directive_academy_order: project.directive_academy_order,
+      two_requires_improvement: project.two_requires_improvement
     )
   end
 
@@ -51,7 +55,8 @@ class Conversion::EditProjectForm
       incoming_trust_ukprn: incoming_trust_ukprn,
       advisory_board_date: advisory_board_date,
       advisory_board_conditions: advisory_board_conditions,
-      directive_academy_order: directive_academy_order
+      directive_academy_order: directive_academy_order,
+      two_requires_improvement: two_requires_improvement
     )
 
     project.save!

--- a/app/forms/create_project_form.rb
+++ b/app/forms/create_project_form.rb
@@ -51,13 +51,6 @@ class CreateProjectForm
     @attributes_with_invalid_values << :advisory_board_date
   end
 
-  def yes_no_responses
-    @yes_no_responses ||= [
-      OpenStruct.new(id: true, name: I18n.t("yes")),
-      OpenStruct.new(id: false, name: I18n.t("no"))
-    ]
-  end
-
   private def establishment
     @establishment || fetch_establishment(urn)
   end

--- a/app/helpers/project_helper.rb
+++ b/app/helpers/project_helper.rb
@@ -84,4 +84,11 @@ module ProjectHelper
       OpenStruct.new(id: false, name: I18n.t("helpers.responses.conversion_project.directive_academy_order.no"))
     ]
   end
+
+  def yes_no_responses
+    @yes_no_responses ||= [
+      OpenStruct.new(id: true, name: I18n.t("yes")),
+      OpenStruct.new(id: false, name: I18n.t("no"))
+    ]
+  end
 end

--- a/app/helpers/project_helper.rb
+++ b/app/helpers/project_helper.rb
@@ -77,4 +77,11 @@ module ProjectHelper
     original_date = project.provisional_date
     "#{confirmed_date.to_fs(:govuk_short_month)} (#{original_date.to_fs(:govuk_short_month)})"
   end
+
+  def directive_academy_order_responses
+    @directive_academy_order_responses ||= [
+      OpenStruct.new(id: true, name: I18n.t("helpers.responses.conversion_project.directive_academy_order.yes")),
+      OpenStruct.new(id: false, name: I18n.t("helpers.responses.conversion_project.directive_academy_order.no"))
+    ]
+  end
 end

--- a/app/views/conversions/project_information/_reasons_for_conversion.html.erb
+++ b/app/views/conversions/project_information/_reasons_for_conversion.html.erb
@@ -9,6 +9,7 @@
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.reasons_for.two_requires_improvement.conversion_project.title") }
           row.with_value { t("project_information.show.reasons_for.two_requires_improvement.#{project.two_requires_improvement}") }
+          row.with_action(text: "Change", href: conversions_edit_path(@project, anchor: "two-requires-improvement"), visually_hidden_text: "the conversion due to two requires improvement")
         end
       end %>
 </div>

--- a/app/views/conversions/project_information/_reasons_for_conversion.html.erb
+++ b/app/views/conversions/project_information/_reasons_for_conversion.html.erb
@@ -4,9 +4,8 @@
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.reasons_for.directive_academy_order.title") }
           row.with_value { t("project_information.show.reasons_for.directive_academy_order.#{project.directive_academy_order}") }
+          row.with_action(text: "Change", href: conversions_edit_path(@project, anchor: "directive-academy-order"), visually_hidden_text: "the directive academy order type")
         end
-      end %>
-  <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.reasons_for.two_requires_improvement.conversion_project.title") }
           row.with_value { t("project_information.show.reasons_for.two_requires_improvement.#{project.two_requires_improvement}") }

--- a/app/views/conversions/projects/edit.html.erb
+++ b/app/views/conversions/projects/edit.html.erb
@@ -17,6 +17,15 @@
         <%= form.govuk_text_field :incoming_trust_sharepoint_link, label: {size: "m", text: t("project.edit.labels.incoming_trust_sharepoint_link")} %>
       </div>
 
+      <div class="govuk-form-group">
+        <%= form.govuk_collection_radio_buttons :directive_academy_order,
+              directive_academy_order_responses,
+              :id,
+              :name,
+              legend: {text: t("helpers.legend.conversion_project.directive_academy_order")},
+              form_group: {id: "directive-academy-order"} %>
+      </div>
+
       <%= form.govuk_submit do %>
         <%= govuk_link_to "Cancel", project_information_path(@project) %>
       <% end %>

--- a/app/views/conversions/projects/edit.html.erb
+++ b/app/views/conversions/projects/edit.html.erb
@@ -26,6 +26,16 @@
               form_group: {id: "directive-academy-order"} %>
       </div>
 
+      <div class="govuk-form-group">
+        <%= form.govuk_collection_radio_buttons :two_requires_improvement,
+              yes_no_responses,
+              :id,
+              :name,
+              legend: {text: t("helpers.legend.conversion_project.two_requires_improvement")},
+              hint: {text: t("helpers.hint.conversion_project.two_requires_improvement")},
+              form_group: {id: "two-requires-improvement"} %>
+      </div>
+
       <%= form.govuk_submit do %>
         <%= govuk_link_to "Cancel", project_information_path(@project) %>
       <% end %>

--- a/app/views/conversions/projects/new.html.erb
+++ b/app/views/conversions/projects/new.html.erb
@@ -34,7 +34,7 @@
       </div>
 
       <div class="govuk-form-group">
-        <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, @project.yes_no_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>
+        <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, yes_no_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>
         <%= form.govuk_text_area :handover_note_body,
               label: {text: t("project.new.handover_comments_label"), size: "m"},
               hint: {text: t("project.new.handover_comments_hint").html_safe} %>
@@ -48,7 +48,7 @@
               legend: {text: t("helpers.legend.conversion_project.directive_academy_order")},
               form_group: {id: "directive-academy-order"} %>
         <%= form.govuk_collection_radio_buttons :two_requires_improvement,
-              @project.yes_no_responses,
+              yes_no_responses,
               :id,
               :name,
               legend: {text: t("helpers.legend.conversion_project.two_requires_improvement")},

--- a/app/views/conversions/projects/new.html.erb
+++ b/app/views/conversions/projects/new.html.erb
@@ -42,7 +42,7 @@
 
       <div class="govuk-form-group">
         <%= form.govuk_collection_radio_buttons :directive_academy_order,
-              @project.directive_academy_order_responses,
+              directive_academy_order_responses,
               :id,
               :name,
               legend: {text: t("helpers.legend.conversion_project.directive_academy_order")},

--- a/app/views/conversions/projects/new_mat.html.erb
+++ b/app/views/conversions/projects/new_mat.html.erb
@@ -38,7 +38,7 @@
       </div>
 
       <div class="govuk-form-group">
-        <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, @project.yes_no_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>
+        <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, yes_no_responses, :id, :name, legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")}, form_group: {id: "assigned-to-regional-caseworker-team"} %>
         <%= form.govuk_text_area :handover_note_body,
               label: {text: t("project.new.handover_comments_label"), size: "m"},
               hint: {text: t("project.new.handover_comments_hint").html_safe} %>
@@ -52,7 +52,7 @@
               legend: {text: t("helpers.legend.conversion_project.directive_academy_order")},
               form_group: {id: "directive-academy-order"} %>
         <%= form.govuk_collection_radio_buttons :two_requires_improvement,
-              @project.yes_no_responses,
+              yes_no_responses,
               :id,
               :name,
               legend: {text: t("helpers.legend.conversion_project.two_requires_improvement")},

--- a/app/views/conversions/projects/new_mat.html.erb
+++ b/app/views/conversions/projects/new_mat.html.erb
@@ -46,7 +46,7 @@
 
       <div class="govuk-form-group">
         <%= form.govuk_collection_radio_buttons :directive_academy_order,
-              @project.directive_academy_order_responses,
+              directive_academy_order_responses,
               :id,
               :name,
               legend: {text: t("helpers.legend.conversion_project.directive_academy_order")},

--- a/app/views/shared/project_information/_advisory_board_details.html.erb
+++ b/app/views/shared/project_information/_advisory_board_details.html.erb
@@ -4,12 +4,16 @@
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.advisory_board_details.rows.advisory_board_date") }
           row.with_value { project.advisory_board_date.to_date.to_formatted_s(:govuk) }
-          row.with_action(text: "Change", href: conversions_edit_path(@project, anchor: "advisory-board"), visually_hidden_text: "the advisory board date")
+          if project.type == "Conversion::Project"
+            row.with_action(text: "Change", href: conversions_edit_path(@project, anchor: "advisory-board"), visually_hidden_text: "the advisory board date")
+          end
         end
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.advisory_board_details.rows.advisory_board_conditions") }
           row.with_value { simple_format(project.advisory_board_conditions, class: "govuk-body") }
-          row.with_action(text: "Change", href: conversions_edit_path(@project, anchor: "advisory-board"), visually_hidden_text: "the advisory board conditions")
+          if project.type == "Conversion::Project"
+            row.with_action(text: "Change", href: conversions_edit_path(@project, anchor: "advisory-board"), visually_hidden_text: "the advisory board conditions")
+          end
         end
       end %>
 </div>

--- a/app/views/shared/project_information/_incoming_trust_details.html.erb
+++ b/app/views/shared/project_information/_incoming_trust_details.html.erb
@@ -8,7 +8,9 @@
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.incoming_trust_details.rows.ukprn") }
           row.with_value { incoming_trust.ukprn.to_s }
-          row.with_action(text: "Change", href: conversions_edit_path(@project, anchor: "incoming-trust-ukprn"), visually_hidden_text: "the incoming trust UKPRN")
+          if project.type == "Conversion::Project"
+            row.with_action(text: "Change", href: conversions_edit_path(@project, anchor: "incoming-trust-ukprn"), visually_hidden_text: "the incoming trust UKPRN")
+          end
         end
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.incoming_trust_details.rows.group_identifier") }

--- a/app/views/transfers/projects/new.html.erb
+++ b/app/views/transfers/projects/new.html.erb
@@ -37,26 +37,26 @@
 
       <div class="govuk-form-group">
         <%= form.govuk_collection_radio_buttons :two_requires_improvement,
-              @project.yes_no_responses,
+              yes_no_responses,
               :id,
               :name,
               form_group: {id: "two-requires-improvement"},
               hint: {text: t("helpers.hint.transfer_project.two_requires_improvement")} %>
 
         <%= form.govuk_collection_radio_buttons :inadequate_ofsted,
-              @project.yes_no_responses,
+              yes_no_responses,
               :id,
               :name,
               form_group: {id: "inadequate-ofsted"} %>
 
         <%= form.govuk_collection_radio_buttons :financial_safeguarding_governance_issues,
-              @project.yes_no_responses,
+              yes_no_responses,
               :id,
               :name,
               form_group: {id: "financial-safeguarding-governance-issues"} %>
 
         <%= form.govuk_collection_radio_buttons :outgoing_trust_to_close,
-              @project.yes_no_responses,
+              yes_no_responses,
               :id,
               :name,
               form_group: {id: "outgoing-trust-to-close"} %>
@@ -64,7 +64,7 @@
 
       <div class="govuk-form-group">
         <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team,
-              @project.yes_no_responses,
+              yes_no_responses,
               :id,
               :name,
               form_group: {id: "assigned-to-regional-caseworker-team"},

--- a/app/views/transfers/projects/new_mat.html.erb
+++ b/app/views/transfers/projects/new_mat.html.erb
@@ -44,26 +44,26 @@
 
       <div class="govuk-form-group">
         <%= form.govuk_collection_radio_buttons :two_requires_improvement,
-              @project.yes_no_responses,
+              yes_no_responses,
               :id,
               :name,
               form_group: {id: "two-requires-improvement"},
               hint: {text: t("helpers.hint.transfer_project.two_requires_improvement")} %>
 
         <%= form.govuk_collection_radio_buttons :inadequate_ofsted,
-              @project.yes_no_responses,
+              yes_no_responses,
               :id,
               :name,
               form_group: {id: "inadequate-ofsted"} %>
 
         <%= form.govuk_collection_radio_buttons :financial_safeguarding_governance_issues,
-              @project.yes_no_responses,
+              yes_no_responses,
               :id,
               :name,
               form_group: {id: "financial-safeguarding-governance-issues"} %>
 
         <%= form.govuk_collection_radio_buttons :outgoing_trust_to_close,
-              @project.yes_no_responses,
+              yes_no_responses,
               :id,
               :name,
               form_group: {id: "outgoing-trust-to-close"} %>
@@ -71,7 +71,7 @@
 
       <div class="govuk-form-group">
         <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team,
-              @project.yes_no_responses,
+              yes_no_responses,
               :id,
               :name,
               form_group: {id: "assigned-to-regional-caseworker-team"},

--- a/spec/features/conversions/users_can_edit_project_details_spec.rb
+++ b/spec/features/conversions/users_can_edit_project_details_spec.rb
@@ -103,6 +103,41 @@ RSpec.feature "Users can edit project details" do
     expect(page).to have_link "View the trust SharePoint folder (opens in a new tab)",
       href: "https://educationgovuk-my.sharepoint.com/incoming-trust-folder-updated-link"
   end
+
+  scenario "they can change the kind of academy order" do
+    visit project_information_path(project)
+
+    row = find("#reasonsFor .govuk-summary-list__row:nth-child(1)")
+
+    within(row) do
+      expect(page).to have_content("No")
+      click_link "Change"
+    end
+
+    within("#directive-academy-order") do
+      choose("Directive academy order")
+    end
+
+    click_on "Continue"
+
+    within(row) do
+      expect(page).to have_content("Yes")
+    end
+
+    within(row) do
+      click_link "Change"
+    end
+
+    within("#directive-academy-order") do
+      choose("Academy order")
+    end
+
+    click_on "Continue"
+
+    within(row) do
+      expect(page).to have_content("No")
+    end
+  end
 end
 
 def mock_api_for_editing

--- a/spec/features/conversions/users_can_edit_project_details_spec.rb
+++ b/spec/features/conversions/users_can_edit_project_details_spec.rb
@@ -138,6 +138,41 @@ RSpec.feature "Users can edit project details" do
       expect(page).to have_content("No")
     end
   end
+
+  scenario "they can change the two requires improvement response" do
+    visit project_information_path(project)
+
+    row = find("#reasonsFor .govuk-summary-list__row:nth-child(2)")
+
+    within(row) do
+      expect(page).to have_content("No")
+      click_link "Change"
+    end
+
+    within("#two-requires-improvement") do
+      choose("Yes")
+    end
+
+    click_on "Continue"
+
+    within(row) do
+      expect(page).to have_content("Yes")
+    end
+
+    within(row) do
+      click_link "Change"
+    end
+
+    within("#two-requires-improvement") do
+      choose("No")
+    end
+
+    click_on "Continue"
+
+    within(row) do
+      expect(page).to have_content("No")
+    end
+  end
 end
 
 def mock_api_for_editing

--- a/spec/forms/conversion/edit_project_form_spec.rb
+++ b/spec/forms/conversion/edit_project_form_spec.rb
@@ -1,7 +1,14 @@
 require "rails_helper"
 
 RSpec.describe Conversion::EditProjectForm, type: :model do
-  let(:project) { build(:conversion_project, assigned_to: user, advisory_board_date: Date.new(2023, 12, 1)) }
+  let(:project) {
+    build(
+      :conversion_project,
+      assigned_to: user,
+      advisory_board_date: Date.new(2023, 12, 1),
+      directive_academy_order: false
+    )
+  }
   let(:user) { build(:user, :caseworker) }
 
   subject { Conversion::EditProjectForm.new_from_project(project) }
@@ -107,6 +114,22 @@ RSpec.describe Conversion::EditProjectForm, type: :model do
 
         expect(subject.update(updated_params)).to be false
         expect(project.incoming_trust_sharepoint_link).to eql("https://educationgovuk-my.sharepoint.com/incoming-trust-folder")
+      end
+    end
+
+    describe "Directive academy order" do
+      it "can be changed" do
+        updated_params = {directive_academy_order: "true"}
+
+        subject.update(updated_params)
+
+        expect(project.directive_academy_order).to be true
+
+        updated_params = {directive_academy_order: "false"}
+
+        subject.update(updated_params)
+
+        expect(project.directive_academy_order).to be false
       end
     end
   end

--- a/spec/forms/conversion/edit_project_form_spec.rb
+++ b/spec/forms/conversion/edit_project_form_spec.rb
@@ -132,5 +132,21 @@ RSpec.describe Conversion::EditProjectForm, type: :model do
         expect(project.directive_academy_order).to be false
       end
     end
+
+    describe "two requires improvement" do
+      it "can be changed" do
+        updated_params = {two_requires_improvement: "true"}
+
+        subject.update(updated_params)
+
+        expect(project.two_requires_improvement).to be true
+
+        updated_params = {two_requires_improvement: "false"}
+
+        subject.update(updated_params)
+
+        expect(project.two_requires_improvement).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
Based on #1481 

Following the existing pattern for allowing users to edit conversion project attributes, here we allow:

-  academy order type
- result of two requires improvement

to be changed.
