### PR TITLE
Release 70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release-70][Release-70]
+
 ### Added
 
 - Add the Grape gem and demonstrate a simple Api endpoint in the application
@@ -1888,7 +1890,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-69...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-70...HEAD
+[release-70]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-69...release-70
 [release-69]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-68...release-69
 [release-68]:


### PR DESCRIPTION
## Added

- Add the Grape gem and demonstrate a simple Api endpoint in the application
- Add simple authentication to the Api endpoints using an Api key
- Add a task to generate Api keys, along with documentation
- A simple POST Api endpoint to create a Conversion project
- API documentation is now available at /api/docs
- Validation on the new Academy URN so that it cannot be the same as the school
  URN has been added.
- The API does validation of URN and UKPRN on project creation

## Fixed

- When creating a new project, two digit dates are no longer accepted which
  means incorrect dates cannot be submitted.
- The 'complete project' button is no longer shown on completed projects.

## Changed

- URLs pointing links in content to SharePoint guidance updated to new guidance
  pages
- The application fetches establishment and trust data from the new v4 Academies
  API endpoints which should improve performance.
- Service Support users can now update project details and tasks even after the
  project is complete.

