### PR TITLE
(API) Form a MAT Conversion endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- A simple POST Api endpoint to create a Form a MAT Conversion project
+
 ## [Release-70][Release-70]
 
 ### Added

--- a/app/api/v1/conversions.rb
+++ b/app/api/v1/conversions.rb
@@ -1,4 +1,8 @@
 class V1::Conversions < Grape::API
+  before do
+    authenticate!
+  end
+
   resource :projects do
     params do
       requires :urn, type: Integer
@@ -18,8 +22,6 @@ class V1::Conversions < Grape::API
 
       desc "Create a conversion project"
       post "/" do
-        authenticate!
-
         project_params = declared(params)
 
         service = Api::Conversions::CreateProjectService.new(project_params)
@@ -38,8 +40,6 @@ class V1::Conversions < Grape::API
 
         desc "Create a form a MAT conversion project"
         post "/" do
-          authenticate!
-
           project_params = declared(params)
 
           service = Api::Conversions::CreateProjectService.new(project_params)

--- a/app/api/v1/conversions.rb
+++ b/app/api/v1/conversions.rb
@@ -29,7 +29,7 @@ class V1::Conversions < Grape::API
 
         {conversion_project_id: project.id}
       rescue Api::Conversions::CreateProjectService::ProjectCreationError => e
-        {error: e.message}
+        error!(e.message)
       end
 
       resource "form-a-mat" do
@@ -47,7 +47,7 @@ class V1::Conversions < Grape::API
 
           {conversion_project_id: project.id}
         rescue Api::Conversions::CreateProjectService::ProjectCreationError => e
-          {error: e.message}
+          error!(e.message)
         end
       end
     end

--- a/app/api/v1/conversions.rb
+++ b/app/api/v1/conversions.rb
@@ -28,6 +28,37 @@ class V1::Conversions < Grape::API
       rescue Api::Conversions::CreateProjectService::ProjectCreationError => e
         {error: e.message}
       end
+
+      resource "form-a-mat" do
+        params do
+          requires :conversion_project, type: Hash do
+            requires :urn, type: Integer
+            requires :new_trust_reference_number, type: String
+            requires :new_trust_name, type: String
+            requires :advisory_board_date, type: Date
+            requires :advisory_board_conditions, type: String
+            requires :provisional_conversion_date, type: Date
+            requires :directive_academy_order, type: Boolean
+            requires :created_by_email, type: String
+            requires :created_by_first_name, type: String
+            requires :created_by_last_name, type: String
+          end
+        end
+
+        desc "Create a form a MAT conversion project"
+        post "/" do
+          authenticate!
+
+          project_params = declared(params)[:conversion_project]
+
+          service = Api::Conversions::CreateProjectService.new(project_params)
+          project = service.call
+
+          {conversion_project: Rails.application.routes.url_helpers.project_information_path(project)}
+        rescue Api::Conversions::CreateProjectService::ProjectCreationError => e
+          {error: e.message}
+        end
+      end
     end
   end
 end

--- a/app/api/v1/conversions.rb
+++ b/app/api/v1/conversions.rb
@@ -25,7 +25,7 @@ class V1::Conversions < Grape::API
         service = Api::Conversions::CreateProjectService.new(project_params)
         project = service.call
 
-        {conversion_project: Rails.application.routes.url_helpers.project_information_path(project)}
+        {conversion_project_id: project.id}
       rescue Api::Conversions::CreateProjectService::ProjectCreationError => e
         {error: e.message}
       end
@@ -45,7 +45,7 @@ class V1::Conversions < Grape::API
           service = Api::Conversions::CreateProjectService.new(project_params)
           project = service.call
 
-          {conversion_project: Rails.application.routes.url_helpers.project_information_path(project)}
+          {conversion_project_id: project.id}
         rescue Api::Conversions::CreateProjectService::ProjectCreationError => e
           {error: e.message}
         end

--- a/app/api/v1/conversions.rb
+++ b/app/api/v1/conversions.rb
@@ -1,25 +1,26 @@
 class V1::Conversions < Grape::API
   resource :projects do
+    params do
+      requires :urn, type: Integer
+      requires :advisory_board_date, type: Date
+      requires :advisory_board_conditions, type: String
+      requires :provisional_conversion_date, type: Date
+      requires :directive_academy_order, type: Boolean
+      requires :created_by_email, type: String
+      requires :created_by_first_name, type: String
+      requires :created_by_last_name, type: String
+    end
+
     resource :conversions do
       params do
-        requires :conversion_project, type: Hash do
-          requires :urn, type: Integer
-          requires :incoming_trust_ukprn, type: Integer
-          requires :advisory_board_date, type: Date
-          requires :advisory_board_conditions, type: String
-          requires :provisional_conversion_date, type: Date
-          requires :directive_academy_order, type: Boolean
-          requires :created_by_email, type: String
-          requires :created_by_first_name, type: String
-          requires :created_by_last_name, type: String
-        end
+        requires :incoming_trust_ukprn, type: Integer
       end
 
       desc "Create a conversion project"
       post "/" do
         authenticate!
 
-        project_params = declared(params)[:conversion_project]
+        project_params = declared(params)
 
         service = Api::Conversions::CreateProjectService.new(project_params)
         project = service.call
