### PR TITLE
Fix the RPA reason export value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Any project that has a risk protection arrangement of 'commercial' will move
+  to in progress until a reason is provided.
+
 ## [Release-65][release-65]
 
 ### Added

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -89,7 +89,7 @@ class Export::Csv::ProjectPresenter
   def risk_protection_arrangement_reason
     return I18n.t("export.csv.project.values.not_applicable") if @project.is_a?(Transfer::Project)
 
-    option = @project.tasks_data.risk_protection_arrangement_reason
+    option = @project.tasks_data.risk_protection_arrangement_option
     return I18n.t("export.csv.project.values.not_applicable") if option.nil? ||
       option.eql?("standard") ||
       option.eql?("church_or_trust")

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -479,6 +479,15 @@ RSpec.describe Export::Csv::ProjectPresenter do
 
       expect(presenter.risk_protection_arrangement_reason).to eql "This is the reason."
     end
+
+    it "presents nothing when an project has no reason but was set to commercial before the reason was added" do
+      tasks_data = build(:conversion_tasks_data, risk_protection_arrangement_option: "commercial", risk_protection_arrangement_reason: nil)
+      project = build(:conversion_project, tasks_data: tasks_data)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.risk_protection_arrangement_reason).to be_nil
+    end
   end
 
   describe "#assigned_to_name" do


### PR DESCRIPTION
In the export presenter the `option` was assigned the reason value when
it should be the option value.

This issue presented itself when we viewed existing projects in
development that were already set to 'commercial' but had `nil` reason -
this case is an exception we cannot do anything about as we don't know
the reason, the only option is for users to backfill the values.

Any project that has RPA of 'commercial' will now be in progress until a
reason is given.
