### PR TITLE
(169272) Significant date reasons

### DIFF
--- a/app/controllers/date_histories_controller.rb
+++ b/app/controllers/date_histories_controller.rb
@@ -2,7 +2,7 @@ class DateHistoriesController < ApplicationController
   include Projectable
 
   def index
-    @dates = @project.date_history.includes([note: [:user]]).order(created_at: :desc)
+    @dates = @project.date_history.includes([reasons: [:note]]).order(created_at: :desc)
   end
 
   def new

--- a/app/forms/conversion/task/stakeholder_kick_off_task_form.rb
+++ b/app/forms/conversion/task/stakeholder_kick_off_task_form.rb
@@ -38,8 +38,8 @@ class Conversion::Task::StakeholderKickOffTaskForm < ::BaseTaskForm
       ::SignificantDateCreatorService.new(
         project: @project,
         revised_date: confirmed_conversion_date,
-        note_body: "Conversion date confirmed as part of the External stakeholder kick off task.",
-        user: @user
+        user: @user,
+        reasons: stakeholder_kick_off_reason
       ).update!
     end
 
@@ -59,5 +59,9 @@ class Conversion::Task::StakeholderKickOffTaskForm < ::BaseTaskForm
 
   def in_progress?
     attributes.values.any?(&:present?) || @project.conversion_date_provisional? == false
+  end
+
+  private def stakeholder_kick_off_reason
+    [{type: :stakeholder_kick_off, note_text: "Conversion date confirmed as part of the External stakeholder kick off task."}]
   end
 end

--- a/app/forms/new_date_history_form.rb
+++ b/app/forms/new_date_history_form.rb
@@ -23,11 +23,20 @@ class NewDateHistoryForm
   def save
     return false unless valid?
 
-    if SignificantDateCreatorService.new(project: project, revised_date: revised_date, note_body: note_body, user: user).update!
+    if SignificantDateCreatorService.new(
+      project: project,
+      revised_date: revised_date,
+      user: user,
+      reasons: change_reason
+    ).update!
       true
     else
       errors.add(:revised_date, :transaction)
       false
     end
+  end
+
+  private def change_reason
+    [{type: :legacy_reason, note_text: note_body}]
   end
 end

--- a/app/forms/transfer/task/stakeholder_kick_off_task_form.rb
+++ b/app/forms/transfer/task/stakeholder_kick_off_task_form.rb
@@ -37,8 +37,8 @@ class Transfer::Task::StakeholderKickOffTaskForm < BaseTaskForm
       SignificantDateCreatorService.new(
         project: @project,
         revised_date: confirmed_transfer_date,
-        note_body: "Transfer date confirmed as part of the External stakeholder kick off task.",
-        user: @user
+        user: @user,
+        reasons: stakeholder_kick_off_reason
       ).update!
     end
 
@@ -57,5 +57,9 @@ class Transfer::Task::StakeholderKickOffTaskForm < BaseTaskForm
 
   def in_progress?
     attributes.values.any?(&:present?) || @project.transfer_date_provisional? == false
+  end
+
+  private def stakeholder_kick_off_reason
+    [{type: :stakeholder_kick_off, note_text: "Conversion date confirmed as part of the External stakeholder kick off task."}]
   end
 end

--- a/app/models/significant_date_history.rb
+++ b/app/models/significant_date_history.rb
@@ -1,5 +1,6 @@
 class SignificantDateHistory < ApplicationRecord
   belongs_to :project, class_name: "Project"
+  belongs_to :user
   has_one :note, dependent: :destroy, foreign_key: :significant_date_history_id
   has_many :reasons, dependent: :destroy, foreign_key: :significant_date_history_id, class_name: "SignificantDateHistoryReason"
 

--- a/app/models/significant_date_history.rb
+++ b/app/models/significant_date_history.rb
@@ -2,7 +2,7 @@ class SignificantDateHistory < ApplicationRecord
   belongs_to :project, class_name: "Project"
   belongs_to :user
   has_one :note, dependent: :destroy, foreign_key: :significant_date_history_id
-  has_many :reasons, dependent: :destroy, foreign_key: :significant_date_history_id, class_name: "SignificantDateHistoryReason"
+  has_many :reasons, -> { order :reason_type }, dependent: :destroy, foreign_key: :significant_date_history_id, class_name: "SignificantDateHistoryReason"
 
   validates :previous_date, :revised_date, presence: true
 end