@@ -31,25 +32,15 @@ class V1::Conversions < Grape::API
 
       resource "form-a-mat" do
         params do
-          requires :conversion_project, type: Hash do
-            requires :urn, type: Integer
-            requires :new_trust_reference_number, type: String
-            requires :new_trust_name, type: String
-            requires :advisory_board_date, type: Date
-            requires :advisory_board_conditions, type: String
-            requires :provisional_conversion_date, type: Date
-            requires :directive_academy_order, type: Boolean
-            requires :created_by_email, type: String
-            requires :created_by_first_name, type: String
-            requires :created_by_last_name, type: String
-          end
+          requires :new_trust_reference_number, type: String
+          requires :new_trust_name, type: String
         end
 
         desc "Create a form a MAT conversion project"
         post "/" do
           authenticate!
 
-          project_params = declared(params)[:conversion_project]
+          project_params = declared(params)
 
           service = Api::Conversions::CreateProjectService.new(project_params)
           project = service.call

--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -14,9 +14,13 @@ class Api::Conversions::CreateProjectService
   attribute :created_by_email
   attribute :created_by_first_name
   attribute :created_by_last_name
+  attribute :new_trust_reference_number
+  attribute :new_trust_name
 
   validates :urn, presence: true, urn: true
-  validates :incoming_trust_ukprn, presence: true, ukprn: true
+  validates :incoming_trust_ukprn, ukprn: true, if: -> { incoming_trust_ukprn.present? }
+  validates :new_trust_reference_number, trust_reference_number: true, if: -> { new_trust_reference_number.present? }
+  validates :new_trust_name, presence: true, if: -> { new_trust_reference_number.present? }
 
   def initialize(project_params)
     super(project_params)
