### PR TITLE
(166101) Update confirmed transfer date task validation

### DIFF
--- a/app/forms/transfer/task/confirm_date_academy_transferred_task_form.rb
+++ b/app/forms/transfer/task/confirm_date_academy_transferred_task_form.rb
@@ -1,12 +1,10 @@
 class Transfer::Task::ConfirmDateAcademyTransferredTaskForm < BaseOptionalTaskForm
-  attribute :date_transferred, :date
-  attribute "date_transferred(1i)"
-  attribute "date_transferred(2i)"
-  attribute "date_transferred(3i)"
+  include ActiveRecord::AttributeAssignment
 
-  validate :govuk_three_field_date_format
+  attribute :date_transferred, :date
 
   def initialize(tasks_data, user)
+    @date_param_errors = ActiveModel::Errors.new(self)
     @tasks_data = tasks_data
     @user = user
     @project = tasks_data.project
@@ -15,51 +13,30 @@ class Transfer::Task::ConfirmDateAcademyTransferredTaskForm < BaseOptionalTaskFo
     self.date_transferred = @project.tasks_data.confirm_date_academy_transferred_date_transferred
   end
 
+  def assign_attributes(attributes)
+    if GovukDateFieldParameters.new(:date_transferred, attributes).invalid?
+      @date_param_errors.add(:date_transferred, I18n.t("transfer.task.confirm_date_academy_transferred.errors.invalid"))
+
+      attributes.delete("date_transferred(3i)")
+      attributes.delete("date_transferred(2i)")
+      attributes.delete("date_transferred(1i)")
+    end
+
+    super(attributes)
+  end
+
+  def valid?(context = nil)
+    super(context)
+    errors.merge!(@date_param_errors)
+    errors.empty?
+  end
+
   def save
     if valid?
       @tasks_data.assign_attributes(
-        confirm_date_academy_transferred_date_transferred: formatted_date
+        confirm_date_academy_transferred_date_transferred: date_transferred
       )
       @tasks_data.save!
     end
-  end
-
-  def formatted_date
-    return nil if month.blank? || year.blank? || day.blank?
-    Date.new(year, month, day)
-  end
-
-  private def govuk_three_field_date_format
-    return if month.blank? && year.blank? && day.blank?
-
-    Date.new(year, month, day)
-  rescue TypeError, Date::Error
-    errors.add(:date_transferred, I18n.t("transfer.task.confirm_date_academy_transferred.errors.format"))
-  end
-
-  private def day
-    day = attributes["date_transferred(3i)"]
-    return if day.blank?
-
-    day.to_i
-  end
-
-  private def month
-    month = attributes["date_transferred(2i)"]
-    return if month.blank?
-
-    month.to_i
-  end
-
-  private def year
-    year = attributes["date_transferred(1i)"]
-    return false unless ("1900".."3000").to_a.include?(year)
-    return if year.blank?
-
-    year.to_i
-  end
-
-  def completed?
-    date_transferred.present?
   end
 end

--- a/config/locales/transfer/tasks/confirm_date_academy_transferred.en.yml
+++ b/config/locales/transfer/tasks/confirm_date_academy_transferred.en.yml
@@ -11,3 +11,4 @@ en:
             html: <p>For example, 1 3 2023</p>
         errors:
           format: Please enter a valid date
+          invalid: Enter a valid date, like 1 1 2025

--- a/spec/forms/transfer/tasks/confirm_date_academy_transferred_task_form_spec.rb
+++ b/spec/forms/transfer/tasks/confirm_date_academy_transferred_task_form_spec.rb
@@ -7,74 +7,138 @@ RSpec.describe Transfer::Task::ConfirmDateAcademyTransferredTaskForm do
 
   before { mock_successful_api_response_to_create_any_project }
 
+  def valid_attributes
+    date_transferred = Date.today - 1.months
+    {
+      "date_transferred(3i)": date_transferred.day.to_s,
+      "date_transferred(2i)": date_transferred.month.to_s,
+      "date_transferred(1i)": date_transferred.year.to_s
+    }.with_indifferent_access
+  end
+
   describe "validations" do
-    describe "day" do
-      it "when the value is 3rd, it is invalid" do
-        form.assign_attributes("date_transferred(1i)": "2024", "date_transferred(2i)": "1", "date_transferred(3i)": "3rd")
+    describe "date_transferred" do
+      describe "day parameters" do
+        it "cannot be be 0" do
+          attributes = valid_attributes
+          attributes["date_transferred(3i)"] = "0"
 
-        expect(form).to be_valid
-      end
+          form.assign_attributes(attributes)
 
-      it "when the value is not in the range of 1..31, it is invalid" do
-        form.assign_attributes("date_transferred(1i)": "2024", "date_transferred(2i)": "1", "date_transferred(3i)": "40")
+          expect(form).to be_invalid
+        end
 
-        expect(form).to be_invalid
-      end
+        it "cannot be be less than 0" do
+          attributes = valid_attributes
+          attributes["date_transferred(3i)"] = "-1"
 
-      it "when the value is not a number, it is invalid" do
-        form.assign_attributes("date_transferred(1i)": "2024", "date_transferred(2i)": "1", "date_transferred(3i)": "not a number")
+          form.assign_attributes(attributes)
 
-        expect(form).to be_invalid
-      end
-    end
+          expect(form).to be_invalid
+        end
 
