### PR TITLE
(146767) Fix: Skip to content style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The transfer project Form M task is now optional and can be marked as not
   applicable.
 
+### Fixed
+
+- The skip to content link is now underlined.
+
 ## [Release-70][Release-70]
 
 ### Added

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -103,3 +103,6 @@ address.govuk-address {
 .moj-sub-navigation__item {
   margin-bottom: 0px;
 }
+
+// force skip link to be underline
+.govuk-skip-link { text-decoration: underline !important; }


### PR DESCRIPTION
We couldn't find the styles that are preventing this from being
underline so had to resort to ensuring it is applied with `!important`.

We can only assume it is either the DfE Frontend or the MOJ Frontend,
but inspecting the page shows `text-decoration: underline` is applied?

<img width="1541" alt="Screenshot 2024-05-24 at 09 14 37" src="https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/aa0e1eed-fd4d-4c87-8b59-f32c9c7719d4">