@@ -31,6 +35,8 @@ class Api::Conversions::CreateProjectService
       project = Conversion::Project.new(
         urn: urn,
         incoming_trust_ukprn: incoming_trust_ukprn,
+        new_trust_reference_number: new_trust_reference_number,
+        new_trust_name: new_trust_name,
         conversion_date: provisional_conversion_date,
         advisory_board_date: advisory_board_date,
         advisory_board_conditions: advisory_board_conditions,

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -22,17 +22,15 @@ RSpec.describe V1::Conversions do
           it "creates a new project" do
             post "/api/v1/projects/conversions",
               params: {
-                conversion_project: {
-                  urn: 121813,
-                  incoming_trust_ukprn: 10066123,
-                  advisory_board_date: "2024-1-1",
-                  advisory_board_conditions: "Some conditions",
-                  provisional_conversion_date: "2025-1-1",
-                  directive_academy_order: true,
-                  created_by_email: regional_delivery_officer.email,
-                  created_by_first_name: regional_delivery_officer.first_name,
-                  created_by_last_name: regional_delivery_officer.last_name
-                }
+                urn: 121813,
+                incoming_trust_ukprn: 10066123,
+                advisory_board_date: "2024-1-1",
+                advisory_board_conditions: "Some conditions",
+                provisional_conversion_date: "2025-1-1",
+                directive_academy_order: true,
+                created_by_email: regional_delivery_officer.email,
+                created_by_first_name: regional_delivery_officer.first_name,
+                created_by_last_name: regional_delivery_officer.last_name
               },
               as: :json,
               headers: {Apikey: "testkey"}
@@ -50,17 +48,15 @@ RSpec.describe V1::Conversions do
           it "returns an error" do
             post "/api/v1/projects/conversions",
               params: {
-                conversion_project: {
-                  urn: 123456,
-                  incoming_trust_ukprn: 10066123,
-                  advisory_board_date: "2024-1-1",
-                  advisory_board_conditions: "Some conditions",
-                  provisional_conversion_date: "2025-1-1",
-                  directive_academy_order: true,
-                  created_by_email: regional_delivery_officer.email,
-                  created_by_first_name: regional_delivery_officer.first_name,
-                  created_by_last_name: regional_delivery_officer.last_name
-                }
+                urn: 123456,
+                incoming_trust_ukprn: 10066123,
+                advisory_board_date: "2024-1-1",
+                advisory_board_conditions: "Some conditions",
+                provisional_conversion_date: "2025-1-1",
+                directive_academy_order: true,
+                created_by_email: regional_delivery_officer.email,
+                created_by_first_name: regional_delivery_officer.first_name,
+                created_by_last_name: regional_delivery_officer.last_name
               },
               as: :json,
               headers: {Apikey: "testkey"}
@@ -73,17 +69,15 @@ RSpec.describe V1::Conversions do
           it "returns an error" do
             post "/api/v1/projects/conversions",
               params: {
-                conversion_project: {
-                  urn: 121813,
-                  incoming_trust_ukprn: 10066123,
-                  advisory_board_date: "2024-1-1",
-                  advisory_board_conditions: "Some conditions",
-                  provisional_conversion_date: "2025-1-1",
-                  directive_academy_order: true,
-                  created_by_email: "nobody@school.gov.uk",
-                  created_by_first_name: "Jane",
-                  created_by_last_name: "Unknown"
-                }
+                urn: 121813,
+                incoming_trust_ukprn: 10066123,
+                advisory_board_date: "2024-1-1",
+                advisory_board_conditions: "Some conditions",
+                provisional_conversion_date: "2025-1-1",
+                directive_academy_order: true,
+                created_by_email: "nobody@school.gov.uk",
+                created_by_first_name: "Jane",
+                created_by_last_name: "Unknown"
               },
               as: :json,
               headers: {Apikey: "testkey"}
@@ -96,17 +90,15 @@ RSpec.describe V1::Conversions do
           it "creates a new project" do
             post "/api/v1/projects/conversions",
               params: {
-                conversion_project: {
-                  urn: 123,
-                  incoming_trust_ukprn: 123,
-                  advisory_board_date: "2024-1-1",
-                  advisory_board_conditions: "Some conditions",
-                  provisional_conversion_date: "2025-1-1",
-                  directive_academy_order: true,
-                  created_by_email: regional_delivery_officer.email,
-                  created_by_first_name: regional_delivery_officer.first_name,
-                  created_by_last_name: regional_delivery_officer.last_name
-                }
+                urn: 123,
+                incoming_trust_ukprn: 123,
+                advisory_board_date: "2024-1-1",
+                advisory_board_conditions: "Some conditions",
+                provisional_conversion_date: "2025-1-1",
+                directive_academy_order: true,
+                created_by_email: regional_delivery_officer.email,
+                created_by_first_name: regional_delivery_officer.first_name,
+                created_by_last_name: regional_delivery_officer.last_name
               },
               as: :json,
               headers: {Apikey: "testkey"}
@@ -123,17 +115,15 @@ RSpec.describe V1::Conversions do
           it "returns an error" do
             post "/api/v1/projects/conversions",
               params: {
-                conversion_project: {
-                  urn: 121813,
-                  incoming_trust_ukprn: 10066123,
-                  advisory_board_date: "2024-1-1",
-                  advisory_board_conditions: "Some conditions",
-                  provisional_conversion_date: "2025-1-1",
-                  directive_academy_order: true,
-                  created_by_email: regional_delivery_officer.email,
-                  created_by_first_name: regional_delivery_officer.first_name,
-                  created_by_last_name: regional_delivery_officer.last_name
-                }
+                urn: 121813,
+                incoming_trust_ukprn: 10066123,
+                advisory_board_date: "2024-1-1",
+                advisory_board_conditions: "Some conditions",
+                provisional_conversion_date: "2025-1-1",
+                directive_academy_order: true,
+                created_by_email: regional_delivery_officer.email,
+                created_by_first_name: regional_delivery_officer.first_name,
+                created_by_last_name: regional_delivery_officer.last_name
               },
               as: :json,
               headers: {Apikey: "testkey"}
@@ -146,7 +136,7 @@ RSpec.describe V1::Conversions do
       context "when any required params are missing" do
         it "returns an error" do
           post "/api/v1/projects/conversions", headers: {Apikey: "testkey"}
-          expect(response.body).to include("conversion_project is missing")
+          expect(response.body).to include("urn is missing, advisory_board_date is missing, advisory_board_conditions is missing")
         end
       end
     end
@@ -166,18 +156,16 @@ RSpec.describe V1::Conversions do
           it "creates a new Form a MAT project" do
             post "/api/v1/projects/conversions/form-a-mat",
               params: {
-                conversion_project: {
-                  urn: 121813,
-                  new_trust_reference_number: "TR12345",
-                  new_trust_name: "The New Trust",
-                  advisory_board_date: "2024-1-1",
-                  advisory_board_conditions: "Some conditions",
-                  provisional_conversion_date: "2025-1-1",
-                  directive_academy_order: true,
-                  created_by_email: regional_delivery_officer.email,
-                  created_by_first_name: regional_delivery_officer.first_name,
-                  created_by_last_name: regional_delivery_officer.last_name
-                }
+                urn: 121813,
+                new_trust_reference_number: "TR12345",
+                new_trust_name: "The New Trust",
+                advisory_board_date: "2024-1-1",
+                advisory_board_conditions: "Some conditions",
+                provisional_conversion_date: "2025-1-1",
+                directive_academy_order: true,
+                created_by_email: regional_delivery_officer.email,
+                created_by_first_name: regional_delivery_officer.first_name,
+                created_by_last_name: regional_delivery_officer.last_name
               },
               as: :json,
               headers: {Apikey: "testkey"}
@@ -191,18 +179,16 @@ RSpec.describe V1::Conversions do
           it "returns an error" do
             post "/api/v1/projects/conversions/form-a-mat",
               params: {
-                conversion_project: {
-                  urn: 121813,
-                  new_trust_reference_number: "12345",
-                  new_trust_name: "The New Trust",
-                  advisory_board_date: "2024-1-1",
-                  advisory_board_conditions: "Some conditions",
-                  provisional_conversion_date: "2025-1-1",
-                  directive_academy_order: true,
-                  created_by_email: regional_delivery_officer.email,
-                  created_by_first_name: regional_delivery_officer.first_name,
-                  created_by_last_name: regional_delivery_officer.last_name
-                }
+                urn: 121813,
+                new_trust_reference_number: "12345",
+                new_trust_name: "The New Trust",
+                advisory_board_date: "2024-1-1",
+                advisory_board_conditions: "Some conditions",
+                provisional_conversion_date: "2025-1-1",
+                directive_academy_order: true,
+                created_by_email: regional_delivery_officer.email,
+                created_by_first_name: regional_delivery_officer.first_name,
+                created_by_last_name: regional_delivery_officer.last_name
               },
               as: :json,
               headers: {Apikey: "testkey"}
@@ -215,7 +201,7 @@ RSpec.describe V1::Conversions do
       context "when any required params are missing" do
         it "returns an error" do
           post "/api/v1/projects/conversions/form-a-mat", headers: {Apikey: "testkey"}
-          expect(response.body).to include("conversion_project is missing")
+          expect(response.body).to include("urn is missing, advisory_board_date is missing, advisory_board_conditions is missing")
         end
       end
 
@@ -223,22 +209,20 @@ RSpec.describe V1::Conversions do
         it "returns an error" do
           post "/api/v1/projects/conversions/form-a-mat",
             params: {
-              conversion_project: {
-                urn: 121813,
-                incoming_trust_ukprn: 10066123,
-                advisory_board_date: "2024-1-1",
-                advisory_board_conditions: "Some conditions",
-                provisional_conversion_date: "2025-1-1",
-                directive_academy_order: true,
-                created_by_email: regional_delivery_officer.email,
-                created_by_first_name: regional_delivery_officer.first_name,
-                created_by_last_name: regional_delivery_officer.last_name
-              }
+              urn: 121813,
+              incoming_trust_ukprn: 10066123,
+              advisory_board_date: "2024-1-1",
+              advisory_board_conditions: "Some conditions",
+              provisional_conversion_date: "2025-1-1",
+              directive_academy_order: true,
+              created_by_email: regional_delivery_officer.email,
+              created_by_first_name: regional_delivery_officer.first_name,
+              created_by_last_name: regional_delivery_officer.last_name
             },
             as: :json,
             headers: {Apikey: "testkey"}
 
-          expect(response.body).to eq({error: "conversion_project[new_trust_reference_number] is missing, conversion_project[new_trust_name] is missing"}.to_json)
+          expect(response.body).to eq({error: "new_trust_reference_number is missing, new_trust_name is missing"}.to_json)
         end
       end
     end

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -124,4 +124,96 @@ RSpec.describe V1::Conversions do
       end
     end
   end
+
+  describe "post form-a-mat/" do
+    context "when there is a valid api key in the header" do
+      before do
+        ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow)
+        mock_successful_api_response_to_create_any_project
+      end
+
+      let(:regional_delivery_officer) { create(:regional_delivery_officer_user) }
+
+      context "when all required params are present" do
+        context "and the required params are valid" do
+          it "creates a new Form a MAT project" do
+            post "/api/v1/projects/conversions/form-a-mat",
+              params: {
+                conversion_project: {
+                  urn: 121813,
+                  new_trust_reference_number: "TR12345",
+                  new_trust_name: "The New Trust",
+                  advisory_board_date: "2024-1-1",
+                  advisory_board_conditions: "Some conditions",
+                  provisional_conversion_date: "2025-1-1",
+                  directive_academy_order: true,
+                  created_by_email: regional_delivery_officer.email,
+                  created_by_first_name: regional_delivery_officer.first_name,
+                  created_by_last_name: regional_delivery_officer.last_name
+                }
+              },
+              as: :json,
+              headers: {Apikey: "testkey"}
+
+            project = Project.last
+            expect(response.body).to eq({conversion_project: "/projects/#{project.id}/information"}.to_json)
+          end
+        end
+
+        context "but the new Trust Reference Number is not valid" do
+          it "returns an error" do
+            post "/api/v1/projects/conversions/form-a-mat",
+              params: {
+                conversion_project: {
+                  urn: 121813,
+                  new_trust_reference_number: "12345",
+                  new_trust_name: "The New Trust",
+                  advisory_board_date: "2024-1-1",
+                  advisory_board_conditions: "Some conditions",
+                  provisional_conversion_date: "2025-1-1",
+                  directive_academy_order: true,
+                  created_by_email: regional_delivery_officer.email,
+                  created_by_first_name: regional_delivery_officer.first_name,
+                  created_by_last_name: regional_delivery_officer.last_name
+                }
+              },
+              as: :json,
+              headers: {Apikey: "testkey"}
+
+            expect(response.body).to eq({error: "New trust reference number The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234"}.to_json)
+          end
+        end
+      end
+
+      context "when any required params are missing" do
+        it "returns an error" do
+          post "/api/v1/projects/conversions/form-a-mat", headers: {Apikey: "testkey"}
+          expect(response.body).to include("conversion_project is missing")
+        end
+      end
+
+      context "when the 'regular' conversion parameters are posted to the Form a MAT endpoint" do
+        it "returns an error" do
+          post "/api/v1/projects/conversions/form-a-mat",
+            params: {
+              conversion_project: {
+                urn: 121813,
+                incoming_trust_ukprn: 10066123,
+                advisory_board_date: "2024-1-1",
+                advisory_board_conditions: "Some conditions",
+                provisional_conversion_date: "2025-1-1",
+                directive_academy_order: true,
+                created_by_email: regional_delivery_officer.email,
+                created_by_first_name: regional_delivery_officer.first_name,
+                created_by_last_name: regional_delivery_officer.last_name
+              }
+            },
+            as: :json,
+            headers: {Apikey: "testkey"}
+
+          expect(response.body).to eq({error: "conversion_project[new_trust_reference_number] is missing, conversion_project[new_trust_name] is missing"}.to_json)
+        end
+      end
+    end
+  end
 end

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -2,13 +2,69 @@ require "rails_helper"
 
 RSpec.describe V1::Conversions do
   describe "get /" do
