### PR TITLE
(Fix) Pick the Headteacher contact for "school main contact" where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Service support users can edit completed projects
+- The school or academy main contact should now attempt to fetch any
+  establishment contacts if the main school contact is not set
 
 ## [Release-74][release-74]
 

--- a/app/models/contact/establishment.rb
+++ b/app/models/contact/establishment.rb
@@ -5,6 +5,8 @@ class Contact::Establishment < Contact
 
   validates :establishment_urn, presence: true
 
+  attribute :category, default: 1
+
   def establishment
     Gias::Establishment.find_by(urn: establishment_urn)
   end

--- a/app/services/contact_establishment_data_migration.rb
+++ b/app/services/contact_establishment_data_migration.rb
@@ -1,0 +1,19 @@
+# Data Migration service
+# This service is designed to be used once to update the category for all Contact::Establishment records
+#
+# Usage:
+#
+# `bin/rails runner "ContactEstablishmentDataMigration.new.migrate!"`
+#
+class ContactEstablishmentDataMigration
+  def migrate!
+    contacts = Contact::Establishment.all
+    puts "#{contacts.count} Contact::Establishment records to update"
+
+    contacts.each do |contact|
+      contact.update!(category: "school_or_academy")
+    end
+
+    puts "All Contact::Establishment records updated"
+  end
+end

--- a/app/services/contacts_fetcher_service.rb
+++ b/app/services/contacts_fetcher_service.rb
@@ -28,7 +28,7 @@ class ContactsFetcherService
     if @project.establishment_main_contact_id.present?
       @all_contacts["school_or_academy"].find { |c| c.id == @project.establishment_main_contact_id }
     else
-      @all_contacts["school_or_academy"].first
+      @all_contacts["school_or_academy"].in_order_of(:type, %w[Contact::Establishment Contact::Project]).first
     end
   end
 

--- a/spec/models/contact/establishment_spec.rb
+++ b/spec/models/contact/establishment_spec.rb
@@ -27,4 +27,11 @@ RSpec.describe Contact::Establishment do
       expect(contact.editable?).to be false
     end
   end
+
+  describe "category" do
+    it "returns school_or_academy" do
+      contact = described_class.new
+      expect(contact.category).to eq("school_or_academy")
+    end
+  end
 end

--- a/spec/services/contact_establishment_data_migration_spec.rb
+++ b/spec/services/contact_establishment_data_migration_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe ContactEstablishmentDataMigration do
+  it "updates the `category` of all Contact::Establishment records" do
+    contact = create(:establishment_contact, category: "other")
+
+    described_class.new.migrate!
+
+    expect(contact.reload.category).to eq("school_or_academy")
+  end
+end

--- a/spec/services/contacts_fetcher_service_spec.rb
+++ b/spec/services/contacts_fetcher_service_spec.rb
@@ -94,6 +94,14 @@ RSpec.describe ContactsFetcherService do
     context "when there is NOT an establishment_main_contact_id" do
       before { allow(project).to receive(:establishment_main_contact_id).and_return(nil) }
 
+      context "and there is an establishment contact (type = Contact::Establishment)" do
+        let!(:establishment_contact) { create(:establishment_contact, establishment_urn: project.urn) }
+
+        it "returns the establishment contact" do
+          expect(described_class.new(project).school_or_academy_contact).to eq(establishment_contact)
+        end
+      end
+
       it "returns the next matching contact" do
         expect(described_class.new(project).school_or_academy_contact).to eq(contact)
       end


### PR DESCRIPTION
## Changes

We ingest Headteacher contact details where possible from GIAS records as `Contact::Establishment` records.

However, due to an oversight we were not marking those contacts as `school_or_academy` contacts (via the `category` attribute). When picking the school main contact for exports, we first try to get the "main contact" (as chosen via a select box on the application), and if none is present then we get the first `school_or_academy` contact. 

Because the Headteacher records were not being marked as `school_or_academy` they were never being chosen.

Fix this via:

- Ensuring all new Contact::Establishment records are always category `school_or_academy`
- Ensuring that when picking the "first" school_or_academy contact, Contact::Establishment records are picked first
- Updating all existing Contact::Establishment records to have the `school_or_academy` category

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
