### PR TITLE
Set Region on project during API creation

### DIFF
--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -36,7 +36,8 @@ class Api::Conversions::CreateProjectService
         advisory_board_conditions: advisory_board_conditions,
         directive_academy_order: directive_academy_order,
         regional_delivery_officer_id: user.id,
-        tasks_data: tasks_data
+        tasks_data: tasks_data,
+        region: establishment.region_code
       )
 
       if project.save(validate: false)
@@ -57,5 +58,12 @@ class Api::Conversions::CreateProjectService
     user
   rescue ActiveRecord::RecordInvalid
     raise ProjectCreationError.new("Failed to save user during API project creation, urn: #{urn}")
+  end
+
+  private def establishment
+    result = Api::AcademiesApi::Client.new.get_establishment(urn)
+    raise ProjectCreationError.new("Failed to fetch establishment from Academies API during project creation, urn: #{urn}") if result.error.present?
+
+    result.object
   end
 end


### PR DESCRIPTION
We don't have a way of setting the region on a project except during project creation. It is set from the region of the establishment. We can fetch the establishment's region and set it during creation via the API.


## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
