### PR TITLE
Add MS Application Insights browser telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Microsoft Application Insights browser tracking has been added to the
+  application and will only be enabled for users who have opted in to optional
+  cookies.
+
 ### Changed
 
 - The academies due to convert export now includes the projects for a supplied

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,6 +30,13 @@ module ApplicationHelper
     cookies[:ACCEPT_OPTIONAL_COOKIES].present?
   end
 
+  def enable_application_insights?
+    return false if ENV["ApplicationInsights__ConnectionString"].blank?
+    return false unless ENV["RAILS_ENV"] == "production"
+    return false unless cookies[:ACCEPT_OPTIONAL_COOKIES] == "true"
+    true
+  end
+
   def enable_google_tag_manager?
     return false unless ENV["USER_ENV"] == "production"
     return false unless ENV["GOOGLE_TAG_MANAGER_ID"].present?

--- a/app/javascript/application-insights.js
+++ b/app/javascript/application-insights.js
@@ -1,0 +1,23 @@
+import { ApplicationInsights } from '@microsoft/applicationinsights-web'
+import { ClickAnalyticsPlugin } from '@microsoft/applicationinsights-clickanalytics-js'
+
+const applicationInsightsConnectionString = document.head.querySelector('meta[name="application-insights-connection"]').content
+
+const clickPluginInstance = new ClickAnalyticsPlugin()
+const clickPluginConfig = {
+  autoCapture: true
+}
+
+const appInsights = new ApplicationInsights({
+  config: {
+    connectionString: applicationInsightsConnectionString
+  },
+  extensions: [clickPluginInstance],
+  extensionConfig: {
+    [clickPluginInstance.identifier]: clickPluginConfig
+  }
+}
+)
+
+appInsights.loadAppInsights()
+appInsights.trackPageView()

--- a/app/views/cookies/edit.html.erb
+++ b/app/views/cookies/edit.html.erb
@@ -46,6 +46,8 @@
 
     <h2 class="govuk-heading-l">Optional cookies</h2>
     <p class="govuk-body">With your permission, we use optional cookies.</p>
+
+    <h3 class="govuk-heading-s">Google Analytics</h3>
     <p class="govuk-body">Optional cookies are used by Google Analytics which we use to learn about how you use this service.</p>
     <p class="govuk-body">Google Analytics stores information about:</p>
     <ul class="govuk-list govuk-list--bullet">
@@ -72,6 +74,44 @@
           <td class="govuk-table__cell">_ga_7H5HDH7D7F</td>
           <td class="govuk-table__cell">Used to persist session state</td>
           <td class="govuk-table__cell">2 years</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 class="govuk-heading-s">Azure Application Insights</h3>
+    <p class="govuk-body">We use Azure Application Insights software to collect information about how you use this website. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.</p>
+    <p class="govuk-body">Azure Application Insights stores information about:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the pages you visit on this website</li>
+      <li>how long you spend on each page</li>
+      <li>how you got to the site</li>
+      <li>what you click on while you're visiting the site</li>
+    </ul>
+    <p class="govuk-body">We don't allow Microsoft to use or share our analytics data.</p>
+    <p class="govuk-body">Azure Application Insights sets the following cookies:</p>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Name</th>
+          <th scope="col" class="govuk-table__header">Purpose</th>
+          <th scope="col" class="govuk-table__header">Expires</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">ai_session</td>
+          <td class="govuk-table__cell">This helps us track activity happening over a single browser session</td>
+          <td class="govuk-table__cell">1 hour</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">ai_user</td>
+          <td class="govuk-table__cell">This helps us to identify the number of distinct users accessing the site over time by tracking if you've visited before</td>
+          <td class="govuk-table__cell">1 year</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">ai_authuser</td>
+          <td class="govuk-table__cell">This helps us to authenticated users and how they interact with the site</td>
+          <td class="govuk-table__cell">When you close your browser</td>
         </tr>
       </tbody>
     </table>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <title><%= content_for?(:page_title) ? yield(:page_title) : t("service_name") %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="theme-color" content="#0b0c0c">
+    <%= tag :meta, name: "application-insights-connection", content: ENV["ApplicationInsights__ConnectionString"] if enable_application_insights? %>
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,8 @@
     <meta property="og:image" content="<%= image_url("govuk-frontend/govuk/assets/images/govuk-opengraph-image.png") %>">
 
     <%= stylesheet_link_tag "application" %>
