### PR TITLE
Do not return a Member of Parliament for projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Turn off Parliamentary Members API, do not show any MP details for any
+  projects
+
 ## [Release-72][release-72]
 
 ### Fixed

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -107,7 +107,7 @@ class Project < ApplicationRecord
   end
 
   def member_of_parliament
-    @member_of_parliament ||= fetch_member_of_parliament
+    nil
   end
 
   def unassigned_to_user?
@@ -132,6 +132,7 @@ class Project < ApplicationRecord
     false
   end
 
+  # :nocov:
   private def fetch_member_of_parliament
     result = Api::MembersApi::Client.new.member_for_constituency(establishment.parliamentary_constituency)
 
@@ -141,6 +142,7 @@ class Project < ApplicationRecord
       result.object
     end
   end
+  # :nocov:
 
   private def fetch_establishment(urn)
     result = Api::AcademiesApi::Client.new.get_establishment(urn)

--- a/app/presenters/export/csv/mp_presenter_module.rb
+++ b/app/presenters/export/csv/mp_presenter_module.rb
@@ -1,3 +1,4 @@
+# :nocov:
 module Export::Csv::MpPresenterModule
   def mp_name
     return if @project.member_of_parliament.nil?
@@ -41,3 +42,4 @@ module Export::Csv::MpPresenterModule
     @project.member_of_parliament.address.postcode
   end
 end
+# :nocov:

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -360,6 +360,7 @@ RSpec.describe Project, type: :model do
 
   describe "#member_of_parliament" do
     it "returns the details of the MP for the projects establishment constituency" do
+      skip "The Parliamentary Members API is not currently efficient enough to use"
       mock_successful_member_details
 
       project = build(:conversion_project)
@@ -373,6 +374,7 @@ RSpec.describe Project, type: :model do
     end
 
     it "only goes to the API once per instance of Project" do
+      skip "The Parliamentary Members API is not currently efficient enough to use"
       mock_api_client = mock_successful_member_details
 
       project = build(:conversion_project)
@@ -396,6 +398,7 @@ RSpec.describe Project, type: :model do
     end
 
     it "sends Applications Insights an event when the API call fails" do
+      skip "The Parliamentary Members API is not currently efficient enough to use"
       ClimateControl.modify(APPLICATION_INSIGHTS_KEY: "fake-application-insights-key") do
         telemetry_client = double(ApplicationInsights::TelemetryClient, track_event: true, flush: true)
         allow(ApplicationInsights::TelemetryClient).to receive(:new).and_return(telemetry_client)
@@ -417,6 +420,12 @@ RSpec.describe Project, type: :model do
       allow(project).to receive(:establishment).and_return(build(:academies_api_establishment))
       member_of_parliament = project.member_of_parliament
 
+      expect(member_of_parliament).to be_nil
+    end
+
+    it "returns nil for member_of_parliament due to the Parliamentary Members API not being useable" do
+      project = build(:conversion_project)
+      member_of_parliament = project.member_of_parliament
       expect(member_of_parliament).to be_nil
     end
   end

--- a/spec/presenters/export/csv/mp_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/mp_presenter_module_spec.rb
@@ -10,18 +10,22 @@ RSpec.describe Export::Csv::MpPresenterModule do
   subject { MpPresenterModuleTestClass.new(project) }
 
   it "presents the name" do
+    skip "The Parliamentary Members API is not currently efficient enough to use"
     expect(subject.mp_name).to eql "First Last"
   end
 
   it "presents the email" do
+    skip "The Parliamentary Members API is not currently efficient enough to use"
     expect(subject.mp_email).to eql "first.last.mp@parliament.uk"
   end
 
   it "presents the constituency" do
+    skip "The Parliamentary Members API is not currently efficient enough to use"
     expect(subject.mp_constituency).to eql "Constituency"
   end
 
   it "presents the address" do
+    skip "The Parliamentary Members API is not currently efficient enough to use"
     expect(subject.mp_address_1).to eql "House of Commons"
     expect(subject.mp_address_2).to eql ""
     expect(subject.mp_address_3).to eql "London"


### PR DESCRIPTION
Background: The Parliamentary Members API is not efficient enough to use when generating exports with large numbers of projects. Additionally, during the pre-election period, the API does not actually return any MP details so it is pointless for us to use a lot of processing power for no results.

Return `nil` for all MPs on all projects. Our presenter code can handle a nil MP record.

We have had to add the `nocov` instruction to the relevant implementation code as our CI rules expect 100% code coverage, and skipped tests do not count towards our code coverage.

