### PR TITLE
Try to prevent concurrency from stopping matrix runs

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -12,7 +12,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.environment }}
+  group: ${{ github.workflow }}-${{ github.event.inputs.environment }}-${{ github.run_number }}
 
 jobs:
   set-env:


### PR DESCRIPTION
When trying to run the matrix in the deployment workflow, only 1 seems to run because of a concurrency condition:

> [Canceling since a higher priority waiting request for xxx](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/actions/runs/8739633643)

So hopefully adding this run_number is enough but it might not be