-    describe "month" do
-      it "when the value is not in the range of 1..12, it is invalid" do
-        form.assign_attributes("date_transferred(1i)": "2024", "date_transferred(2i)": "20", "date_transferred(3i)": "20")
+        it "cannot be greater than 31" do
+          attributes = valid_attributes
+          attributes["date_transferred(3i)"] = "32"
 
-        expect(form).to be_invalid
-      end
+          form.assign_attributes(attributes)
 
-      it "when the value is not a number, it is invalid" do
-        form.assign_attributes("date_transferred(1i)": "2024", "date_transferred(2i)": "January", "date_transferred(3i)": "20")
+          expect(form).to be_invalid
+        end
 
-        expect(form).to be_invalid
-      end
-    end
+        it "must be a number" do
+          attributes = valid_attributes
+          attributes["date_transferred(3i)"] = "twenty first"
 
-    describe "year" do
-      it "when the value is not in the range of 1900..3000, it is invalid" do
-        form.assign_attributes("date_transferred(1i)": "800", "date_transferred(2i)": "2", "date_transferred(3i)": "20")
-
-        expect(form).to be_invalid
-      end
-
-      it "when the value is not a number, it is invalid" do
-        form.assign_attributes("date_transferred(1i)": "Nineteen hundred", "date_transferred(2i)": "1", "date_transferred(3i)": "20")
-
-        expect(form).to be_invalid
-      end
-    end
-
-    describe "the transfer to a date" do
-      context "when the values form a date that is incorrect" do
-        it "is invalid" do
-          form.assign_attributes("date_transferred(1i)": "30", "date_transferred(2i)": "2", "date_transferred(3i)": "2024")
+          form.assign_attributes(attributes)
 
           expect(form).to be_invalid
         end
       end
-    end
 
-    describe "submitting nothing" do
-      it "when a user submits nothing, its valid" do
-        form.assign_attributes("date_transferred(1i)": "", "date_transferred(2i)": "", "date_transferred(3i)": "")
+      describe "month parameters" do
+        it "cannot be be 0" do
+          attributes = valid_attributes
+          attributes["date_transferred(2i)"] = "0"
 
-        expect(form).to be_valid
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be be less than 0" do
+          attributes = valid_attributes
+          attributes["date_transferred(2i)"] = "-1"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be greater than 12" do
+          attributes = valid_attributes
+          attributes["date_transferred(2i)"] = "13"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "must be a number" do
+          attributes = valid_attributes
+          attributes["date_transferred(2i)"] = "January"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
       end
 
-      it "when a user submits spaces, its valid" do
-        form.assign_attributes("date_transferred(1i)": "  ", "date_transferred(2i)": "  ", "date_transferred(3i)": "   ")
+      describe "year parameters" do
+        it "must be a four digit year" do
+          attributes = valid_attributes
+          attributes["date_transferred(1i)"] = "24"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be be less than 2000" do
+          attributes = valid_attributes
+          attributes["date_transferred(1i)"] = "1999"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be greater than 3000" do
+          attributes = valid_attributes
+          attributes["date_transferred(1i)"] = "3001"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "must be a number" do
+          attributes = valid_attributes
+          attributes["date_transferred(1i)"] = "Twenty twenty four"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+      end
+
+      it "can be empty" do
+        attributes = valid_attributes
+        attributes["date_transferred(3i)"] = ""
+        attributes["date_transferred(2i)"] = ""
+        attributes["date_transferred(1i)"] = ""
+
+        form.assign_attributes(attributes)
 
         expect(form).to be_valid
       end
@@ -84,8 +148,12 @@ RSpec.describe Transfer::Task::ConfirmDateAcademyTransferredTaskForm do
   describe "#save" do
     context "when the form is valid" do
       it "saves the task" do
-        form.assign_attributes("date_transferred(1i)": "2024", "date_transferred(2i)": "1", "date_transferred(3i)": "1")
+        attributes = valid_attributes
+        attributes["date_transferred(3i)"] = "1"
+        attributes["date_transferred(2i)"] = "1"
+        attributes["date_transferred(1i)"] = "2024"
 
+        form.assign_attributes(attributes)
         form.save
 
         expect(project.tasks_data.reload.confirm_date_academy_transferred_date_transferred).to eq(Date.new(2024, 1, 1))
@@ -93,13 +161,17 @@ RSpec.describe Transfer::Task::ConfirmDateAcademyTransferredTaskForm do
     end
 
     context "when the form is invalid" do
-      it "shows the error" do
-        form.assign_attributes("date_transferred(1i)": "2024", "date_transferred(2i)": "January", "date_transferred(3i)": "4")
+      it "shows a helpful message" do
+        attributes = valid_attributes
+        attributes["date_transferred(3i)"] = "1"
+        attributes["date_transferred(2i)"] = "January"
+        attributes["date_transferred(1i)"] = "2024"
 
+        form.assign_attributes(attributes)
         form.save
 
         expect(form.errors.messages[:date_transferred])
-          .to include(I18n.t("transfer.task.confirm_date_academy_transferred.errors.format"))
+          .to include("Enter a valid date, like 1 1 2025")
       end
     end
   end


### PR DESCRIPTION
We want to take the same approach to all our date validation, using the
`GovukDateFieldParameters` class before assignment takes place.

Based on #1571 