### PR TITLE
(163286) Make the "Date the academy opened" task mandatory on Conversion projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - the all in progress projects table has been moved into a tab
+- the "Date the academy opened" task is now mandatory in Conversion projects
 
 ### Fixed
 

--- a/app/forms/conversion/task/confirm_date_academy_opened_task_form.rb
+++ b/app/forms/conversion/task/confirm_date_academy_opened_task_form.rb
@@ -1,4 +1,4 @@
-class Conversion::Task::ConfirmDateAcademyOpenedTaskForm < BaseOptionalTaskForm
+class Conversion::Task::ConfirmDateAcademyOpenedTaskForm < BaseTaskForm
   attribute :date_opened, :date
   attribute "date_opened(1i)"
   attribute "date_opened(2i)"

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -22,6 +22,12 @@ class Conversion::Project < Project
   scope :with_academy_urn, -> { where.not(academy_urn: nil) }
   scope :by_conversion_date, -> { ordered_by_significant_date }
 
+  MANDATORY_CONDITIONS = [
+    :all_conditions_met?,
+    :confirmed_date_and_in_the_past?,
+    :grant_payment_certificate_received?
+  ]
+
   def grant_payment_certificate_received?
     user = assigned_to
     tasks = Conversion::Task::ReceiveGrantPaymentCertificateTaskForm.new(tasks_data, user)
@@ -43,8 +49,7 @@ class Conversion::Project < Project
   end
 
   def completable?
-    return true if all_conditions_met? && confirmed_date_and_in_the_past? && grant_payment_certificate_received?
-    false
+    MANDATORY_CONDITIONS.all? { |task| send(task) }
   end
 
   private def fetch_academy(urn)

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -25,7 +25,8 @@ class Conversion::Project < Project
   MANDATORY_CONDITIONS = [
     :all_conditions_met?,
     :confirmed_date_and_in_the_past?,
-    :grant_payment_certificate_received?
+    :grant_payment_certificate_received?,
+    :date_academy_opened_present?
   ]
 
   def grant_payment_certificate_received?
@@ -50,6 +51,11 @@ class Conversion::Project < Project
 
   def completable?
     MANDATORY_CONDITIONS.all? { |task| send(task) }
+  end
+
+  def date_academy_opened_present?
+    return true if tasks_data.confirm_date_academy_opened_date_opened.present?
+    false
   end
 
   private def fetch_academy(urn)

--- a/app/models/transfer/project.rb
+++ b/app/models/transfer/project.rb
@@ -10,13 +10,16 @@ class Transfer::Project < Project
   validates :outgoing_trust_ukprn, ukprn: true
   validate :outgoing_trust_exists, if: -> { outgoing_trust_ukprn.present? }
 
+  MANDATORY_CONDITIONS = [
+    :confirmed_date_and_in_the_past?
+  ]
+
   def outgoing_trust
     @outgoing_trust ||= fetch_trust(outgoing_trust_ukprn)
   end
 
   def completable?
-    return true if confirmed_date_and_in_the_past?
-    false
+    MANDATORY_CONDITIONS.all? { |task| send(task) }
   end
 
   private def outgoing_trust_exists

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -49,6 +49,7 @@ en:
         <li>The conversion date has been confirmed and is in the past</li>
         <li>The confirm all conditions have been met task is completed</li>
         <li>The receive grant payment certificate task is completed</li>
+        <li>The confirm the date the academy opened task is completed</li>
         </ul>
     form_a_mat:
       new:

--- a/spec/accessibility/projects_spec.rb
+++ b/spec/accessibility/projects_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Test projects accessibility", driver: :headless_firefox, accessib
   end
 
   scenario "project completed page" do
