### PR TITLE
API: Consume Prepare ID, return Complete ID

### DIFF
--- a/app/api/v1/conversions.rb
+++ b/app/api/v1/conversions.rb
@@ -13,6 +13,7 @@ class V1::Conversions < Grape::API
       requires :created_by_email, type: String
       requires :created_by_first_name, type: String
       requires :created_by_last_name, type: String
+      requires :prepare_id, type: Integer
     end
 
     resource :conversions do

--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -16,11 +16,13 @@ class Api::Conversions::CreateProjectService
   attribute :created_by_last_name
   attribute :new_trust_reference_number
   attribute :new_trust_name
+  attribute :prepare_id
 
   validates :urn, presence: true, urn: true
   validates :incoming_trust_ukprn, ukprn: true, if: -> { incoming_trust_ukprn.present? }
   validates :new_trust_reference_number, trust_reference_number: true, if: -> { new_trust_reference_number.present? }
   validates :new_trust_name, presence: true, if: -> { new_trust_reference_number.present? }
+  validates :prepare_id, presence: true
 
   def initialize(project_params)
     super(project_params)
@@ -43,7 +45,8 @@ class Api::Conversions::CreateProjectService
         directive_academy_order: directive_academy_order,
         regional_delivery_officer_id: user.id,
         tasks_data: tasks_data,
-        region: establishment.region_code
+        region: establishment.region_code,
+        prepare_id: prepare_id
       )
 
       if project.save(validate: false)

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -470,3 +470,5 @@ en:
       new_trust_name:
         blank: Enter a Trust name
         not_matching: A trust with this TRN already exists. It is called %{trust_name}. Check the trust name you have entered for this conversion/transfer
+      prepare_id:
+        blank: You must supply a Prepare ID when creating a project via the API

--- a/db/migrate/20240517100215_add_prepare_id_to_projects.rb
+++ b/db/migrate/20240517100215_add_prepare_id_to_projects.rb
@@ -1,0 +1,5 @@
+class AddPrepareIdToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :prepare_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_09_104059) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_17_100215) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -288,6 +288,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_09_104059) do
     t.string "new_trust_name"
     t.uuid "chair_of_governors_contact_id"
     t.integer "state", default: 0, null: false
+    t.integer "prepare_id"
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["incoming_trust_ukprn"], name: "index_projects_on_incoming_trust_ukprn"

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -92,7 +92,8 @@ RSpec.describe V1::Conversions do
                 directive_academy_order: true,
                 created_by_email: regional_delivery_officer.email,
                 created_by_first_name: regional_delivery_officer.first_name,
-                created_by_last_name: regional_delivery_officer.last_name
+                created_by_last_name: regional_delivery_officer.last_name,
+                prepare_id: 12345
               },
               as: :json,
               headers: {Apikey: "testkey"}
@@ -119,7 +120,8 @@ RSpec.describe V1::Conversions do
                 directive_academy_order: true,
                 created_by_email: regional_delivery_officer.email,
                 created_by_first_name: regional_delivery_officer.first_name,
-                created_by_last_name: regional_delivery_officer.last_name
+                created_by_last_name: regional_delivery_officer.last_name,
+                prepare_id: 12345
               },
               as: :json,
               headers: {Apikey: "testkey"}
@@ -141,7 +143,8 @@ RSpec.describe V1::Conversions do
                 directive_academy_order: true,
                 created_by_email: "nobody@school.gov.uk",
                 created_by_first_name: "Jane",
-                created_by_last_name: "Unknown"
+                created_by_last_name: "Unknown",
+                prepare_id: 12345
               },
               as: :json,
               headers: {Apikey: "testkey"}
@@ -163,7 +166,8 @@ RSpec.describe V1::Conversions do
                 directive_academy_order: true,
                 created_by_email: regional_delivery_officer.email,
                 created_by_first_name: regional_delivery_officer.first_name,
-                created_by_last_name: regional_delivery_officer.last_name
+                created_by_last_name: regional_delivery_officer.last_name,
+                prepare_id: 12345
               },
               as: :json,
               headers: {Apikey: "testkey"}
@@ -189,7 +193,8 @@ RSpec.describe V1::Conversions do
                 directive_academy_order: true,
                 created_by_email: regional_delivery_officer.email,
                 created_by_first_name: regional_delivery_officer.first_name,
-                created_by_last_name: regional_delivery_officer.last_name
+                created_by_last_name: regional_delivery_officer.last_name,
+                prepare_id: 12345
               },
               as: :json,
               headers: {Apikey: "testkey"}
@@ -233,7 +238,8 @@ RSpec.describe V1::Conversions do
                 directive_academy_order: true,
                 created_by_email: regional_delivery_officer.email,
                 created_by_first_name: regional_delivery_officer.first_name,
-                created_by_last_name: regional_delivery_officer.last_name
+                created_by_last_name: regional_delivery_officer.last_name,
+                prepare_id: 12345
               },
               as: :json,
               headers: {Apikey: "testkey"}
@@ -257,7 +263,8 @@ RSpec.describe V1::Conversions do
                 directive_academy_order: true,
                 created_by_email: regional_delivery_officer.email,
                 created_by_first_name: regional_delivery_officer.first_name,
