### PR TITLE
(Spike) Use the Grape gem to build an API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add the Grape gem and demonstrate a simple Api endpoint in the application
+- Add simple authentication to the Api endpoints using an Api key
 
 ## [Release-69][release-69]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Add the Grape gem and demonstrate a simple Api endpoint in the application
+
 ## [Release-69][release-69]
 
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,8 @@ gem "high_voltage"
 
 gem "nokogiri"
 
+gem "grape", "~> 2.0"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       erubi (~> 1.4)
       parser (>= 2.4)
       smart_properties
+    bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.17.1)
       msgpack (~> 1.2)
@@ -133,6 +134,21 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    dry-core (1.0.1)
+      concurrent-ruby (~> 1.0)
+      zeitwerk (~> 2.6)
+    dry-inflector (1.0.0)
+    dry-logic (1.5.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
+    dry-types (1.7.2)
+      bigdecimal (~> 3.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0)
+      dry-inflector (~> 1.0)
+      dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
     dumb_delegator (1.0.0)
     erb_lint (0.5.0)
       activesupport
@@ -166,6 +182,13 @@ GEM
     govuk_markdown (1.0.0)
       activesupport
       redcarpet
+    grape (2.0.0)
+      activesupport (>= 5)
+      builder
+      dry-types (>= 1.1)
+      mustermann-grape (~> 1.0.0)
+      rack (>= 1.3.0)
+      rack-accept
     hashdiff (1.0.1)
     hashie (5.0.0)
     high_voltage (3.1.2)
@@ -210,6 +233,10 @@ GEM
     minitest (5.22.3)
     msgpack (1.7.2)
     multi_xml (0.6.0)
+    mustermann (3.0.0)
+      ruby2_keywords (~> 0.0.1)
+    mustermann-grape (1.0.2)
+      mustermann (>= 1.0.0)
     net-http (0.4.1)
       uri
     net-imap (0.4.10)
@@ -268,6 +295,8 @@ GEM
       activesupport (>= 3.0.0)
     racc (1.7.3)
     rack (2.2.9)
+    rack-accept (0.4.5)
+      rack (>= 0.4)
     rack-protection (3.1.0)
       rack (~> 2.2, >= 2.2.4)
     rack-test (2.1.0)
@@ -347,6 +376,7 @@ GEM
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -463,6 +493,7 @@ DEPENDENCIES
   govuk-components (~> 4.1, >= 4.1.1)
   govuk_design_system_formbuilder (~> 4.1, >= 4.1.1)
   govuk_markdown
+  grape (~> 2.0)
   high_voltage
   jsbundling-rails (~> 1.3)
   launchy (~> 3.0)

--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -1,0 +1,5 @@
+class Api < Grape::API
+  prefix "api"
+  format :json
+  mount V1::Healthcheck
+end

--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -1,6 +1,5 @@
 class Api < Grape::API
   prefix "api"
   format :json
-  mount V1::Healthcheck
-  mount V1::Auth
+  mount V1::Api
 end

--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -2,4 +2,5 @@ class Api < Grape::API
   prefix "api"
   format :json
   mount V1::Healthcheck
+  mount V1::Auth
 end

--- a/app/api/auth_helpers.rb
+++ b/app/api/auth_helpers.rb
@@ -1,0 +1,13 @@
+module AuthHelpers
+  def authenticate!
+    error!("Unauthorized. Invalid or expired token.", 401) unless valid_token
+  end
+
+  def valid_token
+    api_key = headers["Apikey"]
+    return false unless api_key.present?
+
+    token = ApiKey.find_by(api_key: api_key)
+    token && !token.expired?
+  end
+end

--- a/app/api/v1/api.rb
+++ b/app/api/v1/api.rb
@@ -1,0 +1,8 @@
+module V1
+  class Api < Grape::API
+    version "v1", using: :path
+
+    mount Auth
+    mount Healthcheck
+  end
+end

--- a/app/api/v1/auth.rb
+++ b/app/api/v1/auth.rb
@@ -1,11 +1,9 @@
-module V1
-  class Auth < Grape::API
-    helpers AuthHelpers
+class V1::Auth < Grape::API
+  helpers AuthHelpers
 
-    desc "Authenticate endpoint"
-    get :auth do
-      authenticate!
-      {status: "OK"}
-    end
+  desc "Authenticate endpoint"
+  get :auth do
+    authenticate!
+    {status: "OK"}
   end
 end

--- a/app/api/v1/auth.rb
+++ b/app/api/v1/auth.rb
@@ -1,0 +1,11 @@
+module V1
+  class Auth < Grape::API
+    helpers AuthHelpers
+
+    desc "Authenticate endpoint"
+    get :auth do
+      authenticate!
+      {status: "OK"}
+    end
+  end
+end

--- a/app/api/v1/healthcheck.rb
+++ b/app/api/v1/healthcheck.rb
@@ -1,8 +1,6 @@
-module V1
-  class Healthcheck < Grape::API
-    desc "Api healthcheck endpoint returns 'OK'"
-    get :healthcheck do
-      {status: "OK"}
-    end
+class V1::Healthcheck < Grape::API
+  desc "Api healthcheck endpoint returns 'OK'"
+  get :healthcheck do
+    {status: "OK"}
   end
 end

--- a/app/api/v1/healthcheck.rb
+++ b/app/api/v1/healthcheck.rb
@@ -1,0 +1,8 @@
+module V1
+  class Healthcheck < Grape::API
+    desc "Api healthcheck endpoint returns 'OK'"
+    get :healthcheck do
+      {status: "OK"}
+    end
+  end
+end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,0 +1,8 @@
+class ApiKey < ApplicationRecord
+  validates :api_key, presence: true
+  validates :expires_at, presence: true
+
+  def expired?
+    Date.today > expires_at
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ YEAR_2000_2499_REGEX = /(?:(?:20|21|23|24)[0-9]{2})/
 
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  mount Api => "/"
 
   concern :has_destroy_confirmation do
     get "/delete", action: :confirm_destroy

--- a/db/migrate/20240509104059_create_api_keys.rb
+++ b/db/migrate/20240509104059_create_api_keys.rb
@@ -1,0 +1,10 @@
+class CreateApiKeys < ActiveRecord::Migration[7.0]
+  def change
+    create_table :api_keys, id: :uuid do |t|
+      t.timestamps
+      t.string :api_key, null: false
+      t.datetime :expires_at, null: false
+      t.string :description
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_08_144343) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_09_104059) do
+  create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "api_key", null: false
+    t.datetime "expires_at", null: false
+    t.string "description"
+  end
+
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.uuid "project_id"
     t.string "name", null: false

