### PR TITLE
Disable the Add notes for ESFA task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- The 'Add notes for ESFA task' has been disabled as there is evidence that the
+  data is never used.
+
 ## [Release-63][release-63]
 
 ### Added

--- a/app/models/conversion/task_list.rb
+++ b/app/models/conversion/task_list.rb
@@ -49,7 +49,6 @@ class Conversion::TaskList < ::BaseTaskList
         tasks: [
           Conversion::Task::ConfirmDateAcademyOpenedTaskForm,
           Conversion::Task::RedactAndSendTaskForm,
-          Conversion::Task::UpdateEsfaTaskForm,
           Conversion::Task::ReceiveGrantPaymentCertificateTaskForm
         ]
       }

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -33,7 +33,6 @@ RSpec.feature "Users can complete conversion tasks" do
     main_contact
     proposed_capacity_of_the_academy
     receive_grant_payment_certificate
-    update_esfa
     confirm_date_academy_opened
     chair_of_governors_contact
   ]
@@ -276,6 +275,7 @@ RSpec.feature "Users can complete conversion tasks" do
     let(:project) { create(:conversion_project, assigned_to: user) }
 
     scenario "they can compelte the task" do
+      skip("task is disabled for now")
       visit project_tasks_path(project)
       click_on "Add notes for ESFA"
 

--- a/spec/models/conversion/task_list_spec.rb
+++ b/spec/models/conversion/task_list_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe Conversion::TaskList do
         :share_information,
         :confirm_date_academy_opened,
         :redact_and_send,
-        :update_esfa,
         :receive_grant_payment_certificate
       ]
 
@@ -97,7 +96,6 @@ RSpec.describe Conversion::TaskList do
             tasks: [
               Conversion::Task::ConfirmDateAcademyOpenedTaskForm,
               Conversion::Task::RedactAndSendTaskForm,
-              Conversion::Task::UpdateEsfaTaskForm,
               Conversion::Task::ReceiveGrantPaymentCertificateTaskForm
             ]
           }
@@ -122,7 +120,7 @@ RSpec.describe Conversion::TaskList do
       project = create(:conversion_project)
       task_list = described_class.new(project, user)
 
-      expect(task_list.tasks.count).to eql 32
+      expect(task_list.tasks.count).to eql 31
       expect(task_list.tasks.first).to be_a Conversion::Task::HandoverTaskForm
       expect(task_list.tasks.last).to be_a Conversion::Task::ReceiveGrantPaymentCertificateTaskForm
     end


### PR DESCRIPTION
User research has shown that data consumers do not use this information
so we want to disable the task for now but not delete it.

This is achieved by removing the task from the task list definition.

We've also skipped the spec.

This work called for the note to be removed from the exports, but I cannot find it in any exports? It is in the presenter so may have been missed - so that user need is met?!