### PR TITLE
Do not raise an error when the Members API does not return a constituency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Do not raise an exception in reports when an establishment is in an unknown
+  constituency and the MP details cannot be found.
+
 ## [Release-71][Release-71]
 
 ### Added

--- a/app/models/api/members_api/client.rb
+++ b/app/models/api/members_api/client.rb
@@ -19,7 +19,7 @@ class Api::MembersApi::Client
       body = JSON.parse(response.body)
       Result.new(body, nil)
     else
-      Result.new(nil, Error.new(I18n.t("members_api.errors.other")))
+      Result.new(nil, Error.new(I18n.t("members_api.errors.other", search_term: search_term, status: response.status)))
     end
   end
 
@@ -39,7 +39,9 @@ class Api::MembersApi::Client
 
   def member_id(search_term)
     constituency_data = constituency(search_term)
-    raise constituency_data.error if constituency_data.error.present?
+    if constituency_data.error.present?
+      return Result.new(nil, constituency_data.error)
+    end
 
     if constituency_data.object["items"].count == 0
       Result.new(nil, NotFoundError.new(NotFoundError.new(I18n.t("members_api.errors.search_term_not_found", constituency: search_term))))

--- a/config/locales/members_api.en.yml
+++ b/config/locales/members_api.en.yml
@@ -1,7 +1,7 @@
 en:
   members_api:
     errors:
-      other: "[MEMBERS API] There was an error connecting to the Members API"
+      other: "[MEMBERS API] There was an error connecting to the Members API, status: %{status}, search_term: %{search_term}"
       multiple: "[MEMBERS API] Multiple results found for search term: %{search_term}"
       search_term_not_found: "[MEMBERS_API] Constituency not found: %{constituency}"
       member_not_found: "[MEMBERS API] Member not found: %{member_id}"

--- a/spec/models/api/members_api/client_spec.rb
+++ b/spec/models/api/members_api/client_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Api::MembersApi::Client do
       it "returns a Result with an Error" do
         expect(subject.object).to be_nil
         expect(subject.error).to be_a(Api::MembersApi::Client::Error)
-        expect(subject.error.message).to eq(I18n.t("members_api.errors.other"))
+        expect(subject.error.message).to eq(I18n.t("members_api.errors.other", search_term: "St Albans", status: 500))
       end
     end
 
@@ -143,6 +143,18 @@ RSpec.describe Api::MembersApi::Client do
         expect(subject.object).to be_nil
         expect(subject.error).to be_a(Api::MembersApi::Client::NotFoundError)
         expect(subject.error.message).to eq(I18n.t("members_api.errors.search_term_not_found", constituency: "Mars"))
+      end
+    end
+
+    context "when there is any other error" do
+      subject { client.member_id("nonexistent place") }
+
+      let(:fake_response) { [404, nil] }
+
+      it "returns an Error" do
+        expect(subject.object).to be_nil
+        expect(subject.error).to be_a(Api::MembersApi::Client::Error)
+        expect(subject.error.message).to eq(I18n.t("members_api.errors.other", search_term: "nonexistent place", status: 404))
       end
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -395,7 +395,7 @@ RSpec.describe Project, type: :model do
       expect(member_of_parliament).to be nil
     end
 
-    it "sends Applications Instights an event when the API call fails" do
+    it "sends Applications Insights an event when the API call fails" do
       ClimateControl.modify(APPLICATION_INSIGHTS_KEY: "fake-application-insights-key") do
         telemetry_client = double(ApplicationInsights::TelemetryClient, track_event: true, flush: true)
         allow(ApplicationInsights::TelemetryClient).to receive(:new).and_return(telemetry_client)
@@ -408,6 +408,16 @@ RSpec.describe Project, type: :model do
 
         expect(telemetry_client).to have_received(:track_event)
       end
+    end
+
+    it "returns nil when there is an error from the Members API" do
+      mock_members_api_unavailable_response
+
+      project = build(:conversion_project)
+      allow(project).to receive(:establishment).and_return(build(:academies_api_establishment))
+      member_of_parliament = project.member_of_parliament
+
+      expect(member_of_parliament).to be_nil
     end
   end
 


### PR DESCRIPTION
We found a bug with the exports where a project is in an unknown constituency. We thought we had all exceptions handled but evidently not this one - and this error is likely to become more frequent following the upcoming constituency boundary changes.

Handle an unknown constituency. Also flesh out the error message to return the response status and searched-for term, which will make future debugging easier.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
