### PR TITLE
Release 75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release-75][release-75]
+
 ### Added
 
 - Include incoming trust UKPRN in RPA/SUG report
@@ -1982,7 +1984,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-74...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-75...HEAD
+[release-75]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-74...release-75
 [release-74]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-73...release-74
 [release-73]:


### PR DESCRIPTION
Added

- Include incoming trust UKPRN in RPA/SUG report
- The project date history view is now available from the project sub-navigation.
- The project date history view now includes a section with the current proposed or confirmed date called out.

Changed

- The project date history view (hidden) now uses a 'card' view.
- Extra spacing has been added to the actions buttons for a project
- Any change to the conversion or transfer date now requires a reason and details to be provided.

Fixed

- Service support users can edit completed projects
- The school or academy main contact should now attempt to fetch any establishment contacts if the main school contact is not set


