### PR TITLE
(166099) update date validation for receive grant payment certificate task

### DIFF
--- a/app/forms/conversion/task/receive_grant_payment_certificate_task_form.rb
+++ b/app/forms/conversion/task/receive_grant_payment_certificate_task_form.rb
@@ -1,14 +1,12 @@
 class Conversion::Task::ReceiveGrantPaymentCertificateTaskForm < BaseTaskForm
+  include ActiveRecord::AttributeAssignment
+
   attribute :check_certificate, :boolean
   attribute :save_certificate, :boolean
-  attribute "date_received(1i)"
-  attribute "date_received(2i)"
-  attribute "date_received(3i)"
   attribute :date_received, :date
 
-  validate :date_format
-
   def initialize(tasks_data, user)
+    @date_param_errors = ActiveModel::Errors.new(self)
     @tasks_data = tasks_data
     @user = user
     @project = tasks_data.project
@@ -17,63 +15,30 @@ class Conversion::Task::ReceiveGrantPaymentCertificateTaskForm < BaseTaskForm
     self.date_received = @project.tasks_data.receive_grant_payment_certificate_date_received
   end
 
+  def assign_attributes(attributes)
+    if GovukDateFieldParameters.new(:date_received, attributes).invalid?
+      @date_param_errors.add(:date_received, I18n.t("conversion.task.receive_grant_payment_certificate.date_received.errors.invalid"))
+
+      attributes.delete("date_received(3i)")
+      attributes.delete("date_received(2i)")
+      attributes.delete("date_received(1i)")
+    end
+
+    super(attributes)
+  end
+
+  def valid?(context = nil)
+    super(context)
+    errors.merge!(@date_param_errors)
+    errors.empty?
+  end
+
   def save
     @tasks_data.assign_attributes(
-      receive_grant_payment_certificate_date_received: formatted_date_received,
+      receive_grant_payment_certificate_date_received: date_received,
       receive_grant_payment_certificate_check_certificate: check_certificate,
       receive_grant_payment_certificate_save_certificate: save_certificate
     )
     @tasks_data.save!
-  end
-
-  def formatted_date_received
-    return @project.tasks_data.receive_grant_payment_certificate_date_received if @project.tasks_data.receive_grant_payment_certificate_date_received.present?
-    return nil if month.blank? || year.blank? || day.blank?
-    Date.new(year, month, day)
-  end
-
-  private def date_format
-    return if month.blank? && year.blank? && day.blank?
-
-    Date.new(year, month, day)
-  rescue TypeError, Date::Error
-    errors.add(:date_received, I18n.t("conversion.task.receive_grant_payment_certificate.date_received.errors.format"))
-  end
-
-  private def day
-    day = attributes["date_received(3i)"]
-    return if day.blank?
-
-    day.to_i
-  end
-
-  private def month
-    month = attributes["date_received(2i)"]
-    return if month.blank?
-
-    month.to_i
-  end
-
-  private def year
-    year = attributes["date_received(1i)"]
-    return if year.blank?
-
-    year.to_i
-  end
-
-  def completed?
-    attributes.except(
-      "date_received(3i)",
-      "date_received(2i)",
-      "date_received(1i)"
-    ).values.all?(&:present?)
-  end
-
-  def in_progress?
-    attributes.except(
-      "date_received(3i)",
-      "date_received(2i)",
-      "date_received(1i)"
-    ).values.any?(&:present?)
   end
 end

--- a/config/locales/conversion/tasks/receive_grant_payment_certificate.en.yml
+++ b/config/locales/conversion/tasks/receive_grant_payment_certificate.en.yml
@@ -28,4 +28,4 @@ en:
           received_info:
             html: DfE received the grant payment certificate on %{date}.
           errors:
-            format: Please enter a valid date
+            invalid: Enter a valid date, like 1 1 2025

--- a/spec/forms/conversion/tasks/receive_grant_payment_certificate_task_form_spec.rb
+++ b/spec/forms/conversion/tasks/receive_grant_payment_certificate_task_form_spec.rb
@@ -2,61 +2,190 @@ require "rails_helper"
 
 RSpec.describe Conversion::Task::ReceiveGrantPaymentCertificateTaskForm do
   let(:user) { create(:user) }
