### PR TITLE
Optimise the local authority project fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   date range.
 - The pre transfer grants export now include the projects for a supplied date
   range.
+- The loading time of the by local authority view has been improved, it has to
+  load all projects so is still a slow view.
 
 ## [Release-73][release-73]
 

--- a/app/controllers/all/local_authorities/projects_controller.rb
+++ b/app/controllers/all/local_authorities/projects_controller.rb
@@ -10,9 +10,7 @@ class All::LocalAuthorities::ProjectsController < ApplicationController
   def show
     authorize Project, :index?
     @local_authority = LocalAuthority.find_by!(code: local_authority_code)
-    @pager, @projects = pagy(ByLocalAuthorityProjectFetcherService.new.projects_for_local_authority(@local_authority.code))
-
-    AcademiesApiPreFetcherService.new.call!(@projects)
+    @pager, @projects = pagy_array(ByLocalAuthorityProjectFetcherService.new.projects_for_local_authority(@local_authority.code))
   end
 
   private def local_authority_code

--- a/spec/services/by_local_authority_project_fetcher_service_spec.rb
+++ b/spec/services/by_local_authority_project_fetcher_service_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ByLocalAuthorityProjectFetcherService do
-  it "returns a sorted list of simple local authority objects with conversion and transfer projects" do
+  before do
     establishment = build(:academies_api_establishment, local_authority_code: "909", urn: 121813)
     another_establishment = build(:academies_api_establishment, local_authority_code: "213", urn: 121102)
     yet_another_establishment = build(:academies_api_establishment, local_authority_code: "926", urn: 121583)
@@ -20,40 +20,86 @@ RSpec.describe ByLocalAuthorityProjectFetcherService do
     create(:local_authority, code: "213", name: "Westminster City Council")
     create(:local_authority, code: "926", name: "Norfolk County Council")
 
-    create(:conversion_project, urn: establishment.urn)
+    create(:conversion_project, urn: establishment.urn, conversion_date: Date.new(2024, 1, 1))
     create(:conversion_project, urn: another_establishment.urn)
-    create(:conversion_project, urn: establishment.urn)
+    create(:conversion_project, urn: establishment.urn, conversion_date: Date.new(2024, 2, 1))
 
-    create(:transfer_project, urn: establishment.urn)
+    create(:transfer_project, urn: establishment.urn, transfer_date: Date.new(2024, 3, 1))
     create(:transfer_project, urn: yet_another_establishment.urn)
-
-    result = described_class.new.local_authorities_with_projects
-
-    expect(result.count).to eql 3
-
-    first_result = result.first
-
-    expect(first_result.name).to eql "Cumbria County Council"
-    expect(first_result.code).to eql "909"
-    expect(first_result.conversion_count).to eql 2
-    expect(first_result.transfer_count).to eql 1
-
-    middle_result = result[1]
-
-    expect(middle_result.name).to eql "Norfolk County Council"
-    expect(middle_result.code).to eql "926"
-    expect(middle_result.conversion_count).to eql 0
-    expect(middle_result.transfer_count).to eql 1
-
-    last_result = result.last
-
-    expect(last_result.name).to eql "Westminster City Council"
-    expect(last_result.code).to eql "213"
-    expect(last_result.conversion_count).to eql 1
-    expect(last_result.transfer_count).to eql 0
   end
 
-  it "returns an empty array when there are no projects to source trusts" do
-    expect(described_class.new.local_authorities_with_projects).to eql []
+  describe "#local_authorities_with_projects" do
+    it "returns a sorted list of local authorities with counts of the projects for them" do
+      result = described_class.new.local_authorities_with_projects
+
+      expect(result.count).to eql 3
+
+      first_result = result.first
+
+      expect(first_result.name).to eql "Cumbria County Council"
+      expect(first_result.code).to eql "909"
+      expect(first_result.conversion_count).to eql 2
+      expect(first_result.transfer_count).to eql 1
+
+      middle_result = result[1]
+
+      expect(middle_result.name).to eql "Norfolk County Council"
+      expect(middle_result.code).to eql "926"
+      expect(middle_result.conversion_count).to eql 0
+      expect(middle_result.transfer_count).to eql 1
+
+      last_result = result.last
+
+      expect(last_result.name).to eql "Westminster City Council"
+      expect(last_result.code).to eql "213"
+      expect(last_result.conversion_count).to eql 1
+      expect(last_result.transfer_count).to eql 0
+    end
+
+    it "returns an empty array when there are no projects to source local authorities" do
+      allow(Project).to receive(:active).and_return(Project.none)
+
+      expect(described_class.new.local_authorities_with_projects).to eql []
+    end
+
+    it "only fetches projects and related data once" do
+      spy = AcademiesApiPreFetcherService.new
+      allow(AcademiesApiPreFetcherService).to receive(:new).and_return(spy)
+      allow(spy).to receive(:call!).and_call_original
+
+      result = described_class.new
+
+      result.local_authorities_with_projects
+      result.local_authorities_with_projects
+
+      expect(spy).to have_received(:call!).once
+    end
+  end
+
+  describe "#projects_for_local_authority" do
+    it "returns a sorted list of projects for the supplied local authority" do
+      projects_for_local_authority = described_class.new.projects_for_local_authority("909")
+
+      expect(projects_for_local_authority.count).to eql 3
+      expect(projects_for_local_authority.first.conversion_date).to eql Date.new(2024, 1, 1)
+      expect(projects_for_local_authority.last.transfer_date).to eql Date.new(2024, 3, 1)
+    end
+
+    it "returns an empty array when there are no projects for the supplied local authority code" do
+      expect(described_class.new.projects_for_local_authority("101")).to eql []
+    end
+
+    it "only fetches project and related date once" do
+      spy = AcademiesApiPreFetcherService.new
+      allow(AcademiesApiPreFetcherService).to receive(:new).and_return(spy)
+      allow(spy).to receive(:call!).and_call_original
+
+      result = described_class.new
+
+      result.projects_for_local_authority("909")
+      result.projects_for_local_authority("909")
+
+      expect(spy).to have_received(:call!).once
+    end
   end
 end


### PR DESCRIPTION
We have no option for this fetcher but to load ALL active projects
because of the way our data is structured, with local authority a
property of the establishment and so not in the database.

But we can improve things slightly in two ways:

- ensuring the projects returned always preload the establishments
- when returning projects for a given local authority we re-use the
  already fetched project rather than going to the database again, this
  results in an array instead of an `ActiveRecord::Relation` so we change
  the controller