--- a/app/models/significant_date_history_reason.rb
+++ b/app/models/significant_date_history_reason.rb
@@ -3,4 +3,9 @@ class SignificantDateHistoryReason < ApplicationRecord
   has_one :note, required: true, dependent: :destroy, foreign_key: :significant_date_history_reason_id
 
   validates :reason_type, presence: true
+
+  enum :reason_type, {
+    legacy_reason: "legacy_reason",
+    stakeholder_kick_off: "stakeholder_kick_off"
+  }
 end

--- a/app/services/significant_date_creator_service.rb
+++ b/app/services/significant_date_creator_service.rb
@@ -1,23 +1,50 @@
 class SignificantDateCreatorService
-  def initialize(project:, revised_date:, note_body:, user:)
+  def initialize(project:, revised_date:, user:, reasons: [])
     @project = project
     @previous_date = @project.significant_date
     @revised_date = revised_date
     @user = user
-    @note_body = note_body
+    @reasons = reasons
+
+    raise ArgumentError.new("Reasons cannot be nil") if @reasons.nil?
+    raise ArgumentError.new("You must supply at least one reason.") if @reasons.empty?
   end
 
   def update!
     ActiveRecord::Base.transaction do
-      date_history_note = Note.create!(project_id: @project.id, user_id: @user.id, body: @note_body)
-      date_history = SignificantDateHistory.create!(project_id: @project.id, previous_date: @previous_date, revised_date: @revised_date, note: date_history_note)
+      date_history = SignificantDateHistory.create!(user: @user, project_id: @project.id, previous_date: @previous_date, revised_date: @revised_date)
+
+      reasons = create_reasons_for(date_history)
+
       @project.update!(significant_date: @revised_date, significant_date_provisional: false)
 
-      raise ActiveRecord::RecordInvalid unless date_history_note.persisted? && @project.persisted? && date_history.persisted?
+      raise ActiveRecord::RecordInvalid unless @project.persisted? && date_history.persisted? && reasons.map(&:persisted?)
     rescue ActiveRecord::RecordInvalid
       return false
     end
 
     true
+  end
+
+  private def create_reasons_for(date_history)
+    @reasons.map do |reason|
+      raise ArgumentError.new("Date history reason is invalid, each reason must be a hash with :type and :note_text keys") unless reason_valid?(reason)
+
+      note = create_note_with(reason[:note_text])
+
+      SignificantDateHistoryReason.create!(
+        significant_date_history_id: date_history.id,
+        reason_type: reason[:type],
+        note: note
+      )
+    end
+  end
+
+  private def create_note_with(body)
+    Note.create!(project_id: @project.id, user_id: @user.id, body: body)
+  end
+
+  private def reason_valid?(reason)
+    reason.has_key?(:type) && reason.has_key?(:note_text)
   end
 end

--- a/app/services/significant_date_reasons_data_migration.rb
+++ b/app/services/significant_date_reasons_data_migration.rb
@@ -1,0 +1,63 @@
+# Data Migration service
+# This service is designed to be used once to create SignificantDateHistoryReasons for all projects
+#
+# Usage:
+#
+# `bin/rails runner "SignificantDateReasonsDataMigration.new.migrate!"`
+#
+# If any project already has any reasons it will be skipped.
+#
+# We want to catch all the notes that relate to the stakeholder kick off tasks
+# and the only way to do this is to check the note body
+class SignificantDateReasonsDataMigration
+  def migrate!
+    projects = Project.all
+    puts "#{projects.count} projects to process\n\n"
+
+    projects.each do |project|
+      puts "> Processing project with id: #{project.id}"
+
+      date_history = project.date_history
+
+      puts "> Project with id #{project.id} has #{date_history.count} date changes"
+
+      date_history.each do |history_item|
+        if history_item.reasons.any?
+          puts ">> Date history #{history_item.id} already has reasons, skipping!"
+          break
+        end
+
+        puts ">> Processing date history with id: #{history_item.id}"
+        note = history_item.note
+        created_at = history_item.created_at
+        user = note.user
+
+        reason = SignificantDateHistoryReason.create!(
+          significant_date_history_id: history_item.id,
+          reason_type: reason_type_for_note(note),
+          note: note,
+          created_at: created_at
+        )
+
+        puts ">>> Reason with id #{reason.id} created"
+
+        history_item.update!(user: user)
+
+        puts ">>> User #{user.id} added to date history"
+      end
+
+      puts "> Project with id #{project.id} finished\n\n"
+    end
+
+    puts "All projects finished"
+  end
+
+  private def reason_type_for_note(note)
+    if note.body.eql?("Transfer date confirmed as part of the External stakeholder kick off task.") ||
+        note.body.eql?("Conversion date confirmed as part of the External stakeholder kick off task.")
+      :stakeholder_kick_off
+    else
+      :legacy_reason
+    end
+  end
+end

