### PR TITLE
(162613) Fix: service support can edit all contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - The skip to content link is now underlined.
+- Service support users can now edit all contacts.
 
 ## [Release-70][Release-70]
 

--- a/app/policies/contact_policy.rb
+++ b/app/policies/contact_policy.rb
@@ -8,6 +8,7 @@ class ContactPolicy
   end
 
   def edit?
+    return true if @user.is_service_support?
     return false if @project&.completed?
     return false unless @user.has_role?
 

--- a/spec/policies/contact_policy_spec.rb
+++ b/spec/policies/contact_policy_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe ContactPolicy do
       expect(subject).to permit(application_user, build(:project_contact, project: project))
     end
 
+    it "grants access if the user is in the service support team" do
+      application_user = build(:user, :service_support)
+      project = build(:conversion_project, assigned_to: application_user)
+      expect(subject).to permit(application_user, build(:project_contact, project: project))
+    end
+
     it "denies if the user has no role" do
       user = build(:user)
       project = build(:conversion_project)


### PR DESCRIPTION
During a product review we noticed that as a service support users we
couldn't edit contacts, our product owner felt this group of users
should be able to edit contacts, particularly the chair of governors
once added, this work fixes this.

The cause was the `has_role?` method does not include service support
users, the solution was a early return for service support users,
generally speaking, service support users can do 'anything'.
