### PR TITLE
Fix edit project team works for transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The assigned user autocomplete now works as expected when the project is not
   assigned to a user.
+- The edit project team now works for transfer projects as well as conversion
+  projects.
 
 ## [Release-67][release-67]
 

--- a/app/controllers/internal_contacts/projects_controller.rb
+++ b/app/controllers/internal_contacts/projects_controller.rb
@@ -38,7 +38,7 @@ class InternalContacts::ProjectsController < ApplicationController
   end
 
   def update_team
-    @project.update(edit_team_params)
+    @project.update(edit_conversion_team_params || edit_transfer_team_params)
     redirect_to project_internal_contacts_path(@project), notice: I18n.t("project.assign.assigned_to_team.success")
   end
 
@@ -54,8 +54,12 @@ class InternalContacts::ProjectsController < ApplicationController
     params.require(:internal_contacts_edit_added_by_user_form).permit(:email)
   end
 
-  private def edit_team_params
-    params.require(:conversion_project).permit(:team) || params.require(:transfer_project).permit(:team)
+  private def edit_conversion_team_params
+    params.require(:conversion_project).permit(:team) if params[:conversion_project].present?
+  end
+
+  private def edit_transfer_team_params
+    params.require(:transfer_project).permit(:team) if params[:transfer_project].present?
   end
 
   private def find_project

--- a/spec/requests/internal_contacts/projects_controller_spec.rb
+++ b/spec/requests/internal_contacts/projects_controller_spec.rb
@@ -63,6 +63,24 @@ RSpec.describe InternalContacts::ProjectsController, type: :request do
     end
   end
 
+  describe "editing the team" do
+    it "handles both conversions and transfers" do
+      transfer_project = create(:transfer_project)
+
+      put project_internal_contacts_team_path(transfer_project),
+        params: {transfer_project: {team: "regional_casework_services"}}
+
+      expect(response).to redirect_to(project_internal_contacts_path(transfer_project))
+
+      conversion_project = create(:conversion_project)
+
+      put project_internal_contacts_team_path(conversion_project),
+        params: {conversion_project: {team: "regional_casework_services"}}
+
+      expect(response).to redirect_to(project_internal_contacts_path(conversion_project))
+    end
+  end
+
   def mock_session_with_return_url(url)
     fake_session = double("session")
     allow(fake_session).to receive(:[]).with(:return_url).and_return(url)


### PR DESCRIPTION
The strong params for editing a project team do not work the way this
code tries to use.

Instead we separate out the conversion and transfer params and have each
return nil if the relevant param is missing, shifting the OR into the
calling code.