-    it "returns an error" do
-      get "/api/v1/projects/conversions"
-      expect(response.body).to eq({error: "405 Not Allowed"}.to_json)
+    context "when there is no api key in the header" do
+      it "returns an Unauthorized error" do
+        get "/api/v1/projects/conversions"
+        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+      end
+    end
+
+    context "when there is an invalid api key in the header" do
+      it "returns an Unauthorized error" do
+        get "/api/v1/projects/conversions", headers: {ApiKey: "unknownkey"}
+        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+      end
+    end
+
+    context "when there is an expired api key in the header" do
+      before do
+        ApiKey.create(api_key: "testkey", expires_at: Date.yesterday)
+      end
+
+      it "returns an Unauthorized error" do
+        get "/api/v1/projects/conversions", headers: {ApiKey: "testkey"}
+        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+      end
+    end
+
+    context "when there is a valid api key in the header" do
+      before do
+        ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow)
+      end
+
+      it "returns Not Allowed" do
+        get "/api/v1/projects/conversions", headers: {Apikey: "testkey"}
+        expect(response.body).to eq({error: "405 Not Allowed"}.to_json)
+      end
     end
   end
 
   describe "post /" do
+    context "when there is no api key in the header" do
+      it "returns an error" do
+        post "/api/v1/projects/conversions"
+        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+      end
+    end
+
+    context "when there is an invalid api key in the header" do
+      it "returns an Unauthorized error" do
+        post "/api/v1/projects/conversions", headers: {ApiKey: "unknownkey"}
+        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+      end
+    end
+
+    context "when there is an expired api key in the header" do
+      before do
+        ApiKey.create(api_key: "testkey", expires_at: Date.yesterday)
+      end
+
+      it "returns an Unauthorized error" do
+        post "/api/v1/projects/conversions", headers: {ApiKey: "testkey"}
+        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+      end
+    end
+
     context "when there is a valid api key in the header" do
       before do
         ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow)

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -114,6 +114,33 @@ RSpec.describe V1::Conversions do
             expect(response.body).to eq({error: "Urn URN must be 6 digits long. For example, 123456. Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678."}.to_json)
           end
         end
