### PR TITLE
Create DAO Revocation Model

### DIFF
--- a/app/models/dao_revocation.rb
+++ b/app/models/dao_revocation.rb
@@ -1,0 +1,15 @@
+class DaoRevocation < ApplicationRecord
+  belongs_to :project
+
+  validates :date_of_decision, :decision_makers_name, presence: true
+  validate :conversion_project_with_dao
+  validate :at_least_one_reason
+
+  private def at_least_one_reason
+    errors.add(:base, :reason_required) unless reason_school_closed || reason_school_rating_improved || reason_safeguarding_addressed
+  end
+
+  private def conversion_project_with_dao
+    errors.add(:base, :incorrect_project_type) unless project.is_a?(Conversion::Project) && project.directive_academy_order
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -14,6 +14,7 @@ class Project < ApplicationRecord
   has_many :notes, dependent: :destroy
   has_many :contacts, class_name: "Contact::Project", inverse_of: :project, dependent: :destroy
   has_many :date_history, class_name: "SignificantDateHistory", inverse_of: :project, dependent: :destroy
+  has_one :dao_revocation, class_name: "DaoRevocation", inverse_of: :project, dependent: :destroy
 
   belongs_to :main_contact, inverse_of: :main_contact_for_project, dependent: :destroy, class_name: "Contact::Project", optional: true
   belongs_to :establishment_main_contact, inverse_of: :main_contact_for_establishment, dependent: :destroy, class_name: "Contact::Project", optional: true

--- a/config/locales/dao_revoked_decision.en.yml
+++ b/config/locales/dao_revoked_decision.en.yml
@@ -1,0 +1,6 @@
+en:
+  errors:
+    attributes:
+      base:
+        reason_required: You must select at least one reason
+        incorrect_project_type: A DAO revoked decision can only be recorded against a Conversion project with a Directive academy order

--- a/db/migrate/20240618140233_create_dao_revocations.rb
+++ b/db/migrate/20240618140233_create_dao_revocations.rb
@@ -1,0 +1,13 @@
+class CreateDaoRevocations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :dao_revocations, id: :uuid do |t|
+      t.timestamps
+      t.date :date_of_decision
+      t.string :decision_makers_name
+      t.boolean :reason_school_closed
+      t.boolean :reason_school_rating_improved
+      t.boolean :reason_safeguarding_addressed
+      t.uuid :project_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_12_105707) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_18_140233) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -157,6 +157,17 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_12_105707) do
     t.boolean "receive_grant_payment_certificate_check_certificate"
     t.date "confirm_date_academy_opened_date_opened"
     t.string "risk_protection_arrangement_reason"
+  end
+
+  create_table "dao_revocations", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.date "date_of_decision"
+    t.string "decision_makers_name"
+    t.boolean "reason_school_closed"
+    t.boolean "reason_school_rating_improved"
+    t.boolean "reason_safeguarding_addressed"
+    t.uuid "project_id"
   end
 
   create_table "events", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/models/dao_revocation_spec.rb
+++ b/spec/models/dao_revocation_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe DaoRevocation do
+  describe "Attributes" do
+    it { is_expected.to have_db_column(:date_of_decision).of_type :date }
+    it { is_expected.to have_db_column(:decision_makers_name).of_type :string }
+    it { is_expected.to have_db_column(:reason_school_closed).of_type :boolean }
+    it { is_expected.to have_db_column(:reason_school_rating_improved).of_type :boolean }
+    it { is_expected.to have_db_column(:reason_safeguarding_addressed).of_type :boolean }
+  end
+
+  describe "Validations" do
+    it { is_expected.to validate_presence_of(:date_of_decision) }
+    it { is_expected.to validate_presence_of(:decision_makers_name) }
+
+    describe "#at_least_one_reason" do
+      it "validates that at least one reason is checked" do
+        project = build(:conversion_project, directive_academy_order: true)
+        decision = described_class.new(date_of_decision: Date.today, decision_makers_name: "Bob Smith", project: project)
+        expect(decision.valid?).to be false
+        expect(decision.errors[:base]).to include("You must select at least one reason")
+
+        decision = described_class.new(date_of_decision: Date.today, decision_makers_name: "Bob Smith", project: project, reason_school_closed: true)
+        expect(decision.valid?).to be true
+      end
+    end
+
+    describe "#conversion_project_with_dao" do
+      it "is invalid if it is associated with a transfer project" do
+        project = build(:transfer_project)
+        decision = described_class.new(date_of_decision: Date.today, decision_makers_name: "Bob Smith", project: project)
+        expect(decision.valid?).to be false
+        expect(decision.errors[:base]).to include("A DAO revoked decision can only be recorded against a Conversion project with a Directive academy order")
+      end
+
+      it "is invalid if it is associated with a voluntary conversion" do
+        project = build(:conversion_project, directive_academy_order: false)
+        decision = described_class.new(date_of_decision: Date.today, decision_makers_name: "Bob Smith", project: project)
+        expect(decision.valid?).to be false
+        expect(decision.errors[:base]).to include("A DAO revoked decision can only be recorded against a Conversion project with a Directive academy order")
+      end
+    end
+  end
+
+  describe "Associations" do
+    it { is_expected.to belong_to(:project) }
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to belong_to(:establishment_main_contact).optional(true) }
     it { is_expected.to belong_to(:incoming_trust_main_contact).optional(true) }
     it { is_expected.to belong_to(:outgoing_trust_main_contact).optional(true) }
+    it { is_expected.to have_one(:dao_revocation).dependent(:destroy) }
 
     describe "delete related entities" do
       context "when the project is deleted" do


### PR DESCRIPTION
## Changes

We are going to want to record a DAO Revocation for sponsored projects.
This will be a decision attached to a project, recording when the DAO was
revoked and who authorised the decision.

The DaoRevocation will be a 1:1 association on projects.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
