### PR TITLE
(166102) Update declaration of expenditure date validation

### DIFF
--- a/app/forms/transfer/task/declaration_of_expenditure_certificate_task_form.rb
+++ b/app/forms/transfer/task/declaration_of_expenditure_certificate_task_form.rb
@@ -1,14 +1,12 @@
 class Transfer::Task::DeclarationOfExpenditureCertificateTaskForm < BaseOptionalTaskForm
+  include ActiveRecord::AttributeAssignment
+
   attribute :date_received, :date
   attribute :correct, :boolean
   attribute :saved, :boolean
-  attribute "date_received(1i)"
-  attribute "date_received(2i)"
-  attribute "date_received(3i)"
-
-  validate :govuk_three_field_date_format
 
   def initialize(tasks_data, user)
+    @date_param_errors = ActiveModel::Errors.new(self)
     @tasks_data = tasks_data
     @user = user
     @project = tasks_data.project
@@ -17,54 +15,36 @@ class Transfer::Task::DeclarationOfExpenditureCertificateTaskForm < BaseOptional
     self.date_received = @project.tasks_data.declaration_of_expenditure_certificate_date_received
   end
 
+  def assign_attributes(attributes)
+    if GovukDateFieldParameters.new(:date_received, attributes).invalid?
+      @date_param_errors.add(
+        :date_received,
+        I18n.t("transfer.task.declaration_of_expenditure_certificate.date_received.errors.invalid")
+      )
+
+      attributes.delete("date_received(3i)")
+      attributes.delete("date_received(2i)")
+      attributes.delete("date_received(1i)")
+    end
+
+    super(attributes)
+  end
+
+  def valid?(context = nil)
+    super(context)
+    errors.merge!(@date_param_errors)
+    errors.empty?
+  end
+
   def save
     if valid?
       @tasks_data.assign_attributes(
-        declaration_of_expenditure_certificate_date_received: formatted_date,
+        declaration_of_expenditure_certificate_date_received: date_received,
         declaration_of_expenditure_certificate_not_applicable: not_applicable,
         declaration_of_expenditure_certificate_correct: correct,
         declaration_of_expenditure_certificate_saved: saved
       )
       @tasks_data.save!
     end
-  end
-
-  def formatted_date
-    return nil if month.blank? || year.blank? || day.blank?
-    Date.new(year, month, day)
-  end
-
-  private def govuk_three_field_date_format
-    return if month.blank? && year.blank? && day.blank?
-
-    Date.new(year, month, day)
-  rescue TypeError, Date::Error
-    errors.add(:date_received, I18n.t("transfer.task.confirm_date_academy_transferred.errors.format"))
-  end
-
-  private def day
-    day = attributes["date_received(3i)"]
-    return if day.blank?
-
-    day.to_i
-  end
-
-  private def month
-    month = attributes["date_received(2i)"]
-    return if month.blank?
-
-    month.to_i
-  end
-
-  private def year
-    year = attributes["date_received(1i)"]
-    return false unless ("1900".."3000").to_a.include?(year)
-    return if year.blank?
-
-    year.to_i
-  end
-
-  def completed?
-    date_received.present? && correct.present? && saved.present?
   end
 end

--- a/config/locales/transfer/tasks/declaration_of_expenditure_certificate.en.yml
+++ b/config/locales/transfer/tasks/declaration_of_expenditure_certificate.en.yml
@@ -19,6 +19,8 @@ en:
           title: Enter the date you received the declaration of expenditure certificate
           hint:
             html: For example 27 5 2007
+          errors:
+            invalid: Enter a valid date, like 1 1 2025
         correct:
           title: Check the declaration of expenditure certificate is correct
           hint:

--- a/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
+++ b/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
@@ -222,42 +222,6 @@ RSpec.feature "Users can complete transfer tasks" do
     end
 
     describe "the declaration of expenditure certificate task" do