+  let(:project) { create(:conversion_project) }
+  let(:form) { described_class.new(project.tasks_data, user) }
+
+  before { mock_successful_api_response_to_create_any_project }
+
+  def valid_attributes
+    date_received = Date.today.at_beginning_of_month + 6.months
+    {
+      "date_received(3i)": date_received.day.to_s,
+      "date_received(2i)": date_received.month.to_s,
+      "date_received(1i)": date_received.year.to_s,
+      check_certificate: "false",
+      save_certificate: "false"
+    }.with_indifferent_access
+  end
+
+  describe "validations" do
+    describe "date_received" do
+      it "shows a helpful error message when invalid" do
+        attributes = valid_attributes
+        attributes["date_received(1i)"] = "13"
+
+        form.assign_attributes(attributes)
+
+        expect(form).to be_invalid
+        expect(form.errors.messages_for(:date_received)).to include(
+          "Enter a valid date, like 1 1 2025"
+        )
+      end
+
+      it "can be empty" do
+        attributes = valid_attributes
+        attributes["date_received(3i)"] = ""
+        attributes["date_received(2i)"] = ""
+        attributes["date_received(1i)"] = ""
+
+        form.assign_attributes(attributes)
+
+        expect(form).to be_valid
+      end
+
+      describe "day parameters" do
+        it "cannot be be 0" do
+          attributes = valid_attributes
+          attributes["date_received(3i)"] = "0"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be be less than 0" do
+          attributes = valid_attributes
+          attributes["date_received(3i)"] = "-1"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be greater than 31" do
+          attributes = valid_attributes
+          attributes["date_received(3i)"] = "32"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "must be a number" do
+          attributes = valid_attributes
+          attributes["date_received(3i)"] = "twenty first"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+      end
+
+      describe "month params" do
+        it "cannot be 0" do
+          attributes = valid_attributes
+          attributes["date_received(2i)"] = "0"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be less than 0" do
+          attributes = valid_attributes
+          attributes["date_received(2i)"] = "-1"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be more than 12" do
+          attributes = valid_attributes
+          attributes["date_received(2i)"] = "13"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "must be a number" do
+          attributes = valid_attributes
+          attributes["date_received(2i)"] = "fourth"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+      end
+
+      describe "year params" do
+        it "must be four digits" do
+          attributes = valid_attributes
+          attributes["date_received(1i)"] = "25"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be less than 2000" do
+          attributes = valid_attributes
+          attributes["date_received(1i)"] = "1999"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be more than 3000" do
+          attributes = valid_attributes
+          attributes["date_received(1i)"] = "3001"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "must be a number" do
+          attributes = valid_attributes
+          attributes["date_received(2i)"] = "twenty twenty five"
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+      end
+    end
+  end
 
   describe "#save" do
-    before { mock_successful_api_response_to_create_any_project }
-
-    let(:project) { create(:conversion_project) }
-
     context "when the date is a valid date" do
       it "sets date_received to the supplied date" do
-        form = described_class.new(project.tasks_data, user)
-        form.assign_attributes("date_received(1i)": 2024, "date_received(2i)": 1, "date_received(3i)": 1)
+        attributes = valid_attributes
+        attributes["date_received(3i)"] = "1"
+        attributes["date_received(2i)"] = "1"
+        attributes["date_received(1i)"] = "2024"
+
+        form.assign_attributes(attributes)
+        form.valid?
         form.save
 
         expect(project.tasks_data.receive_grant_payment_certificate_date_received).to eq(Date.new(2024, 1, 1))
       end
+    end
 
-      it "sets date_received to the supplied date (leap year)" do
-        form = described_class.new(project.tasks_data, user)
-        form.assign_attributes("date_received(1i)": 2024, "date_received(2i)": 2, "date_received(3i)": 29)
+    context "when form is invalid" do
+      it "shows a helpful message" do
+        attributes = valid_attributes
+        attributes["date_received(3i)"] = "32"
+        attributes["date_received(2i)"] = "1"
+        attributes["date_received(1i)"] = "2024"
+
+        form.assign_attributes(attributes)
+        form.valid?
         form.save
 
-        expect(project.tasks_data.receive_grant_payment_certificate_date_received).to eq(Date.new(2024, 2, 29))
-      end
-    end
-
-    context "when the date is partially missing" do
-      it "adds an error" do
-        form = described_class.new(project.tasks_data, user)
-        form.assign_attributes("date_received(1i)": 2024, "date_received(2i)": nil, "date_received(3i)": 1)
-
-        expect(form.valid?).to be false
-        expect(form.errors.messages[:date_received])
-          .to include(I18n.t("conversion.task.receive_grant_payment_certificate.date_received.errors.format"))
-        expect(project.tasks_data.receive_grant_payment_certificate_date_received).to be_nil
-      end
-    end
-
-    context "when the date is invalid" do
-      it "adds an error" do
-        form = described_class.new(project.tasks_data, user)
-        form.assign_attributes("date_received(1i)": 2024, "date_received(2i)": 2, "date_received(3i)": 30)
-
-        expect(form.valid?).to be false
-        expect(form.errors.messages[:date_received])
-          .to include(I18n.t("conversion.task.receive_grant_payment_certificate.date_received.errors.format"))
-        expect(project.tasks_data.receive_grant_payment_certificate_date_received).to be_nil
-      end
-    end
-
-    context "when the date is totally missing" do
-      it "saves without the date" do
-        form = described_class.new(project.tasks_data, user)
-        form.assign_attributes("date_received(1i)": nil, "date_received(2i)": nil, "date_received(3i)": nil)
-        form.save
-
-        expect(project.tasks_data.receive_grant_payment_certificate_date_received).to be_nil
+        expect(form.errors.messages_for(:date_received)).to include("Enter a valid date, like 1 1 2025")
       end
     end
   end


### PR DESCRIPTION
We want all out date validation to work in a similar way.

This work updates the receive grant payment certificate task to use the
`GovukDateFieldParameters` before assignment.

Based on #1571 