### PR TITLE
Adding RCS acronym to add project pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - users can now change the academy order type for a conversion project.
 - users can now change the conversion due to intervention following 2RI response
   for a conversion project.
+- RCS acronym to handover question on add project pages
 
 ## [Release-62][release-62]
 

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -97,7 +97,7 @@ en:
       conversion_project:
         provisional_conversion_date: You can find this in the advisory board template.
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.
-        assigned_to_regional_caseworker_team: Are you handing this project over to Regional Casework Services?
+        assigned_to_regional_caseworker_team: Are you handing this project over to RCS (Regional Casework Services)?
         two_requires_improvement: A 2RI conversion is when a local authority maintained school becomes an academy after getting at least 2 overall Requires Improvement ratings from Ofsted.
     responses:
       conversion_project:

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -47,7 +47,7 @@ en:
       transfer_project:
         advisory_board_date: Date of advisory board
         provisional_transfer_date: Provisional transfer date
-        assigned_to_regional_caseworker_team: Are you handing this project over to Regional Casework Services?
+        assigned_to_regional_caseworker_team: Are you handing this project over to RCS (Regional Casework Services)?
       transfer_create_project_form:
         two_requires_improvement: Is this a transfer due to 2RI?
         inadequate_ofsted: Is this transfer due to an inadequate Ofsted rating?


### PR DESCRIPTION
## Changes

This work add the RCS acronym to the "Are you handing this project over to Regional Casework Services?" questions on the add project pages. This follows feedback that delivery officers often recognise the acronym over the name.

## Before and after

![Screenshot 2024-04-09 at 4 04 25 PM](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/19318e28-ab88-4c9a-8583-cca3a9fc6c32)

![Screenshot 2024-04-09 at 4 57 45 PM](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/104517016/b03e79ca-51a6-4776-b2db-bbb9ddbd4a56)


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
