### PR TITLE
Disable autocomplete on uid fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The skip to content link is now underlined.
 - Service support users can now edit all contacts.
+- URN and UKPRN fields no longer autocomplete.
 
 ## [Release-70][Release-70]
 

--- a/app/views/conversions/projects/edit.html.erb
+++ b/app/views/conversions/projects/edit.html.erb
@@ -4,7 +4,7 @@
       <%= form.govuk_error_summary %>
 
       <div class="govuk-form-group" id="incoming-trust-ukprn">
-        <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m"}, width: 10 %>
+        <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m"}, width: 10, autocomplete: :off %>
       </div>
 
       <div class="govuk-form-group" id="advisory-board">

--- a/app/views/conversions/projects/new.html.erb
+++ b/app/views/conversions/projects/new.html.erb
@@ -15,8 +15,8 @@
       <%= t("conversion_project.new.hint_html") %>
 
       <div class="govuk-form-group">
-        <%= form.govuk_text_field :urn, label: {size: "m"}, width: 10 %>
-        <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m"}, width: 10 %>
+        <%= form.govuk_text_field :urn, label: {size: "m"}, width: 10, autocomplete: :off %>
+        <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m"}, width: 10, autocomplete: :off %>
       </div>
 
       <div class="govuk-form-group">

--- a/app/views/conversions/projects/new_mat.html.erb
+++ b/app/views/conversions/projects/new_mat.html.erb
@@ -15,11 +15,11 @@
       <%= t("conversion_project.form_a_mat.new.hint_html") %>
 
       <div class="govuk-form-group">
-        <%= form.govuk_text_field :urn, label: {size: "m"}, width: 10 %>
+        <%= form.govuk_text_field :urn, label: {size: "m"}, width: 10, autocomplete: :off %>
       </div>
 
       <div class="govuk-form-group">
-        <%= form.govuk_text_field :new_trust_reference_number, label: {size: "m"}, width: 10 %>
+        <%= form.govuk_text_field :new_trust_reference_number, label: {size: "m"}, width: 10, autocomplete: :off %>
         <%= form.govuk_text_field :new_trust_name, label: {size: "m"} %>
       </div>
 

--- a/app/views/transfers/projects/edit.html.erb
+++ b/app/views/transfers/projects/edit.html.erb
@@ -4,11 +4,11 @@
       <%= form.govuk_error_summary %>
 
       <div class="govuk-form-group" id="outgoing-trust-ukprn">
-        <%= form.govuk_text_field :outgoing_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.outgoing_trust_ukprn").html_safe}, width: 10 %>
+        <%= form.govuk_text_field :outgoing_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.outgoing_trust_ukprn").html_safe}, width: 10, autocomplete: :off %>
       </div>
 
       <div class="govuk-form-group" id="incoming-trust-ukprn">
-        <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.incoming_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.incoming_trust_ukprn").html_safe}, width: 10 %>
+        <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.incoming_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.incoming_trust_ukprn").html_safe}, width: 10, autocomplete: :off %>
       </div>
 
       <div class="govuk-form-group">

--- a/app/views/transfers/projects/new.html.erb
+++ b/app/views/transfers/projects/new.html.erb
@@ -15,9 +15,9 @@
       <%= t("transfer_project.new.hint_html") %>
 
       <div class="govuk-form-group">
-        <%= form.govuk_text_field :urn, label: {size: "m", text: t("helpers.label.transfer_project.urn")}, hint: {text: t("helpers.hint.transfer_project.urn").html_safe}, width: 10 %>
-        <%= form.govuk_text_field :outgoing_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.outgoing_trust_ukprn").html_safe}, width: 10 %>
-        <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.incoming_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.incoming_trust_ukprn").html_safe}, width: 10 %>
+        <%= form.govuk_text_field :urn, label: {size: "m", text: t("helpers.label.transfer_project.urn")}, hint: {text: t("helpers.hint.transfer_project.urn").html_safe}, width: 10, autocomplete: :off %>
+        <%= form.govuk_text_field :outgoing_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.outgoing_trust_ukprn").html_safe}, width: 10, autocomplete: :off %>
+        <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.incoming_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.incoming_trust_ukprn").html_safe}, width: 10, autocomplete: :off %>
       </div>
 
       <div class="govuk-form-group">

--- a/app/views/transfers/projects/new_mat.html.erb
+++ b/app/views/transfers/projects/new_mat.html.erb
@@ -15,15 +15,15 @@
       <%= t("transfer_project.form_a_mat.new.hint_html") %>
 
       <div class="govuk-form-group">
-        <%= form.govuk_text_field :urn, label: {size: "m", text: t("helpers.label.transfer_project.urn")}, hint: {text: t("helpers.hint.transfer_project.urn").html_safe}, width: 10 %>
+        <%= form.govuk_text_field :urn, label: {size: "m", text: t("helpers.label.transfer_project.urn")}, hint: {text: t("helpers.hint.transfer_project.urn").html_safe}, width: 10, autocomplete: :off %>
       </div>
 
       <div class="govuk-form-group">
-        <%= form.govuk_text_field :outgoing_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.outgoing_trust_ukprn").html_safe}, width: 10 %>
+        <%= form.govuk_text_field :outgoing_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.outgoing_trust_ukprn").html_safe}, width: 10, autocomplete: :off %>
       </div>
 
       <div class="govuk-form-group">
-        <%= form.govuk_text_field :new_trust_reference_number, label: {size: "m"}, width: 10 %>
+        <%= form.govuk_text_field :new_trust_reference_number, label: {size: "m"}, width: 10, autocomplete: :off %>
         <%= form.govuk_text_field :new_trust_name, label: {size: "m"} %>
       </div>
 


### PR DESCRIPTION
***Speculative work***

We have a number of fields where the user has to enter a unique
identifier, having autocomplete enabled on fields like these increases
the chance of errors at the cost of easily entering repeated uids, which
feels like a good trade off.

If a users enters an incorrect uids, the chances of doing so again also
increase as the browser will store the incorrect uid for
autocompletion.

