### PR TITLE
(162958) Form a multi academy trust show view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - All in progress projects now includes at tab to view only conversion projects.
 - All in progress projects now includes at tab to view only transfer projects.
+- All projects in a form a multi academy trust can now be viewed at
+  /form-a-multi-academy-trust/<TRN>
 
 ### Changed
 

--- a/app/controllers/form_a_multi_academy_trust/project_groups_controller.rb
+++ b/app/controllers/form_a_multi_academy_trust/project_groups_controller.rb
@@ -1,0 +1,12 @@
+class FormAMultiAcademyTrust::ProjectGroupsController < ApplicationController
+  after_action :verify_authorized
+  rescue_from FormAMultiAcademyTrust::ProjectGroup::NoProjectsFoundError, with: :not_found_error
+
+  def show
+    @project_group = FormAMultiAcademyTrust::ProjectGroup.new(trn: params[:trn])
+    authorize @project_group
+
+    @pager, @projects = pagy(@project_group.projects)
+    AcademiesApiPreFetcherService.new.call!(@projects)
+  end
+end

--- a/app/models/form_a_multi_academy_trust/project_group.rb
+++ b/app/models/form_a_multi_academy_trust/project_group.rb
@@ -1,0 +1,31 @@
+class FormAMultiAcademyTrust::ProjectGroup
+  def self.policy_class
+    ProjectPolicy
+  end
+
+  class NoProjectsFoundError < StandardError
+  end
+
+  attr_accessor :trn, :name, :projects
+
+  def initialize(trn:)
+    @trn = trn
+    @projects = fetch_projects
+
+    raise NoProjectsFoundError, "No projects with #{@trn} could be found" if @projects.empty?
+
+    @name = fetch_trust_name
+  end
+
+  def deleted?
+    false
+  end
+
+  private def fetch_trust_name
+    @projects.order(:created_at).first.new_trust_name
+  end
+
+  private def fetch_projects
+    Project.where(new_trust_reference_number: @trn).includes(:assigned_to)
+  end
+end

--- a/app/views/form_a_multi_academy_trust/project_groups/_table.html.erb
+++ b/app/views/form_a_multi_academy_trust/project_groups/_table.html.erb
@@ -1,0 +1,31 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <table class="govuk-table" name="projects_table" aria-label="Projects table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
+          <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
+          <th class="govuk-table__header" scope="col"><%= t("project.table.headers.conversion_or_transfer_date") %></th>
+          <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
+          <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% projects.each do |project| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__header govuk-table__cell">
+              <%= link_to project.establishment.name, project_path(project) %>
+            </td>
+            <td class="govuk-table__cell"><%= project.urn %></td>
+            <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
+            <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
+            <td class="govuk-table__cell"><%= display_name(project.assigned_to) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <%= govuk_pagination(pagy: pager) %>
+
+  </div>
+</div>

--- a/app/views/form_a_multi_academy_trust/project_groups/_tabs.html.erb
+++ b/app/views/form_a_multi_academy_trust/project_groups/_tabs.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <nav class="moj-sub-navigation" aria-label="Project sub-navigation">
+      <ul class="moj-sub-navigation__list">
+
+        <%= render partial: "shared/sub_navigation_item", locals: {name: t("form_a_multi_academy_trust.tabs.projects"), path: form_a_multi_academy_trust_path(@project_group.trn)} %>
+
+      </ul>
+    </nav>
+  </div>
+</div>

--- a/app/views/form_a_multi_academy_trust/project_groups/show.html.erb
+++ b/app/views/form_a_multi_academy_trust/project_groups/show.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">
+      TRN: <%= @project_group.trn %>
+    </span>
+    <h1 class="govuk-heading-xl"><%= @project_group.name %></h1>
+  </div>
+</div>
+
+<%= render partial: "tabs" %>
+
+<%= render partial: "table", locals: {projects: @projects, pager: @pager} %>

--- a/config/locales/form_a_multi_academy_trust_en.yml
+++ b/config/locales/form_a_multi_academy_trust_en.yml
@@ -1,0 +1,4 @@
+en:
+  form_a_multi_academy_trust:
+    tabs:
+      projects: Schools and academies forming this trust

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,11 @@ Rails.application.routes.draw do
     end
   end
 
+  # A single form a multi academy trust project group
+  namespace :form_a_multi_academy_trust, path: "form-a-multi-academy-trust" do
+    get "/:trn", to: "project_groups#show"
+  end
+
   # New projects by type
   scope :projects do
     namespace :conversions do

