### PR TITLE
Display school type instead of phase if the school phase is not applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - the all in progress projects table has been moved into a tab
 - the "Date the academy opened" task is now mandatory in Conversion projects
+- If a school phase is "Not applicable" display the school type instead for
+  exports
 
 ### Fixed
 

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -24,7 +24,8 @@ module Export::Csv::SchoolPresenterModule
   def school_phase
     return unless @project.establishment.present?
 
-    @project.establishment.phase
+    return school_type if @project.establishment&.phase == "Not applicable"
+    @project.establishment&.phase
   end
 
   def school_dfe_number

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
     expect(subject.school_phase).to eql "Secondary"
   end
 
+  context "when a school is a PRU or special school and has a school phase of Not applicable" do
+    let(:project) { create(:conversion_project, establishment: special_establishment) }
+    subject { SchoolPresenterModuleTestClass.new(project) }
+
+    it "presents the school type instead" do
+      expect(subject.school_phase).to eql "Community school"
+    end
+  end
+
   it "presents the school age range" do
     expect(subject.school_age_range).to eql "5 - 16"
   end
@@ -104,6 +113,14 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
       address_postcode: "MK19 6HJ",
       age_range_lower: 5,
       age_range_upper: 16
+    )
+  end
+
+  def special_establishment
+    double(
+      Api::AcademiesApi::Establishment,
+      phase: "Not applicable",
+      type: "Community school"
     )
   end
 end


### PR DESCRIPTION
## Changes

If a school is a PRU/special school, the `school phase` will be "Not applicable" within the Academies API.
ESFA do not want to see "Not applicable" in the `school phase` column within the exports. So instead we now show the `school type` in the `school phase` column if the `phase` is missing.


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
