### PR TITLE
Fix: missing export file extension

### DIFF
--- a/app/controllers/all/export/rpa_sug_and_fa_letters_controller.rb
+++ b/app/controllers/all/export/rpa_sug_and_fa_letters_controller.rb
@@ -1,5 +1,5 @@
 class All::Export::RpaSugAndFaLettersController < ApplicationController
-  EXPORT_FILE_NAME_SUFFIX = "rpa_sug_and_fa_letters"
+  EXPORT_FILE_NAME_SUFFIX = "rpa_sug_and_fa_letters.csv"
 
   def new
     authorize :export

--- a/spec/requests/all/export/new_rpa_sug_fa_letters_export_spec.rb
+++ b/spec/requests/all/export/new_rpa_sug_fa_letters_export_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe All::Export::RpaSugAndFaLettersController, type: :request do
 
         expect(response.status).to be 200
         expect(response.headers["Content-type"]).to eql "text/csv"
-        expect(response.headers["Content-disposition"]).to include "rpa_sug_and_fa_letters"
+        expect(response.headers["Content-disposition"]).to include "rpa_sug_and_fa_letters.csv"
       end
     end
 


### PR DESCRIPTION
Some browsers do not use the file mime type to identify the exported
file, so we add `.csv` to help.

