### PR TITLE
(160908) Users can change the conversion advisory board details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   export when available
 - users can now change the incoming trust UKPRN on a conversion project, this
   allows mistakes to be corrected.
+- users can now change the advisory board date and any conditions on a
+  conversion project.
 
 ## [Release-62][release-62]
 

--- a/app/controllers/conversions/projects_controller.rb
+++ b/app/controllers/conversions/projects_controller.rb
@@ -44,14 +44,14 @@ class Conversions::ProjectsController < ProjectsController
 
   def edit
     authorize project
-    @project_form = Conversion::EditProjectForm.new(project: project)
+    @project_form = Conversion::EditProjectForm.new_from_project(project)
   end
 
   def update
     authorize project
-    @project_form = Conversion::EditProjectForm.new(project: project, args: edit_project_params)
+    @project_form = Conversion::EditProjectForm.new_from_project(project)
 
-    if @project_form.save
+    if @project_form.update(edit_project_params)
       redirect_to project_information_path(project), notice: I18n.t("project.update.success")
     else
       render :edit
@@ -66,7 +66,9 @@ class Conversions::ProjectsController < ProjectsController
     params.require(:conversion_edit_project_form).permit(
       :establishment_sharepoint_link,
       :incoming_trust_sharepoint_link,
-      :incoming_trust_ukprn
+      :incoming_trust_ukprn,
+      :advisory_board_date,
+      :advisory_board_conditions
     )
   end
 

--- a/app/models/govuk_date_field_parameters.rb
+++ b/app/models/govuk_date_field_parameters.rb
@@ -1,0 +1,91 @@
+class GovukDateFieldParameters
+  # The years range top and tails the year input to something reasonable as
+  # Ruby Dates can be negative and unreasonable values like 100 or 0.
+  # do not try to use this as regular validation of the year value, use Rails
+  # validators for that only override it the default range is unsuitable and you
+  # want the range consistent across the application.
+  YEARS_RANGE = (2000..3000)
+
+  def initialize(attribute_name, params, years_range = YEARS_RANGE)
+    @params = params
+    @attribute_name = attribute_name.to_sym
+    @years_range = years_range
+  end
+
+  def valid?
+    return true unless parameters_present?
+    return true if values_empty?
+    return false unless values_in_range?
+
+    valid_date?
+  end
+
+  def invalid?
+    !valid?
+  end
+
+  # If the parameters are not present we have to assume the current value of
+  # the date is valid, we only deal with changes via form submission.
+  #
+  # When omitting the day value in a form, you will still be sent '1' as the day:
+  # https://govuk-form-builder.netlify.app/form-elements/date-input/#approximate-dates-recording-the-closest-month
+  private def parameters_present?
+    @params.has_key?(year_key) &&
+      @params.has_key?(month_key) &&
+      @params.has_key?(day_key)
+  end
+
+  # nil is a valid date to store and can be set when the parameters are present and
+  # empty, this allows the form to be submitted with blank values, Rails presence
+  # validation can be used later if you do not want nil dates
+  private def values_empty?
+    year_value.blank? && month_value.blank? && day_value.blank?
+  end
+
+  # Ruby Dates are very flexible and accept many values that would confuse users,
+  # we make sure the three values fall in to reasonable ranges to exclude things
+  # like negative values.
+  #
+  # This also catches any strings that were cast to integers as `0`.
+  private def values_in_range?
+    (1..31).cover?(day_value.to_i) &&
+      (1..12).cover?(month_value.to_i) &&
+      @years_range.cover?(year_value.to_i)
+  end
+
+  # If all other validations have succeeded, we convert the three values to a Date
+  # object, this catches anything left, leap years for example or months that do
+  # not have 31 days.
+  private def valid_date?
+    Date.new(year_value.to_i, month_value.to_i, day_value.to_i)
+    true
+  rescue Date::Error
+    false
+  end
+
+  # Accessors for the keys and values, we keep the values as strings, casting to
+  # integers only when required so we can deal with empty strings ("").
+  private def year_key
+    "#{@attribute_name}(1i)"
+  end
+
+  private def month_key
+    "#{@attribute_name}(2i)"
+  end
+
+  private def day_key
+    "#{@attribute_name}(3i)"
+  end
+
+  private def year_value
+    @params.fetch(year_key)
+  end
+
+  private def month_value
+    @params.fetch(month_key)
+  end
+
+  private def day_value
+    @params.fetch(day_key)
+  end
+end

