### PR TITLE
Put the newly-created user (from API) into a regional team

### DIFF
--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -52,8 +52,9 @@ class Api::Conversions::CreateProjectService
 
   private def find_or_create_user
     user = User.find_or_create_by(email: created_by_email)
+    establishment_region = Project.regions.key(establishment.region_code)
     unless user.persisted?
-      user.update!(first_name: created_by_first_name, last_name: created_by_last_name, team: :regional_casework_services)
+      user.update!(first_name: created_by_first_name, last_name: created_by_last_name, team: establishment_region)
     end
     user
   rescue ActiveRecord::RecordInvalid

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -66,6 +66,13 @@ RSpec.describe Api::Conversions::CreateProjectService do
       expect(result.id).to eq(Conversion::Project.last.id)
       expect(result.regional_delivery_officer_id).to eq(new_user.id)
     end
+
+    it "puts the new user in the same regional team as the establishment" do
+      project = described_class.new(params).call
+      new_user = User.find_by(email: "bob@education.gov.uk")
+
+      expect(new_user.team).to eq(project.region)
+    end
   end
 
   context "when the user's email is not valid" do


### PR DESCRIPTION
When we create a new project via the API with a new (unknown to Complete) user, we were putting this new user into the Regional casework services team. This is most likely incorrect, as RCS do not use the Prepare service. Instead, make an assumption that the Prepare user is from the same region as the establishment, and put them in the same regional team.

If this is not correct, the new user can be amended by Service Support later on

