### PR TITLE
Add SignificantDateHistoryReasons

### DIFF
--- a/app/models/significant_date_history.rb
+++ b/app/models/significant_date_history.rb
@@ -1,6 +1,7 @@
 class SignificantDateHistory < ApplicationRecord
   belongs_to :project, class_name: "Project"
   has_one :note, dependent: :destroy, foreign_key: :significant_date_history_id
+  has_many :reasons, dependent: :destroy, foreign_key: :significant_date_history_id, class_name: "SignificantDateHistoryReason"
 
   validates :previous_date, :revised_date, presence: true
 end

--- a/app/models/significant_date_history_reason.rb
+++ b/app/models/significant_date_history_reason.rb
@@ -1,0 +1,6 @@
+class SignificantDateHistoryReason < ApplicationRecord
+  belongs_to :significant_date_history, class_name: "SignificantDateHistory"
+  has_one :note, required: true, dependent: :destroy, foreign_key: :significant_date_history_reason_id
+
+  validates :reason_type, presence: true
+end

--- a/db/migrate/20240606152236_create_significant_date_history_reason.rb
+++ b/db/migrate/20240606152236_create_significant_date_history_reason.rb
@@ -1,0 +1,11 @@
+class CreateSignificantDateHistoryReason < ActiveRecord::Migration[7.0]
+  def change
+    create_table :significant_date_history_reasons, id: :uuid do |t|
+      t.timestamps
+      t.string :reason_type, index: true
+      t.uuid :significant_date_history_id
+    end
+
+    add_column :notes, :significant_date_history_reason_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_03_102728) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_06_152236) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -250,6 +250,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_03_102728) do
     t.datetime "updated_at", null: false
     t.string "task_identifier"
     t.uuid "significant_date_history_id"
+    t.uuid "significant_date_history_reason_id"
     t.index ["project_id"], name: "index_notes_on_project_id"
     t.index ["user_id"], name: "index_notes_on_user_id"
   end
@@ -308,6 +309,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_03_102728) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["project_id"], name: "index_significant_date_histories_on_project_id"
+  end
+
+  create_table "significant_date_history_reasons", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "reason_type"
+    t.uuid "significant_date_history_id"
+    t.index ["reason_type"], name: "index_significant_date_history_reasons_on_reason_type"
   end
 
   create_table "transfer_tasks_data", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/models/significant_date_history_reason_spec.rb
+++ b/spec/models/significant_date_history_reason_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe SignificantDateHistoryReason do
+  describe "Attributes" do
+    it { is_expected.to have_db_column(:reason_type).of_type :string }
+  end
+
+  describe "Validations" do
+    it { is_expected.to validate_presence_of(:reason_type) }
+  end
+
+  describe "Associations" do
+    it { is_expected.to have_one(:note).dependent(:destroy) }
+    it { is_expected.to belong_to(:significant_date_history).required(true) }
+  end
+end

--- a/spec/models/significant_date_history_spec.rb
+++ b/spec/models/significant_date_history_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe SignificantDateHistory do
 
   describe "Associations" do
     it { is_expected.to have_one(:note).dependent(:destroy) }
+    it { is_expected.to have_many(:reasons).dependent(:destroy).class_name("SignificantDateHistoryReason") }
     it { is_expected.to belong_to(:project).required(true) }
   end
 end


### PR DESCRIPTION
## Changes

We will need to start recording a reason for a chaange to Significant Dates on
projects. These reasons will be taken from a list of predefined reasons in a
form. To begin, we add a SignificantDateHistoryReason model, which sits between
the SignificantDateHistory record and its Note.

To ensure we do not break the existing SignificantDateHistory functionality, we
need ot preserve the connection between SignificantDateHistory and Note. Once
the new SignificantDateHistoryReasons are in place, we can do a data migration
to break these connections and re-join the existing SignificantDateHistory
records to their Notes via a SignificantDateHistoryReason record.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
