### PR TITLE
(161624) Service support users can "soft delete" a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Service support users can "soft delete" a project
+
 ### Changed
 
 - The 'Add notes for ESFA task' has been disabled as there is evidence that the

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -14,4 +14,18 @@ class ProjectsController < ApplicationController
 
     redirect_to in_progress_your_projects_path
   end
+
+  def confirm_delete
+    authorize Project, :delete?
+
+    @project = Project.find(params[:id])
+  end
+
+  def delete
+    authorize Project, :delete?
+
+    @project = Project.find(params[:id])
+    @project.update(state: :deleted)
+    redirect_to all_in_progress_projects_path, notice: I18n.t("project.delete.success")
+  end
 end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -97,6 +97,10 @@ class ProjectPolicy
     @user.team != "regional_casework_services"
   end
 
+  def delete?
+    @user.is_service_support?
+  end
+
   private def project_assigned_to_user?
     @record.assigned_to == @user
   end

--- a/app/views/projects/confirm_delete.html.erb
+++ b/app/views/projects/confirm_delete.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title do %>
+  <%= page_title(t("project.delete.title", establishment_name: @project.establishment.name)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">
+      <%= t("project.delete.#{@project.type_locale}.urn", urn: @project.urn) %>
+    </span>
+    <h1 class="govuk-heading-xl"><%= t("project.delete.title", establishment_name: @project.establishment.name) %></h1>
+    <%= t("project.delete.confirmation_html") %>
+    <%= form_for @project, url: project_path(@project), method: :patch do |form| %>
+      <%= form.govuk_submit t("project.delete.button"), warning: true do %>
+        <%= govuk_link_to t("cancel"), project_information_path(@project) %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/projects/_actions.html.erb
+++ b/app/views/shared/projects/_actions.html.erb
@@ -9,3 +9,7 @@
         project_change_date_path(@project),
         secondary: true
     end %>
+
+<%= if policy(@project).delete?
+      govuk_button_link_to t("project.delete.button"), confirm_delete_project_path(@project), warning: true
+    end %>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -342,6 +342,18 @@ en:
       tabs:
         conversions: Conversions
         transfers: Transfers
+    delete:
+      title: Delete %{establishment_name}
+      conversion_project:
+        urn: "School URN %{urn}"
+      transfer_project:
+        urn: "Academy URN %{urn}"
+      confirmation_html:
+        <p>You are about to delete this project.</p>
+        <p>It will no longer appear in the application or in exports, and will not be counted in project statistics.</p>
+        <p>Only delete this project if you are sure you want to proceed.</p>
+      success: The project was deleted.
+      button: Delete project
   member_of_parliament:
     show:
       title: Member of Parliament details

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,10 @@ Rails.application.routes.draw do
         memberable
         academy_urn_updateable
       ]
+    resources :projects, except: :destroy do
+      get "confirm_delete", on: :member, action: :confirm_delete, as: :confirm_delete
+      patch "/", on: :member, action: :delete, as: :delete
+    end
   end
 
   # New projects by type

--- a/spec/features/service_support/users_can_soft_delete_a_project_spec.rb
+++ b/spec/features/service_support/users_can_soft_delete_a_project_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.feature "Service support users can soft delete a project" do
+  let(:user) { create(:service_support_user) }
+
+  before do
+    sign_in_with_user(user)
+    mock_successful_api_response_to_create_any_project
+  end
+
+  scenario "a service support user can 'soft delete' a project" do
+    project_to_delete = create(:conversion_project, assigned_to: create(:regional_casework_services_user))
+
+    visit project_path(project_to_delete)
+    expect(page).to have_content(project_to_delete.urn.to_s)
+
+    click_link "Delete project"
+    expect(page).to have_content("Delete #{project_to_delete.establishment.name}")
+    expect(page).to have_content("You are about to delete this project")
+
+    click_button("Delete project")
+    expect(page).to have_content("The project was deleted")
+    expect(page).to_not have_content(project_to_delete.establishment.name)
+
+    expect(project_to_delete.reload.state).to eq("deleted")
+  end
+end

--- a/spec/requests/projects_controller_spec.rb
+++ b/spec/requests/projects_controller_spec.rb
@@ -27,4 +27,32 @@ RSpec.describe ProjectsController, type: :request do
       expect(response).to redirect_to(in_progress_your_projects_path)
     end
   end
+
+  describe "#confirm_destroy" do
+    context "with a non-service support user" do
+      let(:user) { create(:regional_casework_services_user) }
+
+      it "returns unauthorised" do
+        project = create(:conversion_project)
+
+        get confirm_delete_project_path(project)
+        expect(response).not_to render_template(:confirm_delete)
+        expect(response).to redirect_to(root_path)
+        follow_redirect!
+        expect(flash.alert).to eq I18n.t("unauthorised_action.message")
+      end
+    end
+
+    context "with a service support user" do
+      let(:user) { create(:service_support_user) }
+
+      it "returns success" do
+        project = create(:conversion_project)
+
+        get confirm_delete_project_path(project)
+        expect(response).to render_template(:confirm_delete)
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Now that projects can have a "deleted" state (where they do not appear on the UI but are still in the database) we want to allow service support users to "soft delete" a project.

To do this, we have used a "delete" route as opposed to the usual "destroy". As a result, the delete routes are not the same as the destroy routes for notes and contacts. "Destroy" implies the record is removed from the database, while the projects are only hidden, not removed.

We use a "confirm delete" pattern to be absolutely sure the user wants to delete the project, as there is currently no way for a user to restore a "deleted" project.

Once a project is "soft deleted", the user is returned to the All Projects list page, with a confirmation the project was deleted.

<img width="855" alt="Screenshot 2024-04-12 at 14 31 21" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/fd8e7916-3859-4cd3-8eff-5cc0c18b39a2">

<img width="864" alt="Screenshot 2024-04-12 at 11 31 03" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/36bc63c0-21c9-44aa-80b2-a855ec0663e4">

<img width="1192" alt="Screenshot 2024-04-12 at 14 24 47" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/1089521/0eec431f-607f-4437-8635-5d445e99256d">

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