--- a/spec/api/v1/auth_spec.rb
+++ b/spec/api/v1/auth_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe V1::Auth do
+  context "when there is a valid api key in the header" do
+    it "returns OK" do
+      _api_key = ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow)
+      get "/api/auth", headers: {Apikey: "testkey"}
+      expect(response.body).to eq({status: "OK"}.to_json)
+    end
+  end
+
+  context "when there is no api key in the header" do
+    it "returns unauthorised" do
+      get "/api/auth"
+      expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+    end
+  end
+
+  context "when there is an invalid api key in the header" do
+    it "returns unauthorised" do
+      get "/api/auth", headers: {Apikey: "somethingelse"}
+      expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+    end
+  end
+
+  context "when there is an expired api key in the header" do
+    it "returns unauthorised" do
+      _api_key = ApiKey.create(api_key: "testkey", expires_at: Date.yesterday)
+      get "/api/auth", headers: {Apikey: "testkey"}
+      expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+    end
+  end
+end

--- a/spec/api/v1/auth_spec.rb
+++ b/spec/api/v1/auth_spec.rb
@@ -4,21 +4,21 @@ RSpec.describe V1::Auth do
   context "when there is a valid api key in the header" do
     it "returns OK" do
       _api_key = ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow)
-      get "/api/auth", headers: {Apikey: "testkey"}
+      get "/api/v1/auth", headers: {Apikey: "testkey"}
       expect(response.body).to eq({status: "OK"}.to_json)
     end
   end
 
   context "when there is no api key in the header" do
     it "returns unauthorised" do
-      get "/api/auth"
+      get "/api/v1/auth"
       expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
     end
   end
 
   context "when there is an invalid api key in the header" do
     it "returns unauthorised" do
-      get "/api/auth", headers: {Apikey: "somethingelse"}
+      get "/api/v1/auth", headers: {Apikey: "somethingelse"}
       expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
     end
   end
@@ -26,7 +26,7 @@ RSpec.describe V1::Auth do
   context "when there is an expired api key in the header" do
     it "returns unauthorised" do
       _api_key = ApiKey.create(api_key: "testkey", expires_at: Date.yesterday)
-      get "/api/auth", headers: {Apikey: "testkey"}
+      get "/api/v1/auth", headers: {Apikey: "testkey"}
       expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
     end
   end

--- a/spec/api/v1/healthcheck_spec.rb
+++ b/spec/api/v1/healthcheck_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe V1::Healthcheck do
+  it "returns OK" do
+    get "/api/healthcheck"
+    expect(response.body).to eq({status: "OK"}.to_json)
+  end
+end

--- a/spec/api/v1/healthcheck_spec.rb
+++ b/spec/api/v1/healthcheck_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe V1::Healthcheck do
   it "returns OK" do
-    get "/api/healthcheck"
+    get "/api/v1/healthcheck"
     expect(response.body).to eq({status: "OK"}.to_json)
   end
 end

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe ApiKey do
+  describe "Columns" do
+    it { is_expected.to have_db_column(:api_key).of_type :string }
+    it { is_expected.to have_db_column(:expires_at).of_type :datetime }
+    it { is_expected.to have_db_column(:description).of_type :string }
+  end
+
+  describe "#expired?" do
+    it "returns true if expires_at is in the past" do
+      api_key = ApiKey.new(api_key: "testkey", expires_at: Date.yesterday)
+      expect(api_key.expired?).to be true
+    end
+
+    it "returns false if expires_at is in the future" do
+      api_key = ApiKey.new(api_key: "testkey", expires_at: Date.tomorrow)
+      expect(api_key.expired?).to be false
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -83,6 +83,9 @@ RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
 
+  # Api specs are request specs
+  config.include RSpec::Rails::RequestExampleGroup, type: :request, file_path: /spec\/api/
+
   # cleanup Omniauth after each example
   config.after(:each) do |example|
     OmniAuth.config.mock_auth[:azure_activedirectory_v2] = nil


### PR DESCRIPTION
## Changes

Add the [Grape](https://github.com/ruby-grape/grape/) gem to enable us to add an API to the application. 

To demonstrate the API works, add a very simple "healthcheck" endpoint (cribbed from the [Grape demo app](https://github.com/ruby-grape/grape-on-rails)).

Next, show we can use Api key based authentication. Create a basic ApiKey model with a token & expiry date. Use this token in an "auth" endpoint to show we can authenticate users.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
