### PR TITLE
Ensure data sources always output HCL instead of JSON

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -125,6 +125,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.1 |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 1.13.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.59.0 |
 | <a name="requirement_statuscake"></a> [statuscake](#requirement\_statuscake) | >= 2.1.0 |
 

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -6,3 +6,7 @@ provider "azurerm" {
 provider "statuscake" {
   api_token = var.statuscake_api_token
 }
+
+provider "azapi" {
+  enable_hcl_output_for_data_source = true
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -9,5 +9,9 @@ terraform {
       source  = "StatusCakeDev/statuscake"
       version = ">= 2.1.0"
     }
+    azapi = {
+      source  = "Azure/azapi"
+      version = ">= 1.13.0"
+    }
   }
 }


### PR DESCRIPTION
## Changes

By setting this value to `true` we can ensure any data sources used by the Container App module are correctly handled as HCL syntax instead of JSON.

JSON output was previously used in earlier versions of the AzAPI provider but they have since switched to using HCL which will eventually become the default instead of JSON.