### PR TITLE
(162943) Split all projects in progress into tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- All in progress projects now includes at tab to view only conversion projects.
+
 ### Changed
 
 - the all in progress projects table has been moved into a tab

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - All in progress projects now includes at tab to view only conversion projects.
+- All in progress projects now includes at tab to view only transfer projects.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- the all in progress projects table has been moved into a tab
+
 ### Fixed
 
 - Broken link to SharePoint guidance in footer and sign-in page now correct

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Broken link to SharePoint guidance in footer and sign-in page now correct
+- The margin beneath the sub navigation items is now rendered correctly.
 
 ## [Release-66][release-66]
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,8 @@ $dfe-blue: #003a69;
 @import "govuk-frontend/govuk/all";
 @import "accessible-autocomplete/src/autocomplete";
 
+@import "dfefrontend";
+
 @import "@ministryofjustice/frontend/moj/settings/all";
 @import "@ministryofjustice/frontend/moj/helpers/all";
 @import "@ministryofjustice/frontend/moj/objects/all";
@@ -22,8 +24,6 @@ $dfe-blue: #003a69;
 @import "@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";
 @import "@ministryofjustice/frontend/moj/components/header/header";
 @import "@ministryofjustice/frontend/moj/utilities/all";
-
-@import "dfefrontend";
 
 @import "components/task-list";
 @import "components/task_list/check-box-action-component";