+
+        context "but the Academies API is not responding" do
+          before do
+            mock_establishment_not_found(urn: 121813)
+          end
+
+          it "returns an error" do
+            post "/api/v1/projects/conversions",
+              params: {
+                conversion_project: {
+                  urn: 121813,
+                  incoming_trust_ukprn: 10066123,
+                  advisory_board_date: "2024-1-1",
+                  advisory_board_conditions: "Some conditions",
+                  provisional_conversion_date: "2025-1-1",
+                  directive_academy_order: true,
+                  created_by_email: regional_delivery_officer.email,
+                  created_by_first_name: regional_delivery_officer.first_name,
+                  created_by_last_name: regional_delivery_officer.last_name
+                }
+              },
+              as: :json,
+              headers: {Apikey: "testkey"}
+
+            expect(response.body).to eq({error: "Failed to fetch establishment from Academies API during project creation, urn: 121813"}.to_json)
+          end
+        end
       end
 
       context "when any required params are missing" do

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe V1::Conversions do
       it "returns an Unauthorized error" do
         get "/api/v1/projects/conversions"
         expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+        expect(response.status).to eq(401)
       end
     end
 
@@ -13,6 +14,7 @@ RSpec.describe V1::Conversions do
       it "returns an Unauthorized error" do
         get "/api/v1/projects/conversions", headers: {ApiKey: "unknownkey"}
         expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+        expect(response.status).to eq(401)
       end
     end
 
@@ -24,6 +26,7 @@ RSpec.describe V1::Conversions do
       it "returns an Unauthorized error" do
         get "/api/v1/projects/conversions", headers: {ApiKey: "testkey"}
         expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+        expect(response.status).to eq(401)
       end
     end
 
@@ -35,6 +38,7 @@ RSpec.describe V1::Conversions do
       it "returns Not Allowed" do
         get "/api/v1/projects/conversions", headers: {Apikey: "testkey"}
         expect(response.body).to eq({error: "405 Not Allowed"}.to_json)
+        expect(response.status).to eq(405)
       end
     end
   end
@@ -44,6 +48,7 @@ RSpec.describe V1::Conversions do
       it "returns an error" do
         post "/api/v1/projects/conversions"
         expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+        expect(response.status).to eq(401)
       end
     end
 
@@ -51,6 +56,7 @@ RSpec.describe V1::Conversions do
       it "returns an Unauthorized error" do
         post "/api/v1/projects/conversions", headers: {ApiKey: "unknownkey"}
         expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+        expect(response.status).to eq(401)
       end
     end
 
@@ -93,6 +99,7 @@ RSpec.describe V1::Conversions do
 
             project = Project.last
             expect(response.body).to eq({conversion_project_id: project.id}.to_json)
+            expect(response.status).to eq(201)
           end
         end
 
