### PR TITLE
(162946) Form a multi academy trust index view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - All in progress projects now includes at tab to view only transfer projects.
 - All projects in a form a multi academy trust can now be viewed at
   /form-a-multi-academy-trust/<TRN>
+- All form a multi academy trust project groups can now be viewed from the All
+  projects > In progress > Form a MAT view.
 
 ### Changed
 

--- a/app/controllers/all/in_progress/projects_controller.rb
+++ b/app/controllers/all/in_progress/projects_controller.rb
@@ -22,4 +22,10 @@ class All::InProgress::ProjectsController < ApplicationController
     @pager, @projects = pagy(Project.transfers.in_progress.includes(:assigned_to).ordered_by_significant_date)
     AcademiesApiPreFetcherService.new.call!(@projects)
   end
+
+  def form_a_multi_academy_trust_index
+    authorize Project, :index?
+
+    @pager, @project_groups = pagy_array(FormAMultiAcademyTrust::ProjectGroupFetcherService.new.call)
+  end
 end

--- a/app/helpers/form_a_multi_academy_trust_helper.rb
+++ b/app/helpers/form_a_multi_academy_trust_helper.rb
@@ -1,0 +1,8 @@
+module FormAMultiAcademyTrustHelper
+  def projects_establishment_name_list(project_group)
+    name_list = project_group.projects.map do |project|
+      project.establishment.name
+    end
+    name_list.join("; ")
+  end
+end

--- a/app/models/form_a_multi_academy_trust/project_group.rb
+++ b/app/models/form_a_multi_academy_trust/project_group.rb
@@ -6,7 +6,7 @@ class FormAMultiAcademyTrust::ProjectGroup
   class NoProjectsFoundError < StandardError
   end
 
-  attr_accessor :trn, :name, :projects
+  attr_accessor :trn, :name, :projects, :region
 
   def initialize(trn:)
     @trn = trn
@@ -15,10 +15,15 @@ class FormAMultiAcademyTrust::ProjectGroup
     raise NoProjectsFoundError, "No projects with #{@trn} could be found" if @projects.empty?
 
     @name = fetch_trust_name
+    @region = fetch_region
   end
 
   def deleted?
     false
+  end
+
+  private def fetch_region
+    @projects.order(:created_at).first.region
   end
 
   private def fetch_trust_name

--- a/app/models/form_a_multi_academy_trust/project_group.rb
+++ b/app/models/form_a_multi_academy_trust/project_group.rb
@@ -6,7 +6,7 @@ class FormAMultiAcademyTrust::ProjectGroup
   class NoProjectsFoundError < StandardError
   end
 
-  attr_accessor :trn, :name, :projects, :region
+  attr_accessor :trn, :name, :projects, :region, :assigned_to
 
   def initialize(trn:)
     @trn = trn
@@ -16,10 +16,15 @@ class FormAMultiAcademyTrust::ProjectGroup
 
     @name = fetch_trust_name
     @region = fetch_region
+    @assigned_to = fetch_assigned_to
   end
 
   def deleted?
     false
+  end
+
+  private def fetch_assigned_to
+    @projects.order(:created_at).first.assigned_to
   end
 
   private def fetch_region

--- a/app/services/form_a_multi_academy_trust/project_group_fetcher_service.rb
+++ b/app/services/form_a_multi_academy_trust/project_group_fetcher_service.rb
@@ -1,0 +1,15 @@
+class FormAMultiAcademyTrust::ProjectGroupFetcherService
+  def call
+    fetch_project_groups
+  end
+
+  private def fetch_project_groups
+    unique_trns.map do |trn|
+      FormAMultiAcademyTrust::ProjectGroup.new(trn: trn)
+    end
+  end
+
+  private def unique_trns
+    Project.active.order(:new_trust_name).pluck(:new_trust_reference_number).uniq.compact
+  end
+end

--- a/app/views/all/in_progress/projects/_all_projects_tabs.html.erb
+++ b/app/views/all/in_progress/projects/_all_projects_tabs.html.erb
@@ -6,6 +6,7 @@
         <%= render partial: "shared/sub_navigation_item", locals: {name: t("project.all.in_progress.tab"), path: all_all_in_progress_projects_path} %>
         <%= render partial: "shared/sub_navigation_item", locals: {name: t("project.all.in_progress.conversions.tab"), path: conversions_all_in_progress_projects_path} %>
         <%= render partial: "shared/sub_navigation_item", locals: {name: t("project.all.in_progress.transfers.tab"), path: transfers_all_in_progress_projects_path} %>
+        <%= render partial: "shared/sub_navigation_item", locals: {name: t("project.all.in_progress.form_a_multi_academy_trust.tab"), path: form_a_multi_academy_trust_all_in_progress_projects_path} %>
 
       </ul>
     </nav>

