### PR TITLE
Update export header and value

### DIFF
--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -159,7 +159,7 @@ class Export::Csv::ProjectPresenter
 
   def sponsored_grant_type
     return I18n.t("export.csv.project.values.not_applicable") if @project.is_a?(Transfer::Project)
-    return I18n.t("export.csv.project.values.not_applicable") if @project.tasks_data.sponsored_support_grant_not_applicable?
+    return I18n.t("export.csv.project.values.sponsored_grant_type.not_eligible") if @project.tasks_data.sponsored_support_grant_not_applicable?
     return I18n.t("export.csv.project.values.unconfirmed") if @project.tasks_data.sponsored_support_grant_type.nil?
 
     I18n.t("export.csv.project.values.sponsored_grant_type.#{@project.tasks_data.sponsored_support_grant_type}")

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -16,7 +16,7 @@ en:
           seven_to_eleven_years: Proposed capacity for pupils in years 7 to 11
           twelve_or_above_years: Proposed capacity for students in year 12 or above
           two_requires_improvement: 2RI (Two Requires Improvement)
-          sponsored_grant_type: Sponsored Grant Type
+          sponsored_grant_type: Project route and sponsored grant type
           transfer_grant_level: Transfer grant level
           assigned_to_name: Assigned to name
           assigned_to_email: Assigned to email
@@ -153,6 +153,7 @@ en:
             fast_track: fast track
             intermediate: intermediate
             sponsored: sponsored
+            not_eligible: Voluntary converter - not eligible
           unconfirmed: unconfirmed
           confirmed: confirmed
           unassigned: unassigned

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -212,13 +212,13 @@ RSpec.describe Export::Csv::ProjectPresenter do
       expect(presenter.sponsored_grant_type).to eql "full sponsored"
     end
 
-    it "presents not applicable" do
+    it "presents not Voluntary converter - not eligible" do
       tasks_data = build(:conversion_tasks_data, sponsored_support_grant_type: nil, sponsored_support_grant_not_applicable: true)
       project = build(:conversion_project, tasks_data: tasks_data)
 
       presenter = described_class.new(project)
 
-      expect(presenter.sponsored_grant_type).to eql "not applicable"
+      expect(presenter.sponsored_grant_type).to eql "Voluntary converter - not eligible"
     end
   end
 


### PR DESCRIPTION
We have heard from users that their preference for the
'sponsored_grant_type' column header must be 'Project route and
sponsored grant type' and when not applicable the value must be
'voluntary converter - not eligible'.

Our content designer came up with this solution after much discussion
with users.

## Changes

_Add a summary of the changes in this pull request_

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
