### PR TITLE
handle when UKPRNs are changed upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - URN and UKPRN fields no longer autocomplete.
 - When creating a new project and submitting an empty form, the errors are now
   shown correctly.
+- If a UKPRN is changed in the Academies DB, handle the exception so that the
+  application remains usable for end users
 
 ## [Release-70][Release-70]
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -33,7 +33,6 @@ class Project < ApplicationRecord
   validates :new_trust_reference_number, trust_reference_number: true, if: -> { new_trust_reference_number.present? }
 
   validate :establishment_exists, if: -> { urn.present? }
-  validate :trust_exists, if: -> { incoming_trust_ukprn.present? }
 
   belongs_to :caseworker, class_name: "User", optional: true
   belongs_to :regional_delivery_officer, class_name: "User", optional: true
@@ -164,11 +163,5 @@ class Project < ApplicationRecord
     establishment
   rescue Api::AcademiesApi::Client::NotFoundError
     errors.add(:urn, :no_establishment_found)
-  end
-
-  private def trust_exists
-    incoming_trust
-  rescue Api::AcademiesApi::Client::NotFoundError
-    errors.add(:incoming_trust_ukprn, :no_trust_found)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -153,7 +153,7 @@ class Project < ApplicationRecord
 
     if result.error.present?
       track_event(result.error.message)
-      raise result.error
+      return Api::AcademiesApi::Trust.new.from_hash({referenceNumber: "", name: result.error.message})
     end
 
     result.object

--- a/app/models/transfer/project.rb
+++ b/app/models/transfer/project.rb
@@ -8,7 +8,6 @@ class Transfer::Project < Project
 
   validates :outgoing_trust_ukprn, presence: true
   validates :outgoing_trust_ukprn, ukprn: true
-  validate :outgoing_trust_exists, if: -> { outgoing_trust_ukprn.present? }
 
   MANDATORY_CONDITIONS = [
     :confirmed_date_and_in_the_past?
@@ -22,11 +21,5 @@ class Transfer::Project < Project
 
   def completable?
     MANDATORY_CONDITIONS.all? { |task| send(task) }
-  end
-
-  private def outgoing_trust_exists
-    outgoing_trust
-  rescue Api::AcademiesApi::Client::NotFoundError
-    errors.add(:outgoing_trust_ukprn, :no_trust_found)
   end
 end

--- a/app/services/academies_api_pre_fetcher_service.rb
+++ b/app/services/academies_api_pre_fetcher_service.rb
@@ -1,4 +1,6 @@
 class AcademiesApiPreFetcherService
+  include ApplicationInsightsEventTrackable
+
   def call!(projects)
     @projects = projects
     pre_fetch_academies_api_entities
@@ -57,7 +59,8 @@ class AcademiesApiPreFetcherService
     if response.error.nil?
       trusts.concat(response.object)
     else
-      raise Api::AcademiesApi::Client::Error.new
+      track_event(response.error.message)
+      trusts.concat([])
     end
     trusts
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -315,8 +315,9 @@ RSpec.describe Project, type: :model do
             receive(:get_trust).with(ukprn) { error }
         end
 
-        it "raises the error" do
-          expect { subject.incoming_trust }.to raise_error(Api::AcademiesApi::Client::NotFoundError, error_message)
+        it "returns a 'not found' Trust object" do
+          expect(subject.incoming_trust).to be_a(Api::AcademiesApi::Trust)
+          expect(subject.incoming_trust.name).to eq("Could Not Find Trust For Ukprn 10061021")
         end
 
         it "sends the event to Application Insights" do
@@ -324,7 +325,7 @@ RSpec.describe Project, type: :model do
             telemetry_client = double(ApplicationInsights::TelemetryClient, track_event: true, flush: true)
             allow(ApplicationInsights::TelemetryClient).to receive(:new).and_return(telemetry_client)
 
-            expect { subject.incoming_trust }.to raise_error(Api::AcademiesApi::Client::NotFoundError)
+            subject.incoming_trust
             expect(telemetry_client).to have_received(:track_event)
           end
         end
@@ -339,8 +340,9 @@ RSpec.describe Project, type: :model do
             receive(:get_trust).with(ukprn) { error }
         end
 
-        it "raises the error" do
-          expect { subject.incoming_trust }.to raise_error(Api::AcademiesApi::Client::Error, error_message)
+        it "returns a 'could not connect' Trust object" do
+          expect(subject.incoming_trust).to be_a(Api::AcademiesApi::Trust)
+          expect(subject.incoming_trust.name).to eq("There Was An Error Connecting To The Academies Api, Could Not Fetch Trust With Ukprn 10061021")
         end
       end
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -189,24 +189,6 @@ RSpec.describe Project, type: :model do
           expect(project).to be_valid
         end
       end
-
-      context "when no trust with that UKPRN exists in the API and the UKPRN is present" do
-        let(:no_trust_found_result) do
-          Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::NotFoundError.new("No trust found with that UKPRN. Enter a valid UKPRN."))
-        end
-
-        before do
-          allow_any_instance_of(Api::AcademiesApi::Client).to \
-            receive(:get_trust) { no_trust_found_result }
-
-          subject.assign_attributes(incoming_trust_ukprn: 12345678)
-        end
-
-        it "is invalid" do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:incoming_trust_ukprn]).to include(I18n.t("errors.attributes.incoming_trust_ukprn.no_trust_found"))
-        end
-      end
     end
 
     describe "#establishment_sharepoint_link" do

