### PR TITLE
Remove duplicate presenter method

### DIFF
--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -213,10 +213,6 @@ class Export::Csv::ProjectPresenter
     I18n.t("project.region.#{@project.region}")
   end
 
-  def school_phase
-    @project.establishment&.phase
-  end
-
   def link_to_project
     "https://#{ENV.fetch("HOSTNAME", "localhost:3000")}/projects/#{@project.id}"
   end

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -615,14 +615,6 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.main_contact_title).to be_nil
   end
 
-  it "presents the school phase" do
-    project = build(:conversion_project)
-
-    presenter = described_class.new(project)
-
-    expect(presenter.school_phase).to eql "Secondary"
-  end
-
   it "presents the link to the project" do
     ClimateControl.modify(
       HOSTNAME: "www.complete.education.gov.uk"


### PR DESCRIPTION
The correct implementation and location for the `school_phase` method is
the `school_presenter` so we remove this one.

