### PR TITLE
(Fix) Allow service support users to edit completed projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The project date history view (hidden) now uses a 'card' view.
 
+### Fixed
+
+- Service support users can edit completed projects
+
 ## [Release-74][release-74]
 
 ### Added

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -21,8 +21,9 @@ class ProjectPolicy
   end
 
   def edit?
-    return false if @record.completed?
     return false if @record.deleted?
+    return true if @user.is_service_support?
+    return false if @record.completed?
 
     true
   end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -68,6 +68,18 @@ RSpec.describe ProjectPolicy do
       project = build(:conversion_project, :deleted, assigned_to: application_user)
       expect(subject).not_to permit(application_user, project)
     end
+
+    context "when the user is service support" do
+      it "grants access if the project is completed" do
+        project = build(:conversion_project, :completed, assigned_to: application_user, conversion_date_provisional: false)
+        expect(subject).to permit(service_support_user, project)
+      end
+
+      it "denies access if the project is deleted" do
+        project = build(:conversion_project, :deleted, assigned_to: application_user)
+        expect(subject).not_to permit(service_support_user, project)
+      end
+    end
   end
 
   permissions :change_conversion_date? do


### PR DESCRIPTION
Service support users should be able to edit completed projects, as this is a work request we get occasionally and service support should be able to manage on their own.


## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
