### PR TITLE
(170900) (Fix) Allow users to select ingested contacts in the Main project contact task

### DIFF
--- a/app/controllers/external_contacts_controller.rb
+++ b/app/controllers/external_contacts_controller.rb
@@ -2,7 +2,7 @@ class ExternalContactsController < ApplicationController
   include Projectable
 
   def index
-    @grouped_contacts = ContactsFetcherService.new(@project).all_project_contacts
+    @grouped_contacts = ContactsFetcherService.new(@project).all_project_contacts_grouped
   end
 
   def new

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -133,6 +133,10 @@ class Project < ApplicationRecord
     false
   end
 
+  def all_contacts
+    ContactsFetcherService.new(self).all_project_contacts
+  end
+
   # :nocov:
   private def fetch_member_of_parliament
     result = Api::MembersApi::Client.new.member_for_constituency(establishment.parliamentary_constituency)

--- a/app/presenters/export/csv/academy_presenter_module.rb
+++ b/app/presenters/export/csv/academy_presenter_module.rb
@@ -72,14 +72,14 @@ module Export::Csv::AcademyPresenterModule
   end
 
   def academy_contact_name
-    contacts = @contacts_fetcher.all_project_contacts
+    contacts = @contacts_fetcher.all_project_contacts_grouped
     return if contacts["school_or_academy"].blank?
 
     contacts["school_or_academy"].pluck(:name).join(",")
   end
 
   def academy_contact_email
-    contacts = @contacts_fetcher.all_project_contacts
+    contacts = @contacts_fetcher.all_project_contacts_grouped
     return if contacts["school_or_academy"].blank?
 
     contacts["school_or_academy"].pluck(:email).join(",")

--- a/app/presenters/export/csv/local_authority_presenter_module.rb
+++ b/app/presenters/export/csv/local_authority_presenter_module.rb
@@ -12,14 +12,14 @@ module Export::Csv::LocalAuthorityPresenterModule
   end
 
   def local_authority_contact_name
-    contacts = @contacts_fetcher.all_project_contacts
+    contacts = @contacts_fetcher.all_project_contacts_grouped
     return if contacts["local_authority"].blank?
 
     contacts["local_authority"].pluck(:name).join(",")
   end
 
   def local_authority_contact_email
-    contacts = @contacts_fetcher.all_project_contacts
+    contacts = @contacts_fetcher.all_project_contacts_grouped
     return if contacts["local_authority"].blank?
 
     contacts["local_authority"].pluck(:email).join(",")

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -238,14 +238,14 @@ class Export::Csv::ProjectPresenter
   end
 
   def diocese_contact_name
-    contacts = @contacts_fetcher.all_project_contacts
+    contacts = @contacts_fetcher.all_project_contacts_grouped
     return if contacts["diocese"].blank?
 
     contacts["diocese"].pluck(:name).join(",")
   end
 
   def diocese_contact_email
-    contacts = @contacts_fetcher.all_project_contacts
+    contacts = @contacts_fetcher.all_project_contacts_grouped
     return if contacts["diocese"].blank?
 
     contacts["diocese"].pluck(:email).join(",")
@@ -264,14 +264,14 @@ class Export::Csv::ProjectPresenter
   end
 
   def solicitor_contact_name
-    contacts = @contacts_fetcher.all_project_contacts
+    contacts = @contacts_fetcher.all_project_contacts_grouped
     return if contacts["solicitor"].blank?
 
     contacts["solicitor"].pluck(:name).join(",")
   end
 
   def solicitor_contact_email
-    contacts = @contacts_fetcher.all_project_contacts
+    contacts = @contacts_fetcher.all_project_contacts_grouped
     return if contacts["solicitor"].blank?
 
     contacts["solicitor"].pluck(:email).join(",")

--- a/app/services/contacts_fetcher_service.rb
+++ b/app/services/contacts_fetcher_service.rb
@@ -5,11 +5,11 @@ class ContactsFetcherService
     @project = project
     @project_contacts = @project.contacts
     @establishment_contacts = Contact::Establishment.find_by(establishment_urn: @project.urn)
-    @all_contacts = all_project_contacts
+    @all_contacts = all_project_contacts_grouped
     @director_of_child_services = @project.director_of_child_services
   end
 