--- a/app/views/shared/projects/_significant_dates_table.html.erb
+++ b/app/views/shared/projects/_significant_dates_table.html.erb
@@ -15,10 +15,10 @@
       <% @dates.each do |date| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell"><%= date.created_at.to_fs(:govuk_date_time) %></td>
-          <td class="govuk-table__cell"><%= date.note.user.email %></td>
+          <td class="govuk-table__cell"><%= date.reasons.first.note.user.email %></td>
           <td class="govuk-table__cell"><%= date.previous_date.to_fs(:govuk_month) %></td>
           <td class="govuk-table__cell"><%= date.revised_date.to_fs(:govuk_month) %></td>
-          <td class="govuk-table__cell"><%= date.note.body %></td>
+          <td class="govuk-table__cell"><%= date.reasons.first.note.body %></td>
         </tr>
       <% end %>
     </tbody>

--- a/db/migrate/20240612105707_add_user_reference_to_significant_date_history.rb
+++ b/db/migrate/20240612105707_add_user_reference_to_significant_date_history.rb
@@ -1,0 +1,5 @@
+class AddUserReferenceToSignificantDateHistory < ActiveRecord::Migration[7.0]
+  def change
+    add_column :significant_date_histories, :user_id, :uuid, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_06_152236) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_12_105707) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -308,6 +308,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_06_152236) do
     t.uuid "project_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "user_id"
     t.index ["project_id"], name: "index_significant_date_histories_on_project_id"
   end
 

--- a/spec/factories/conversion/date_history_factory.rb
+++ b/spec/factories/conversion/date_history_factory.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :date_history, class: SignificantDateHistory do
+    user { association :user, email: "user-#{SecureRandom.uuid}@education.gov.uk" }
     project { association :conversion_project }
     previous_date { Date.today.at_beginning_of_month - 1.month }
     revised_date { previous_date + 2.months }

--- a/spec/features/conversions/users_can_change_the_conversion_date_spec.rb
+++ b/spec/features/conversions/users_can_change_the_conversion_date_spec.rb
@@ -78,6 +78,9 @@ RSpec.feature "Users can change the conversion date" do
     confirmed_date = provisional_date
     first_revised_date = confirmed_date + 1.month
     second_revised_date = first_revised_date + 2.months
+    first_reason = [{type: :legacy_reason, note_text: "This is the first test reason note."}]
+    second_reason = [{type: :legacy_reason, note_text: "This is the second test reason note."}]
+    third_reason = [{type: :legacy_reason, note_text: "This is the third test reason note."}]
 
     project = create(:conversion_project, conversion_date: provisional_date, conversion_date_provisional: true, assigned_to: user)
 
@@ -86,7 +89,7 @@ RSpec.feature "Users can change the conversion date" do
     expect(page).to have_content "Conversion date history"
     expect(page).to have_content "No date history"
 
-    SignificantDateCreatorService.new(project: project, revised_date: confirmed_date, note_body: "confirmed date", user: user).update!
+    SignificantDateCreatorService.new(project: project, revised_date: confirmed_date, reasons: first_reason, user: user).update!
 
     visit project_dates_path(project)
 
@@ -94,10 +97,10 @@ RSpec.feature "Users can change the conversion date" do
       expect(page).to have_content user.email
       expect(page).to have_content provisional_date.to_fs(:govuk_month)
       expect(page).to have_content confirmed_date.to_fs(:govuk_month)
-      expect(page).to have_content "confirmed date"
+      expect(page).to have_content "This is the first test reason note."
     end
 
-    SignificantDateCreatorService.new(project: project, revised_date: first_revised_date, note_body: "first revised date", user: user).update!
+    SignificantDateCreatorService.new(project: project, revised_date: first_revised_date, reasons: second_reason, user: user).update!
 
     visit project_dates_path(project)
 
