### PR TITLE
Updating content in high needs places task to use right name for form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The 'Add notes for ESFA task' has been disabled as there is evidence that the
   data is never used.
 - come tweaks to content in the high needs places tasks to use the correct name
-for the notification of changes to funded high needs places form
+  for the notification of changes to funded high needs places form
 
 ## [Release-63][release-63]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The 'Add notes for ESFA task' has been disabled as there is evidence that the
   data is never used.
-- come tweaks to content in the high needs places tasks to use the correct name
+- some tweaks to content in the high needs places tasks to use the correct name
   for the notification of changes to funded high needs places form
 
 ## [Release-63][release-63]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The 'Add notes for ESFA task' has been disabled as there is evidence that the
   data is never used.
+- come tweaks to content in the high needs places tasks to use the correct name
+for the notification of changes to funded high needs places form
 
 ## [Release-63][release-63]
 

--- a/config/locales/conversion/tasks/check_accuracy_of_higher_needs.en.yml
+++ b/config/locales/conversion/tasks/check_accuracy_of_higher_needs.en.yml
@@ -57,7 +57,7 @@ en:
               </ul>
 
               <h3 class="govuk-heading-s">How to update the section 251 spreadsheet</h3>
-              <p>Missing or incorrect information can be changed using a notification of changes document.</p>
-              <p>The local authority and school must complete one and send it to you.</p>
+              <p>Missing or incorrect information can be changed using a notification of changes to funded high needs places form.</p>
+              <p>The local authority must complete one and send it to you.</p>
               <p>You must email the notification of changes to the academy openers team once you have it.</p>
               <p>Email the openers team at <a href="mailto:academy.openers@education.gov.uk">academy.openers@education.gov.uk</a> if you, the local authority or the school have any questions about the section 251 spreadsheet.</p>

--- a/config/locales/conversion/tasks/complete_notification_of_change.en.yml
+++ b/config/locales/conversion/tasks/complete_notification_of_change.en.yml
@@ -2,10 +2,10 @@ en:
   conversion:
     task:
       complete_notification_of_change:
-        title: Complete a notification of change document
+        title: Complete a notification of changes to funded high needs places form
         hint:
           html:
-            <p>The local authority must complete a notification of change document if the section 251 spreadsheet is incorrect.</p>
+            <p>The local authority must complete a notification of changes to funded high needs places form if the section 251 spreadsheet is incorrect.</p>
         guidance_link: When to use the notification of change document
         guidance:
           html:


### PR DESCRIPTION
## Changes

This work corrects references to the notification of change document. 

The correct name is the "notification of changes to funded high needs places form".

This change is reflected in content, including a task name.

The work also clarifies that it is the local authority who complete that form.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