-  def all_project_contacts
+  def all_project_contacts_grouped
     all_contacts = @project_contacts.to_a
 
     all_contacts << @director_of_child_services unless @director_of_child_services.nil?

--- a/app/services/contacts_fetcher_service.rb
+++ b/app/services/contacts_fetcher_service.rb
@@ -9,7 +9,7 @@ class ContactsFetcherService
     @director_of_child_services = @project.director_of_child_services
   end
 
-  def all_project_contacts_grouped
+  def all_project_contacts
     all_contacts = @project_contacts.to_a
 
     all_contacts << @director_of_child_services unless @director_of_child_services.nil?
@@ -17,9 +17,13 @@ class ContactsFetcherService
     establishment_contacts = @establishment_contacts
     all_contacts << establishment_contacts unless establishment_contacts.nil?
 
-    return {} unless all_contacts.any?
+    all_contacts.sort_by(&:name)
+  end
 
-    all_contacts.sort_by(&:name).group_by(&:category)
+  def all_project_contacts_grouped
+    return {} unless all_project_contacts.any?
+
+    all_project_contacts.sort_by(&:name).group_by(&:category)
   end
 
   def school_or_academy_contact

--- a/app/views/conversions/tasks/main_contact/edit.html.erb
+++ b/app/views/conversions/tasks/main_contact/edit.html.erb
@@ -26,12 +26,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @project.contacts.count > 0 %>
+    <% if @project.all_contacts.count > 0 %>
       <%= form_for @task, url: project_edit_task_path(@project, @task.identifier), method: :put do |form| %>
         <%= form.govuk_error_summary %>
 
         <%= form.govuk_collection_radio_buttons :main_contact_id,
-              @project.contacts,
+              @project.all_contacts,
               :id,
               :name,
               :title,

--- a/app/views/transfers/tasks/main_contact/edit.html.erb
+++ b/app/views/transfers/tasks/main_contact/edit.html.erb
@@ -26,12 +26,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @project.contacts.count > 0 %>
+    <% if @project.all_contacts.count > 0 %>
       <%= form_for @task, url: project_edit_task_path(@project, @task.identifier), method: :put do |form| %>
         <%= form.govuk_error_summary %>
 
         <%= form.govuk_collection_radio_buttons :main_contact_id,
-              @project.contacts,
+              @project.all_contacts,
               :id,
               :name,
               :title,

--- a/spec/features/conversions/users_can_select_a_main_contact_spec.rb
+++ b/spec/features/conversions/users_can_select_a_main_contact_spec.rb
@@ -27,6 +27,24 @@ RSpec.feature "Users select a main contact for a conversion" do
     end
   end
 
+  context "when the project has contacts which were ingested, not manually added (e.g. Head teacher from GIAS)" do
+    let!(:contact_1) { create(:establishment_contact, establishment_urn: project.urn, name: "John Headteacher") }
+    let!(:contact_2) { create(:director_of_child_services, local_authority: project.local_authority, name: "Jane Director") }
+
+    it "allows the user to select one of the ingested contacts on the Main Contact task page" do
+      visit project_tasks_path(project)
+      click_on "Confirm the main contact"
+      expect(page).to have_content(contact_1.name)
+      expect(page).to have_content(contact_2.name)
+
+      choose contact_1.name
+      click_button "Save and return"
+
+      expect(project.reload.main_contact_id).to eq(contact_1.id)
+      expect(page.find("#confirm-the-main-contact-status").text).to eq("Completed")
+    end
+  end
+
   context "when the project already has a main contact set" do
     let!(:contact_1) { create(:project_contact, project: project, name: "John Smith") }
     let!(:contact_2) { create(:project_contact, project: project, name: "Jane Jones") }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -880,6 +880,21 @@ RSpec.describe Project, type: :model do
     end
   end
 
+  describe "#all_contacts" do
+    it "returns all contacts, including director of child services and any establishment contacts" do
+      mock_successful_api_responses(urn: any_args, ukprn: any_args)
+      project = build(:conversion_project)
+      create(:project_contact, project: project)
+      create(:establishment_contact, establishment_urn: project.urn)
+
+      director_of_child_services_contact = create(:director_of_child_services)
+      allow(project).to receive(:director_of_child_services).and_return(director_of_child_services_contact)
+
+      result = project.all_contacts
+      expect(result.count).to eql(3)
+    end
+  end
+
   describe "delegation" do
     it "delegates local_authority to establishment" do
       local_authotity = double(code: 100)