-      scenario "can be not applicable" do
-        visit project_tasks_path(project)
-        click_on "Receive declaration of expenditure certificate"
-        click_not_applicable(page)
-        click_on I18n.t("task_list.continue_button.text")
-
-        table_row = page.find("li.app-task-list__item", text: "Receive declaration of expenditure certificate")
-
-        expect(table_row).to have_content("Not applicable")
-      end
-
-      scenario "can be in progress" do
-        visit project_tasks_path(project)
-        click_on "Receive declaration of expenditure certificate"
-        check "Check the declaration of expenditure certificate is correct"
-        click_on I18n.t("task_list.continue_button.text")
-
-        table_row = page.find("li.app-task-list__item", text: "Receive declaration of expenditure certificate")
-        expect(table_row).to have_content("In progress")
-
-        click_on "Receive declaration of expenditure certificate"
-        check "Save the declaration of expenditure certificate in the academy's SharePoint folder"
-        click_on I18n.t("task_list.continue_button.text")
-
-        table_row = page.find("li.app-task-list__item", text: "Receive declaration of expenditure certificate")
-        expect(table_row).to have_content("In progress")
-
-        click_on "Receive declaration of expenditure certificate"
-        fill_in "Day", with: "1"
-        fill_in "Month", with: "1"
-        fill_in "Year", with: "2024"
-        click_on I18n.t("task_list.continue_button.text")
-
-        table_row = page.find("li.app-task-list__item", text: "Receive declaration of expenditure certificate")
-        expect(table_row).to have_content("Complete")
-      end
       scenario "can be completed" do
         visit project_tasks_path(project)
         click_on "Receive declaration of expenditure certificate"
@@ -270,28 +234,6 @@ RSpec.feature "Users can complete transfer tasks" do
 
         table_row = page.find("li.app-task-list__item", text: "Receive declaration of expenditure certificate")
         expect(table_row).to have_content("Complete")
-      end
-
-      scenario "records the date" do
-        visit project_tasks_path(project)
-        click_on "Receive declaration of expenditure certificate"
-        fill_in "Day", with: "1"
-        fill_in "Month", with: "1"
-        fill_in "Year", with: "2024"
-        click_on I18n.t("task_list.continue_button.text")
-
-        expect(project.reload.tasks_data.declaration_of_expenditure_certificate_date_received).to eql(Date.new(2024, 1, 1))
-      end
-
-      scenario "shows an error when the date is not valid" do
-        visit project_tasks_path(project)
-        click_on "Receive declaration of expenditure certificate"
-        fill_in "Day", with: "1"
-        fill_in "Month", with: "24"
-        fill_in "Year", with: "2024"
-        click_on I18n.t("task_list.continue_button.text")
-
-        expect(page).to have_content("Please enter a valid date")
       end
     end
   end

