### PR TITLE
(162272) Make all primary buttons green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   for a conversion project.
 - RCS acronym to handover question on add project pages
 
+### Changed
+
+- all primary buttons are now green instead of blue
+
 ## [Release-62][release-62]
 
 ### Fixed

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,9 +10,7 @@ $moj-page-width: $govuk-page-width;
 $govuk-font-family: BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu,
   Cantarell, "Helvetica Neue", sans-serif;
 
-// DfE blue buttons
 $dfe-blue: #003a69;
-$govuk-button-background-colour: $dfe-blue;
 
 @import "govuk-frontend/govuk/all";
 @import "accessible-autocomplete/src/autocomplete";


### PR DESCRIPTION
When we adopted the DfE design system we switched the button colour to
DfE blue, this is not part of the design system and not consistent with
other products so we switch them back.

