### PR TITLE
(163941) Refactor out the previous `Project.completed?` method

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -107,10 +107,6 @@ class Project < ApplicationRecord
     @member_of_parliament ||= fetch_member_of_parliament
   end
 
-  def completed?
-    completed_at.present?
-  end
-
   def unassigned_to_user?
     assigned_to.nil?
   end

--- a/spec/factories/conversion/project_factory.rb
+++ b/spec/factories/conversion/project_factory.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
 
     trait :completed do
       state { 1 }
+      completed_at { Date.yesterday }
     end
 
     trait :deleted do

--- a/spec/features/projects/viewing_completed_projects_spec.rb
+++ b/spec/features/projects/viewing_completed_projects_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Viewing completed projects" do
   let(:user) { create(:user, :caseworker) }
-  let(:project) { create(:conversion_project, completed_at: Date.today - 3.months, assigned_to: user) }
+  let(:project) { create(:conversion_project, :completed, assigned_to: user) }
 
   before do
     mock_successful_api_response_to_create_any_project

--- a/spec/helpers/project_helper_spec.rb
+++ b/spec/helpers/project_helper_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe ProjectHelper, type: :helper do
           user = build(:user)
           other_user = build(:user, email: "other.user@education.gov.uk")
 
-          project = build(:conversion_project, completed_at: Date.today - 3.months, assigned_to: other_user)
+          project = build(:conversion_project, :completed, assigned_to: other_user)
 
           expect(project_notification_banner(project, user))
             .to include("Project completed")
@@ -262,7 +262,7 @@ RSpec.describe ProjectHelper, type: :helper do
           user = build(:user)
           other_user = build(:user, email: "other.user@education.gov.uk")
 
-          project = build(:conversion_project, completed_at: Date.today - 3.months, assigned_to: other_user)
+          project = build(:conversion_project, :completed, assigned_to: other_user)
 
           expect(project_notification_banner(project, user))
             .to include("Project completed")

--- a/spec/policies/contact_policy_spec.rb
+++ b/spec/policies/contact_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ContactPolicy do
 
   permissions :edit?, :update?, :destroy?, :confirm_destroy? do
     it "grants access if project is not completed" do
-      project = build(:conversion_project, assigned_to: application_user, completed_at: nil)
+      project = build(:conversion_project, assigned_to: application_user)
       expect(subject).to permit(application_user, build(:project_contact, project: project))
     end
 
@@ -20,7 +20,7 @@ RSpec.describe ContactPolicy do
     end
 
     it "denies access if project is completed" do
-      project = build(:conversion_project, assigned_to: application_user, completed_at: Date.yesterday)
+      project = build(:conversion_project, :completed, assigned_to: application_user)
       expect(subject).not_to permit(application_user, build(:project_contact, project: project))
     end
   end

--- a/spec/policies/note_policy_spec.rb
+++ b/spec/policies/note_policy_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe NotePolicy do
       end
 
       it "denies access if project is completed" do
-        project = build(:conversion_project, assigned_to: application_user, completed_at: Date.yesterday)
+        project = build(:conversion_project, :completed, assigned_to: application_user)
         expect(subject).not_to permit(application_user, build(:note, project: project, user: application_user))
       end
     end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ProjectPolicy do
     end
 
     it "denies access if the project is completed" do
-      project = build(:conversion_project, assigned_to: application_user, conversion_date_provisional: false, completed_at: Date.yesterday)
+      project = build(:conversion_project, :completed, assigned_to: application_user, conversion_date_provisional: false)
       expect(subject).not_to permit(application_user, project)
     end
   end
@@ -56,7 +56,7 @@ RSpec.describe ProjectPolicy do
     end
 
     it "denies access if the project is completed" do
-      project = build(:conversion_project, assigned_to: application_user, conversion_date_provisional: false, completed_at: Date.yesterday)
+      project = build(:conversion_project, :completed, assigned_to: application_user, conversion_date_provisional: false)
       expect(subject).not_to permit(application_user, project)
     end
 
@@ -102,12 +102,12 @@ RSpec.describe ProjectPolicy do
 
   permissions :new_note?, :new_contact? do
     it "grants access if project is not completed" do
-      project = build(:conversion_project, assigned_to: application_user, completed_at: nil)
+      project = build(:conversion_project, assigned_to: application_user)
       expect(subject).to permit(application_user, project)
     end
 
     it "denies access if project is completed" do
-      project = build(:conversion_project, assigned_to: application_user, completed_at: Date.yesterday)
+      project = build(:conversion_project, :completed, assigned_to: application_user)
       expect(subject).not_to permit(application_user, project)
     end
 
@@ -121,24 +121,24 @@ RSpec.describe ProjectPolicy do
 
   permissions :update_assigned_to? do
     it "grants access if project is not completed" do
-      project = build(:conversion_project, assigned_to: application_user, completed_at: nil)
+      project = build(:conversion_project, assigned_to: application_user)
       expect(subject).to permit(application_user, project)
     end
 
     it "denies access if project is completed" do
-      project = build(:conversion_project, assigned_to: application_user, completed_at: Date.yesterday)
+      project = build(:conversion_project, :completed, assigned_to: application_user)
       expect(subject).not_to permit(application_user, project)
     end
   end
 
   permissions :update_regional_delivery_officer? do
     it "grants access if project is not completed" do
-      project = build(:conversion_project, assigned_to: application_user, completed_at: nil)
+      project = build(:conversion_project, assigned_to: application_user)
       expect(subject).to permit(application_user, project)
     end
 
     it "denies access if project is completed" do
-      project = build(:conversion_project, assigned_to: application_user, completed_at: Date.yesterday)
+      project = build(:conversion_project, :completed, assigned_to: application_user)
       expect(subject).not_to permit(application_user, project)
     end
   end

--- a/spec/policies/task_list_policy_spec.rb
+++ b/spec/policies/task_list_policy_spec.rb
@@ -49,17 +49,17 @@ RSpec.describe TaskListPolicy do
 
     context "when the project is completed" do
       it "denies access if project is assigned to the same user" do
-        task_list = create(:conversion_project, assigned_to: application_user, completed_at: Date.yesterday).tasks_data
+        task_list = create(:conversion_project, :completed, assigned_to: application_user).tasks_data
         expect(subject).not_to permit(application_user, task_list)
       end
 
       it "denies access if project is assigned to a different user" do
-        task_list = create(:conversion_project, assigned_to: build(:user), completed_at: Date.yesterday).tasks_data
+        task_list = create(:conversion_project, :completed, assigned_to: build(:user)).tasks_data
         expect(subject).not_to permit(application_user, task_list)
       end
 
       it "denies access if project is assigned to nil" do
-        task_list = create(:conversion_project, assigned_to: nil, completed_at: Date.yesterday).tasks_data
+        task_list = create(:conversion_project, :completed, assigned_to: nil).tasks_data
         expect(subject).not_to permit(application_user, task_list)
       end
     end


### PR DESCRIPTION
We previously determined if a project was completed by seeing if the `completed_at` date was present. Since we added an enum value for Project.state, which includes `completed`, we get `Project.completed?` for free. The enum method looks to see if a project has a state of `completed`.

We forgot to remove the old `Project.completed?` method which looks at the value of `completed_at`. This was an oversight.

Remove this old method and let the enum value of `state` take over. When we introduced the enum, we did a data migration to update all projects with a `completed_at` date to have the `completed` state, so this refactor should not affect the live data.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