@@ -105,10 +108,10 @@ RSpec.feature "Users can change the conversion date" do
       expect(page).to have_content user.email
       expect(page).to have_content confirmed_date.to_fs(:govuk_month)
       expect(page).to have_content first_revised_date.to_fs(:govuk_month)
-      expect(page).to have_content "first revised date"
+      expect(page).to have_content "This is the second test reason note."
     end
 
-    SignificantDateCreatorService.new(project: project, revised_date: second_revised_date, note_body: "second revised date", user: user).update!
+    SignificantDateCreatorService.new(project: project, revised_date: second_revised_date, reasons: third_reason, user: user).update!
 
     visit project_dates_path(project)
 
@@ -116,7 +119,7 @@ RSpec.feature "Users can change the conversion date" do
       expect(page).to have_content user.email
       expect(page).to have_content first_revised_date.to_fs(:govuk_month)
       expect(page).to have_content second_revised_date.to_fs(:govuk_month)
-      expect(page).to have_content "second revised date"
+      expect(page).to have_content "This is the third test reason note."
     end
   end
 end

--- a/spec/models/significant_date_history_spec.rb
+++ b/spec/models/significant_date_history_spec.rb
@@ -10,5 +10,6 @@ RSpec.describe SignificantDateHistory do
     it { is_expected.to have_one(:note).dependent(:destroy) }
     it { is_expected.to have_many(:reasons).dependent(:destroy).class_name("SignificantDateHistoryReason") }
     it { is_expected.to belong_to(:project).required(true) }
+    it { is_expected.to belong_to(:user) }
   end
 end

--- a/spec/models/significant_date_history_spec.rb
+++ b/spec/models/significant_date_history_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SignificantDateHistory do
 
   describe "Associations" do
     it { is_expected.to have_one(:note).dependent(:destroy) }
-    it { is_expected.to have_many(:reasons).dependent(:destroy).class_name("SignificantDateHistoryReason") }
+    it { is_expected.to have_many(:reasons).order(:reason_type).dependent(:destroy).class_name("SignificantDateHistoryReason") }
     it { is_expected.to belong_to(:project).required(true) }
     it { is_expected.to belong_to(:user) }
   end

--- a/spec/services/significant_date_creator_service_spec.rb
+++ b/spec/services/significant_date_creator_service_spec.rb
@@ -94,17 +94,16 @@ RSpec.describe SignificantDateCreatorService do
       expect {
         described_class.new(project: project, revised_date: revised_date, user: user, reasons: [invalid_reason]).update!
       }.to raise_error(ArgumentError)
-
     end
 
-    it "raises an error when there is an invalid reason value" do
+    it "returns false with a invalid reason type because the reason will not be saved" do
       project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
       revised_date = project.conversion_date + 2.months
       invalid_reason = {type: "", note_text: "This is not valid"}
 
-      expect {
-        described_class.new(project: project, revised_date: revised_date, user: user, reasons: [invalid_reason]).update!
-      }.to raise_error(ActiveRecord::RecordInvalid)
+      result = described_class.new(project: project, revised_date: revised_date, user: user, reasons: [invalid_reason]).update!
+
+      expect(result).to be false
     end
   end
 end

--- a/spec/services/significant_date_creator_service_spec.rb
+++ b/spec/services/significant_date_creator_service_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe SignificantDateCreatorService do
   let(:user) { create(:user, :caseworker) }
-  let(:note_body) { "This is my note body." }
+  let(:reasons) { [{type: :legacy_reason, note_text: "This is my note body."}] }
 
   before do
     mock_successful_api_calls(establishment: any_args, trust: any_args)
@@ -13,35 +13,41 @@ RSpec.describe SignificantDateCreatorService do
       project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
       revised_date = project.conversion_date + 2.months
 
-      conversion_date_updater = described_class.new(project: project, revised_date: revised_date, note_body: note_body, user: user)
+      conversion_date_updater = described_class.new(project: project, revised_date: revised_date, user: user, reasons: reasons)
 
       expect(conversion_date_updater.update!).to be true
     end
 
-    it "creates the conversion date history and note" do
+    it "creates the conversion date history, reason and note" do
       project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
       revised_date = project.conversion_date + 2.months
 
-      conversion_date_updater = described_class.new(project: project, revised_date: revised_date, note_body: note_body, user: user)
+      conversion_date_updater = described_class.new(project: project, revised_date: revised_date, user: user, reasons: reasons)
 
       expect(conversion_date_updater.update!).to be true
