### PR TITLE
(162804) Change RPA task export unconfirmed value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   match any existing values with the same new trust reference number
 - The 'confirm the academy's risk protection arrangement' task now includes
   additional guidance about auto enrollment.
+- When the 'Confirm the academy's risk protection arrangements' task value is
+  exported it is set to 'standard' when the task is incomplete.
 
 ## [Release-63][release-63]
 

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -80,7 +80,7 @@ class Export::Csv::ProjectPresenter
 
   def risk_protection_arrangement
     if @project.tasks_data.risk_protection_arrangement_option.nil?
-      return I18n.t("export.csv.project.values.unconfirmed")
+      return I18n.t("export.csv.project.values.standard")
     end
 
     I18n.t("export.csv.project.values.#{@project.tasks_data.risk_protection_arrangement_option}")

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -426,13 +426,13 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.risk_protection_arrangement).to eql "commercial"
   end
 
-  it "presents all risk protection arrangement when it is not yet confirmed" do
+  it "presents all risk protection arrangement as 'standard' when it is not yet confirmed" do
     tasks_data = build(:conversion_tasks_data, risk_protection_arrangement_option: nil)
     project = build(:conversion_project, tasks_data: tasks_data)
 
     presenter = described_class.new(project)
 
-    expect(presenter.risk_protection_arrangement).to eql "unconfirmed"
+    expect(presenter.risk_protection_arrangement).to eql "standard"
   end
 
   describe "#assigned_to_name" do


### PR DESCRIPTION
When exporting the data we want the value to be shown as 'standard' not
'unconfirmed'. This is because the academy will be auto enrolled into
the standard agreement unless they say otherwise, regardless of the
unconfirmed state of the task.

