### PR TITLE
Release 67

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release-67][release-67]
+
 ### Added
 
 - All in progress projects now includes at tab to view only conversion projects.
@@ -1831,7 +1833,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-66...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-67...HEAD
+[release-67]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-66...release-67
 [release-66]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-65...release-66
 [release-65]:


### PR DESCRIPTION
Added

- All in progress projects now includes at tab to view only conversion projects.
- All in progress projects now includes at tab to view only transfer projects.
- All projects in a form a multi academy trust can now be viewed at /form-a-multi-academy-trust/<TRN>
- All form a multi academy trust project groups can now be viewed from the All projects > In progress > Form a MAT view.

Changed

- the all in progress projects table has been moved into a tab
- the "Date the academy opened" task is now mandatory in Conversion projects
- If a school phase is "Not applicable" display the school type instead for exports

Fixed

- Broken link to SharePoint guidance in footer and sign-in page now correct
- The margin beneath the sub navigation items is now rendered correctly.