@@ -97,4 +97,9 @@ address.govuk-address {
 // We want persitently acitve navigation items
 .moj-header__navigation-link[aria-current] {
   color: govuk-colour("blue");
+}
+
+// Undo the changes the the DfE styles do to the MOJ styles
+.moj-sub-navigation__item {
+  margin-bottom: 0px;
 }

--- a/app/controllers/all/in_progress/projects_controller.rb
+++ b/app/controllers/all/in_progress/projects_controller.rb
@@ -8,4 +8,11 @@ class All::InProgress::ProjectsController < ApplicationController
     @pager, @projects = pagy(Project.in_progress.includes(:assigned_to).ordered_by_significant_date)
     AcademiesApiPreFetcherService.new.call!(@projects)
   end
+
+  def conversions_index
+    authorize Project, :index?
+
+    @pager, @projects = pagy(Project.conversions.in_progress.includes(:assigned_to).ordered_by_significant_date)
+    AcademiesApiPreFetcherService.new.call!(@projects)
+  end
 end

--- a/app/controllers/all/in_progress/projects_controller.rb
+++ b/app/controllers/all/in_progress/projects_controller.rb
@@ -15,4 +15,11 @@ class All::InProgress::ProjectsController < ApplicationController
     @pager, @projects = pagy(Project.conversions.in_progress.includes(:assigned_to).ordered_by_significant_date)
     AcademiesApiPreFetcherService.new.call!(@projects)
   end
+
+  def transfers_index
+    authorize Project, :index?
+
+    @pager, @projects = pagy(Project.transfers.in_progress.includes(:assigned_to).ordered_by_significant_date)
+    AcademiesApiPreFetcherService.new.call!(@projects)
+  end
 end

--- a/app/controllers/all/in_progress/projects_controller.rb
+++ b/app/controllers/all/in_progress/projects_controller.rb
@@ -2,7 +2,7 @@ class All::InProgress::ProjectsController < ApplicationController
   after_action :verify_authorized
   rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
 
-  def index
+  def all_index
     authorize Project, :index?
 
     @pager, @projects = pagy(Project.in_progress.includes(:assigned_to).ordered_by_significant_date)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -26,6 +26,6 @@ class ProjectsController < ApplicationController
 
     @project = Project.find(params[:id])
     @project.update(state: :deleted)
-    redirect_to all_in_progress_projects_path, notice: I18n.t("project.delete.success")
+    redirect_to all_all_in_progress_projects_path, notice: I18n.t("project.delete.success")
   end
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -6,6 +6,6 @@ class RootController < ApplicationController
 
     return redirect_to in_progress_your_projects_path if current_user.assign_to_project? || current_user.add_new_project?
 
-    redirect_to all_in_progress_projects_path
+    redirect_to all_all_in_progress_projects_path
   end
 end

--- a/app/views/all/in_progress/projects/_all_projects_tabs.html.erb
+++ b/app/views/all/in_progress/projects/_all_projects_tabs.html.erb
@@ -4,6 +4,7 @@
       <ul class="moj-sub-navigation__list">
 
         <%= render partial: "shared/sub_navigation_item", locals: {name: t("project.all.in_progress.tab"), path: all_all_in_progress_projects_path} %>
+        <%= render partial: "shared/sub_navigation_item", locals: {name: t("project.all.in_progress.conversions.tab"), path: conversions_all_in_progress_projects_path} %>
 
       </ul>
     </nav>

--- a/app/views/all/in_progress/projects/_all_projects_tabs.html.erb
+++ b/app/views/all/in_progress/projects/_all_projects_tabs.html.erb
@@ -5,6 +5,7 @@
 
         <%= render partial: "shared/sub_navigation_item", locals: {name: t("project.all.in_progress.tab"), path: all_all_in_progress_projects_path} %>
         <%= render partial: "shared/sub_navigation_item", locals: {name: t("project.all.in_progress.conversions.tab"), path: conversions_all_in_progress_projects_path} %>
+        <%= render partial: "shared/sub_navigation_item", locals: {name: t("project.all.in_progress.transfers.tab"), path: transfers_all_in_progress_projects_path} %>
 
       </ul>
     </nav>

--- a/app/views/all/in_progress/projects/_all_projects_tabs.html.erb
+++ b/app/views/all/in_progress/projects/_all_projects_tabs.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <nav class="moj-sub-navigation" aria-label="Project sub-navigation">
+      <ul class="moj-sub-navigation__list">
+
+        <%= render partial: "shared/sub_navigation_item", locals: {name: t("project.all.in_progress.tab"), path: all_all_in_progress_projects_path} %>
+
+      </ul>
+    </nav>
+  </div>
+</div>

--- a/app/views/all/in_progress/projects/_conversions_table.html.erb
+++ b/app/views/all/in_progress/projects/_conversions_table.html.erb
@@ -1,0 +1,30 @@
+<% if projects.empty? %>
+  <%= govuk_inset_text(text: t("project.table.in_progress.conversions.empty")) %>
+<% else %>
+  <table class="govuk-table" name="projects_table" aria-label="Projects table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.form_a_mat") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% projects.each do |project| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__header govuk-table__cell">
+          <%= link_to project.establishment.name, project_path(project) %>
+        </td>
+        <td class="govuk-table__cell"><%= project.urn %></td>
+        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
+        <td class="govuk-table__cell"><%= project.form_a_mat? ? t("yes") : t("no") %></td>
+        <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<%= govuk_pagination(pagy: pager) %>

--- a/app/views/all/in_progress/projects/_transfers_table.html.erb
+++ b/app/views/all/in_progress/projects/_transfers_table.html.erb
@@ -1,0 +1,30 @@
+<% if projects.empty? %>
+  <%= govuk_inset_text(text: t("project.table.in_progress.transfers.empty")) %>
+<% else %>
+  <table class="govuk-table" name="projects_table" aria-label="Projects table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.transfer_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.form_a_mat") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% projects.each do |project| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__header govuk-table__cell">
+          <%= link_to project.establishment.name, project_path(project) %>
+        </td>
+        <td class="govuk-table__cell"><%= project.urn %></td>
+        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
+        <td class="govuk-table__cell"><%= project.form_a_mat? ? t("yes") : t("no") %></td>
+        <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<%= govuk_pagination(pagy: pager) %>