-                created_by_last_name: regional_delivery_officer.last_name
+                created_by_last_name: regional_delivery_officer.last_name,
+                prepare_id: 12345
               },
               as: :json,
               headers: {Apikey: "testkey"}
@@ -287,7 +294,8 @@ RSpec.describe V1::Conversions do
               directive_academy_order: true,
               created_by_email: regional_delivery_officer.email,
               created_by_first_name: regional_delivery_officer.first_name,
-              created_by_last_name: regional_delivery_officer.last_name
+              created_by_last_name: regional_delivery_officer.last_name,
+              prepare_id: 12345
             },
             as: :json,
             headers: {Apikey: "testkey"}

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_db_column(:team).of_type :string }
     it { is_expected.to have_db_column(:all_conditions_met).of_type :boolean }
     it { is_expected.to have_db_column(:state).of_type :integer }
+    it { is_expected.to have_db_column(:prepare_id).of_type :integer }
   end
 
   describe "Relationships" do

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Api::Conversions::CreateProjectService do
           directive_academy_order: true,
           created_by_email: user.email,
           created_by_first_name: user.first_name,
-          created_by_last_name: user.last_name
+          created_by_last_name: user.last_name,
+          prepare_id: 123456
         }
       }
 
@@ -42,6 +43,12 @@ RSpec.describe Api::Conversions::CreateProjectService do
 
         expect(result.region).to eq("west_midlands")
       end
+
+      it "saves the Prepare ID on the project" do
+        result = described_class.new(params).call
+
+        expect(result.prepare_id).to eq(123456)
+      end
     end
 
     context "when the params contain details for an unknown user" do
@@ -55,7 +62,8 @@ RSpec.describe Api::Conversions::CreateProjectService do
           directive_academy_order: true,
           created_by_email: "bob@education.gov.uk",
           created_by_first_name: "Bob",
-          created_by_last_name: "Governor"
+          created_by_last_name: "Governor",
+          prepare_id: 123456
         }
       }
 
@@ -87,7 +95,8 @@ RSpec.describe Api::Conversions::CreateProjectService do
           directive_academy_order: true,
           created_by_email: "bob@school.gov.uk",
           created_by_first_name: "Bob",
-          created_by_last_name: "Teacher"
+          created_by_last_name: "Teacher",
+          prepare_id: 123456
         }
       }
 
@@ -109,7 +118,8 @@ RSpec.describe Api::Conversions::CreateProjectService do
           directive_academy_order: true,
           created_by_email: "bob@education.gov.uk",
           created_by_first_name: "Bob",
-          created_by_last_name: "Teacher"
+          created_by_last_name: "Teacher",
+          prepare_id: 123456
         }
       }
 
@@ -117,6 +127,28 @@ RSpec.describe Api::Conversions::CreateProjectService do
         expect { described_class.new(params).call }
           .to raise_error(Api::Conversions::CreateProjectService::ProjectCreationError,
             "Urn URN must be 6 digits long. For example, 123456. Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678.")
+      end
+    end
+
+    context "when the Prepare ID is missing" do
+      let(:params) {
+        {
+          urn: 123456,
+          incoming_trust_ukprn: 10000001,
+          advisory_board_date: "2024-1-1",
+          advisory_board_conditions: "Some conditions",
+          provisional_conversion_date: "2025-1-1",
+          directive_academy_order: true,
+          created_by_email: "bob@education.gov.uk",
+          created_by_first_name: "Bob",
+          created_by_last_name: "Teacher"
+        }
+      }
+
+      it "returns validation errors" do
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Conversions::CreateProjectService::ProjectCreationError,
+            "Prepare You must supply a Prepare ID when creating a project via the API")
       end
     end
 
@@ -132,7 +164,8 @@ RSpec.describe Api::Conversions::CreateProjectService do
           directive_academy_order: true,
           created_by_email: user.email,
           created_by_first_name: user.first_name,
-          created_by_last_name: user.last_name
+          created_by_last_name: user.last_name,
+          prepare_id: 123456
         }
       }
 
@@ -163,7 +196,8 @@ RSpec.describe Api::Conversions::CreateProjectService do
           directive_academy_order: true,
           created_by_email: user.email,
           created_by_first_name: user.first_name,
-          created_by_last_name: user.last_name
+          created_by_last_name: user.last_name,
+          prepare_id: 123456
         }
       }
 
@@ -189,7 +223,8 @@ RSpec.describe Api::Conversions::CreateProjectService do
           directive_academy_order: true,
           created_by_email: user.email,
           created_by_first_name: user.first_name,
-          created_by_last_name: user.last_name
+          created_by_last_name: user.last_name,
+          prepare_id: 123456
         }
       }
 
@@ -219,7 +254,8 @@ RSpec.describe Api::Conversions::CreateProjectService do
           directive_academy_order: true,
           created_by_email: "bob@education.gov.uk",
           created_by_first_name: "Bob",
-          created_by_last_name: "Teacher"
+          created_by_last_name: "Teacher",
+          prepare_id: 123456
         }
       }
 


### PR DESCRIPTION
## Changes

API changes:

- We now require the Prepare project ID on project creation, and store it on the created project. The Prepare ID is an integer.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
