### PR TITLE
(163645) Remove form columns from form a multi academy trust index table

### DIFF
--- a/app/views/all/in_progress/projects/_form_a_multi_academy_trust_table.html.erb
+++ b/app/views/all/in_progress/projects/_form_a_multi_academy_trust_table.html.erb
@@ -6,9 +6,7 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.trust_name") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.trn") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.region") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.schools_included") %></th>
-        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.assigned_to") %></th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -18,9 +16,7 @@
           <%= link_to project_group.name, form_a_multi_academy_trust_path(project_group.trn) %>
         </td>
         <td class="govuk-table__cell"><%= project_group.trn %></td>
-        <td class="govuk-table__cell"><%= t("project.region.#{project_group.region}") %></td>
         <td class="govuk-table__cell"><%= projects_establishment_name_list(project_group) %></td>
-        <td class="govuk-table__cell"><%= display_name(project_group.assigned_to) %></td>
       </tr>
     <% end %>
     </tbody>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -221,6 +221,7 @@ en:
         previous_date: Previous date
         revised_date: Revised date
         note: Note
+        trn: TRN
       body:
         type_name:
           conversion_project: Conversion


### PR DESCRIPTION
Because form a multi academy trust project groups do not exists, we just
load a collection based on the 'trust reference number', we cannot
really show the region and assigned to for the collection, they could be
different.

We did show them by using the values from the first project in the
collection, but this could cause confusion so we decided to take the
columns out.