--- a/spec/services/contacts_fetcher_service_spec.rb
+++ b/spec/services/contacts_fetcher_service_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe ContactsFetcherService do
     end
   end
 
-  describe "#all_project_contacts" do
-    it "returns the contacts for a given project" do
+  describe "#all_project_contacts_grouped" do
+    it "returns the contacts for a given project in groups" do
       project_contact = create(:project_contact, project: project, category: "school_or_academy")
 
       director_of_child_services_contact = create(:director_of_child_services)
@@ -32,7 +32,7 @@ RSpec.describe ContactsFetcherService do
 
       establishment_contact = create(:establishment_contact, establishment_urn: project.urn)
 
-      result = described_class.new(project).all_project_contacts
+      result = described_class.new(project).all_project_contacts_grouped
 
       expect(result.count).to eql(2)
       expect(result["school_or_academy"].count).to eql(2)
@@ -48,7 +48,7 @@ RSpec.describe ContactsFetcherService do
           director_of_child_services = create(:director_of_child_services)
           allow(project).to receive(:director_of_child_services).and_return(director_of_child_services)
 
-          result = described_class.new(project).all_project_contacts
+          result = described_class.new(project).all_project_contacts_grouped
 
           expect(result.values.flatten.count).to eql(1)
           expect(result.values.flatten.first).to be(director_of_child_services)
@@ -60,7 +60,7 @@ RSpec.describe ContactsFetcherService do
           project = create(:transfer_project)
           establishment_contact = create(:establishment_contact, establishment_urn: project.urn)
 
-          result = described_class.new(project).all_project_contacts
+          result = described_class.new(project).all_project_contacts_grouped
 
           expect(result.values.flatten.count).to eql(1)
           expect(result.values.flatten.first).to eq(establishment_contact)
@@ -72,7 +72,7 @@ RSpec.describe ContactsFetcherService do
           project = create(:transfer_project)
           allow(project).to receive(:director_of_child_services).and_return(nil)
 
-          result = described_class.new(project).all_project_contacts
+          result = described_class.new(project).all_project_contacts_grouped
 
           expect(result).to be_empty
         end

--- a/spec/services/contacts_fetcher_service_spec.rb
+++ b/spec/services/contacts_fetcher_service_spec.rb
@@ -23,6 +23,29 @@ RSpec.describe ContactsFetcherService do
     end
   end
 
+  describe "#all_project_contacts" do
+    it "returns the contacts for a given project in name order" do
+      project_contact = create(:project_contact, project: project, name: "Ann Altman")
+
+      director_of_child_services_contact = create(:director_of_child_services, name: "Bob Brown")
+      allow(project).to receive(:director_of_child_services).and_return(director_of_child_services_contact)
+
+      establishment_contact = create(:establishment_contact, establishment_urn: project.urn, name: "Chloe Christian")
+
+      result = described_class.new(project).all_project_contacts
+
+      expect(result.count).to eql(3)
+      expect(result.first).to eq(project_contact)
+      expect(result[1]).to eq(director_of_child_services_contact)
+      expect(result.last).to eq(establishment_contact)
+    end
+
+    it "returns an empty array when there are no contacts" do
+      result = described_class.new(project).all_project_contacts
+      expect(result).to eq([])
+    end
+  end
+
   describe "#all_project_contacts_grouped" do
     it "returns the contacts for a given project in groups" do
       project_contact = create(:project_contact, project: project, category: "school_or_academy")


### PR DESCRIPTION
## Changes

The "Confirm the main contact" task should show all eligible contacts associated with a project. However, due to an oversight, contacts which were ingested - e.g. Head teachers from GIAS and Director of Child services for the local authority - were not being shown on this page. 

This had a knock on effect of meaning the Main project contact in exports was usually incorrect.

In the "Confirm the main contact" task show ALL project contacts, whether a project association or not. Use existing functionality from the ContactsFetcherService to do this.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