--- a/app/views/conversions/projects/edit.html.erb
+++ b/app/views/conversions/projects/edit.html.erb
@@ -7,6 +7,11 @@
         <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m"}, width: 10 %>
       </div>
 
+      <div class="govuk-form-group" id="advisory-board">
+        <%= form.govuk_date_field :advisory_board_date, legend: {text: t("helpers.legend.project.advisory_board_date")}, form_group: {id: "advisory-board-date"}, hint: {text: t("helpers.hint.project.advisory_board_date").html_safe} %>
+        <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m", text: t("helpers.label.conversion_project.advisory_board_conditions")} %>
+      </div>
+
       <div class="govuk-form-group" id="sharepoint-folder-links">
         <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m", text: t("project.edit.labels.school_sharepoint_link")} %>
         <%= form.govuk_text_field :incoming_trust_sharepoint_link, label: {size: "m", text: t("project.edit.labels.incoming_trust_sharepoint_link")} %>

--- a/app/views/shared/project_information/_advisory_board_details.html.erb
+++ b/app/views/shared/project_information/_advisory_board_details.html.erb
@@ -4,10 +4,12 @@
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.advisory_board_details.rows.advisory_board_date") }
           row.with_value { project.advisory_board_date.to_date.to_formatted_s(:govuk) }
+          row.with_action(text: "Change", href: conversions_edit_path(@project, anchor: "advisory-board"), visually_hidden_text: "the advisory board date")
         end
         summary_list.with_row do |row|
           row.with_key { t("project_information.show.advisory_board_details.rows.advisory_board_conditions") }
           row.with_value { simple_format(project.advisory_board_conditions, class: "govuk-body") }
+          row.with_action(text: "Change", href: conversions_edit_path(@project, anchor: "advisory-board"), visually_hidden_text: "the advisory board conditions")
         end
       end %>
 </div>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -406,6 +406,7 @@ en:
         blank: Enter a date for the advisory board, like 01 04 2023
         must_be_in_the_past: The advisory board date must be in the past
         must_be_within_parameters: The advisory board date cannot be before 2010
+        invalid: Enter a valid date, like 1 4 2023
       establishment_sharepoint_link:
         blank: Enter a school SharePoint link
         invalid: Enter a school SharePoint link in the correct format

--- a/spec/features/conversions/users_can_edit_project_details_spec.rb
+++ b/spec/features/conversions/users_can_edit_project_details_spec.rb
@@ -26,6 +26,48 @@ RSpec.feature "Users can edit project details" do
     end
   end
 
+  scenario "they can change the advisory board date" do
+    visit project_information_path(project)
+
+    row = find("#advisoryBoardDetails .govuk-summary-list__row:nth-child(1)")
+
+    within(row) do
+      click_link "Change"
+    end
+
+    date_value = Date.yesterday
+
+    fill_in "Day", with: date_value.day
+    fill_in "Month", with: date_value.month
+    fill_in "Year", with: date_value.year
+
+    click_button "Continue"
+
+    within(row) do
+      expect(page).to have_content date_value.to_fs(:govuk)
+    end
+  end
+
+  scenario "they can change the advisory board conditions" do
+    visit project_information_path(project)
+
+    row = find("#advisoryBoardDetails .govuk-summary-list__row:nth-child(2)")
+
+    within(row) do
+      click_link "Change"
+    end
+
+    text_value = "These are the conditions for the conversion."
+
+    fill_in "Advisory board conditions", with: text_value
+
+    click_button "Continue"
+
+    within(row) do
+      expect(page).to have_content text_value
+    end
+  end
+
   scenario "they can change the sharepoint link for an establishment" do
     visit project_information_path(project)
 

--- a/spec/forms/conversion/edit_project_form_spec.rb
+++ b/spec/forms/conversion/edit_project_form_spec.rb
@@ -1,78 +1,112 @@
 require "rails_helper"
 
 RSpec.describe Conversion::EditProjectForm, type: :model do
-  let(:project) { build(:conversion_project, assigned_to: user) }
+  let(:project) { build(:conversion_project, assigned_to: user, advisory_board_date: Date.new(2023, 12, 1)) }
   let(:user) { build(:user, :caseworker) }
+
+  subject { Conversion::EditProjectForm.new_from_project(project) }
 
   before do
     mock_successful_api_responses(urn: any_args, ukprn: any_args)
   end
 
-  describe "#save" do
-    describe "Incoming trust UKPRN" do
+  describe "#update" do
+    describe "the incoming trust UKPRN" do
       it "can be changed" do