+
       expect(project.significant_dates.count).to eql 1
+      expect(project.significant_dates.first.reasons.count).to eql 1
       expect(Note.count).to eql 1
 
       conversion_date_history = project.significant_dates.first
       expect(conversion_date_history.revised_date).to eql revised_date
+      expect(conversion_date_history.user).to eql user
 
-      note = conversion_date_history.note
+      first_reason = conversion_date_history.reasons.first
+      expect(first_reason.reason_type).to eql "legacy_reason"
+
+      note = first_reason.note
       expect(note.user).to eql user
       expect(note.project).to eql project
-      expect(note.body).to eql note_body
+      expect(note.body).to eql "This is my note body."
     end
 
     it "updates the project conversion date with the revised date" do
       project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
       revised_date = project.conversion_date + 2.months
 
-      conversion_date_updater = described_class.new(project: project, revised_date: revised_date, note_body: note_body, user: user)
+      conversion_date_updater = described_class.new(project: project, revised_date: revised_date, user: user, reasons: reasons)
 
       expect(conversion_date_updater.update!).to be true
 
@@ -54,12 +60,51 @@ RSpec.describe SignificantDateCreatorService do
 
       allow(project).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
 
-      conversion_date_updater = described_class.new(project: project, revised_date: revised_date, note_body: note_body, user: user)
+      conversion_date_updater = described_class.new(project: project, revised_date: revised_date, user: user, reasons: reasons)
 
       expect(conversion_date_updater.update!).to be false
       expect(project.reload.conversion_date).not_to eql revised_date
       expect(Note.count).to be_zero
       expect(project.significant_dates.count).to be_zero
+    end
+
+    it "raises an error when reasons is nil" do
+      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+      revised_date = project.conversion_date + 2.months
+
+      expect {
+        described_class.new(project: project, revised_date: revised_date, user: user, reasons: nil)
+      }.to raise_error(ArgumentError)
+    end
+
+    it "raises an error when reasons is empty" do
+      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+      revised_date = project.conversion_date + 2.months
+
+      expect {
+        described_class.new(project: project, revised_date: revised_date, user: user, reasons: [])
+      }.to raise_error(ArgumentError)
+    end
+
+    it "raises an error when there is an invalid reason key" do
+      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+      revised_date = project.conversion_date + 2.months
+      invalid_reason = {invalid_key: :reason_type, note_text: "This is not valid"}
+
+      expect {
+        described_class.new(project: project, revised_date: revised_date, user: user, reasons: [invalid_reason]).update!
+      }.to raise_error(ArgumentError)
+
+    end
+
+    it "raises an error when there is an invalid reason value" do
+      project = create(:conversion_project, conversion_date: Date.today.at_beginning_of_month)
+      revised_date = project.conversion_date + 2.months
+      invalid_reason = {type: "", note_text: "This is not valid"}
+
+      expect {
+        described_class.new(project: project, revised_date: revised_date, user: user, reasons: [invalid_reason]).update!
+      }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 end

