### PR TITLE
(152117) Change the "All conditions met" task for transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - A simple POST Api endpoint to create a Form a MAT Conversion project
 
+### Changed
+
+- Changed the "All conditions met" task for Transfers to "Authority to proceed"
+
 ## [Release-70][Release-70]
 
 ### Added

--- a/app/forms/transfer/task/conditions_met_task_form.rb
+++ b/app/forms/transfer/task/conditions_met_task_form.rb
@@ -1,5 +1,7 @@
 class Transfer::Task::ConditionsMetTaskForm < BaseTaskForm
   attribute :confirm_all_conditions_met, :boolean
+  attribute :check_any_information_changed, :boolean
+  attribute :baseline_sheet_approved, :boolean
 
   def initialize(tasks_data, user)
     @tasks_data = tasks_data
@@ -10,6 +12,11 @@ class Transfer::Task::ConditionsMetTaskForm < BaseTaskForm
   end
 
   def save
-    @project.update!(all_conditions_met: confirm_all_conditions_met)
+    @tasks_data.assign_attributes(
+      conditions_met_check_any_information_changed: check_any_information_changed,
+      conditions_met_baseline_sheet_approved: baseline_sheet_approved
+    )
+    @tasks_data.save!
+    @project.update!(authority_to_proceed: confirm_all_conditions_met)
   end
 end

--- a/app/models/transfer/project.rb
+++ b/app/models/transfer/project.rb
@@ -14,6 +14,8 @@ class Transfer::Project < Project
     :confirmed_date_and_in_the_past?
   ]
 
+  alias_attribute :authority_to_proceed, :all_conditions_met
+
   def outgoing_trust
     @outgoing_trust ||= fetch_trust(outgoing_trust_ukprn)
   end

--- a/app/views/transfers/tasks/conditions_met/edit.html.erb
+++ b/app/views/transfers/tasks/conditions_met/edit.html.erb
@@ -27,6 +27,8 @@
       <%= form.govuk_error_summary %>
 
       <div class="govuk-form-group">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :check_any_information_changed)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :baseline_sheet_approved)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :confirm_all_conditions_met)) %>
       </div>
 

--- a/config/locales/transfer/tasks/conditions_met.en.yml
+++ b/config/locales/transfer/tasks/conditions_met.en.yml
@@ -2,25 +2,36 @@ en:
   transfer:
     task:
       conditions_met:
-        title: Confirm all conditions have been met
+        title: Confirm this transfer has authority to proceed
         hint:
           html:
-            The deadline for meeting all conditions is in the email you got from the AIOP (Academy Intervention Operational Policy) team. All conditions must be met by the the deadline or the academy will not transfer on %{transfer_date}.
-        guidance_link: How to check all conditions have been met
+            The deadline for getting authority to proceed is in the email you got from AOPU (Academy Operational Practice Unit). The project must have authority to proceed by the deadline or the academy will not transfer on %{transfer_date}.
+        guidance_link: How to check the transfer has authority to proceed
         guidance:
           html:
-            <p>You need to check that:</p>
+            <p>The transfer cannot proceed until:</p>
             <ul>
-            <li>legal documents are cleared</li>
-            <li>legal documents are signed by the necessary people</li>
+            <li>legal documents are cleared and signed</li>
             <li>the academy have confirmed all of their actions are complete</li>
+            <li>information in the baseline spreadsheet is correct and approved</li>
+            </ul>
+        check_any_information_changed:
+          title: Check if any information has changed from the first baseline
+          hint:
+            html:
+              <p>You must update any changed information in this month's <a href="https://educationgovuk.sharepoint.com/sites/ag/WorkplaceDocuments/Forms/AllItems.aspx?id=%2Fsites%2Fag%2FWorkplaceDocuments%2FADG%20Knowledge%2FAcademy%5FInternal%5FGuidance%2F04%5FOpen%2F02%5FRebrokerage%2FMonthly%20Rebrokerage%20Documents&viewid=193ea09b%2D5b14%2D45d5%2D89ea%2D4d688b0440f2&OR=Teams%2DHL&CT=1702652013687&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiIyOC8yMzExMDIyNDcwNSIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3D%3D">second baseline spreadsheet (opens in new tab)</a>.</p>
+        baseline_sheet_approved:
+          title: Baseline spreadsheet approved
+          hint:
+            html:
+              <p>A Deputy Director, or a Grade 6 civil servant with delegated authority, must sign-off on this month's transfers.</p>
         confirm_all_conditions_met:
