### PR TITLE
(165750) update significant date validation

### DIFF
--- a/app/controllers/date_histories_controller.rb
+++ b/app/controllers/date_histories_controller.rb
@@ -12,7 +12,7 @@ class DateHistoriesController < ApplicationController
 
   def create
     authorize(@project, :change_significant_date?)
-    @form = NewDateHistoryForm.new(**new_date_history_form, project: @project, user: current_user)
+    @form = NewDateHistoryForm.new(**date_history_params, project: @project, user: current_user)
 
     if @form.save
       @project.reload
@@ -22,7 +22,7 @@ class DateHistoriesController < ApplicationController
     end
   end
 
-  private def new_date_history_form
+  private def date_history_params
     params.require(:new_date_history_form).permit(:revised_date, :note_body)
   end
 end

--- a/app/forms/new_date_history_form.rb
+++ b/app/forms/new_date_history_form.rb
@@ -1,51 +1,33 @@
 class NewDateHistoryForm
   include ActiveModel::Model
   include ActiveModel::Attributes
-
-  CONVERSION_DATE_DAY = 1
+  include ActiveRecord::AttributeAssignment
 
   attribute :project
   attribute :user
   attribute :note_body
-  attribute :revised_date
-  attribute "revised_date(3i)"
-  attribute "revised_date(2i)"
-  attribute "revised_date(1i)"
+  attribute :revised_date, :date
 
-  validates :project, :user, :note_body, presence: true
+  validates :project, :user, :revised_date, :note_body, presence: true
 
-  validate :revised_date_format
+  def assign_attributes(attributes)
+    if GovukDateFieldParameters.new(:revised_date, attributes, without_day: true).invalid?
+      attributes.delete("revised_date(3i)")
+      attributes.delete("revised_date(2i)")
+      attributes.delete("revised_date(1i)")
+    end
+
+    super(attributes)
+  end
 
   def save
     return false unless valid?
 
-    if SignificantDateCreatorService.new(project: project, revised_date: date_from_attributes, note_body: note_body, user: user).update!
+    if SignificantDateCreatorService.new(project: project, revised_date: revised_date, note_body: note_body, user: user).update!
       true
     else
       errors.add(:revised_date, :transaction)
       false
     end
-  end
-
-  private def revised_date_format
-    errors.add(:revised_date, :format) if month.blank? || year.blank?
-    errors.add(:revised_date, :format) unless (1..12).cover?(month.to_i)
-    errors.add(:revised_date, :format) unless (2000..2500).cover?(year.to_i)
-  end
-
-  private def day
-    CONVERSION_DATE_DAY.to_i
-  end
-
-  private def month
-    attributes["revised_date(2i)"].to_i
-  end
-
-  private def year
-    attributes["revised_date(1i)"].to_i
-  end
-
-  private def date_from_attributes
-    Date.new(year, month, day)
   end
 end

--- a/config/locales/conversion_date_history.en.yml
+++ b/config/locales/conversion_date_history.en.yml
@@ -22,7 +22,8 @@ en:
     attributes:
       revised_date:
         format: Enter a valid month and year
-        transaction: Conversion date could not be saved
+        transaction: Revised date could not be saved
+        blank: Enter a valid month and year for the revised date, like 9 2024
       note_body:
         blank: Enter a reason
   helpers:

--- a/config/locales/transfer_date_history.en.yml
+++ b/config/locales/transfer_date_history.en.yml
@@ -22,7 +22,8 @@ en:
     attributes:
       revised_date:
         format: Enter a valid month and year
-        transaction: Conversion date could not be saved
+        transaction: Revised date could not be saved
+        blank: Enter a valid month and year for the revised date, like 9 2024
       note_body:
         blank: Enter a reason
   helpers:

--- a/spec/forms/new_date_form_spec.rb
+++ b/spec/forms/new_date_form_spec.rb
@@ -1,99 +1,211 @@
 require "rails_helper"
 
 RSpec.describe NewDateHistoryForm, type: :model do
-  let(:form) { create_valid_form_object }
+  let(:project) { create(:conversion_project, conversion_date: Date.today.at_beginning_of_month) }
+  let(:user) { create(:user, :caseworker) }
+  let(:form) { described_class.new }
+
+  before { mock_all_academies_api_responses }
+
+  def valid_attributes
+    revised_date = Date.today.at_beginning_of_month + 6.months
+    {
+      "revised_date(3i)": revised_date.day.to_s,
+      "revised_date(2i)": revised_date.month.to_s,
+      "revised_date(1i)": revised_date.year.to_s,
+      note_body: "Test note body.",
+      user: user,
+      project: project
+    }.with_indifferent_access
+  end
 
   describe "validations" do
-    it "requires a valid year" do
-      form = create_valid_form_object
+    it "can be valid in this test" do
+      attributes = valid_attributes
 
-      form.send(:"revised_date(1i)=", "")
-      expect(form).to be_invalid
+      form.assign_attributes(attributes)
 
-      form.send(:"revised_date(1i)=", "not a string")
-      expect(form).to be_invalid
-
-      form.send(:"revised_date(1i)=", "1901")
-      expect(form).to be_invalid
-
-      form.send(:"revised_date(1i)=", "3023")
-      expect(form).to be_invalid
-
-      form.send(:"revised_date(1i)=", "23")
-      expect(form).to be_invalid
+      expect(form).to be_valid
     end
 
-    it "requires a valid month" do
-      form = create_valid_form_object
+    describe "revised date" do
+      it "shows a helpful error message when invalid" do
+        attributes = valid_attributes
+        attributes["revised_date(2i)"] = "13"
 