--- a/spec/forms/transfer/tasks/declaration_of_expenditure_certificate_task_form_spec.rb
+++ b/spec/forms/transfer/tasks/declaration_of_expenditure_certificate_task_form_spec.rb
@@ -1,0 +1,229 @@
+require "rails_helper"
+
+RSpec.describe Transfer::Task::DeclarationOfExpenditureCertificateTaskForm do
+  let(:user) { create(:user) }
+  let(:project) { create(:transfer_project) }
+  let(:form) { described_class.new(project.tasks_data, user) }
+
+  before { mock_successful_api_response_to_create_any_project }
+
+  def valid_attributes
+    date_received = Date.today - 1.months
+    {
+      "date_received(3i)": date_received.day.to_s,
+      "date_received(2i)": date_received.month.to_s,
+      "date_received(1i)": date_received.year.to_s,
+      correct: "true",
+      saved: "true"
+    }.with_indifferent_access
+  end
+
+  describe "validations" do
+    describe "date_received" do
+      it "must be a valid date" do
+        attributes = valid_attributes
+        attributes["date_received(3i)"] = "31"
+        attributes["date_received(2i)"] = "9"
+
+        form.assign_attributes(attributes)
+
+        expect(form).to be_invalid
+      end
+
+      describe "day parameters" do
+        it "cannot be be 0" do
+          attributes = valid_attributes
+          attributes["date_received(3i)"] = "0"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be be less than 0" do
+          attributes = valid_attributes
+          attributes["date_received(3i)"] = "-1"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be greater than 31" do
+          attributes = valid_attributes
+          attributes["date_received(3i)"] = "32"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "must be a number" do
+          attributes = valid_attributes
+          attributes["date_received(3i)"] = "twenty first"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+      end
+
+      describe "month parameters" do
+        it "cannot be be 0" do
+          attributes = valid_attributes
+          attributes["date_received(2i)"] = "0"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be be less than 0" do
+          attributes = valid_attributes
+          attributes["date_received(2i)"] = "-1"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be greater than 12" do
+          attributes = valid_attributes
+          attributes["date_received(2i)"] = "13"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "must be a number" do
+          attributes = valid_attributes
+          attributes["date_received(2i)"] = "January"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+      end
+
+      describe "year parameters" do
+        it "must be a four digit year" do
+          attributes = valid_attributes
+          attributes["date_received(1i)"] = "24"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be be less than 2000" do
+          attributes = valid_attributes
+          attributes["date_received(1i)"] = "1999"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "cannot be greater than 3000" do
+          attributes = valid_attributes
+          attributes["date_received(1i)"] = "3001"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+
+        it "must be a number" do
+          attributes = valid_attributes
+          attributes["date_received(1i)"] = "Twenty twenty four"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid
+        end
+      end
+
+      it "can be empty" do
+        attributes = valid_attributes
+        attributes["date_received(3i)"] = ""
+        attributes["date_received(2i)"] = ""
+        attributes["date_received(1i)"] = ""
+
+        form.assign_attributes(attributes)
+
+        expect(form).to be_valid
+      end
+    end
+  end
+
+  describe "not applicable" do
+    it "can be no applicable" do
+      attributes = valid_attributes
+      attributes["not_applicable"] = "true"
+
+      form.assign_attributes(attributes)
+      form.save
+
+      expect(project.tasks_data.reload.declaration_of_expenditure_certificate_not_applicable).to be true
+    end
+  end
+
+  describe "status" do
+    it "can be not started" do
+      expect(form.status).to eql(:not_started)
+    end
+
+    it "can be in progress" do
+      attributes = valid_attributes
+      attributes["correct"] = "false"
+
+      form.assign_attributes(attributes)
+      form.save
+
+      expect(form.status).to eql(:in_progress)
+    end
+
+    it "can be completed" do
+      attributes = valid_attributes
+
+      form.assign_attributes(attributes)
+      form.save
+
+      expect(form.status).to eql(:completed)
+    end
+  end
+
+  describe "#save" do
+    context "when the form is valid" do
+      it "saves the task" do
+        attributes = valid_attributes
+        attributes["date_received(3i)"] = "1"
+        attributes["date_received(2i)"] = "1"
+        attributes["date_received(1i)"] = "2024"
+
+        form.assign_attributes(attributes)
+        form.valid?
+        form.save
+
+        expect(project.tasks_data.reload.declaration_of_expenditure_certificate_date_received).to eq(Date.new(2024, 1, 1))
+      end
+    end
+
+    context "when the form is invalid" do
+      it "shows a helpful error" do
+        attributes = valid_attributes
+        attributes["date_received(3i)"] = "1"
+        attributes["date_received(2i)"] = "Jan"
+        attributes["date_received(1i)"] = "2024"
+
+        form.assign_attributes(attributes)
+        form.valid?
+        form.save
+
+        expect(form.errors.messages_for(:date_received))
+          .to include("Enter a valid date, like 1 1 2025")
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want all our date validations to work the same way, using the
`GovukDateFieldParameters` class before assignment.

This work updates the transfer project declaration of expenditure task.

We've moved some feature specs into the form spec as they run faster
there.

Based on #1571