+
+    <%= javascript_include_tag "application-insights" if enable_application_insights? %>
     <%= javascript_include_tag "govuk-frontend/govuk/all" %>
     <%= javascript_include_tag "dfefrontend" %>
     <%= javascript_include_tag "application", defer: true %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -9,6 +9,7 @@ Rails.application.configure do
     policy.default_src :self, "https://region1.google-analytics.com"
     policy.font_src :self
     policy.img_src :self, "https://region1.google-analytics.com"
+    policy.connect_src :self, "https://js.monitor.azure.com", "https://westeurope-5.in.applicationinsights.azure.com"
     policy.object_src :none
     policy.script_src :self, "https://www.googletagmanager.com/gtm.js"
     policy.style_src :self

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "standard": "^17.1.0"
   },
   "dependencies": {
+    "@microsoft/applicationinsights-clickanalytics-js": "^3.2.1",
+    "@microsoft/applicationinsights-web": "^3.2.1",
     "@ministryofjustice/frontend": "^1.8.0",
     "accessible-autocomplete": "^3.0.0",
     "govuk-frontend": "^4.7.0",

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -92,6 +92,51 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe "#enable_application_insights?" do
+    it "returns true when all the variables are set" do
+      ClimateControl.modify(
+        RAILS_ENV: "production",
+        ApplicationInsights__ConnectionString: "test"
+      ) do
+        cookies[:ACCEPT_OPTIONAL_COOKIES] = "true"
+
+        expect(enable_application_insights?).to eq(true)
+      end
+    end
+
+    it "returns false when the user is not opted in to optional cookies" do
+      ClimateControl.modify(
+        RAILS_ENV: "production",
+        ApplicationInsights__ConnectionString: "test"
+      ) do
+        cookies[:ACCEPT_OPTIONAL_COOKIES] = "false"
+
+        expect(enable_application_insights?).to eq(false)
+      end
+    end
+
+    it "returns false when not running in one of the 'production' environments" do
+      ClimateControl.modify(
+        RAILS_ENV: "development",
+        ApplicationInsights__ConnectionString: "test"
+      ) do
+        cookies[:ACCEPT_OPTIONAL_COOKIES] = "true"
+
+        expect(enable_application_insights?).to eq(false)
+      end
+    end
+
+    it "returns false when the connection string is not set" do
+      ClimateControl.modify(
+        RAILS_ENV: "production"
+      ) do
+        cookies[:ACCEPT_OPTIONAL_COOKIES] = "true"
+
+        expect(enable_application_insights?).to eq(false)
+      end
+    end
+  end
+
   describe "#enable_google_tag_manager?" do
     context "when not in production" do
       it "returns false" do

--- a/yarn.lock
+++ b/yarn.lock
@@ -168,6 +168,127 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
+"@microsoft/applicationinsights-analytics-js@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-3.2.1.tgz#1a7fda8c8e453962f962aadfd63811c7e9f77f41"
+  integrity sha512-BDFnV0WwLcUIqgPmC3Sl8Z35ybf4898WSbrfCC80BNbxi2zztyJSLlxWXKSw9j+DCkKZMYIJIsWnpKQfEtqA7g==
+  dependencies:
+    "@microsoft/applicationinsights-common" "3.2.1"
+    "@microsoft/applicationinsights-core-js" "3.2.1"
+    "@microsoft/applicationinsights-shims" "3.0.1"
+    "@microsoft/dynamicproto-js" "^2.0.3"
+    "@nevware21/ts-utils" ">= 0.11.1 < 2.x"
+
+"@microsoft/applicationinsights-cfgsync-js@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-cfgsync-js/-/applicationinsights-cfgsync-js-3.2.1.tgz#3247a8c3fac9f111f7593dae8be535a2b7e2623f"
+  integrity sha512-a0gf3czbRycOXwIRO/dYqmTThYkGRS26TVETRpSnW12IcAuLE82FJfWHlHRmSNX9xY/F+wWc0N7BqHcWjFIbeQ==
+  dependencies:
+    "@microsoft/applicationinsights-common" "3.2.1"
+    "@microsoft/applicationinsights-core-js" "3.2.1"
+    "@microsoft/applicationinsights-shims" "3.0.1"
+    "@microsoft/dynamicproto-js" "^2.0.3"
+    "@nevware21/ts-async" ">= 0.5.1 < 2.x"
+    "@nevware21/ts-utils" ">= 0.11.1 < 2.x"
+
+"@microsoft/applicationinsights-channel-js@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.2.1.tgz#fa882b81aed5a40e47a78f6d996e5ed01ba29586"
+  integrity sha512-+aWBBbIW4/Tf4sLGZmWhd5chktBpKQpnCbkuoTHGe+AWO8Q8fsDa4w2Y89OGuEg9OJ3kr2VKTUU7LgILKFz/cg==
+  dependencies:
+    "@microsoft/applicationinsights-common" "3.2.1"
+    "@microsoft/applicationinsights-core-js" "3.2.1"
+    "@microsoft/applicationinsights-shims" "3.0.1"
+    "@microsoft/dynamicproto-js" "^2.0.3"
+    "@nevware21/ts-async" ">= 0.5.1 < 2.x"
+    "@nevware21/ts-utils" ">= 0.11.1 < 2.x"
+
+"@microsoft/applicationinsights-clickanalytics-js@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-clickanalytics-js/-/applicationinsights-clickanalytics-js-3.2.1.tgz#19d92fcaf416bda54c45ea77484b2cf965358980"
+  integrity sha512-e1/pnuYr0FiEx2lEXT0J6ZzTBlIl8Y5JFXgej1vmpl0+XPdN5cNdjqgFPxWkUuECcyeY/6QbEZ96RrmR5txBiA==
+  dependencies:
+    "@microsoft/applicationinsights-common" "3.2.1"
+    "@microsoft/applicationinsights-core-js" "3.2.1"
+    "@microsoft/applicationinsights-properties-js" "3.2.1"
+    "@microsoft/applicationinsights-shims" "3.0.1"
+    "@microsoft/dynamicproto-js" "^2.0.3"
+    "@nevware21/ts-utils" ">= 0.11.1 < 2.x"
+
+"@microsoft/applicationinsights-common@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-common/-/applicationinsights-common-3.2.1.tgz#133603acda71fa20aa1f83f13075c814adcde190"
+  integrity sha512-vRYQ1SIZJEz1eFbs2AQiLtev5L+zmjZ1Jkj3BWfIxJLd6n0cVR4NZETBSyMuk11KH7MIOrDLvh1CzjBIJIpDAg==
+  dependencies:
+    "@microsoft/applicationinsights-core-js" "3.2.1"
+    "@microsoft/applicationinsights-shims" "3.0.1"
+    "@microsoft/dynamicproto-js" "^2.0.3"
+    "@nevware21/ts-utils" ">= 0.11.1 < 2.x"
+
+"@microsoft/applicationinsights-core-js@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.2.1.tgz#960547930cf6424ba633f9490adf382443cc65a0"
+  integrity sha512-euxkDrF5BroAY7wgviaTVZdMvRAENQtUW4pDTsIjJK26shi1m5fPCc5l+vMn7kO2wQEaEgAOVw+/kSQgXDHN+Q==
+  dependencies:
+    "@microsoft/applicationinsights-shims" "3.0.1"
+    "@microsoft/dynamicproto-js" "^2.0.3"
+    "@nevware21/ts-async" ">= 0.5.1 < 2.x"
+    "@nevware21/ts-utils" ">= 0.11.1 < 2.x"
+
+"@microsoft/applicationinsights-dependencies-js@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-3.2.1.tgz#e5da12f2d32852532bc1cfac18055b47344f89e4"
+  integrity sha512-NZ7OY/7KYmJ6/TFsDZojsr9mA4uNv4ZTrNNXfWqtPxx0ClYalSm6Xyjna0N1d1wktrfecHe8K/ZrWJgxI2bfRw==
+  dependencies:
+    "@microsoft/applicationinsights-common" "3.2.1"
+    "@microsoft/applicationinsights-core-js" "3.2.1"
+    "@microsoft/applicationinsights-shims" "3.0.1"
+    "@microsoft/dynamicproto-js" "^2.0.3"
+    "@nevware21/ts-async" ">= 0.5.1 < 2.x"
+    "@nevware21/ts-utils" ">= 0.11.1 < 2.x"
+
+"@microsoft/applicationinsights-properties-js@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-3.2.1.tgz#c78f3a77b91a52aa6a7c5b9a6b35435be71dbc0e"
+  integrity sha512-GO96t7tQ1eEHPENVXjOlf91h/Iz8p4I0XayALTSshHMc+eDfsi1a/b2JYrfNDC4fanPU44Kmx3QZkXrBb1ri5A==
+  dependencies:
+    "@microsoft/applicationinsights-common" "3.2.1"
+    "@microsoft/applicationinsights-core-js" "3.2.1"
+    "@microsoft/applicationinsights-shims" "3.0.1"
+    "@microsoft/dynamicproto-js" "^2.0.3"
+    "@nevware21/ts-utils" ">= 0.11.1 < 2.x"
+
+"@microsoft/applicationinsights-shims@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz#3865b73ace8405b9c4618cc5c571f2fe3876f06f"
+  integrity sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==
+  dependencies:
+    "@nevware21/ts-utils" ">= 0.9.4 < 2.x"
+
+"@microsoft/applicationinsights-web@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-web/-/applicationinsights-web-3.2.1.tgz#6d047653c402373c1f5e4709c6edf65e44b30208"
+  integrity sha512-+U0wsifFEmvdT2hckmsoNcMx/SQrAA8qBBM7y0zefT03wHbFh0jCL/kd2MFOyKZ39v9C4uIO5L8Ftu4hBpnYWA==
+  dependencies:
+    "@microsoft/applicationinsights-analytics-js" "3.2.1"
+    "@microsoft/applicationinsights-cfgsync-js" "3.2.1"
+    "@microsoft/applicationinsights-channel-js" "3.2.1"
+    "@microsoft/applicationinsights-common" "3.2.1"
+    "@microsoft/applicationinsights-core-js" "3.2.1"
+    "@microsoft/applicationinsights-dependencies-js" "3.2.1"
+    "@microsoft/applicationinsights-properties-js" "3.2.1"
+    "@microsoft/applicationinsights-shims" "3.0.1"
+    "@microsoft/dynamicproto-js" "^2.0.3"
+    "@nevware21/ts-async" ">= 0.5.1 < 2.x"
+    "@nevware21/ts-utils" ">= 0.11.1 < 2.x"
+
+"@microsoft/dynamicproto-js@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.3.tgz#ae2b408061e3ff01a97078429fc768331e239256"
+  integrity sha512-JTWTU80rMy3mdxOjjpaiDQsTLZ6YSGGqsjURsY6AUQtIj0udlF/jYmhdLZu8693ZIC0T1IwYnFa0+QeiMnziBA==
+  dependencies:
+    "@nevware21/ts-utils" ">= 0.10.4 < 2.x"
+
 "@ministryofjustice/frontend@^1.8.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-1.8.1.tgz#6bac39524ba406533d1ce51c55d4c8ff96ad358e"
@@ -175,6 +296,18 @@
   dependencies:
     govuk-frontend "^3.0.0 || ^4.0.0"
     moment "^2.27.0"
+
+"@nevware21/ts-async@>= 0.5.1 < 2.x":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@nevware21/ts-async/-/ts-async-0.5.1.tgz#3f55fa5222b0af5a5bb019f67092cdcd6a5f82e6"
+  integrity sha512-O2kN8n2HpDWJ7Oji+oTMnhITrCndmrNvrHbGDwAIBydx+FWvLE/vrw4QwnRRMvSCa2AJrcP59Ryklxv30KfkWQ==
+  dependencies:
+    "@nevware21/ts-utils" ">= 0.11.2 < 2.x"
+
+"@nevware21/ts-utils@>= 0.10.4 < 2.x", "@nevware21/ts-utils@>= 0.11.1 < 2.x", "@nevware21/ts-utils@>= 0.11.2 < 2.x", "@nevware21/ts-utils@>= 0.9.4 < 2.x":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@nevware21/ts-utils/-/ts-utils-0.11.2.tgz#5836f338c091f47358298da1f77a67a88219a6a5"
+  integrity sha512-80W8BkS09kkGuUHJX50Fqq+QqAslxUaOQytH+3JhRacXs1EpEt2JOOkYKytqFZAYir3SeH9fahniEaDzIBxlUw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
We want to run Application Insights browser telemetry alongside Google Analytics
so we can evaluate whether we can stop using Google Analytics.

This works only aims to get the connection working and allow us to validate
that, we may want or need to tweak things as we move forward.

We only want to enable tracking:

- in the production like environments of development, test and production
- if the connection string is set
- if the user has allowed optional cookies

@DrizzlyOwl has updated the cookie policy so we are assuming this is all good, I
noticed this along the way, it might be worth double checking:

https://github.com/microsoft/ApplicationInsights-JS?tab=readme-ov-file#data-collection