--- a/spec/features/form_a_multi_academy_trust_spec.rb
+++ b/spec/features/form_a_multi_academy_trust_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.feature "Form a multi academy trust" do
+  before do
+    user = create(:user)
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  let!(:conversion_project) {
+    create(
+      :conversion_project,
+      :form_a_mat,
+      urn: 122957,
+      new_trust_name: "The Big trust",
+      new_trust_reference_number: "TR12345"
+    )
+  }
+
+  let!(:transfer_project) {
+    create(
+      :transfer_project,
+      :form_a_mat,
+      urn: 138205,
+      new_trust_name: "The Big trust",
+      new_trust_reference_number: "TR12345"
+    )
+  }
+
+  scenario "users can view the group of projects" do
+    visit form_a_multi_academy_trust_path("TR12345")
+
+    expect(page).to have_selector("span.govuk-caption-l", text: "TR12345")
+    expect(page).to have_selector("h1.govuk-heading-xl", text: "The Big trust")
+
+    within("tbody.govuk-table__body") do
+      expect(page).to have_content(conversion_project.urn)
+      expect(page).to have_content(transfer_project.urn)
+    end
+  end
+end

--- a/spec/models/form_a_multi_academy_trust/project_group_spec.rb
+++ b/spec/models/form_a_multi_academy_trust/project_group_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe FormAMultiAcademyTrust::ProjectGroup do
+  before do
+    mock_all_academies_api_responses
+  end
+
+  it "raises an error when no projects with the trust reference number can be found" do
+    expect { described_class.new(trn: "TR00000") }.to raise_error FormAMultiAcademyTrust::ProjectGroup::NoProjectsFoundError
+  end
+
+  describe "#name" do
+    it "returns the first new trust name from the projects" do
+      project = create(:conversion_project, :form_a_mat)
+
+      subject = described_class.new(trn: project.new_trust_reference_number)
+
+      expect(subject.name).to eql project.new_trust_name
+    end
+  end
+
+  describe "#trn" do
+    it "returns the trn that the instance was initialized with" do
+      project = create(:conversion_project, :form_a_mat)
+
+      subject = described_class.new(trn: project.new_trust_reference_number)
+
+      expect(subject.trn).to eql project.new_trust_reference_number
+    end
+  end
+
+  describe "#projects" do
+    it "returns the projects that make the TRN" do
+      conversion_project = create(:conversion_project, :form_a_mat, new_trust_reference_number: "TR12345")
+      transfer_project = create(:transfer_project, :form_a_mat, new_trust_reference_number: "TR12345")
+      other_project = create(:conversion_project, :form_a_mat, new_trust_reference_number: "TR55555")
+
+      subject = described_class.new(trn: "TR12345")
+
+      expect(subject.projects).to include conversion_project
+      expect(subject.projects).to include transfer_project
+      expect(subject.projects).not_to include other_project
+    end
+  end
+
+  describe "#deleted?" do
+    it "returns false as project groups don't exist to be deleted" do
+      project = create(:conversion_project, :form_a_mat)
+
+      subject = described_class.new(trn: project.new_trust_reference_number)
+
+      expect(subject.deleted?).to be false
+    end
+  end
+
+  describe ".policy_class" do
+    it "returns ProjectPolicy so authorisation is the same as a project" do
+      expect(described_class.policy_class).to eql ProjectPolicy
+    end
+  end
+end

--- a/spec/requests/form_a_multi_academy_trust/project_groups_controller_spec.rb
+++ b/spec/requests/form_a_multi_academy_trust/project_groups_controller_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe FormAMultiAcademyTrust::ProjectGroupsController, type: :request do
+  before do
+    user = create(:user)
+    sign_in_with(user)
+  end
+
+  describe "#show" do
+    context "when a project with the trn can be found" do
+      it "renders the show view" do
+        mock_all_academies_api_responses
+        project = create(:conversion_project, :form_a_mat)
+
+        get form_a_multi_academy_trust_path(project.new_trust_reference_number)
+
+        expect(response).to render_template("form_a_multi_academy_trust/project_groups/show")
+      end
+    end
+
+    context "when a project with the trn cannot be found" do
+      it "renders the not found view" do
+        get form_a_multi_academy_trust_path("TR00000")
+
+        expect(response).to render_template("pages/page_not_found")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Schools and academies may come together to form a new Multi academy trust and users want to see these collections of projects reflected in the applicaiton.

We've creeated a simple object as an interface to this need and then added a show view for the object.

The `ProjectGroup` object loads projects with the same trust reference number so we can show them in a table.

The only gotya here is that we felt the same authorisation as projects applies to the project group, so we have to implement the `deleted?` method to use the `ProjectPolicy`.

The  `ProjectGroup` is so close to being an ActiveRecord model, I think it possibly should be, this would also make fetching multiple project groups faster (this is not implemented at this point).

## Screenshot (Fake data)
![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/42574f3d-0782-4c43-8893-08e3cb1eaba7)
