### PR TITLE
Fixing broken link to SharePoint guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Broken link to SharePoint guidance in footer and sign-in page now correct
+
 ## [Release-66][release-66]
 
 ### Changed

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -23,7 +23,7 @@
     <li>job title</li>
    </ul>
   <h2 class="govuk-heading-m">How to use Complete conversions, transfers and changes</h2>
-  <p class="govuk-body">You can <a href="https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/using-the-complete-conversions-transfers-and-changes-digital-product.aspx" class="govuk-link" rel="noreferrer noopener" target="_blank">read our guidance about how to use the product (opens in new tab)</a> if you’re new to Complete conversions transfers and changes or just unsure on how to do certain things with it.</p>
+  <p class="govuk-body">You can <a href="https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/complete-conversions-transfers-and-changes.aspx" class="govuk-link" rel="noreferrer noopener" target="_blank">read our guidance about how to use the product (opens in new tab)</a> if you’re new to Complete conversions transfers and changes or just unsure on how to do certain things with it.</p>
   <h2 class="govuk-heading-m">Updates and releases</h2>
   <p class="govuk-body">We regularly update the product and release new versions of it, based on user feedback.</p>
   <p class="govuk-body">You can <a href="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/releases" class="govuk-link" rel="noreferrer noopener" target="_blank">read our release notes (opens in new tab)</a> to find out what we’ve done to improve the product.</p>

--- a/app/views/shared/_dfe_footer.html.erb
+++ b/app/views/shared/_dfe_footer.html.erb
@@ -15,7 +15,7 @@
           </li>
           <li class="govuk-footer__inline-list-item">
             <%= link_to "How to use this service (opens in new tab)",
-                  "https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/using-the-complete-conversions-transfers-and-changes-digital-product.aspx",
+                  "https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/complete-conversions-transfers-and-changes.aspx",
                   class: "govuk-footer__link",
                   target: "_blank" %>
           </li>


### PR DESCRIPTION
## Changes

This work fixes 2 broken links. One in the footer and one on the sign in page.

Both pointed to SharePoint guidance which has been moved.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
