### PR TITLE
Users can view date history

### DIFF
--- a/app/controllers/date_histories_controller.rb
+++ b/app/controllers/date_histories_controller.rb
@@ -1,6 +1,10 @@
 class DateHistoriesController < ApplicationController
   include Projectable
 
+  def index
+    @dates = @project.date_history.includes([note: [:user]]).order(created_at: :desc)
+  end
+
   def new
     authorize(@project, :change_significant_date?)
     @form = NewDateHistoryForm.new

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -13,6 +13,7 @@ class Project < ApplicationRecord
 
   has_many :notes, dependent: :destroy
   has_many :contacts, class_name: "Contact::Project", inverse_of: :project, dependent: :destroy
+  has_many :date_history, class_name: "SignificantDateHistory", inverse_of: :project, dependent: :destroy
 
   belongs_to :main_contact, inverse_of: :main_contact_for_project, dependent: :destroy, class_name: "Contact::Project", optional: true
   belongs_to :establishment_main_contact, inverse_of: :main_contact_for_establishment, dependent: :destroy, class_name: "Contact::Project", optional: true

--- a/app/views/conversions/date_histories/index.html.erb
+++ b/app/views/conversions/date_histories/index.html.erb
@@ -1,0 +1,12 @@
+<%= render partial: "shared/project_summary" %>
+
+<%= render partial: "shared/projects/sub_navigation" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-l">Conversion date history</h2>
+
+    <%= render partial: "shared/projects/significant_dates_table", locals: {dates: @dates} %>
+
+  </div>
+</div>

--- a/app/views/shared/projects/_significant_dates_table.html.erb
+++ b/app/views/shared/projects/_significant_dates_table.html.erb
@@ -1,0 +1,26 @@
+<% if @dates.empty? %>
+  <%= govuk_inset_text(text: "No date history") %>
+<% else %>
+  <table class="govuk-table" name="projects_table" aria-label="Table of date history">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.date_and_time") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.changed_by") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.previous_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.revised_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.note") %></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% @dates.each do |date| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><%= date.created_at.to_fs(:govuk_date_time) %></td>
+          <td class="govuk-table__cell"><%= date.note.user.email %></td>
+          <td class="govuk-table__cell"><%= date.previous_date.to_fs(:govuk_month) %></td>
+          <td class="govuk-table__cell"><%= date.revised_date.to_fs(:govuk_month) %></td>
+          <td class="govuk-table__cell"><%= date.note.body %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/transfers/date_histories/index.html.erb
+++ b/app/views/transfers/date_histories/index.html.erb
@@ -1,0 +1,12 @@
+<%= render partial: "shared/project_summary" %>
+
+<%= render partial: "shared/projects/sub_navigation" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-l">Transfer date history</h2>
+
+    <%= render partial: "shared/projects/significant_dates_table", locals: {dates: @dates} %>
+
+  </div>
+</div>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -206,6 +206,11 @@ en:
         all_conditions_met: All conditions met
         authority_to_proceed: Authority to proceed
         form_a_mat: Form a MAT project?
+        date_and_time: Date and time
+        changed_by: Changed by
+        previous_date: Previous date
+        revised_date: Revised date
+        note: Note
       body:
         type_name:
           conversion_project: Conversion

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
   concern :significant_date_historyable do
     get "change-date", to: "date_histories#new"
     post "change-date", to: "date_histories#create"
+    get "dates", to: "date_histories#index"
   end
 
   concern :academy_urn_updateable do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Project, type: :model do
   describe "Relationships" do
     before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 
+    it { is_expected.to have_many(:date_history).dependent(:destroy) }
     it { is_expected.to have_many(:notes).dependent(:destroy) }
     it { is_expected.to belong_to(:caseworker).required(false) }
     it { is_expected.to belong_to(:team_leader).required(false) }


### PR DESCRIPTION
We store and some users want to see the history of the changes to the
significant date over time.

This commit adds a `/dates` path to projects and displays a table of the
date history.

We have intentionally not added a link to this view as it has not been
designed, it is merely a technical response to the fact we model this
behaviour.