-      form.send(:"revised_date(2i)=", "")
-      expect(form).to be_invalid
+        form.assign_attributes(attributes)
 
-      form.send(:"revised_date(2i)=", "not a string")
-      expect(form).to be_invalid
+        expect(form).to be_invalid
+        expect(form.errors.messages_for(:revised_date)).to include(
+          "Enter a valid month and year for the revised date, like 9 2024"
+        )
+      end
 
-      form.send(:"revised_date(2i)=", "0")
-      expect(form).to be_invalid
+      it "cannot be empty" do
+        attributes = valid_attributes
+        attributes["revised_date(3i)"] = "1"
+        attributes["revised_date(2i)"] = ""
+        attributes["revised_date(1i)"] = ""
 
-      form.send(:"revised_date(2i)=", "24")
-      expect(form).to be_invalid
-    end
+        form.assign_attributes(attributes)
 
-    it "requires the note body" do
-      form = create_valid_form_object
+        expect(form).to be_invalid
+      end
 
-      form.note_body = ""
-      expect(form).to be_invalid
-    end
+      describe "month params" do
+        it "cannot be 0" do
+          attributes = valid_attributes
+          attributes["revised_date(2i)"] = "0"
 
-    it "requires the project" do
-      form = create_valid_form_object
-      form.project = nil
+          form.assign_attributes(attributes)
 
-      expect(form).to be_invalid
-    end
+          expect(form).to be_invalid
+        end
 
-    it "requires the user" do
-      form = create_valid_form_object
-      form.user = nil
+        it "cannot be less than 0" do
+          attributes = valid_attributes
+          attributes["revised_date(2i)"] = "-1"
 
-      expect(form).to be_invalid
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be more than 12" do
+          attributes = valid_attributes
+          attributes["revised_date(2i)"] = "13"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "must be a number" do
+          attributes = valid_attributes
+          attributes["revised_date(2i)"] = "fourth"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+      end
+
+      describe "year params" do
+        it "must be four digits" do
+          attributes = valid_attributes
+          attributes["revised_date(1i)"] = "25"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be less than 2000" do
+          attributes = valid_attributes
+          attributes["revised_date(1i)"] = "1999"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be more than 3000" do
+          attributes = valid_attributes
+          attributes["revised_date(1i)"] = "3001"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "must be a number" do
+          attributes = valid_attributes
+          attributes["revised_date(2i)"] = "twenty twenty five"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+      end
+
+      it "requires the note body" do
+        attributes = valid_attributes
+        attributes["note_body"] = ""
+
+        form.assign_attributes(attributes)
+
+        expect(form).to be_invalid
+      end
+
+      it "requires the project" do
+        attributes = valid_attributes
+        attributes["project"] = ""
+
+        form.assign_attributes(attributes)
+
+        expect(form).to be_invalid
+      end
+
+      it "requires the user" do
+        attributes = valid_attributes
+        attributes["user"] = ""
+
+        form.assign_attributes(attributes)
+
+        expect(form).to be_invalid
+      end
     end
   end
 
   describe "#save" do
-    let(:project) { create(:conversion_project, conversion_date: Date.today.at_beginning_of_month) }
-    let(:user) { create(:user, :caseworker) }
-
-    before { mock_successful_api_calls(establishment: any_args, trust: any_args) }
-
     it "returns true when successful" do
-      form.project = project
-      form.user = user
-      form.note_body = "This is my note body."
+      attributes = valid_attributes
+
+      form.assign_attributes(attributes)
 
       expect(form.save).to be true
     end
 
     it "adds an error and returns false if unsuccessful" do
-      form.project = project
-      form.user = user
+      attributes = valid_attributes
+      attributes["note_body"] = ""
 
-      allow_any_instance_of(SignificantDateCreatorService).to receive("update!").and_return(false)
+      form.assign_attributes(attributes)
 
       expect(form.save).to eq false
-      expect(form.errors.messages[:revised_date]).to include(I18n.t("errors.attributes.revised_date.transaction"))
+      expect(form.errors.messages_for(:note_body)).to include("Enter a reason")
+    end
+
+    it "adds an error and returns false if the data cannot be saved" do
+      attributes = valid_attributes
+      allow_any_instance_of(SignificantDateCreatorService).to receive("update!").and_return(false)
+
+      form.assign_attributes(attributes)
+
+      expect(form.save).to eq false
+      expect(form.errors.messages_for(:revised_date)).to include("Revised date could not be saved")
     end
   end
 
-  def create_valid_form_object
-    described_class.new(
-      project: build(:conversion_project),
-      user: build(:user),
-      note_body: "Note body",
-      "revised_date(3i)": "1",
-      "revised_date(2i)": "1",
-      "revised_date(1i)": "2023"
-    )
+  describe "works for transfers" do
+    let(:project) { create(:transfer_project, transfer_date: Date.today.at_beginning_of_month) }
+
+    it "returns true when successful" do
+      attributes = valid_attributes
+
+      form.assign_attributes(attributes)
+
+      expect(form.save).to be true
+    end
+
+    it "adds an error and returns false if unsuccessful" do
+      attributes = valid_attributes
+      attributes["note_body"] = ""
+
+      form.assign_attributes(attributes)
+
+      expect(form.save).to eq false
+      expect(form.errors.messages_for(:note_body)).to include("Enter a reason")
+    end
   end
 end


### PR DESCRIPTION
We are consolidating our approach to date validation to use the
`GovukDateFieldParameters` class before assignment.

This work updates the conversion and transfer change significant date
form to use it. Because the validation sets any invalid dates to `nil`
and for this form, nil is not allowed, we can do nothing other than show
the error for blank state.

Base on #1569 