### PR TITLE
(168868) Rename csv transfers export services

### DIFF
--- a/app/forms/export/new_pre_transfer_grants_form.rb
+++ b/app/forms/export/new_pre_transfer_grants_form.rb
@@ -3,6 +3,6 @@ class Export::NewPreTransferGrantsForm < Export::BaseForm
     projects = Project.transfers.advisory_board_date_in_range(from_date.to_s, to_date.to_s)
     pre_fetched_projects = AcademiesApiPreFetcherService.new.call!(projects)
 
-    Export::Transfers::GrantManagementAndFinanceUnitCsvExportService.new(pre_fetched_projects).call
+    Export::Transfers::PreTransferGrantsCsvExportService.new(pre_fetched_projects).call
   end
 end

--- a/app/services/export/transfers/pre_transfer_grants_csv_export_service.rb
+++ b/app/services/export/transfers/pre_transfer_grants_csv_export_service.rb
@@ -1,4 +1,4 @@
-class Export::Transfers::GrantManagementAndFinanceUnitCsvExportService < Export::CsvExportService
+class Export::Transfers::PreTransferGrantsCsvExportService < Export::CsvExportService
   COLUMN_HEADERS = %i[
     academy_name
     academy_urn

--- a/spec/forms/export/new_pre_transfer_grants_form_spec.rb
+++ b/spec/forms/export/new_pre_transfer_grants_form_spec.rb
@@ -37,11 +37,11 @@ RSpec.describe Export::NewPreTransferGrantsForm, type: :model do
       form = described_class.new(from_date: from_date, to_date: to_date)
       fake_csv_export_service = double(call: [])
 
-      allow(Export::Transfers::GrantManagementAndFinanceUnitCsvExportService).to receive(:new).and_return(fake_csv_export_service)
+      allow(Export::Transfers::PreTransferGrantsCsvExportService).to receive(:new).and_return(fake_csv_export_service)
 
       form.export
 
-      expect(Export::Transfers::GrantManagementAndFinanceUnitCsvExportService).to have_received(:new).once
+      expect(Export::Transfers::PreTransferGrantsCsvExportService).to have_received(:new).once
       expect(fake_csv_export_service).to have_received(:call).once
     end
   end

--- a/spec/services/export/transfers/pre_transfer_grants_csv_export_service_spec.rb
+++ b/spec/services/export/transfers/pre_transfer_grants_csv_export_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Export::Transfers::GrantManagementAndFinanceUnitCsvExportService do
+RSpec.describe Export::Transfers::PreTransferGrantsCsvExportService do
   describe "#call" do
     before do
       mock_successful_api_response_to_create_any_project
@@ -12,7 +12,7 @@ RSpec.describe Export::Transfers::GrantManagementAndFinanceUnitCsvExportService 
       rdo = build(:regional_delivery_officer_user, email: "rdo.name@education.gov.uk")
       project = build(:transfer_project, urn: 123456, assigned_to: user, regional_delivery_officer: rdo)
 
-      csv_export = Export::Transfers::GrantManagementAndFinanceUnitCsvExportService.new([project]).call
+      csv_export = Export::Transfers::PreTransferGrantsCsvExportService.new([project]).call
 
       expect(csv_export).to include("Added by email")
       expect(csv_export).to include("rdo.name@education.gov.uk")


### PR DESCRIPTION
We are attempting to keep all the code that relates to a specific export
coupled together, this works follows up on the new exports by matching the
namers of the transfers export service classes to that of the specific export.

Based on #1634 