--- a/spec/models/transfer/project_spec.rb
+++ b/spec/models/transfer/project_spec.rb
@@ -20,24 +20,6 @@ RSpec.describe Transfer::Project do
         expect(subject.errors[:outgoing_trust_ukprn]).to include(I18n.t("errors.attributes.outgoing_trust_ukprn.must_be_correct_format"))
       end
     end
-
-    context "when no trust with that UKPRN exists in the API and the UKPRN is present" do
-      let(:no_trust_found_result) do
-        Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::NotFoundError.new("No trust found with that UKPRN. Enter a valid UKPRN."))
-      end
-
-      subject { described_class.new(outgoing_trust_ukprn: 12345678) }
-
-      before do
-        allow_any_instance_of(Api::AcademiesApi::Client).to \
-          receive(:get_trust) { no_trust_found_result }
-      end
-
-      it "is invalid" do
-        expect(subject).to_not be_valid
-        expect(subject.errors[:outgoing_trust_ukprn]).to include(I18n.t("errors.attributes.outgoing_trust_ukprn.no_trust_found"))
-      end
-    end
   end
 
   describe "#completable?" do

--- a/spec/services/academies_api_pre_fetcher_service_spec.rb
+++ b/spec/services/academies_api_pre_fetcher_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe AcademiesApiPreFetcherService do
     expect(projects.last.all_conditions_met?).to be false
   end
 
-  it "raises and Academies API error if the establishments requests fail" do
+  it "raises an Academies API error if the establishments requests fail" do
     mock_academies_api_client_get_establishments_and_trusts_failure
 
     10.times do
@@ -46,18 +46,24 @@ RSpec.describe AcademiesApiPreFetcherService do
     expect { AcademiesApiPreFetcherService.new.call!(projects) }.to raise_error(Api::AcademiesApi::Client::Error)
   end
 
-  it "raises and Academies API error if the trusts requests fail" do
-    establishment = double("Establishment", name: "Establishment Name", urn: "123456")
-    api_client = mock_academies_api_client_get_establishments_and_trusts_failure
-    allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new([establishment], nil))
+  it "tracks the Academies API error if the trusts requests fail but does not raise" do
+    ClimateControl.modify(APPLICATION_INSIGHTS_KEY: "fake-application-insights-key") do
+      telemetry_client = double(ApplicationInsights::TelemetryClient, track_event: true, flush: true)
+      allow(ApplicationInsights::TelemetryClient).to receive(:new).and_return(telemetry_client)
 
-    10.times do
-      create(:conversion_project, urn: 123456, incoming_trust_ukprn: 10010010)
+      establishment = double("Establishment", name: "Establishment Name", urn: "123456")
+      api_client = mock_academies_api_client_get_establishments_and_trusts_failure
+      allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new([establishment], nil))
+
+      10.times do
+        create(:conversion_project, urn: 123456, incoming_trust_ukprn: 10010010)
+      end
+
+      projects = Project.all
+      AcademiesApiPreFetcherService.new.call!(projects)
+
+      expect(telemetry_client).to have_received(:track_event)
     end
-
-    projects = Project.all
-
-    expect { AcademiesApiPreFetcherService.new.call!(projects) }.to raise_error(Api::AcademiesApi::Client::Error)
   end
 
   def mock_academies_api_client_get_establishments_and_trusts

--- a/spec/services/academies_api_pre_fetcher_service_spec.rb
+++ b/spec/services/academies_api_pre_fetcher_service_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe AcademiesApiPreFetcherService do
     expect(api_client).to have_received(:get_trusts).exactly(2).times
 
     expect(api_client).to have_received(:get_establishment).exactly(25).times
-    expect(api_client).to have_received(:get_trust).exactly(25).times
   end
 
   it "handles eager loading" do


### PR DESCRIPTION
## Changes

Background: We have an issue on Production where projects keep becoming invalid.
The UKPRN entered for the incoming trust, which was valid when the project was
created, is being changed upstream in the Academies DB. That change is then
being ingested into the Academies API, and when we try to load an existing
project, the UKPRN is not found and it significantly breaks the application
for users.

Because the Project model is "at rest", we do not think it needs validations.
Any Project creation or editing is done via FormObjects, which have their own
validations. We do not need to be validating the Projects on load into listing
pages, view pages or exports.

This PR enables the application to still work (load listing pages, show pages and exports) even if an invalid UKPRN is present in one of the projects.

This work is not ideal - ideally, noone should be updating UKPRNs in the Academies DB! - but we need to handle this reality and keep the app usable. 

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
