### PR TITLE
(162829) form a multi academy trust name validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   data is never used.
 - some tweaks to content in the high needs places tasks to use the correct name
   for the notification of changes to funded high needs places form
+- new form a multi-academy trust projects now require the new trust name to
+  match any existing values with the same new trust reference number
 
 ## [Release-63][release-63]
 

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -14,6 +14,8 @@ class Conversion::CreateProjectForm < CreateProjectForm
   validates :directive_academy_order, :assigned_to_regional_caseworker_team, inclusion: {in: [true, false]}
   validates :two_requires_improvement, inclusion: {in: [true, false], message: I18n.t("errors.conversion_project.attributes.two_requires_improvement.inclusion")}
 
+  validates_with FormAMultiAcademyTrustNameValidator
+
   def initialize(params = {})
     @attributes_with_invalid_values = []
     super(params)

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -24,6 +24,8 @@ class Transfer::CreateProjectForm < CreateProjectForm
 
   validates_with OutgoingIncomingTrustsUkprnValidator
 
+  validates_with FormAMultiAcademyTrustNameValidator
+
   def initialize(params = {})
     @attributes_with_invalid_values = []
     super(params)

--- a/app/validators/form_a_multi_academy_trust_name_validator.rb
+++ b/app/validators/form_a_multi_academy_trust_name_validator.rb
@@ -1,0 +1,16 @@
+class FormAMultiAcademyTrustNameValidator < ActiveModel::Validator
+  def validate(record)
+    return if record.new_trust_reference_number.blank? || record.new_trust_name.blank?
+
+    other_project = Project.find_by_new_trust_reference_number(record.new_trust_reference_number)
+    trust_name = other_project&.new_trust_name
+
+    unless trust_name.blank? || record.new_trust_name.upcase.eql?(trust_name.upcase)
+      record.errors.add(
+        :new_trust_name,
+        :not_matching,
+        message: I18n.t("errors.attributes.new_trust_name.not_matching", trust_name: trust_name)
+      )
+    end
+  end
+end

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -450,3 +450,4 @@ en:
         invalid_trust_reference_number: The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234
       new_trust_name:
         blank: Enter a Trust name
+        not_matching: A trust with this TRN already exists. It is called %{trust_name}. Check the trust name you have entered for this conversion/transfer

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -280,6 +280,40 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
         expect(form.errors[:two_requires_improvement]).to include("State if the conversion is due to 2RI. Choose yes or no")
       end
     end
+
+    describe "new trust reference number" do
+      it "is required when there is no incoming trust UKPRN" do
+        form = build(:create_project_form, incoming_trust_ukprn: nil)
+
+        expect(form).to be_invalid
+        expect(form.errors.messages[:new_trust_reference_number].first).to eql "Enter a Trust reference number (TRN)"
+      end
+
+      it "is a valid reference number" do
+        form = build(:create_project_form, incoming_trust_ukprn: nil, new_trust_reference_number: "12345")
+
+        expect(form).to be_invalid
+        expect(form.errors.messages[:new_trust_reference_number].first).to include "Trust reference number must be 'TR'"
+      end
+    end
+
+    describe "new trust name" do
+      it "is required when there is no incoming trust UKPRN" do
+        form = build(:create_project_form, incoming_trust_ukprn: nil)
+
+        expect(form).to be_invalid
+        expect(form.errors.messages[:new_trust_name].first).to eql "Enter a Trust name"
+      end
+
+      it "must match the value from any other project with the same reference number" do
+        create(:conversion_project, new_trust_reference_number: "TR12345", new_trust_name: "The big trust")
+        form = build(:create_project_form, incoming_trust_ukprn: nil, new_trust_reference_number: "TR12345", new_trust_name: "The little trust")
+
+        expect(form).to be_invalid
+        expect(form.errors.messages[:new_trust_name].first).to include "A trust with this TRN already exists"
+        expect(form.errors.messages[:new_trust_name].first).to include "The big trust"
+      end
+    end
   end
 
   describe "urn" do

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -117,6 +117,40 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
         expect(form).to be_invalid
       end
     end