--- a/spec/services/significant_date_reasons_data_migration_spec.rb
+++ b/spec/services/significant_date_reasons_data_migration_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+
+RSpec.describe SignificantDateReasonsDataMigration do
+  let(:user) { create(:user) }
+
+  before do
+    mock_all_academies_api_responses
+  end
+
+  it "adds a SignificantDateReason for every SignificantDate a project has" do
+    conversion_without_history = create_project_helper(:conversion, 0)
+    conversion_with_single_history = create_project_helper(:conversion, 1)
+    conversion_with_multiple_history = create_project_helper(:conversion, 3)
+
+    transfer_without_history = create_project_helper(:transfer, 0)
+    transfer_with_single_history = create_project_helper(:transfer, 1)
+    transfer_with_multiple_history = create_project_helper(:transfer, 3)
+
+    described_class.new.migrate!
+
+    expect(conversion_without_history.date_history.count).to be_zero
+
+    date_history = conversion_with_single_history.date_history.order(:created_at)
+
+    expect(date_history.first.reasons.count).to be 1
+    expect(date_history.first.reasons.first.note.body).to eql "Note for date history reason number 1"
+
+    date_history = conversion_with_multiple_history.date_history.order(:created_at)
+
+    expect(date_history.first.reasons.count).to be 1
+    expect(date_history.first.reasons.first.note.body).to eql "Note for date history reason number 1"
+
+    expect(date_history.last.reasons.count).to be 1
+    expect(date_history.last.reasons.first.note.body).to eql "Note for date history reason number 3"
+
+    expect(transfer_without_history.date_history.count).to be_zero
+
+    date_history = transfer_with_single_history.date_history.order(:created_at)
+
+    expect(date_history.first.reasons.count).to be 1
+    expect(date_history.first.reasons.first.note.body).to eql "Note for date history reason number 1"
+
+    date_history = transfer_with_multiple_history.date_history.order(:created_at)
+
+    expect(date_history.first.reasons.count).to be 1
+    expect(date_history.first.reasons.first.note.body).to eql "Note for date history reason number 1"
+
+    expect(date_history.last.reasons.count).to be 1
+    expect(date_history.last.reasons.first.note.body).to eql "Note for date history reason number 3"
+  end
+
+  it "assigns the two different reason types correctly" do
+    conversion_project = create_project_helper(:conversion, 1)
+    conversion_project_with_stakeholder_kick_off = create_project_with_stakeholder_kick_off(:conversion)
+
+    transfer_project = create_project_helper(:conversion, 1)
+    transfer_project_with_stakeholder_kick_off = create_project_with_stakeholder_kick_off(:conversion)
+
+    described_class.new.migrate!
+
+    expect(conversion_project_with_stakeholder_kick_off.date_history.first.reasons.first.reason_type).to eql "stakeholder_kick_off"
+    expect(conversion_project.date_history.first.reasons.first.reason_type).to eql "legacy_reason"
+    expect(transfer_project_with_stakeholder_kick_off.date_history.first.reasons.first.reason_type).to eql "stakeholder_kick_off"
+    expect(transfer_project.date_history.first.reasons.first.reason_type).to eql "legacy_reason"
+  end
+
+  it "skips any history that already has a reason, i.e. will not create duplicates" do
+    create_project_helper(:conversion, 3)
+    create_project_helper(:transfer, 3)
+
+    allow(SignificantDateHistoryReason).to receive(:create!).and_call_original
+
+    described_class.new.migrate!
+
+    described_class.new.migrate!
+
+    expect(SignificantDateHistoryReason).to have_received(:create!).exactly(6).times
+  end
+
+  def create_project_helper(project_type, history_count = 0)
+    case project_type
+    when :conversion
+      project = create(:conversion_project)
+    when :transfer
+      project = create(:transfer_project)
+    else
+      raise ArgumentError.new("Supply a project type!")
+    end
+
+    history_count.times do |index|
+      note = Note.create!(user:, body: "Note for date history reason number #{index + 1}", project: project)
+
+      SignificantDateHistory.create!(
+        user: user,
+        previous_date: Date.today.at_beginning_of_month,
+        revised_date: Date.today.at_beginning_of_month + index.month,
+        created_at: Date.today + index.days,
+        project: project,
+        note: note
+      )
+    end
+
+    project
+  end
+
+  def create_project_with_stakeholder_kick_off(project_type)
+    case project_type
+    when :conversion
+      project = create(:conversion_project)
+      note_body = "Transfer date confirmed as part of the External stakeholder kick off task."
+    when :transfer
+      project = create(:transfer_project)
+      note_body = "Conversion date confirmed as part of the External stakeholder kick off task."
+    else
+      raise ArgumentError.new("Supply a project type!")
+    end
+
+    note = Note.create!(user:, body: note_body, project: project)
+
+    SignificantDateHistory.create!(
+      user: user,
+      previous_date: Date.today.at_beginning_of_month,
+      revised_date: Date.today.at_beginning_of_month + 1.month,
+      created_at: Date.today,
+      project: project,
+      note: note
+    )
+
+    project
+  end
+end


### PR DESCRIPTION
With the new `SignificantDateHistoryReason` model in place, we want any changes to significant dates to add a new reason.

We update the `SignificantDateCreatorService` and the two places it is currently used:

- the stakeholder kick off task for conversions and transfers
- any change to significant date

We also add a user to the date history as there is no longer a one to one association between a date history and the note which made delegating the user possible.

## This work includes a data migration

We also want to migrate the existing data to use a reason.

Once deployed, we need to run the `SignificantDateReasonsDataMigration`, see the file for details.