--- a/app/views/all/in_progress/projects/_form_a_multi_academy_trust_table.html.erb
+++ b/app/views/all/in_progress/projects/_form_a_multi_academy_trust_table.html.erb
@@ -1,0 +1,30 @@
+<% if project_groups.empty? %>
+  <%= govuk_inset_text(text: t("project.table.in_progress.form_a_multi_academy_trust.empty")) %>
+<% else %>
+  <table class="govuk-table" name="projects_table" aria-label="Form a multi academy trust table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.trust_name") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.trn") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.region") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.schools_included") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% project_groups.each do |project_group| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__header govuk-table__cell">
+          <%= link_to project_group.name, form_a_multi_academy_trust_path(project_group.trn) %>
+        </td>
+        <td class="govuk-table__cell"><%= project_group.trn %></td>
+        <td class="govuk-table__cell"><%= t("project.region.#{project_group.region}") %></td>
+        <td class="govuk-table__cell"><%= projects_establishment_name_list(project_group) %></td>
+        <td class="govuk-table__cell"><%= display_name(project_group.assigned_to) %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<%= govuk_pagination(pagy: pager) %>

--- a/app/views/all/in_progress/projects/form_a_multi_academy_trust_index.html.erb
+++ b/app/views/all/in_progress/projects/form_a_multi_academy_trust_index.html.erb
@@ -1,0 +1,23 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("project.all.in_progress.form_a_multi_academy_trust.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      <%= t("project.all.in_progress.form_a_multi_academy_trust.title") %>
+    </h1>
+  </div>
+</div>
+
+<%= render partial: "all_projects_tabs" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render partial: "form_a_multi_academy_trust_table", locals: {project_groups: @project_groups, pager: @pager} %>
+  </div>
+</div>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -24,6 +24,9 @@ en:
         transfers:
           title: All transfers in progress
           tab: Transfers
+        form_a_multi_academy_trust:
+          title: All form a MAT projects in progress
+          tab: Form a MAT
       by_trust:
         title: All projects by trust
       completed:
@@ -243,6 +246,8 @@ en:
           empty: There are no in-progress conversion projects
         transfers:
           empty: There are no in-progress transfer projects
+        form_a_multi_academy_trust:
+          empty: There are no form a MAT projects
       completed:
         empty: There are no completed projects.
       unassigned:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,7 @@ Rails.application.routes.draw do
           get "all", to: "projects#all_index"
           get "conversions", to: "projects#conversions_index"
           get "transfers", to: "projects#transfers_index"
+          get "form-a-multi-academy-trust", to: "projects#form_a_multi_academy_trust_index"
         end
       end
     end

--- a/spec/features/projects/in_progress/users_can_view_all_in_progress_projects_by_type_spec.rb
+++ b/spec/features/projects/in_progress/users_can_view_all_in_progress_projects_by_type_spec.rb
@@ -34,4 +34,41 @@ RSpec.feature "Users can view all in progress projects by type" do
     expect(page).to have_content transfer_project.urn
     expect(page).not_to have_content conversion_project.urn
   end
+
+  scenario "view all form a multi academy trust projects in a table" do
+    # This view loads n number of ProjectGroups which eager load the
+    # assigned_to associations on their projects, showing a single ProjectGroup
+    # uses ALL assigned_to.
+    #
+    # Whilst every ProjectGroup in this view  will use 1 single assigned_to,
+    # Bullet will raise a false positive on the
+    # projects_establishment_name_list helper that fetches the establishment
+    # names, where the assigned_to is not used hence the warning.
+    #
+    # The simplest fix seems to be to disable Bullet where we know it is making
+    # a false positive.
+    Bullet.enable = false
+
+    create(:conversion_project, :form_a_mat, urn: 132198)
+    create(:transfer_project, :form_a_mat, urn: 131182)
+
+    test_client = Api::AcademiesApi::Client.new
+    allow(Api::AcademiesApi::Client).to receive(:new).and_return(test_client)
+    allow(test_client).to receive(:get_establishment).with(132198).and_return(double(object: double(name: "First Establishment"), error: nil))
+    allow(test_client).to receive(:get_establishment).with(131182).and_return(double(object: double(name: "Last Establishment"), error: nil))
+
+    visit all_all_in_progress_projects_path
+
+    click_on "Form a MAT"
+
+    within("tbody.govuk-table__body") do
+      expect(page).to have_content "First Establishment"
+      expect(page).to have_content "Last Establishment"
+
+      expect(page).not_to have_content conversion_project.establishment.name
+    end
+
+    # Bullet re-enabled
+    Bullet.enable = true
+  end
 end

--- a/spec/helpers/form_a_multi_academy_trust_helper_spec.rb
+++ b/spec/helpers/form_a_multi_academy_trust_helper_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe FormAMultiAcademyTrustHelper, type: :helper do
+  describe "#projects_establishment_name_list" do
+    it "returns all the project establishment names separated by a semi colon" do
+      first_fake_project = double(Project, establishment: double(name: "Fake establishment one"))
+      last_fake_project = double(Project, establishment: double(name: "Fake establishment two"))
+      fake_project_group = double(FormAMultiAcademyTrust::ProjectGroup, projects: [first_fake_project, last_fake_project])
+
+      expect(projects_establishment_name_list(fake_project_group)).to eql "Fake establishment one; Fake establishment two"
+    end
+
+    it "returns an empty string when there are no projects" do
+      fake_project_group = double(FormAMultiAcademyTrust::ProjectGroup, projects: [])
+
+      expect(projects_establishment_name_list(fake_project_group)).to eql ""
+    end
+  end
+end

--- a/spec/models/form_a_multi_academy_trust/project_group_spec.rb
+++ b/spec/models/form_a_multi_academy_trust/project_group_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe FormAMultiAcademyTrust::ProjectGroup do
     end
   end
 
+  describe "#assigned_to" do
+    it "returns the name of the user from the first project" do
+      project = create(:conversion_project, :form_a_mat)
+
+      subject = described_class.new(trn: project.new_trust_reference_number)
+
+      expect(subject.assigned_to).to eql project.assigned_to
+    end
+  end
+
   describe "#projects" do
     it "returns the projects that make the TRN" do
       conversion_project = create(:conversion_project, :form_a_mat, new_trust_reference_number: "TR12345")

--- a/spec/models/form_a_multi_academy_trust/project_group_spec.rb
+++ b/spec/models/form_a_multi_academy_trust/project_group_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe FormAMultiAcademyTrust::ProjectGroup do
     end
   end
 
+  describe "#region" do
+    it "returns the region region from the first project" do
+      project = create(:conversion_project, :form_a_mat)
+
+      subject = described_class.new(trn: project.new_trust_reference_number)
+
+      expect(subject.region).to eql project.region
+    end
+  end
+
   describe "#projects" do
     it "returns the projects that make the TRN" do
       conversion_project = create(:conversion_project, :form_a_mat, new_trust_reference_number: "TR12345")

--- a/spec/requests/all/in_progress/projects_controller_spec.rb
+++ b/spec/requests/all/in_progress/projects_controller_spec.rb
@@ -34,4 +34,14 @@ RSpec.describe All::InProgress::ProjectsController, type: :request do
       end
     end
   end
+
+  describe "#form_a_multi_academy_trust_index" do
+    context "when there are no projects to group into a form a mat" do
+      it "shows a helpful message" do
+        get form_a_multi_academy_trust_all_in_progress_projects_path
+
+        expect(response.body).to include "There are no form a MAT projects"
+      end
+    end
+  end
 end

--- a/spec/services/form_a_multi_academy_trust/project_group_fetcher_service_spec.rb
+++ b/spec/services/form_a_multi_academy_trust/project_group_fetcher_service_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe FormAMultiAcademyTrust::ProjectGroupFetcherService do
+  describe "#call" do
+    context "when there are projects to group" do
+      it "returns an array of ProjectGroup" do
+        mock_all_academies_api_responses
+        conversion_project = create(:conversion_project, :form_a_mat, new_trust_reference_number: "TR12345", new_trust_name: "The big trust")
+        transfer_project = create(:transfer_project, :form_a_mat, new_trust_reference_number: "TR12345", new_trust_name: "The big trust")
+        other_project = create(:conversion_project, :form_a_mat, new_trust_reference_number: "TR10000", new_trust_name: "Another trust")
+
+        result = described_class.new.call
+
+        expect(result.count).to be 2
+
+        first_group = result.first
+
+        expect(first_group.name).to eql "Another trust"
+        expect(first_group.projects).to include other_project
+        expect(first_group.projects).not_to include conversion_project
+        expect(first_group.projects).not_to include transfer_project
+
+        last_group = result.last
+
+        expect(last_group.name).to eql "The big trust"
+        expect(last_group.projects).to include conversion_project
+        expect(last_group.projects).to include transfer_project
+        expect(last_group.projects).not_to include other_project
+      end
+    end
+
+    context "when there are only completed projects to group" do
+      it "returns empty" do
+        mock_all_academies_api_responses
+        create(:conversion_project, :form_a_mat, state: :completed)
+        create(:transfer_project, :form_a_mat, state: :completed)
+
+        result = described_class.new.call
+
+        expect(result).to be_empty
+      end
+    end
+
+    context "when there are no projects to group" do
+      it "returns empty" do
+        result = described_class.new.call
+
+        expect(result).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the final step to expose all 'form a multi academy trust' project groups to users.

This work adds a service object to collate the project groups and an index view to show them.

Some of this design is a bit odd:

- showing a single region for a project group assumes all project regions are the same which we have no validation for, so we show the region from the first project
- showing a single assigned_to users for a project groups assumes all projects are assigned the same, which we have no way to enforce, so we show the user from the first project

We also hit a Bullet false positive which is documented in the commit, but we ended up skipping bullet on the spec as our best option - please let us know if there is a better way.

## Screenshot with fake data
![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/fe06f404-e02a-407c-9e19-8d282480273a)
