### PR TITLE
Release 64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release-64][release-64]
+
 ### Added
 
 - Service support users can "soft delete" a project
@@ -1794,7 +1796,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-63...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-64...HEAD
+[release-64]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-63...release-64
 [release-63]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-62...release-63
 [release-62]:


### PR DESCRIPTION
Added

- Service support users can "soft delete" a project

Changed

- The 'Add notes for ESFA task' has been disabled as there is evidence that the data is never used.
- some tweaks to content in the high needs places tasks to use the correct name for the notification of changes to funded high needs places form
- new form a multi-academy trust projects now require the new trust name to match any existing values with the same new trust reference number
- The 'confirm the academy's risk protection arrangement' task now includes additional guidance about auto enrollment.
- When the 'Confirm the academy's risk protection arrangements' task value is exported it is set to 'standard' when the task is incomplete.