@@ -118,6 +125,7 @@ RSpec.describe V1::Conversions do
               headers: {Apikey: "testkey"}
 
             expect(response.body).to eq({error: "Project could not be created via API, urn: 123456"}.to_json)
+            expect(response.status).to eq(500)
           end
         end
 
@@ -139,6 +147,7 @@ RSpec.describe V1::Conversions do
               headers: {Apikey: "testkey"}
 
             expect(response.body).to eq({error: "Failed to save user during API project creation, urn: 121813"}.to_json)
+            expect(response.status).to eq(500)
           end
         end
 
@@ -160,6 +169,7 @@ RSpec.describe V1::Conversions do
               headers: {Apikey: "testkey"}
 
             expect(response.body).to eq({error: "Urn URN must be 6 digits long. For example, 123456. Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678."}.to_json)
+            expect(response.status).to eq(500)
           end
         end
 
@@ -185,6 +195,7 @@ RSpec.describe V1::Conversions do
               headers: {Apikey: "testkey"}
 
             expect(response.body).to eq({error: "Failed to fetch establishment from Academies API during project creation, urn: 121813"}.to_json)
+            expect(response.status).to eq(500)
           end
         end
       end
@@ -193,6 +204,7 @@ RSpec.describe V1::Conversions do
         it "returns an error" do
           post "/api/v1/projects/conversions", headers: {Apikey: "testkey"}
           expect(response.body).to include("urn is missing, advisory_board_date is missing, advisory_board_conditions is missing")
+          expect(response.status).to eq(400)
         end
       end
     end
@@ -228,6 +240,7 @@ RSpec.describe V1::Conversions do
 
             project = Project.last
             expect(response.body).to eq({conversion_project_id: project.id}.to_json)
+            expect(response.status).to eq(201)
           end
         end
 
@@ -250,6 +263,7 @@ RSpec.describe V1::Conversions do
               headers: {Apikey: "testkey"}
 
             expect(response.body).to eq({error: "New trust reference number The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234"}.to_json)
+            expect(response.status).to eq(500)
           end
         end
       end
@@ -279,6 +293,7 @@ RSpec.describe V1::Conversions do
             headers: {Apikey: "testkey"}
 
           expect(response.body).to eq({error: "new_trust_reference_number is missing, new_trust_name is missing"}.to_json)
+          expect(response.status).to eq(400)
         end
       end
     end

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe V1::Conversions do
               headers: {Apikey: "testkey"}
 
             project = Project.last
-            expect(response.body).to eq({conversion_project: "/projects/#{project.id}/information"}.to_json)
+            expect(response.body).to eq({conversion_project_id: project.id}.to_json)
           end
         end
 
@@ -171,7 +171,7 @@ RSpec.describe V1::Conversions do
               headers: {Apikey: "testkey"}
 
             project = Project.last
-            expect(response.body).to eq({conversion_project: "/projects/#{project.id}/information"}.to_json)
+            expect(response.body).to eq({conversion_project_id: project.id}.to_json)
           end
         end
 

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -5,171 +5,229 @@ RSpec.describe Api::Conversions::CreateProjectService do
     mock_successful_api_response_to_create_any_project
   end
 