+
+    describe "new trust reference number" do
+      it "is required when there is no incoming trust UKPRN" do
+        form = build(:create_transfer_project_form, incoming_trust_ukprn: nil)
+
+        expect(form).to be_invalid
+        expect(form.errors.messages[:new_trust_reference_number].first).to eql "Enter a Trust reference number (TRN)"
+      end
+
+      it "is a valid reference number" do
+        form = build(:create_transfer_project_form, incoming_trust_ukprn: nil, new_trust_reference_number: "12345")
+
+        expect(form).to be_invalid
+        expect(form.errors.messages[:new_trust_reference_number].first).to include "Trust reference number must be 'TR'"
+      end
+    end
+
+    describe "new trust name" do
+      it "is required when there is no incoming trust UKPRN" do
+        form = build(:create_transfer_project_form, incoming_trust_ukprn: nil)
+
+        expect(form).to be_invalid
+        expect(form.errors.messages[:new_trust_name].first).to eql "Enter a Trust name"
+      end
+
+      it "must match the value from any other project with the same reference number" do
+        create(:transfer_project, new_trust_reference_number: "TR12345", new_trust_name: "The big trust")
+        form = build(:create_transfer_project_form, incoming_trust_ukprn: nil, new_trust_reference_number: "TR12345", new_trust_name: "The little trust")
+
+        expect(form).to be_invalid
+        expect(form.errors.messages[:new_trust_name].first).to include "A trust with this TRN already exists"
+        expect(form.errors.messages[:new_trust_name].first).to include "The big trust"
+      end
+    end
   end
 
   describe "urn" do

--- a/spec/validators/form_a_multi_academy_trust_name_validator_spec.rb
+++ b/spec/validators/form_a_multi_academy_trust_name_validator_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+class FormAMultiAcademyTrustNameValidatorTest
+  include ActiveModel::Validations
+  attr_accessor :new_trust_reference_number
+  attr_accessor :new_trust_name
+
+  validates_with FormAMultiAcademyTrustNameValidator
+end
+
+RSpec.describe FormAMultiAcademyTrustNameValidator do
+  subject { FormAMultiAcademyTrustNameValidatorTest.new }
+
+  before do
+    mock_successful_api_response_to_create_any_project
+    create(:conversion_project, new_trust_reference_number: "TR12345", new_trust_name: "Big new trust")
+    create(:conversion_project, new_trust_reference_number: "TR12345", new_trust_name: "Big new trust")
+  end
+
+  it "is valid if there is no new trust reference number" do
+    subject.new_trust_reference_number = ""
+    subject.new_trust_name = "New trust name"
+
+    expect(subject).to be_valid
+  end
+
+  it "is valid if there is no new trust name" do
+    subject.new_trust_reference_number = "TR1234567"
+    subject.new_trust_name = ""
+
+    expect(subject).to be_valid
+  end
+
+  it "is valid if the new trust name matches the existing name" do
+    subject.new_trust_reference_number = "TR12345"
+    subject.new_trust_name = "Big new trust"
+
+    expect(subject).to be_valid
+  end
+
+  it "is valid if there are no other projects with the same reference number" do
+    subject.new_trust_reference_number = "TR00000"
+    subject.new_trust_name = "Big new trust"
+
+    expect(subject).to be_valid
+  end
+
+  it "adds an error if the new trust name is different to the name in the existing project" do
+    subject.new_trust_reference_number = "TR12345"
+    subject.new_trust_name = "New trust name"
+
+    expect(subject).to be_invalid
+    expect(subject.errors.messages[:new_trust_name].first).to include "Big new trust"
+  end
+end


### PR DESCRIPTION
We want users to use the same New trust name on all projects in a 'form
a multi academy trust' collection.

To aid this we want to validate that:

- if a project for the same new trust already exists, the provided trust
  names must match

The validator relies on the first returned project i.e. the first
project in the application locks the trust name, subsequent projects
will have to match or the first be corrected.

The trust names are not case sensitive, we convert them to UPPERCASE for
comparison.

We then use the validator on conversion and transfer projects.