### PR TITLE
Correct asset paths for Swagger UI

### DIFF
--- a/app/views/layouts/swagger.html.erb
+++ b/app/views/layouts/swagger.html.erb
@@ -7,11 +7,11 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag "swagger-ui.css" %>
-    <%= stylesheet_link_tag "index.css" %>
+    <%= stylesheet_link_tag "swagger-ui-dist/swagger-ui.css" %>
+    <%= stylesheet_link_tag "swagger-ui-dist/index.css" %>
 
-    <%= javascript_include_tag "swagger-ui-bundle.js" %>
-    <%= javascript_include_tag "swagger-ui-standalone-preset.js" %>
+    <%= javascript_include_tag "swagger-ui-dist/swagger-ui-bundle.js" %>
+    <%= javascript_include_tag "swagger-ui-dist/swagger-ui-standalone-preset.js" %>
     <%= javascript_include_tag "swagger-initializer.js" %>
   </head>
 


### PR DESCRIPTION
We need to prefix these paths for them to work in production where they
are pre-compiled into the directory `swagger-ui-dist`.