### PR TITLE
(167284) Update service support policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - When creating a new project, two digit dates are no longer accepted which
   means incorrect dates cannot be submitted.
+- The 'complete project' button is no longer shown on completed projects.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   pages
 - The application fetches establishment and trust data from the new v4 Academies
   API endpoints which should improve performance.
+- Service Support users can now update project details and tasks even after the
+  project is complete.
 
 ## [Release-69][release-69]
 

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -48,15 +48,15 @@ class ProjectPolicy
   end
 
   def update?
-    return false if @record.completed?
     return true if @user.is_service_support?
+    return false if @record.completed?
 
     project_assigned_to_user?
   end
 
   def change_significant_date?
-    return false if @record.significant_date_provisional?
     return true if @user.is_service_support?
+    return false if @record.significant_date_provisional?
 
     project_assigned_to_user?
   end

--- a/app/policies/task_list_policy.rb
+++ b/app/policies/task_list_policy.rb
@@ -12,6 +12,7 @@ class TaskListPolicy
   end
 
   def update?
+    return true if @user.is_service_support?
     return false if @project.completed?
 
     @task_list.project.assigned_to == @user || @user.is_service_support?

--- a/app/views/shared/projects/_task_list.html.erb
+++ b/app/views/shared/projects/_task_list.html.erb
@@ -40,7 +40,7 @@
         </ol>
       </div>
       <div class="govuk-grid-row">
-        <%= render "projects/show/complete" if policy(@project).update? %>
+        <%= render "projects/show/complete" if @project.active? && policy(@project).update? %>
       </div>
     </div>
   </div>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -321,7 +321,11 @@ en:
             html:
               Open <span class="govuk-visually-hidden">%{school_name}</span> project
     notifications:
-      completed_html: <h3>Project completed<h3><p>This project was completed on %{date} and cannot be changed.</p>
+      completed_html:
+        <h3>Project completed<h3>
+        <p>This project was completed on %{date}.</p>
+        <p>Only Service Support team members can make changes to this project.</p>
+
       not_assigned_html: <h3>Not assigned to project</h3><p>This project is not assigned to you and cannot be changed, you can add notes or contacts if required.</p>
     region:
       london: London

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe ProjectPolicy do
       expect(subject).to permit(application_user, build(:conversion_project, assigned_to: application_user, conversion_date_provisional: false))
     end
 
+    it "grants access if the project is completed and the user is service support" do
+      expect(subject).to permit(service_support_user, build(:conversion_project, completed_at: Date.yesterday, assigned_to: application_user, conversion_date_provisional: false))
+    end
+
     it "grants access if the user is service support but assigned to a different user" do
       expect(subject).to permit(service_support_user, build(:conversion_project, assigned_to: application_user, conversion_date_provisional: false))
     end
@@ -74,6 +78,10 @@ RSpec.describe ProjectPolicy do
 
       it "grants access if the user is service support" do
         expect(subject).to permit(build(:user, :service_support), build(:conversion_project, assigned_to: application_user, conversion_date_provisional: false))
+      end
+
+      it "grants access if the project is complete and the user is service support" do
+        expect(subject).to permit(build(:user, :service_support), build(:conversion_project, completed_at: Date.yesterday, assigned_to: application_user, conversion_date_provisional: false))
       end
 
       it "denies access if the project is assigned to another user" do

--- a/spec/policies/task_list_policy_spec.rb
+++ b/spec/policies/task_list_policy_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe TaskListPolicy do
         expect(subject).to permit(application_user, task_list)
       end
 
+      it "grants access if the project is completed and the user is service support" do
+        task_list = create(:conversion_project, completed_at: Date.yesterday, assigned_to: application_user).tasks_data
+        expect(subject).to permit(service_support_user, task_list)
+      end
+
       it "grants access if the user is service support and the project is assigned to a different user" do
         task_list = create(:conversion_project, assigned_to: application_user).tasks_data
         expect(subject).to permit(service_support_user, task_list)

--- a/spec/requests/project_complete_spec.rb
+++ b/spec/requests/project_complete_spec.rb
@@ -18,7 +18,17 @@ RSpec.describe "Completing projects", type: :request do
     end
   end
 
-  describe "completing an already completed project" do
+  context "when a project is already completed" do
+    it "shows a helpful banner" do
+      project = create(:conversion_project, state: :completed, completed_at: Date.yesterday, assigned_to: user)
+
+      get project_path(project)
+
+      follow_redirect!
+
+      expect(response.body).to include "Only Service Support team members can make changes to this project."
+    end
+
     it "does not update the value of completed_at" do
       completed_date = DateTime.now
       project = create(:conversion_project, completed_at: completed_date)

--- a/spec/requests/project_complete_spec.rb
+++ b/spec/requests/project_complete_spec.rb
@@ -10,11 +10,33 @@ RSpec.describe "Completing projects", type: :request do
 
   describe "the complete project button" do
     it "is not shown on a completed project" do
-      project = create(:conversion_project, completed_at: DateTime.now)
+      project = create(:conversion_project, state: :completed, completed_at: DateTime.now)
 
       get project_path(project)
 
-      expect(response).not_to render_template "projects/show/_complete"
+      follow_redirect!
+
+      expect(response.body).not_to include project_complete_path(project)
+    end
+
+    it "is not shown for a user that is not assigned to the project" do
+      project = create(:conversion_project, completed_at: nil, assigned_to: build(:user))
+
+      get project_path(project)
+
+      follow_redirect!
+
+      expect(response.body).not_to include project_complete_path(project)
+    end
+
+    it "is shown to a user that is assigned to an active project" do
+      project = create(:conversion_project, state: :active, completed_at: nil, assigned_to: user)
+
+      get project_path(project)
+
+      follow_redirect!
+
+      expect(response.body).to include project_complete_path(project)
     end
   end
 


### PR DESCRIPTION
This work allow Service Support users to update project and task data even after the project is completed.

It also fixes an issue where the 'complete project' button was shown on complted projects.