-        form = Conversion::EditProjectForm.new(project: project, args: {incoming_trust_ukprn: "12345678"})
-        form.save
+        updated_params = {incoming_trust_ukprn: "12345678"}
+
+        subject.update(updated_params)
 
         expect(project.incoming_trust_ukprn).to eql 12345678
       end
 
       it "cannot be invalid" do
-        form = Conversion::EditProjectForm.new(project: project, args: {incoming_trust_ukprn: "2461810"})
+        updated_params = {incoming_trust_ukprn: "2461810"}
 
-        expect(form.valid?).to be false
+        expect(subject.update(updated_params)).to be false
         expect(project.incoming_trust_ukprn).to eql 10061021
       end
 
       it "the trust must exist" do
         mock_trust_not_found(ukprn: 12345678)
 
-        form = Conversion::EditProjectForm.new(project: project, args: {incoming_trust_ukprn: "12345678"})
+        updated_params = {incoming_trust_ukprn: "12345678"}
 
-        expect(form.valid?).to be false
+        expect(subject.update(updated_params)).to be false
         expect(project.incoming_trust_ukprn).to eql 10061021
+      end
+    end
+
+    describe "the advisory board date" do
+      it "can be changed" do
+        updated_params = {
+          "advisory_board_date(3i)" => "1",
+          "advisory_board_date(2i)" => "1",
+          "advisory_board_date(1i)" => "2024"
+        }
+
+        subject.update(updated_params)
+
+        expect(project.advisory_board_date).to eql Date.new(2024, 1, 1)
+      end
+
+      it "cannot be invalid" do
+        updated_params = {
+          "advisory_board_date(3i)" => "32",
+          "advisory_board_date(2i)" => "1",
+          "advisory_board_date(1i)" => "2024"
+        }
+
+        expect(subject.update(updated_params)).to be false
+        expect(project.advisory_board_date).to eql project.advisory_board_date
       end
     end
 
     describe "Establishment SharePoint link" do
       it "can be changed" do
-        form = Conversion::EditProjectForm.new(project: project, args: {establishment_sharepoint_link: "https://educationgovuk-my.sharepoint.com/establishment-folder-updated-link"})
-        form.save
+        updated_params = {establishment_sharepoint_link: "https://educationgovuk-my.sharepoint.com/establishment-folder-updated-link"}
+
+        subject.update(updated_params)
 
         expect(project.establishment_sharepoint_link).to eql("https://educationgovuk-my.sharepoint.com/establishment-folder-updated-link")
       end
 
       it "cannot be invalid" do
-        form = Conversion::EditProjectForm.new(project: project, args: {establishment_sharepoint_link: "https://some-other-domain.com/establishment-folder-updated-link"})
+        updated_params = {establishment_sharepoint_link: "https://some-other-domain.com/establishment-folder-updated-link"}
 
-        expect(form.valid?).to be false
+        expect(subject.update(updated_params)).to be false
+        expect(project.establishment_sharepoint_link).to eql("https://educationgovuk-my.sharepoint.com/establishment-folder")
       end
 
       it "cannot be empty" do
-        form = Conversion::EditProjectForm.new(project: project, args: {establishment_sharepoint_link: ""})
+        updated_params = {establishment_sharepoint_link: ""}
 
-        expect(form.valid?).to be false
+        expect(subject.update(updated_params)).to be false
+        expect(project.establishment_sharepoint_link).to eql("https://educationgovuk-my.sharepoint.com/establishment-folder")
       end
     end
 
     describe "Incoming trust SharePoint link" do
       it "can be changed" do
-        form = Conversion::EditProjectForm.new(project: project, args: {incoming_trust_sharepoint_link: "https://educationgovuk-my.sharepoint.com/incoming-trust-folder-updated-link"})
-        form.save
+        updated_params = {incoming_trust_sharepoint_link: "https://educationgovuk-my.sharepoint.com/incoming-trust-folder-updated-link"}
+
+        subject.update(updated_params)
 
         expect(project.incoming_trust_sharepoint_link).to eql("https://educationgovuk-my.sharepoint.com/incoming-trust-folder-updated-link")
       end
 
       it "cannot be invalid" do
-        form = Conversion::EditProjectForm.new(project: project, args: {incoming_trust_sharepoint_link: "https://some-other-domain.com/incoming-trust-folder-updated-link"})
+        updated_params = {incoming_trust_sharepoint_link: "https://some-other-domain.com/incoming-trust-folder-updated-link"}
 
