### PR TITLE
When creating the project via the API, also create an empty TasksData

### DIFF
--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -26,6 +26,8 @@ class Api::Conversions::CreateProjectService
     user = find_or_create_user
 
     if valid?
+      tasks_data = Conversion::TasksData.new
+
       project = Conversion::Project.new(
         urn: urn,
         incoming_trust_ukprn: incoming_trust_ukprn,
@@ -33,7 +35,8 @@ class Api::Conversions::CreateProjectService
         advisory_board_date: advisory_board_date,
         advisory_board_conditions: advisory_board_conditions,
         directive_academy_order: directive_academy_order,
-        regional_delivery_officer_id: user.id
+        regional_delivery_officer_id: user.id,
+        tasks_data: tasks_data
       )
 
       if project.save(validate: false)

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe Api::Conversions::CreateProjectService do
       expect(result).to be_a(Conversion::Project)
       expect(result.id).to eq(Conversion::Project.last.id)
     end
+
+    it "creates a TasksData and assigns it to the project" do
+      result = described_class.new(params).call
+      tasks_data = Conversion::TasksData.last
+
+      expect(result).to be_a(Conversion::Project)
+      expect(result.tasks_data).to eq(tasks_data)
+    end
   end
 
   context "when the params contain details for an unknown user" do


### PR DESCRIPTION
## Changes

When we create projects, we also create their TasksData. We need to do this when creating projects via the API, as there is no other way to create a TasksData object (not even if we manually edit the project).

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
