### PR TITLE
Annotate App Insights after each release

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -64,6 +64,7 @@ jobs:
         RAILS_ENV=development
         CURRENT_GIT_SHA="${{ needs.set-env.outputs.checked-out-sha }}"
         TIME_OF_BUILD="${{ needs.set-env.outputs.date }}"
+      annotate-release: ${{ needs.set-env.outputs.environment == 'development' && matrix.suffix == '' }}
     secrets:
       azure-acr-credentials: ${{ secrets.ACR_CREDENTIALS }}
       azure-acr-name: ${{ secrets.ACR_NAME }}


### PR DESCRIPTION
* This is only set up for development whilst we test the changes
* The `matrix.suffix == '' ` condition is to ensure we don't write the same release note twice when the worker container gets deployed

## Type of change
<!--- Tick the appropriate checkbox -->
- [x] New feature (non-breaking change which adds functionality)

## Expected behaviour
After a deployment to the 'Development' environment has been completed, an annotation should be added to App Insights to mark the release in the timeline

## Steps to test this PR
<!--- Suggested steps reviewers need to take to test this PR -->
1. Deploy a release to Development
2. View the associated App Insights instance 
3. See an annotation on the transaction timeline