-  context "when the params contain details for an existing user" do
-    let(:user) { create(:regional_casework_services_user) }
-    let(:params) {
-      {
-        urn: 123456,
-        incoming_trust_ukprn: 10066123,
-        advisory_board_date: "2024-1-1",
-        advisory_board_conditions: "Some conditions",
-        provisional_conversion_date: "2025-1-1",
-        directive_academy_order: true,
-        created_by_email: user.email,
-        created_by_first_name: user.first_name,
-        created_by_last_name: user.last_name
+  context "a 'regular' Conversion project" do
+    context "when the params contain details for an existing user" do
+      let(:user) { create(:regional_casework_services_user) }
+      let(:params) {
+        {
+          urn: 123456,
+          incoming_trust_ukprn: 10066123,
+          advisory_board_date: "2024-1-1",
+          advisory_board_conditions: "Some conditions",
+          provisional_conversion_date: "2025-1-1",
+          directive_academy_order: true,
+          created_by_email: user.email,
+          created_by_first_name: user.first_name,
+          created_by_last_name: user.last_name
+        }
       }
-    }
 
-    it "creates the project using the existing user" do
-      result = described_class.new(params).call
+      it "creates the project using the existing user" do
+        result = described_class.new(params).call
 
-      expect(result).to be_a(Conversion::Project)
-      expect(result.id).to eq(Conversion::Project.last.id)
+        expect(result).to be_a(Conversion::Project)
+        expect(result.id).to eq(Conversion::Project.last.id)
+      end
+
+      it "creates a TasksData and assigns it to the project" do
+        result = described_class.new(params).call
+        tasks_data = Conversion::TasksData.last
+
+        expect(result).to be_a(Conversion::Project)
+        expect(result.tasks_data).to eq(tasks_data)
+      end
+
+      it "sets the project region to be the same as the establishment region" do
+        result = described_class.new(params).call
+
+        expect(result.region).to eq("west_midlands")
+      end
     end
 
-    it "creates a TasksData and assigns it to the project" do
-      result = described_class.new(params).call
-      tasks_data = Conversion::TasksData.last
+    context "when the params contain details for an unknown user" do
+      let(:params) {
+        {
+          urn: 123456,
+          incoming_trust_ukprn: 10066123,
+          advisory_board_date: "2024-1-1",
+          advisory_board_conditions: "Some conditions",
+          provisional_conversion_date: "2025-1-1",
+          directive_academy_order: true,
+          created_by_email: "bob@education.gov.uk",
+          created_by_first_name: "Bob",
+          created_by_last_name: "Governor"
+        }
+      }
 
-      expect(result).to be_a(Conversion::Project)
-      expect(result.tasks_data).to eq(tasks_data)
+      it "creates the project and a new user" do
+        result = described_class.new(params).call
+        new_user = User.find_by(email: "bob@education.gov.uk")
+
+        expect(result).to be_a(Conversion::Project)
+        expect(result.id).to eq(Conversion::Project.last.id)
+        expect(result.regional_delivery_officer_id).to eq(new_user.id)
+      end
+
+      it "puts the new user in the same regional team as the establishment" do
+        project = described_class.new(params).call
+        new_user = User.find_by(email: "bob@education.gov.uk")
+
+        expect(new_user.team).to eq(project.region)
+      end
     end
 
-    it "sets the project region to be the same as the establishment region" do
-      result = described_class.new(params).call
+    context "when the user's email is not valid" do
+      let(:params) {
+        {
+          urn: 123456,
+          incoming_trust_ukprn: 10066123,
+          advisory_board_date: "2024-1-1",
+          advisory_board_conditions: "Some conditions",
+          provisional_conversion_date: "2025-1-1",
+          directive_academy_order: true,
+          created_by_email: "bob@school.gov.uk",
+          created_by_first_name: "Bob",
+          created_by_last_name: "Teacher"
+        }
+      }
 
-      expect(result.region).to eq("west_midlands")
+      it "returns an error" do
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Conversions::CreateProjectService::ProjectCreationError,
+            "Failed to save user during API project creation, urn: 123456")
+      end
+    end
+
+    context "when the URN or UKPRN are not valid" do
+      let(:params) {
+        {
+          urn: 123,
+          incoming_trust_ukprn: 100,
+          advisory_board_date: "2024-1-1",
+          advisory_board_conditions: "Some conditions",
+          provisional_conversion_date: "2025-1-1",
+          directive_academy_order: true,
+          created_by_email: "bob@education.gov.uk",
+          created_by_first_name: "Bob",
+          created_by_last_name: "Teacher"
+        }
+      }
+
+      it "returns validation errors" do
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Conversions::CreateProjectService::ProjectCreationError,
+            "Urn URN must be 6 digits long. For example, 123456. Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678.")
+      end
+    end
+
+    context "when the Academies API returns an error on fetching the establishment" do
+      let(:user) { create(:regional_casework_services_user) }
+      let(:params) {
+        {
+          urn: 123456,
+          incoming_trust_ukprn: 10066123,
+          advisory_board_date: "2024-1-1",
+          advisory_board_conditions: "Some conditions",
+          provisional_conversion_date: "2025-1-1",
+          directive_academy_order: true,
+          created_by_email: user.email,
+          created_by_first_name: user.first_name,
+          created_by_last_name: user.last_name
+        }
+      }
+
+      before do
+        mock_establishment_not_found(urn: 123456)
+      end
+
+      it "returns an error" do
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Conversions::CreateProjectService::ProjectCreationError,
+            "Failed to fetch establishment from Academies API during project creation, urn: 123456")
+      end
+    end
+
+    context "when the project save fails for an unknown reason" do
+      before do
+        allow_any_instance_of(Conversion::Project).to receive(:save).and_return(nil)
+      end
+
+      let(:user) { create(:regional_casework_services_user) }
+      let(:params) {
+        {
+          urn: 123456,
+          incoming_trust_ukprn: 10066123,
+          advisory_board_date: "2024-1-1",
+          advisory_board_conditions: "Some conditions",
+          provisional_conversion_date: "2025-1-1",
+          directive_academy_order: true,
+          created_by_email: user.email,
+          created_by_first_name: user.first_name,
+          created_by_last_name: user.last_name
+        }
+      }
+
+      it "returns an error" do
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Conversions::CreateProjectService::ProjectCreationError,
+            "Project could not be created via API, urn: 123456")
+      end
     end
   end
 
