### PR TITLE
(168868) Rename csv conversion export services

### DIFF
--- a/app/forms/export/new_pre_conversion_grants_form.rb
+++ b/app/forms/export/new_pre_conversion_grants_form.rb
@@ -3,6 +3,6 @@ class Export::NewPreConversionGrantsForm < Export::BaseForm
     projects = Project.conversions.advisory_board_date_in_range(from_date.to_s, to_date.to_s)
     pre_fetched_projects = AcademiesApiPreFetcherService.new.call!(projects)
 
-    Export::Conversions::GrantManagementAndFinanceUnitCsvExportService.new(pre_fetched_projects).call
+    Export::Conversions::PreConversionGrantsCsvExportService.new(pre_fetched_projects).call
   end
 end

--- a/app/forms/export/new_rpa_sug_and_fa_letters_form.rb
+++ b/app/forms/export/new_rpa_sug_and_fa_letters_form.rb
@@ -3,6 +3,6 @@ class Export::NewRpaSugAndFaLettersForm < Export::BaseForm
     projects = Project.conversions.significant_date_in_range(from_date.to_s, to_date.to_s)
     pre_fetched_projects = AcademiesApiPreFetcherService.new.call!(projects)
 
-    Export::Conversions::SchoolsDueToConvertCsvExportService.new(pre_fetched_projects).call
+    Export::Conversions::RpaSugAndFaLettersCsvExportService.new(pre_fetched_projects).call
   end
 end

--- a/app/services/export/conversions/pre_conversion_grants_csv_export_service.rb
+++ b/app/services/export/conversions/pre_conversion_grants_csv_export_service.rb
@@ -1,4 +1,4 @@
-class Export::Conversions::GrantManagementAndFinanceUnitCsvExportService < Export::CsvExportService
+class Export::Conversions::PreConversionGrantsCsvExportService < Export::CsvExportService
   COLUMN_HEADERS = %i[
     school_urn
     school_name

--- a/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
+++ b/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
@@ -1,4 +1,4 @@
-class Export::Conversions::SchoolsDueToConvertCsvExportService < Export::CsvExportService
+class Export::Conversions::RpaSugAndFaLettersCsvExportService < Export::CsvExportService
   COLUMN_HEADERS = %i[
     school_urn
     school_name

--- a/spec/forms/export/new_pre_conversion_grants_form_spec.rb
+++ b/spec/forms/export/new_pre_conversion_grants_form_spec.rb
@@ -37,11 +37,11 @@ RSpec.describe Export::NewPreConversionGrantsForm, type: :model do
       form = described_class.new(from_date: from_date, to_date: to_date)
       fake_csv_export_service = double(call: [])
 
-      allow(Export::Conversions::GrantManagementAndFinanceUnitCsvExportService).to receive(:new).and_return(fake_csv_export_service)
+      allow(Export::Conversions::PreConversionGrantsCsvExportService).to receive(:new).and_return(fake_csv_export_service)
 
       form.export
 
-      expect(Export::Conversions::GrantManagementAndFinanceUnitCsvExportService).to have_received(:new).once
+      expect(Export::Conversions::PreConversionGrantsCsvExportService).to have_received(:new).once
       expect(fake_csv_export_service).to have_received(:call).once
     end
   end

--- a/spec/forms/export/new_rpa_sug_and_fa_letters_form_spec.rb
+++ b/spec/forms/export/new_rpa_sug_and_fa_letters_form_spec.rb
@@ -37,11 +37,11 @@ RSpec.describe Export::NewRpaSugAndFaLettersForm, type: :model do
       form = described_class.new(from_date: from_date, to_date: to_date)
       fake_csv_export_service = double(call: [])
 
-      allow(Export::Conversions::SchoolsDueToConvertCsvExportService).to receive(:new).and_return(fake_csv_export_service)
+      allow(Export::Conversions::RpaSugAndFaLettersCsvExportService).to receive(:new).and_return(fake_csv_export_service)
 
       form.export
 
-      expect(Export::Conversions::SchoolsDueToConvertCsvExportService).to have_received(:new).once
+      expect(Export::Conversions::RpaSugAndFaLettersCsvExportService).to have_received(:new).once
       expect(fake_csv_export_service).to have_received(:call).once
     end
   end

--- a/spec/services/export/conversions/pre_conversion_grants_csv_export_service_spec.rb
+++ b/spec/services/export/conversions/pre_conversion_grants_csv_export_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Export::Conversions::GrantManagementAndFinanceUnitCsvExportService do
+RSpec.describe Export::Conversions::PreConversionGrantsCsvExportService do
   describe "#call" do
     before do
       mock_successful_api_response_to_create_any_project
@@ -11,7 +11,7 @@ RSpec.describe Export::Conversions::GrantManagementAndFinanceUnitCsvExportServic
       user = build(:user, email: "user.name@education.gov.uk")
       project = build(:conversion_project, urn: 123456, assigned_to: user)
 
-      csv_export = Export::Conversions::GrantManagementAndFinanceUnitCsvExportService.new([project]).call
+      csv_export = Export::Conversions::PreConversionGrantsCsvExportService.new([project]).call
 
       expect(csv_export).to include("School URN")
       expect(csv_export).to include("123456")

--- a/spec/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service_spec.rb
+++ b/spec/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Export::Conversions::SchoolsDueToConvertCsvExportService do
+RSpec.describe Export::Conversions::RpaSugAndFaLettersCsvExportService do
   describe "#call" do
     it "returns only the headers when there are no projects" do
       projects = []


### PR DESCRIPTION
We are attempting to keep all the code that relates to a specific export
coupled together, this works follows up on the new exports by matching the
namers of the conversion export service classes to that of the specific export.
