### PR TITLE
Fix autocomplete handles no user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The autocomplete for assigning a user to a project no longer loads all users
   onto the page, instead it fetches the users as they are typed.
 
+### Fixed
+
+- The assigned user autocomplete now works as expected when the project is not
+  assigned to a user.
+
 ## [Release-67][release-67]
 
 ### Added

--- a/app/javascript/assign_user_autocomplete.js
+++ b/app/javascript/assign_user_autocomplete.js
@@ -68,6 +68,8 @@ export class AssignUserAutocomplete {
   // when we load the form and switch to the autocomplete we only have the email address, this method
   // turns that into a user and returns a formatted value
   emailToUser = async (email) => {
+    if (!email) return
+
     const response = await fetch('/search/user?query=' + email)
     const results = await response.json()
     const user = results[0]

--- a/spec/features/internal_contacts/users_can_change_the_assigned_user_with_autocomplete_spec.rb
+++ b/spec/features/internal_contacts/users_can_change_the_assigned_user_with_autocomplete_spec.rb
@@ -146,6 +146,21 @@ RSpec.feature "Users change the assigned user", driver: :headless_firefox do
         expect(page).to have_content("No results found")
       end
     end
+
+    it "shows nothing when the project is not assigned" do
+      project = create(:conversion_project, assigned_to: nil)
+      visit project_path(project)
+      click_on "Internal contacts"
+      within("#projectInternalContacts dl.govuk-summary-list div:first-of-type") do
+        click_on "Change"
+      end
+
+      fill_in "Assign to", with: user.email
+
+      within(autocomplete_first_suggestion) do
+        expect(page).to have_content("#{user.first_name} #{user.last_name} (#{user.email})")
+      end
+    end
   end
 
   def autocomplete_first_suggestion


### PR DESCRIPTION
As soon as we deployed the new autocomplete to development we realised
it was assume there is ALWAYS an assigned user, which is not true.

This work adds a spec to test this and fixes the autocomplete code to
handle the scenario.