-  context "when the params contain details for an unknown user" do
-    let(:params) {
-      {
-        urn: 123456,
-        incoming_trust_ukprn: 10066123,
-        advisory_board_date: "2024-1-1",
-        advisory_board_conditions: "Some conditions",
-        provisional_conversion_date: "2025-1-1",
-        directive_academy_order: true,
-        created_by_email: "bob@education.gov.uk",
-        created_by_first_name: "Bob",
-        created_by_last_name: "Governor"
+  context "a Form a MAT Conversion project" do
+    context "when the params contain details for an existing user" do
+      let(:user) { create(:regional_casework_services_user) }
+      let(:params) {
+        {
+          urn: 123456,
+          new_trust_reference_number: "TR12345",
+          new_trust_name: "The New Trust",
+          advisory_board_date: "2024-1-1",
+          advisory_board_conditions: "Some conditions",
+          provisional_conversion_date: "2025-1-1",
+          directive_academy_order: true,
+          created_by_email: user.email,
+          created_by_first_name: user.first_name,
+          created_by_last_name: user.last_name
+        }
       }
-    }
 
-    it "creates the project and a new user" do
-      result = described_class.new(params).call
-      new_user = User.find_by(email: "bob@education.gov.uk")
+      it "creates the project using the existing user" do
+        result = described_class.new(params).call
 
-      expect(result).to be_a(Conversion::Project)
-      expect(result.id).to eq(Conversion::Project.last.id)
-      expect(result.regional_delivery_officer_id).to eq(new_user.id)
+        expect(result).to be_a(Conversion::Project)
+        expect(result.id).to eq(Conversion::Project.last.id)
+      end
+
+      it "the project is a Form a MAT project" do
+        result = described_class.new(params).call
+
+        expect(result.form_a_mat?).to be true
+      end
     end
 
-    it "puts the new user in the same regional team as the establishment" do
-      project = described_class.new(params).call
-      new_user = User.find_by(email: "bob@education.gov.uk")
-
-      expect(new_user.team).to eq(project.region)
-    end
-  end
-
-  context "when the user's email is not valid" do
-    let(:params) {
-      {
-        urn: 123456,
-        incoming_trust_ukprn: 10066123,
-        advisory_board_date: "2024-1-1",
-        advisory_board_conditions: "Some conditions",
-        provisional_conversion_date: "2025-1-1",
-        directive_academy_order: true,
-        created_by_email: "bob@school.gov.uk",
-        created_by_first_name: "Bob",
-        created_by_last_name: "Teacher"
+    context "when the new Trust Reference Number is not valid" do
+      let(:params) {
+        {
+          urn: 123456,
+          new_trust_reference_number: "12345",
+          new_trust_name: "The New Trust",
+          advisory_board_date: "2024-1-1",
+          advisory_board_conditions: "Some conditions",
+          provisional_conversion_date: "2025-1-1",
+          directive_academy_order: true,
+          created_by_email: "bob@education.gov.uk",
+          created_by_first_name: "Bob",
+          created_by_last_name: "Teacher"
+        }
       }
-    }
 
-    it "returns an error" do
-      expect { described_class.new(params).call }
-        .to raise_error(Api::Conversions::CreateProjectService::ProjectCreationError,
-          "Failed to save user during API project creation, urn: 123456")
-    end
-  end
-
-  context "when the URN or UKPRN are not valid" do
-    let(:params) {
-      {
-        urn: 123,
-        incoming_trust_ukprn: 100,
-        advisory_board_date: "2024-1-1",
-        advisory_board_conditions: "Some conditions",
-        provisional_conversion_date: "2025-1-1",
-        directive_academy_order: true,
-        created_by_email: "bob@education.gov.uk",
-        created_by_first_name: "Bob",
-        created_by_last_name: "Teacher"
-      }
-    }
-
-    it "returns validation errors" do
-      expect { described_class.new(params).call }
-        .to raise_error(Api::Conversions::CreateProjectService::ProjectCreationError,
-          "Urn URN must be 6 digits long. For example, 123456. Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678.")
-    end
-  end
-
-  context "when the Academies API returns an error on fetching the establishment" do
-    let(:user) { create(:regional_casework_services_user) }
-    let(:params) {
-      {
-        urn: 123456,
-        incoming_trust_ukprn: 10066123,
-        advisory_board_date: "2024-1-1",
-        advisory_board_conditions: "Some conditions",
-        provisional_conversion_date: "2025-1-1",
-        directive_academy_order: true,
-        created_by_email: user.email,
-        created_by_first_name: user.first_name,
-        created_by_last_name: user.last_name
-      }
-    }
-
-    before do
-      mock_establishment_not_found(urn: 123456)
-    end
-
-    it "returns an error" do
-      expect { described_class.new(params).call }
-        .to raise_error(Api::Conversions::CreateProjectService::ProjectCreationError,
-          "Failed to fetch establishment from Academies API during project creation, urn: 123456")
-    end
-  end
-
-  context "when the project save fails for an unknown reason" do
-    before do
-      allow_any_instance_of(Conversion::Project).to receive(:save).and_return(nil)
-    end
-
-    let(:user) { create(:regional_casework_services_user) }
-    let(:params) {
-      {
-        urn: 123456,
-        incoming_trust_ukprn: 10066123,
-        advisory_board_date: "2024-1-1",
-        advisory_board_conditions: "Some conditions",
-        provisional_conversion_date: "2025-1-1",
-        directive_academy_order: true,
-        created_by_email: user.email,
-        created_by_first_name: user.first_name,
-        created_by_last_name: user.last_name
-      }
-    }
-
-    it "returns an error" do
-      expect { described_class.new(params).call }
-        .to raise_error(Api::Conversions::CreateProjectService::ProjectCreationError,
-          "Project could not be created via API, urn: 123456")
+      it "returns validation errors" do
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Conversions::CreateProjectService::ProjectCreationError,
+            "New trust reference number The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234")
+      end
     end
   end
 end


### PR DESCRIPTION
## Changes

The API can now create a Conversion Form a MAT project. The endpoint is `/api/v1/projects/conversions/form-a-mat` and is documented in the API Docs.

I created this as a spike branch but feel it can be added to the codebase alongside the `conversions` endpoint for now. Both endpoints need refining once we have more of the required data to create projects in Prepare.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
