### PR TITLE
(163285) Add service for one off academy open date import

### DIFF
--- a/app/services/import/academy_open_date_importer_service.rb
+++ b/app/services/import/academy_open_date_importer_service.rb
@@ -1,0 +1,36 @@
+require "csv"
+
+class Import::AcademyOpenDateImporterService
+  def initialize(path)
+    @path = path
+  end
+
+  def import!
+    result = []
+
+    CSV.foreach(@path, headers: true, header_converters: :symbol) do |row|
+      previous_urn = row.field(:previous_urn)
+      academy_urn = row.field(:academy_urn)
+      date = Date.parse(row.field(:date))
+
+      project = project(previous_urn, academy_urn)
+
+      if project
+        success = update_project(project, date)
+        result << {previous_urn: previous_urn, academy_urn: academy_urn, project_id: project.id, success: success}
+      else
+        result << {previous_urn: previous_urn, academy_urn: academy_urn, project_id: nil, success: false}
+      end
+    end
+
+    result
+  end
+
+  private def update_project(project, date)
+    project.tasks_data.update!(confirm_date_academy_opened_date_opened: date)
+  end
+
+  private def project(previous_urn, academy_urn)
+    Project.find_by(urn: previous_urn, academy_urn: academy_urn)
+  end
+end

--- a/spec/services/import/academy_open_date_importer_service_spec.rb
+++ b/spec/services/import/academy_open_date_importer_service_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe Import::AcademyOpenDateImporterService do
+  let(:good_csv) do
+    <<~CSV
+      previous_urn,academy_urn,date
+      122957,138205,01/01/2024
+    CSV
+  end
+
+  before do
+    allow(File).to receive(:open).and_return(good_csv)
+
+    mock_all_academies_api_responses
+  end
+
+  subject { described_class.new("/path/to/fake.csv").import! }
+
+  context "when a project with the two urns exists" do
+    it "updates the date and returns a result with success set to true" do
+      tasks_data = create(:conversion_tasks_data, confirm_date_academy_opened_date_opened: nil)
+      project = create(:conversion_project, tasks_data: tasks_data, urn: 122957, academy_urn: 138205)
+
+      expect(subject.first[:success]).to be true
+      expect(project.reload.tasks_data.confirm_date_academy_opened_date_opened).to eql Date.new(2024, 1, 1)
+    end
+  end
+
+  context "when a project with the two urns does not exist" do
+    it "returns a result with success set to false" do
+      tasks_data = create(:conversion_tasks_data, confirm_date_academy_opened_date_opened: nil)
+      project = create(:conversion_project, tasks_data: tasks_data, urn: 120685, academy_urn: 120685)
+
+      expect(subject.first[:success]).to be false
+      expect(project.reload.tasks_data.confirm_date_academy_opened_date_opened).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This import service is intended to be run once by a developer and
assumes:

- we have console access in production
- we can upload the source data to the file share that is mounted inside
  the running container

As this is a real data migration, we cannot run it in the development or
test environments as the data in those will not match the supplied data; 
This makes any kind of testing in those environments pretty low value.

We return a result that the developer running this service can copy and
paste from the console and supply to Service Support if there are
errors.

To run this service from the console:

```
result =
Import::AcademyOpenDateImporterService.new("path/to/source/file.csv").import!
```

