### PR TITLE
(168420) Move scoping of project exports

### DIFF
--- a/app/models/concerns/significant_date.rb
+++ b/app/models/concerns/significant_date.rb
@@ -41,8 +41,7 @@ module SignificantDate
     end
 
     def significant_date_in_range(from_date, to_date)
-      in_progress.confirmed
-        .where("significant_date >= ?", Date.parse(from_date).at_beginning_of_month)
+      where("significant_date >= ?", Date.parse(from_date).at_beginning_of_month)
         .where("significant_date <= ?", Date.parse(to_date).at_end_of_month)
         .ordered_by_significant_date
     end

--- a/app/services/by_month_project_fetcher_service.rb
+++ b/app/services/by_month_project_fetcher_service.rb
@@ -4,13 +4,13 @@ class ByMonthProjectFetcherService
   end
 
   def conversion_projects_by_date_range(from_date, to_date)
-    projects = Project.conversions.significant_date_in_range(from_date, to_date)
+    projects = Project.conversions.in_progress.confirmed.significant_date_in_range(from_date, to_date)
 
     AcademiesApiPreFetcherService.new.call!(projects) if @pre_fetch_academies_api
   end
 
   def transfer_projects_by_date_range(from_date, to_date)
-    projects = Project.transfers.significant_date_in_range(from_date, to_date)
+    projects = Project.transfers.in_progress.confirmed.significant_date_in_range(from_date, to_date)
 
     AcademiesApiPreFetcherService.new.call!(projects) if @pre_fetch_academies_api
   end

--- a/spec/models/concerns/significant_date_spec.rb
+++ b/spec/models/concerns/significant_date_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe SignificantDate do
     end
 
     describe ".significant_date_in_range" do
-      it "only returns projects with a confirmed significant date within the given range of dates" do
+      it "only returns projects with a significant date within the given range of dates" do
         january = Date.parse("2023-1-1")
         february = Date.parse("2023-2-1")
         march = Date.parse("2023-3-1")
@@ -137,12 +137,9 @@ RSpec.describe SignificantDate do
         other_project = create(:conversion_project, significant_date: october, significant_date_provisional: false)
         create(:date_history, project: other_project, previous_date: october, revised_date: october)
 
-        unconfirmed_project = create(:transfer_project, significant_date: january, significant_date_provisional: true)
-
         scoped_projects = Project.significant_date_in_range("2023-1-1", "2023-3-1")
 
         expect(scoped_projects).to include(matching_project_1, matching_project_2, matching_project_3)
-        expect(scoped_projects).to_not include(other_project, unconfirmed_project)
       end
     end
   end

--- a/spec/services/by_month_project_fetcher_service_spec.rb
+++ b/spec/services/by_month_project_fetcher_service_spec.rb
@@ -16,12 +16,17 @@ RSpec.describe ByMonthProjectFetcherService do
         project_2 = create(:conversion_project, significant_date_provisional: false, significant_date: february)
         project_3 = create(:conversion_project, significant_date_provisional: false, significant_date: march)
 
+        unconfirmed_project = create(:conversion_project, significant_date_provisional: true, significant_date: january)
+        completed_project = create(:conversion_project, :completed, significant_date: january)
+
         create(:date_history, project: project_1, previous_date: january, revised_date: january)
         create(:date_history, project: project_2, previous_date: february, revised_date: march)
         create(:date_history, project: project_3, previous_date: march, revised_date: march)
 
-        projects_fetcher = described_class.new
-        expect(projects_fetcher.conversion_projects_by_date_range("2023-1-1", "2023-3-1")).to eq([project_1, project_2, project_3])
+        result = described_class.new.conversion_projects_by_date_range("2023-1-1", "2023-3-1")
+        expect(result).to eq([project_1, project_2, project_3])
+        expect(result).not_to include(unconfirmed_project)
+        expect(result).not_to include(completed_project)
       end
     end
   end
@@ -45,8 +50,13 @@ RSpec.describe ByMonthProjectFetcherService do
         create(:date_history, project: project_2, previous_date: february, revised_date: march)
         create(:date_history, project: project_3, previous_date: march, revised_date: march)
 
-        projects_fetcher = described_class.new
-        expect(projects_fetcher.transfer_projects_by_date_range("2023-1-1", "2023-3-1")).to eq([project_1, project_2, project_3])
+        unconfirmed_project = create(:transfer_project, significant_date_provisional: true, significant_date: january)
+        completed_project = create(:transfer_project, :completed, significant_date: january)
+
+        result = described_class.new.transfer_projects_by_date_range("2023-1-1", "2023-3-1")
+        expect(result).to eq([project_1, project_2, project_3])
+        expect(result).not_to include(unconfirmed_project)
+        expect(result).not_to include(completed_project)
       end
     end
   end


### PR DESCRIPTION
The 'by month' export has a different criteria for which projects to
include than the other exports.

We want to offer all exports with a date range and want to utilise the
`significant_date_in_range` scope but without the `in_progress` and
`confirmed` scopes pre applied.

To do so we move those pre scopes to where they get used to render the
'by month' views and exports, leaving the scope focused only on the date
range and available for use in other exports.