-        expect(form.valid?).to be false
+        expect(subject.update(updated_params)).to be false
+        expect(project.incoming_trust_sharepoint_link).to eql("https://educationgovuk-my.sharepoint.com/incoming-trust-folder")
       end
 
       it "cannot be empty" do
-        form = Conversion::EditProjectForm.new(project: project, args: {incoming_trust_sharepoint_link: ""})
+        updated_params = {incoming_trust_sharepoint_link: ""}
 
-        expect(form.valid?).to be false
+        expect(subject.update(updated_params)).to be false
+        expect(project.incoming_trust_sharepoint_link).to eql("https://educationgovuk-my.sharepoint.com/incoming-trust-folder")
       end
     end
   end

--- a/spec/models/govuk_date_field_parameters_spec.rb
+++ b/spec/models/govuk_date_field_parameters_spec.rb
@@ -1,0 +1,259 @@
+require "rails_helper"
+
+RSpec.describe GovukDateFieldParameters do
+  it "is valid when the parameters are not present" do
+    params = {}
+    attribute_name = :test_date_attribute
+
+    subject = described_class.new(attribute_name, params)
+
+    expect(subject.valid?).to be true
+    expect(subject.invalid?).to be false
+  end
+
+  it "is valid when the parameters are present and empty" do
+    params = {
+      "test_date_attribute(1i)" => "",
+      "test_date_attribute(2i)" => "",
+      "test_date_attribute(3i)" => ""
+    }
+    attribute_name = :test_date_attribute
+
+    subject = described_class.new(attribute_name, params)
+
+    expect(subject.valid?).to be true
+    expect(subject.invalid?).to be false
+  end
+
+  it "is valid when the parameters are present and acceptable" do
+    params = {
+      "test_date_attribute(1i)" => "2024",
+      "test_date_attribute(2i)" => "1",
+      "test_date_attribute(3i)" => "1"
+    }
+    attribute_name = :test_date_attribute
+
+    subject = described_class.new(attribute_name, params)
+
+    expect(subject.valid?).to be true
+    expect(subject.invalid?).to be false
+  end
+
+  it "is invalid when the date is not valid" do
+    params = {
+      "test_date_attribute(1i)" => "2024",
+      "test_date_attribute(2i)" => "2",
+      "test_date_attribute(3i)" => "30"
+    }
+    attribute_name = :test_date_attribute
+
+    subject = described_class.new(attribute_name, params)
+
+    expect(subject.valid?).to be false
+    expect(subject.invalid?).to be true
+  end
+
+  describe "years range" do
+    it "has a default 2000 to 3000" do
+      params = {
+        "test_date_attribute(1i)" => "3001",
+        "test_date_attribute(2i)" => "1",
+        "test_date_attribute(3i)" => "1"
+      }
+      attribute_name = :test_date_attribute
+
+      subject = described_class.new(attribute_name, params)
+
+      expect(subject.valid?).to be false
+      expect(subject.invalid?).to be true
+    end
+
+    it "can be set to any range" do
+      params = {
+        "test_date_attribute(1i)" => "3001",
+        "test_date_attribute(2i)" => "1",
+        "test_date_attribute(3i)" => "1"
+      }
+      attribute_name = :test_date_attribute
+
+      subject = described_class.new(attribute_name, params, (2000..4000))
+
+      expect(subject.valid?).to be true
+      expect(subject.invalid?).to be false
+    end
+  end
+
+  describe "year errors" do
+    it "is invalid when the year is outside of the acceptable range" do
+      params = {
+        "test_date_attribute(1i)" => "3001",
+        "test_date_attribute(2i)" => "1",
+        "test_date_attribute(3i)" => "1"
+      }
+      attribute_name = :test_date_attribute
+
+      subject = described_class.new(attribute_name, params)
+
+      expect(subject.valid?).to be false
+      expect(subject.invalid?).to be true
+    end
+
+    it "is invalid when the year is negative" do
+      params = {
+        "test_date_attribute(1i)" => "-2024",
+        "test_date_attribute(2i)" => "1",
+        "test_date_attribute(3i)" => "1"
+      }
+      attribute_name = :test_date_attribute
+
+      subject = described_class.new(attribute_name, params)
+
+      expect(subject.valid?).to be false
+      expect(subject.invalid?).to be true
+    end
+
+    it "is invalid when the year is not a integer" do
+      params = {
+        "test_date_attribute(1i)" => "Twenty twenty four",
+        "test_date_attribute(2i)" => "1",
+        "test_date_attribute(3i)" => "1"
+      }
+      attribute_name = :test_date_attribute
+
+      subject = described_class.new(attribute_name, params)
+
+      expect(subject.valid?).to be false
+      expect(subject.invalid?).to be true
+    end
+
+    it "is invalid when the year is zero" do
+      params = {
+        "test_date_attribute(1i)" => "0",
+        "test_date_attribute(2i)" => "1",
+        "test_date_attribute(3i)" => "1"
+      }
+      attribute_name = :test_date_attribute
+
+      subject = described_class.new(attribute_name, params)
+
+      expect(subject.valid?).to be false
+      expect(subject.invalid?).to be true
+    end
+  end
+
+  describe "month errors" do
+    it "is invalid when the month is outside of the acceptable range" do
+      params = {
+        "test_date_attribute(1i)" => "2024",
+        "test_date_attribute(2i)" => "13",
+        "test_date_attribute(3i)" => "1"
+      }
+      attribute_name = :test_date_attribute
+
+      subject = described_class.new(attribute_name, params)
+
+      expect(subject.valid?).to be false
+      expect(subject.invalid?).to be true
+    end
+
+    it "is invalid when the month is negative" do
+      params = {
+        "test_date_attribute(1i)" => "2024",
+        "test_date_attribute(2i)" => "-2",
+        "test_date_attribute(3i)" => "1"
+      }
+      attribute_name = :test_date_attribute
+
+      subject = described_class.new(attribute_name, params)
+
+      expect(subject.valid?).to be false
+      expect(subject.invalid?).to be true
+    end
+
+    it "is invalid when the month is not a integer" do
+      params = {
+        "test_date_attribute(1i)" => "2024",
+        "test_date_attribute(2i)" => "January",
+        "test_date_attribute(3i)" => "1"
+      }
+      attribute_name = :test_date_attribute
+
+      subject = described_class.new(attribute_name, params)
+
+      expect(subject.valid?).to be false
+      expect(subject.invalid?).to be true
+    end
+
+    it "is invalid when the month is zero" do
+      params = {
+        "test_date_attribute(1i)" => "2024",
+        "test_date_attribute(2i)" => "0",
+        "test_date_attribute(3i)" => "1"
+      }
+      attribute_name = :test_date_attribute
+
+      subject = described_class.new(attribute_name, params)
+
+      expect(subject.valid?).to be false
+      expect(subject.invalid?).to be true
+    end
+  end
+
+  describe "day errors" do
+    it "is invalid when the day is outside of the acceptable range" do
+      params = {
+        "test_date_attribute(1i)" => "2024",
+        "test_date_attribute(2i)" => "1",
+        "test_date_attribute(3i)" => "32"
+      }
+      attribute_name = :test_date_attribute
+
+      subject = described_class.new(attribute_name, params)
+
+      expect(subject.valid?).to be false
+      expect(subject.invalid?).to be true
+    end
+
+    it "is invalid when the day is negative" do
+      params = {
+        "test_date_attribute(1i)" => "2024",
+        "test_date_attribute(2i)" => "1",
+        "test_date_attribute(3i)" => "-32"
+      }
+      attribute_name = :test_date_attribute
+
+      subject = described_class.new(attribute_name, params)
+
+      expect(subject.valid?).to be false
+      expect(subject.invalid?).to be true
+    end
+
+    it "is invalid when the day is not a integer" do
+      params = {
+        "test_date_attribute(1i)" => "2024",
+        "test_date_attribute(2i)" => "1",
+        "test_date_attribute(3i)" => "first"
+      }
+      attribute_name = :test_date_attribute
+
+      subject = described_class.new(attribute_name, params)
+
+      expect(subject.valid?).to be false
+      expect(subject.invalid?).to be true
+    end
+
+    it "is invalid when the day is zero" do
+      params = {
+        "test_date_attribute(1i)" => "2024",
+        "test_date_attribute(2i)" => "1",
+        "test_date_attribute(3i)" => "0"
+      }
+      attribute_name = :test_date_attribute
+
+      subject = described_class.new(attribute_name, params)
+
+      expect(subject.valid?).to be false
+      expect(subject.invalid?).to be true
+    end
+  end
+end


### PR DESCRIPTION
As these attribute include a date, we had to overcome our friend 'three field date validation' - we've tried to solve it once for all and hope this new `GovukDateFieldParameter` class can be used wheneve we have a date, except on tasks as they are special!

@lozette we want you to have a look at this to make sure you are happy with the approach and then we can go back and refactor other forms to use this.

The rest of this work follows the existing patterns to allow project attributes to be changed.