### PR TITLE
Use validation on URN and UKPRN in the API project creation service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - API documentation is now available at /api/docs
 - Validation on the new Academy URN so that it cannot be the same as the school
   URN has been added.
+- The API does validation of URN and UKPRN on project creation
 
 ### Fixed
 

--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -1,36 +1,58 @@
 class Api::Conversions::CreateProjectService
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
   class ProjectCreationError < StandardError; end
 
+  attribute :urn
+  attribute :incoming_trust_ukprn
+  attribute :advisory_board_date
+  attribute :advisory_board_conditions
+  attribute :provisional_conversion_date
+  attribute :directive_academy_order
+  attribute :created_by_email
+  attribute :created_by_first_name
+  attribute :created_by_last_name
+
+  validates :urn, presence: true, urn: true
+  validates :incoming_trust_ukprn, presence: true, ukprn: true
+
   def initialize(project_params)
-    @project_params = project_params
+    super(project_params)
   end
 
   def call
     user = find_or_create_user
-    project = Conversion::Project.new(
-      urn: @project_params[:urn],
-      incoming_trust_ukprn: @project_params[:incoming_trust_ukprn],
-      conversion_date: @project_params[:provisional_conversion_date],
-      advisory_board_date: @project_params[:advisory_board_date],
-      advisory_board_conditions: @project_params[:advisory_board_conditions],
-      directive_academy_order: @project_params[:directive_academy_order],
-      regional_delivery_officer_id: user.id
-    )
 
-    if project.save(validate: false)
-      project
+    if valid?
+      project = Conversion::Project.new(
+        urn: urn,
+        incoming_trust_ukprn: incoming_trust_ukprn,
+        conversion_date: provisional_conversion_date,
+        advisory_board_date: advisory_board_date,
+        advisory_board_conditions: advisory_board_conditions,
+        directive_academy_order: directive_academy_order,
+        regional_delivery_officer_id: user.id
+      )
+
+      if project.save(validate: false)
+        project
+      else
+        raise ProjectCreationError.new("Project could not be created via API, urn: #{urn}")
+      end
     else
-      raise ProjectCreationError.new("Project could not be created via API, urn: #{@project_params[:urn]}")
+      raise ProjectCreationError.new(errors.full_messages.join(" "))
     end
   end
 
   private def find_or_create_user
-    user = User.find_or_create_by(email: @project_params[:created_by_email])
+    user = User.find_or_create_by(email: created_by_email)
     unless user.persisted?
-      user.update!(first_name: @project_params[:created_by_first_name], last_name: @project_params[:created_by_last_name], team: :regional_casework_services)
+      user.update!(first_name: created_by_first_name, last_name: created_by_last_name, team: :regional_casework_services)
     end
     user
   rescue ActiveRecord::RecordInvalid
-    raise ProjectCreationError.new("Failed to save user during API project creation, email: #{@project_params[:created_by_email]}")
+    raise ProjectCreationError.new("Failed to save user during API project creation, urn: #{urn}")
   end
 end

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe V1::Conversions do
             post "/api/v1/projects/conversions",
               params: {
                 conversion_project: {
-                  urn: 12345,
+                  urn: 123456,
                   incoming_trust_ukprn: 10066123,
                   advisory_board_date: "2024-1-1",
                   advisory_board_conditions: "Some conditions",
@@ -65,7 +65,7 @@ RSpec.describe V1::Conversions do
               as: :json,
               headers: {Apikey: "testkey"}
 
-            expect(response.body).to eq({error: "Project could not be created via API, urn: 12345"}.to_json)
+            expect(response.body).to eq({error: "Project could not be created via API, urn: 123456"}.to_json)
           end
         end
 
@@ -88,7 +88,30 @@ RSpec.describe V1::Conversions do
               as: :json,
               headers: {Apikey: "testkey"}
 
-            expect(response.body).to eq({error: "Failed to save user during API project creation, email: nobody@school.gov.uk"}.to_json)
+            expect(response.body).to eq({error: "Failed to save user during API project creation, urn: 121813"}.to_json)
+          end
+        end
+
+        context "but the URN or UKPRN parameters are not valid" do
+          it "creates a new project" do
+            post "/api/v1/projects/conversions",
+              params: {
+                conversion_project: {
+                  urn: 123,
+                  incoming_trust_ukprn: 123,
+                  advisory_board_date: "2024-1-1",
+                  advisory_board_conditions: "Some conditions",
+                  provisional_conversion_date: "2025-1-1",
+                  directive_academy_order: true,
+                  created_by_email: regional_delivery_officer.email,
+                  created_by_first_name: regional_delivery_officer.first_name,
+                  created_by_last_name: regional_delivery_officer.last_name
+                }
+              },
+              as: :json,
+              headers: {Apikey: "testkey"}
+
+            expect(response.body).to eq({error: "Urn URN must be 6 digits long. For example, 123456. Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678."}.to_json)
           end
         end
       end


### PR DESCRIPTION

## Changes

We use these validators to validate URN and UKPRN in the Create project form and Project model. Use them in the service object that creates projects via the API as well.

We also had to correct the URN in one of the API tests, as the original URN in that test (12345) was invalid. That test was not demonstrating param validation failure, so correct it to get the right test case!

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