-          title: Confirm all conditions are met
+          title: Confirm the project has authority to proceed
           hint:
             html:
               <p>This will change the transfer's status on the By Month project list.</p>
-              <p>AIOP and ESFA (Education and Skills Funding Agency) use it to prepare and send GAG (general annual grant) funding.</p>
-          guidance_link: What to do if conditions are not met
+              <p>AOPU and ESFA (Education and Skills Funding Agency) use it to prepare and send the GAG (general annual grant) funding.</p>
+          guidance_link: What to do if the transfer does not have authority to proceed
           guidance:
             html:
               You must agree a new transfer date with all stakeholders, then change the transfer date for this project.

--- a/db/migrate/20240523104451_add_additional_fields_to_all_conditions_met_for_transfers.rb
+++ b/db/migrate/20240523104451_add_additional_fields_to_all_conditions_met_for_transfers.rb
@@ -1,0 +1,6 @@
+class AddAdditionalFieldsToAllConditionsMetForTransfers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :transfer_tasks_data, :conditions_met_check_any_information_changed, :boolean
+    add_column :transfer_tasks_data, :conditions_met_baseline_sheet_approved, :boolean
+  end
+end

--- a/db/migrate/20240523125015_update_all_completed_transfers.rb
+++ b/db/migrate/20240523125015_update_all_completed_transfers.rb
@@ -1,0 +1,15 @@
+class UpdateAllCompletedTransfers < ActiveRecord::Migration[7.0]
+  def change
+    ActiveRecord::Base.transaction do
+      Transfer::Project.all.each do |project|
+        if project.all_conditions_met?
+          tasks_data = project.tasks_data
+          tasks_data.update(
+            conditions_met_check_any_information_changed: true,
+            conditions_met_baseline_sheet_approved: true
+          )
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_17_100215) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_23_104451) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -414,6 +414,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_17_100215) do
     t.boolean "declaration_of_expenditure_certificate_correct", default: false
     t.boolean "declaration_of_expenditure_certificate_saved", default: false
     t.boolean "declaration_of_expenditure_certificate_not_applicable", default: false
+    t.boolean "conditions_met_check_any_information_changed"
+    t.boolean "conditions_met_baseline_sheet_approved"
   end
 
   create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_23_104451) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_23_125015) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/features/transfers/tasks/users_can_complete_all_conditions_met_spec.rb
+++ b/spec/features/transfers/tasks/users_can_complete_all_conditions_met_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Users can complete the all conditions met task" do
+RSpec.feature "Users can complete the authority to proceed" do
   let(:user) { create(:user, :regional_delivery_officer) }
   let(:project) { create(:transfer_project, assigned_to: user) }
 
@@ -10,14 +10,14 @@ RSpec.feature "Users can complete the all conditions met task" do
     visit project_tasks_path(project)
   end
 
-  describe "the confirm all conditions met task" do
-    scenario "they can confirm all conditions have been met" do
+  describe "the authority to proceed task" do
+    scenario "they can confirm the transfer has authority to proceed" do
       visit project_tasks_path(project)
-      click_on "Confirm all conditions have been met"
+      click_on "Confirm this transfer has authority to proceed"
       page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
       click_on I18n.t("task_list.continue_button.text")
 
-      expect(project.reload.all_conditions_met).to be true
+      expect(project.reload.authority_to_proceed).to be true
     end
   end
 end


### PR DESCRIPTION

## Changes

The "All conditions met" task should be called "Authority to proceed" for Transfers.

We have decided to keep the name of the attribute the same (`all_conditions_met`) for simplicity, but change the accompanying text. We have added an alias `authority_to_proceed` on the attribute.

We have also added two more checkboxes to this task. 

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
