### PR TITLE
Generate Api keys using a task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add the Grape gem and demonstrate a simple Api endpoint in the application
 - Add simple authentication to the Api endpoints using an Api key
+- Add a task to generate Api keys, along with documentation
 
 ## [Release-69][release-69]
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,0 +1,17 @@
+# Api
+
+The application has an Api for creating projects via a POST endpoint (TBA)
+
+## Api key generation
+
+Other applications can authenticate to our Api via a key. The keys are stored
+in the `api_keys` table and are a simple ActiveRecord object with an api_key 
+token (UUID) and an `expires_at` Datetime (initially set to 3 years' time).
+
+To generate an Api key for a user, use the `api_key:generate` task.
+
+For production users, this task must be run by first
+[accessing the production console](console-and-logs.md), then running 
+`api_key:generate['Key for Foobar application']`. Use the argument to briefly
+describe who or what the Api Key is for. Send the generated Api key to the user
+using a secure method if possible (for example, sharing in 1Password).

--- a/lib/tasks/api_key/generate_api_key.rake
+++ b/lib/tasks/api_key/generate_api_key.rake
@@ -1,0 +1,11 @@
+namespace :api_key do
+  desc ">> Generate an Api key for the application"
+  task :generate, [:description] => :environment do |_task, args|
+    abort "Please supply a brief description of who this key is for, e.g. api_key:generate['Key for Prepare application']" if args[:description].nil?
+
+    key = ApiKey.new(api_key: SecureRandom.uuid, expires_at: Date.today + 3.years, description: args[:description])
+    if key.save
+      puts "New key generated: #{key.api_key}"
+    end
+  end
+end

--- a/spec/lib/tasks/api_key/generate_api_key_spec.rb
+++ b/spec/lib/tasks/api_key/generate_api_key_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "api_key:generate", type: :task do
+  subject { Rake::Task["api_key:generate"] }
+
+  it "exits if no description is supplied" do
+    expect { subject.execute }.to raise_error(SystemExit, "Please supply a brief description of who this key is for, e.g. api_key:generate['Key for Prepare application']")
+  end
+
+  it "generates a new Api key" do
+    expect { subject.invoke("Description") }.to change { ApiKey.count }.by(1)
+  end
+end


### PR DESCRIPTION
## Changes

Now that we have Api keys in the application, we need a way to generate them.
Add a rake task to generate keys, and documentation to inform developers of how
to generate them for production users.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
