### PR TITLE
App includes Swagger UI for the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add simple authentication to the Api endpoints using an Api key
 - Add a task to generate Api keys, along with documentation
 - A simple POST Api endpoint to create a Conversion project
+- API documentation is now available at /api/docs
 
 ### Fixed
 

--- a/Gemfile
+++ b/Gemfile
@@ -107,3 +107,5 @@ group :development do
 end
 
 gem "jsbundling-rails", "~> 1.3"
+
+gem "grape-swagger", "~> 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,9 @@ GEM
       mustermann-grape (~> 1.0.0)
       rack (>= 1.3.0)
       rack-accept
+    grape-swagger (2.1.0)
+      grape (>= 1.7, < 3.0)
+      rack-test (~> 2)
     hashdiff (1.0.1)
     hashie (5.0.0)
     high_voltage (3.1.2)
@@ -494,6 +497,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder (~> 4.1, >= 4.1.1)
   govuk_markdown
   grape (~> 2.0)
+  grape-swagger (~> 2.1)
   high_voltage
   jsbundling-rails (~> 1.3)
   launchy (~> 3.0)

--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -9,5 +9,6 @@ class Api < Grape::API
     info: {
       title: "Complete conversions, transfers and changes API"
     },
-    mount_path: "/swagger"
+    mount_path: "/swagger",
+    version: "0.0.1" # the semversion of the API
 end

--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -4,4 +4,10 @@ class Api < Grape::API
   prefix "api"
   format :json
   mount V1::Api
+
+  add_swagger_documentation \
+    info: {
+      title: "Complete conversions, transfers and changes API"
+    },
+    mount_path: "/swagger"
 end

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -12,5 +12,10 @@
 //= link "@ministryofjustice/frontend/moj/assets/images/moj-logotype-crest.png"
 //= link dfefrontend.js
 //= link accessible-autocomplete/dist/accessible-autocomplete.min.js
+//= link swagger-ui-dist/swagger-ui-bundle.js
+//= link swagger-ui-dist/swagger-ui-standalone-preset.js
+//= link swagger-ui-dist/swagger-ui.css
+//= link swagger-ui-dist/index.css
+//= link swagger-initializer.js
 
 //= link_tree ../builds

--- a/app/controllers/swagger_controller.rb
+++ b/app/controllers/swagger_controller.rb
@@ -1,0 +1,15 @@
+class SwaggerController < ApplicationController
+  skip_before_action :redirect_unauthenticated_user
+
+  layout "swagger"
+
+  # Allow unsafe inline styles is the only way to get Swagger UI to work
+  # we only do so for this controller
+  content_security_policy do |policy|
+    policy.style_src_elem :self, :unsafe_inline
+  end
+
+  def show
+    # Action renders the show template only
+  end
+end

--- a/app/javascript/swagger-initializer.js
+++ b/app/javascript/swagger-initializer.js
@@ -1,0 +1,17 @@
+/* eslint-disable no-undef */
+window.onload = function () {
+  window.ui = SwaggerUIBundle({
+    url: 'http://localhost:3000/api/swagger.json',
+    dom_id: '#swagger-ui',
+    deepLinking: true,
+    presets: [
+      SwaggerUIBundle.presets.apis,
+      SwaggerUIStandalonePreset
+    ],
+    plugins: [
+      SwaggerUIBundle.plugins.DownloadUrl
+    ],
+    layout: 'StandaloneLayout'
+  })
+}
+/* eslint-enable no-undef */

--- a/app/views/layouts/swagger.html.erb
+++ b/app/views/layouts/swagger.html.erb
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Swagger UI - <%= t("service_name") %></title>
+
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= stylesheet_link_tag "swagger-ui.css" %>
+    <%= stylesheet_link_tag "index.css" %>
+
+    <%= javascript_include_tag "swagger-ui-bundle.js" %>
+    <%= javascript_include_tag "swagger-ui-standalone-preset.js" %>
+    <%= javascript_include_tag "swagger-initializer.js" %>
+  </head>
+
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/swagger/show.html.erb
+++ b/app/views/swagger/show.html.erb
@@ -1,0 +1,1 @@
+<div id="swagger-ui"></div>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,6 +9,7 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 Rails.application.config.assets.paths << Rails.root.join("node_modules", "govuk-frontend", "govuk", "assets", "fonts")
 Rails.application.config.assets.paths << Rails.root.join("node_modules", "govuk-frontend", "govuk", "assets", "images")
 Rails.application.config.assets.paths << Rails.root.join("node_modules", "@ministryofjustice", "frontend", "moj", "assets", "images")
+Rails.application.config.assets.paths << Rails.root.join("node_modules", "swagger-ui-dist")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -20,6 +20,6 @@ Rails.application.configure do
   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
   config.content_security_policy_nonce_directives = %w[script-src]
 
-  #   # Report violations without enforcing the policy.
-  #   # config.content_security_policy_report_only = true
+  # Report violations without enforcing the policy.
+  # config.content_security_policy_report_only = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   mount Api => "/"
 
+  # Swagger UI
+  get "api/docs", to: "swagger#show"
+
   concern :has_destroy_confirmation do
     get "/delete", action: :confirm_destroy
   end

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --target=chrome61,edge79,firefox60,safari11 --outdir=app/assets/builds --public-path=/assets"
   },
   "devDependencies": {
+    "esbuild": "^0.21.0",
     "prettier": "^3.0.2",
-    "standard": "^17.1.0",
-    "esbuild": "^0.21.0"
+    "standard": "^17.1.0"
   },
   "dependencies": {
     "@ministryofjustice/frontend": "^1.8.0",
+    "accessible-autocomplete": "^3.0.0",
     "govuk-frontend": "^4.7.0",
-    "accessible-autocomplete": "^3.0.0"
+    "swagger-ui-dist": "^5.17.9"
   }
 }

--- a/spec/requests/swagger_controller_spec.rb
+++ b/spec/requests/swagger_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "swagger controller" do
+  describe "#show" do
+    it "is public" do
+      get "/api/docs"
+
+      expect(response).to have_http_status :success
+    end
+
+    it "renders the show template" do
+      get "/api/docs"
+
+      expect(response).to render_template :show
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1918,6 +1918,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+swagger-ui-dist@^5.17.9:
+  version "5.17.9"
+  resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-5.17.9.tgz#4550c54f27ae61951199b5c890db4f6ff7e27242"
+  integrity sha512-qhZdoXIleblFxufohnd4ir4KmVA7/uFfd/9sDTtH8A6Qm1lEK40MhrMrDqy9AygGjw1bnJpZH4yZ5wu12vW1aw==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"


### PR DESCRIPTION
 This work adds the Swagger UI to the application on a public path and renders the Swagger docs that get generated by our API code.

The UI is at `/api/docs` and relies heavily on JavaScript, but out regular users are not the audiance for this information.

Our API is still in very early development and having the docs generated will help us build it out as well as provide low effort, long term documentation.

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/e529bf73-6a2d-48c4-920b-1157ab0ec880)