-    tasks_data = create(:conversion_tasks_data, receive_grant_payment_certificate_check_certificate: true, receive_grant_payment_certificate_save_certificate: true, receive_grant_payment_certificate_date_received: Date.today)
+    tasks_data = create(:conversion_tasks_data, receive_grant_payment_certificate_check_certificate: true, receive_grant_payment_certificate_save_certificate: true, receive_grant_payment_certificate_date_received: Date.today, confirm_date_academy_opened_date_opened: Date.today)
     project = create(:conversion_project,
       regional_delivery_officer: user,
       assigned_to: user,

--- a/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
+++ b/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
@@ -10,7 +10,11 @@ RSpec.feature "Users can complete a conversion project" do
 
   context "when all conditions have been met and the academy has opened" do
     let(:tasks_data) {
-      create(:conversion_tasks_data, receive_grant_payment_certificate_check_certificate: true, receive_grant_payment_certificate_save_certificate: true, receive_grant_payment_certificate_date_received: Date.today)
+      create(:conversion_tasks_data,
+        receive_grant_payment_certificate_check_certificate: true,
+        receive_grant_payment_certificate_save_certificate: true,
+        receive_grant_payment_certificate_date_received: Date.today,
+        confirm_date_academy_opened_date_opened: Date.today)
     }
     let(:project) {
       create(:conversion_project,

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -188,4 +188,22 @@ RSpec.describe Conversion::Project do
       end
     end
   end
+
+  describe "#completable?" do
+    it "returns true when all the mandatory conditions are completed" do
+      project = create(:conversion_project, all_conditions_met: true)
+      allow(project).to receive(:confirmed_date_and_in_the_past?).and_return(true)
+      allow(project).to receive(:grant_payment_certificate_received?).and_return(true)
+
+      expect(project.completable?).to eq true
+    end
+
+    it "returns false if any of the mandatory conditions are not completed" do
+      project = create(:conversion_project, all_conditions_met: true)
+      allow(project).to receive(:confirmed_date_and_in_the_past?).and_return(false)
+      allow(project).to receive(:grant_payment_certificate_received?).and_return(true)
+
+      expect(project.completable?).to eq false
+    end
+  end
 end

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -191,7 +191,8 @@ RSpec.describe Conversion::Project do
 
   describe "#completable?" do
     it "returns true when all the mandatory conditions are completed" do
-      project = create(:conversion_project, all_conditions_met: true)
+      tasks_data = create(:conversion_tasks_data, confirm_date_academy_opened_date_opened: Date.yesterday)
+      project = create(:conversion_project, all_conditions_met: true, tasks_data: tasks_data)
       allow(project).to receive(:confirmed_date_and_in_the_past?).and_return(true)
       allow(project).to receive(:grant_payment_certificate_received?).and_return(true)
 
@@ -199,11 +200,28 @@ RSpec.describe Conversion::Project do
     end
 
     it "returns false if any of the mandatory conditions are not completed" do
-      project = create(:conversion_project, all_conditions_met: true)
+      tasks_data = create(:conversion_tasks_data, confirm_date_academy_opened_date_opened: nil)
+      project = create(:conversion_project, all_conditions_met: true, tasks_data: tasks_data)
       allow(project).to receive(:confirmed_date_and_in_the_past?).and_return(false)
       allow(project).to receive(:grant_payment_certificate_received?).and_return(true)
 
       expect(project.completable?).to eq false
+    end
+  end
+
+  describe "#date_academy_opened_present?" do
+    it "returns true if date_academy_opened is present in the tasks data" do
+      tasks_data = create(:conversion_tasks_data, confirm_date_academy_opened_date_opened: Date.yesterday)
+      project = create(:conversion_project, tasks_data: tasks_data)
+
+      expect(project.date_academy_opened_present?).to eq true
+    end
+
+    it "returns true if date_academy_opened is nil in the tasks data" do
+      tasks_data = create(:conversion_tasks_data, confirm_date_academy_opened_date_opened: nil)
+      project = create(:conversion_project, tasks_data: tasks_data)
+
+      expect(project.date_academy_opened_present?).to eq false
     end
   end
 end

--- a/spec/models/transfer/project_spec.rb
+++ b/spec/models/transfer/project_spec.rb
@@ -39,4 +39,22 @@ RSpec.describe Transfer::Project do
       end
     end
   end
+
+  describe "#completable?" do
+    before { mock_successful_api_response_to_create_any_project }
+
+    it "returns true when all the mandatory conditions are completed" do
+      project = create(:transfer_project)
+      allow(project).to receive(:confirmed_date_and_in_the_past?).and_return(true)
+
+      expect(project.completable?).to eq true
+    end
+
+    it "returns false if any of the mandatory conditions are not completed" do
+      project = create(:transfer_project)
+      allow(project).to receive(:confirmed_date_and_in_the_past?).and_return(false)
+
+      expect(project.completable?).to eq false
+    end
+  end
 end


### PR DESCRIPTION
## Changes

We want to make the "Date the academy opened" task mandatory on Conversion projects.

To do this, we have to add the task to the list of mandatory conditions & tasks in the project. Before adding it, we have refactored the `Conversion::Project.completable?` method slightly to make it easier to add more tasks/conditions.

Now when a user goes to complete a project, if the "Date the academy opened" task is not filled out, the user will see an error message telling them this task needs to be completed before the project is completed.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