--- a/app/views/all/in_progress/projects/all_index.html.erb
+++ b/app/views/all/in_progress/projects/all_index.html.erb
@@ -8,10 +8,16 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">
+    <h1 class="govuk-heading-xl">
       <%= t("project.all.in_progress.title") %>
     </h1>
+  </div>
+</div>
 
+<%= render partial: "all_projects_tabs" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
     <%= render partial: "/projects/shared/in_progress_table", locals: {projects: @projects, pager: @pager} %>
   </div>
 </div>

--- a/app/views/all/in_progress/projects/conversions_index.html.erb
+++ b/app/views/all/in_progress/projects/conversions_index.html.erb
@@ -1,0 +1,23 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("project.all.in_progress.conversions.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      <%= t("project.all.in_progress.conversions.title") %>
+    </h1>
+  </div>
+</div>
+
+<%= render partial: "all_projects_tabs" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render partial: "conversions_table", locals: {projects: @projects, pager: @pager} %>
+  </div>
+</div>

--- a/app/views/all/in_progress/projects/transfers_index.html.erb
+++ b/app/views/all/in_progress/projects/transfers_index.html.erb
@@ -1,0 +1,23 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("project.all.in_progress.transfers.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      <%= t("project.all.in_progress.transfers.title") %>
+    </h1>
+  </div>
+</div>
+
+<%= render partial: "all_projects_tabs" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render partial: "transfers_table", locals: {projects: @projects, pager: @pager} %>
+  </div>
+</div>

--- a/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
@@ -8,7 +8,7 @@
 
         <ul class="moj-primary-navigation__list">
 
-          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.in_progress"), path: all_in_progress_projects_path, namespace: "/projects/all/in-progress"} %>
+          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.in_progress"), path: all_all_in_progress_projects_path, namespace: "/projects/all/in-progress"} %>
 
           <% if policy(:export).index? %>
             <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_month"), path: date_range_this_month_all_by_month_conversions_projects_path, namespace: "/projects/all/by-month"} %>

--- a/app/views/shared/navigation/_dfe_header_navigation.html.erb
+++ b/app/views/shared/navigation/_dfe_header_navigation.html.erb
@@ -22,7 +22,7 @@
 
             <%= if policy(:navigation).show_all_projects_header_navigation?
                   render partial: "shared/navigation/dfe_header_navigation_item",
-                    locals: {title: t("navigation.header.all_projects"), path: all_in_progress_projects_path, namespace: "/projects/all/"}
+                    locals: {title: t("navigation.header.all_projects"), path: all_all_in_progress_projects_path, namespace: "/projects/all/"}
                 end %>
 
             <%= if policy(:navigation).show_service_support_header_navigation?

--- a/app/views/shared/navigation/_header_navigation.html.erb
+++ b/app/views/shared/navigation/_header_navigation.html.erb
@@ -15,7 +15,7 @@
 
       <%= if policy(:navigation).show_all_projects_header_navigation?
             render partial: "shared/navigation/header_navigation_item",
-              locals: {name: t("navigation.header.all_projects"), path: all_in_progress_projects_path, namespace: "/projects/all/"}
+              locals: {name: t("navigation.header.all_projects"), path: all_all_in_progress_projects_path, namespace: "/projects/all/"}
           end %>
 
       <%= if policy(:navigation).show_service_support_header_navigation?

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -18,6 +18,9 @@ en:
       in_progress:
         title: All projects in progress
         tab: All projects
+        conversions:
+          title: All conversions in progress
+          tab: Conversions
       by_trust:
         title: All projects by trust
       completed:
@@ -233,6 +236,8 @@ en:
         projects: There are no projects
       in_progress:
         empty: There are no projects in progress.
+        conversions:
+          empty: There are no in-progress conversion projects
       completed:
         empty: There are no completed projects.
       unassigned:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -17,6 +17,7 @@ en:
     all:
       in_progress:
         title: All projects in progress
+        tab: All projects
       by_trust:
         title: All projects by trust
       completed:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -21,6 +21,9 @@ en:
         conversions:
           title: All conversions in progress
           tab: Conversions
+        transfers:
+          title: All transfers in progress
+          tab: Transfers
       by_trust:
         title: All projects by trust
       completed:
@@ -238,6 +241,8 @@ en:
         empty: There are no projects in progress.
         conversions:
           empty: There are no in-progress conversion projects
+        transfers:
+          empty: There are no in-progress transfer projects
       completed:
         empty: There are no completed projects.
       unassigned:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,7 @@ Rails.application.routes.draw do
       namespace :all do
         namespace :in_progress, path: "in-progress" do
           get "all", to: "projects#all_index"
+          get "conversions", to: "projects#conversions_index"
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,13 +107,20 @@ Rails.application.routes.draw do
   end
 
   # All projects
+  resources :projects, only: %i[index] do
+    collection do
+      namespace :all do
+        namespace :in_progress, path: "in-progress" do
+          get "all", to: "projects#all_index"
+        end
+      end
+    end
+  end
+
   constraints(id: VALID_UUID_REGEX) do
     resources :projects, only: %i[index] do
       collection do
         namespace :all do
-          namespace :in_progress, path: "in-progress" do
-            get "/", to: "projects#index"
-          end
           namespace :completed do
             get "/", to: "projects#index"
           end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,7 @@ Rails.application.routes.draw do
         namespace :in_progress, path: "in-progress" do
           get "all", to: "projects#all_index"
           get "conversions", to: "projects#conversions_index"
+          get "transfers", to: "projects#transfers_index"
         end
       end
     end

--- a/spec/accessibility/all_projects_spec.rb
+++ b/spec/accessibility/all_projects_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "All projects", driver: :headless_firefox, accessibility: true do
   scenario "> In progress" do
     project = create(:conversion_project, assigned_to: user, urn: 123456)
 
-    visit all_in_progress_projects_path
+    visit all_all_in_progress_projects_path
 
     expect(page).to have_content(project.urn)
     expect(page).to have_link("In progress")

--- a/spec/features/all_projects/export/esfa_users_can_export_download_spec.rb
+++ b/spec/features/all_projects/export/esfa_users_can_export_download_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "ESFA users can export" do
     user = create(:regional_delivery_officer_user)
 
     sign_in_with_user(user)
-    visit all_in_progress_projects_path
+    visit all_all_in_progress_projects_path
 
     expect(page).not_to have_link("Exports")
   end
@@ -14,7 +14,7 @@ RSpec.feature "ESFA users can export" do
     user = create(:user, team: :education_and_skills_funding_agency)
 
     sign_in_with_user(user)
-    visit all_in_progress_projects_path
+    visit all_all_in_progress_projects_path
 
     expect(page).to have_link("Exports")
   end
@@ -23,7 +23,7 @@ RSpec.feature "ESFA users can export" do
     user = create(:user, team: :education_and_skills_funding_agency)
 
     sign_in_with_user(user)
-    visit all_in_progress_projects_path
+    visit all_all_in_progress_projects_path
 
     click_on "Exports"
 
@@ -37,7 +37,7 @@ RSpec.feature "ESFA users can export" do
     user = create(:user, team: :education_and_skills_funding_agency)
 
     sign_in_with_user(user)
-    visit all_in_progress_projects_path
+    visit all_all_in_progress_projects_path
 
     click_on "Exports"
 

--- a/spec/features/all_projects/export/export_users_can_see_an_export_landing_page_spec.rb
+++ b/spec/features/all_projects/export/export_users_can_see_an_export_landing_page_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Export users can see the exports landing page" do
     user = create(:regional_delivery_officer_user)
 
     sign_in_with_user(user)
-    visit all_in_progress_projects_path
+    visit all_all_in_progress_projects_path
 
     expect(page).not_to have_link("Exports")
   end

--- a/spec/features/home_page/user_without_role_spec.rb
+++ b/spec/features/home_page/user_without_role_spec.rb
@@ -10,6 +10,6 @@ RSpec.feature "The home page for a user without a role" do
     visit root_path
     click_on "In progress"
 
-    expect(page.current_path).to eql all_in_progress_projects_path
+    expect(page.current_path).to eql all_all_in_progress_projects_path
   end
 end

--- a/spec/features/information_banner_spec.rb
+++ b/spec/features/information_banner_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Users can see an information banner" do
 
         expect(page).to have_selector("#information-banner")
 
-        visit all_in_progress_projects_path
+        visit all_all_in_progress_projects_path
 
         expect(page).to have_selector("#information-banner")
       end

--- a/spec/features/navigation/header_navigation_spec.rb
+++ b/spec/features/navigation/header_navigation_spec.rb
@@ -16,8 +16,10 @@ RSpec.feature "Header navigation" do
       sign_in_with_user(user)
       visit root_path
 
-      expect(page).not_to have_link "All projects"
-      expect(page).not_to have_css ".dfe-header__navigation"
+      within("header") do
+        expect(page).not_to have_link "All projects"
+        expect(page).not_to have_css ".dfe-header__navigation"
+      end
     end
   end
 

--- a/spec/features/projects/in_progress/users_can_view_a_list_of_all_projects_spec.rb
+++ b/spec/features/projects/in_progress/users_can_view_a_list_of_all_projects_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Viewing all in-progress projects" do
 
   context "when there are no projects" do
     scenario "they can see a helpful message" do
-      visit all_in_progress_projects_path
+      visit all_all_in_progress_projects_path
 
       expect(page).to have_content(I18n.t("project.table.in_progress.empty"))
     end
@@ -20,7 +20,7 @@ RSpec.feature "Viewing all in-progress projects" do
       completed_project = create(:conversion_project, :completed, urn: 121583, completed_at: Date.yesterday)
       in_progress_project = create(:conversion_project, urn: 115652)
 
-      visit all_in_progress_projects_path
+      visit all_all_in_progress_projects_path
 
       expect(page).to have_content(I18n.t("project.all.in_progress.title"))
 
@@ -35,7 +35,7 @@ RSpec.feature "Viewing all in-progress projects" do
       last_project = create(:conversion_project, conversion_date: Date.parse("2023-12-1"), urn: 165432)
       first_project = create(:conversion_project, conversion_date: Date.parse("2023-1-1"), urn: 123456)
 
-      visit all_in_progress_projects_path
+      visit all_all_in_progress_projects_path
 
       within "tbody tr:first-child" do
         expect(page).to have_content(first_project.urn)
@@ -50,7 +50,7 @@ RSpec.feature "Viewing all in-progress projects" do
         create(:conversion_project, region: :london)
       end
 
-      visit all_in_progress_projects_path
+      visit all_all_in_progress_projects_path
 
       expect(page).to have_css(".govuk-pagination")
     end
@@ -58,7 +58,7 @@ RSpec.feature "Viewing all in-progress projects" do
     scenario "the projects show if they are 'Form a MAT' or not" do
       _project = create(:conversion_project, :form_a_mat, urn: 115652)
 
-      visit all_in_progress_projects_path
+      visit all_all_in_progress_projects_path
       expect(page).to have_content("Form a MAT project?")
       expect(page).to have_content("Yes")
     end
@@ -67,7 +67,7 @@ RSpec.feature "Viewing all in-progress projects" do
       deleted_project = create(:conversion_project, :deleted, urn: 121583)
       in_progress_project = create(:conversion_project, urn: 115652)
 
-      visit all_in_progress_projects_path
+      visit all_all_in_progress_projects_path
 
       expect(page).to_not have_content(deleted_project.urn.to_s)
       expect(page).to have_content(in_progress_project.urn.to_s)

--- a/spec/features/projects/in_progress/users_can_view_all_in_progress_projects_by_type_spec.rb
+++ b/spec/features/projects/in_progress/users_can_view_all_in_progress_projects_by_type_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.feature "Users can view all in progress projects by type" do
+  before do
+    user = create(:user, :caseworker)
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  let!(:conversion_project) { create(:conversion_project, urn: 123456) }
+  let!(:transfer_project) { create(:transfer_project, urn: 165432) }
+
+  scenario "view all projects in a table" do
+    visit all_all_in_progress_projects_path
+
+    expect(page).to have_content conversion_project.urn
+    expect(page).to have_content transfer_project.urn
+  end
+end

--- a/spec/features/projects/in_progress/users_can_view_all_in_progress_projects_by_type_spec.rb
+++ b/spec/features/projects/in_progress/users_can_view_all_in_progress_projects_by_type_spec.rb
@@ -25,4 +25,13 @@ RSpec.feature "Users can view all in progress projects by type" do
     expect(page).to have_content conversion_project.urn
     expect(page).not_to have_content transfer_project.urn
   end
+
+  scenario "view all transfer projects in a table" do
+    visit all_all_in_progress_projects_path
+
+    click_on "Transfers"
+
+    expect(page).to have_content transfer_project.urn
+    expect(page).not_to have_content conversion_project.urn
+  end
 end

--- a/spec/features/projects/in_progress/users_can_view_all_in_progress_projects_by_type_spec.rb
+++ b/spec/features/projects/in_progress/users_can_view_all_in_progress_projects_by_type_spec.rb
@@ -16,4 +16,13 @@ RSpec.feature "Users can view all in progress projects by type" do
     expect(page).to have_content conversion_project.urn
     expect(page).to have_content transfer_project.urn
   end
+
+  scenario "view all conversion projects in a table" do
+    visit all_all_in_progress_projects_path
+
+    click_on "Conversions"
+
+    expect(page).to have_content conversion_project.urn
+    expect(page).not_to have_content transfer_project.urn
+  end
 end

--- a/spec/requests/all/in_progress/projects_controller_spec.rb
+++ b/spec/requests/all/in_progress/projects_controller_spec.rb
@@ -24,4 +24,14 @@ RSpec.describe All::InProgress::ProjectsController, type: :request do
       end
     end
   end
+
+  describe "#transfers_index" do
+    context "when there are no projects" do
+      it "shows a helpful message" do
+        get transfers_all_in_progress_projects_path
+
+        expect(response.body).to include "There are no in-progress transfer projects"
+      end
+    end
+  end
 end

--- a/spec/requests/all/in_progress/projects_controller_spec.rb
+++ b/spec/requests/all/in_progress/projects_controller_spec.rb
@@ -14,4 +14,14 @@ RSpec.describe All::InProgress::ProjectsController, type: :request do
       end
     end
   end
+
+  describe "#conversions_index" do
+    context "when there are no projects" do
+      it "shows a helpful message" do
+        get conversions_all_in_progress_projects_path
+
+        expect(response.body).to include "There are no in-progress conversion projects"
+      end
+    end
+  end
 end

--- a/spec/requests/all/in_progress/projects_controller_spec.rb
+++ b/spec/requests/all/in_progress/projects_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe All::InProgress::ProjectsController, type: :request do
+  before do
+    sign_in_with(create(:user))
+  end
+
+  describe "#all_index" do
+    context "when there are no projects" do
+      it "shows a helpful message" do
+        get all_all_in_progress_projects_path
+
+        expect(response.body).to include "There are no projects in progress"
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to split the all in progress projects view up into different tabs so users can scope in progress projects to:

- all
- conversions only
- transfers only

Then later this is the home for form a multi academy trust projects.

This work updates the existing view so that it sits in a tab and then adds the conversions and transfers tabs.

Along the way we noticed a style bug on the MOJ sub navigation item, and fixed it.

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/05cb6f77-d1d6-4751-a6fc-c034463d7bb6)
