### PR TITLE
(168445) DAO Revocation flow

### DIFF
--- a/app/controllers/dao_revocations_controller.rb
+++ b/app/controllers/dao_revocations_controller.rb
@@ -1,0 +1,132 @@
+class DaoRevocationsController < ApplicationController
+  include Projectable
+
+  before_action :redirect_if_project_revoked
+  before_action :redirect_if_invalid_step, only: %i[step update_step change_step update_change_step]
+
+  def start
+    authorize @project, :dao_revocation?
+  end
+
+  def step
+    authorize @project, :dao_revocation?
+    if requested_step.eql?(DaoRevocationSteppedForm.first_step)
+      delete_session
+    end
+
+    @step_form = DaoRevocationSteppedForm.new
+
+    render requested_step.to_s
+  end
+
+  def update_step
+    authorize @project, :dao_revocation?
+    @step_form = DaoRevocationSteppedForm.new(get_session)
+    @step_form.assign_attributes(dao_revocations_params.to_h)
+
+    if @step_form.valid?(requested_step)
+      set_session(@step_form.to_h)
+
+      if requested_step.eql?(DaoRevocationSteppedForm.last_step)
+        redirect_to project_dao_revocation_check_path(@project)
+      else
+        redirect_to next_step
+      end
+    else
+      render requested_step.to_s
+    end
+  end
+
+  def change_step
+    authorize @project, :dao_revocation?
+    @step_form = DaoRevocationSteppedForm.new(get_session)
+
+    render "change_#{requested_step}"
+  end
+
+  def update_change_step
+    authorize @project, :dao_revocation?
+    @step_form = DaoRevocationSteppedForm.new(get_session)
+    @step_form.assign_attributes(dao_revocations_params.to_h)
+
+    if @step_form.valid?(requested_step)
+      set_session(@step_form.to_h)
+
+      redirect_to project_dao_revocation_check_path(@project)
+    else
+      render "change_#{requested_step}"
+    end
+  end
+
+  def check
+    authorize @project, :dao_revocation?
+    @step_form = DaoRevocationSteppedForm.new(get_session)
+
+    redirect_to project_dao_revocation_start_path(@project) unless @step_form.checkable?
+  end
+
+  def save
+    authorize @project, :dao_revocation?
+    @step_form = DaoRevocationSteppedForm.new(get_session)
+
+    if @step_form.save_to_project(@project)
+      delete_session
+      redirect_to project_path(@project), notice: I18n.t("dao_revocations.check.successful")
+    else
+      render :check
+    end
+  end
+
+  private def set_session(values)
+    session[session_key] = values
+  end
+
+  private def get_session
+    session[session_key]
+  end
+
+  private def delete_session
+    session.delete(session_key)
+  end
+
+  private def session_key
+    "dao_revocation_#{@project.id}"
+  end
+
+  private def dao_revocations_params
+    params
+      .require(:dao_revocation_stepped_form)
+      .permit(
+        :reason_school_closed,
+        :reason_school_rating_improved,
+        :reason_safeguarding_addressed,
+        :minister_name,
+        :date_of_decision,
+        :confirm_minister_approved,
+        :confirm_letter_sent,
+        :confirm_letter_saved
+      )
+  end
+
+  private def requested_step
+    params["step"].to_sym
+  end
+
+  private def steps
+    DaoRevocationSteppedForm.steps
+  end
+
+  private def next_step
+    next_index = steps.find_index(requested_step) + 1
+
+    project_dao_revocation_step_path(@project, steps[next_index])
+  end
+
+  private def redirect_if_project_revoked
+    redirect_to project_path(@project) if @project.dao_revocation.present?
+  end
+
+  private def redirect_if_invalid_step
+    not_found_error unless steps.include?(requested_step)
+  end
+end

--- a/app/forms/dao_revocation_stepped_form.rb
+++ b/app/forms/dao_revocation_stepped_form.rb
@@ -1,0 +1,108 @@
+class DaoRevocationSteppedForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
+  STEPS = %i[
+    confirm
+    reasons
+    minister
+    date
+  ]
+
+  attribute :reason_school_closed, :boolean
+  attribute :reason_school_rating_improved, :boolean
+  attribute :reason_safeguarding_addressed, :boolean
+  attribute :minister_name, :string
+  attribute :date_of_decision, :date
+
+  attribute :confirm_minister_approved, :boolean
+  attribute :confirm_letter_sent, :boolean
+  attribute :confirm_letter_saved, :boolean
+
+  validate :at_least_one_reason, on: :reasons
+  validates :minister_name, presence: true, on: :minister
+  validates :date_of_decision, presence: true, on: :date
+  validate :all_confirmed, on: :confirm
+
+  def assign_attributes(attributes)
+    if GovukDateFieldParameters.new(:date_of_decision, attributes).invalid?
+      attributes.delete("date_of_decision(3i)")
+      attributes.delete("date_of_decision(2i)")
+      attributes.delete("date_of_decision(1i)")
+      self.date_of_decision = nil
+    end
+
+    super
+  end
+
+  def self.first_step
+    STEPS.first
+  end
+
+  def self.last_step
+    STEPS.last
+  end
+
+  def self.steps
+    STEPS
+  end
+
+  def reasons
+    reasons = []
+
+    reasons << :reason_school_closed if reason_school_closed
+    reasons << :reason_school_rating_improved if reason_school_rating_improved
+    reasons << :reason_safeguarding_addressed if reason_safeguarding_addressed
+
+    reasons
+  end
+
+  def reasons_empty?
+    reasons.filter_map { |reason| reason }.empty?
+  end
+
+  def checkable?
+    (reason_school_closed.present? || reason_school_rating_improved.present? || reason_safeguarding_addressed.present?) &&
+      minister_name.present? && date_of_decision.present?
+  end
+
+  def to_h
+    {
+      reason_school_closed: reason_school_closed.to_s,
+      reason_school_rating_improved: reason_school_rating_improved.to_s,
+      reason_safeguarding_addressed: reason_safeguarding_addressed.to_s,
+      minister_name: minister_name,
+      date_of_decision: date_of_decision.to_s
+    }
+  end
+
+  def save_to_project(project)
+    revocation = DaoRevocation.new(
+      project_id: project.id,
+      reason_school_closed: reason_school_closed,
+      reason_school_rating_improved: reason_school_rating_improved,
+      reason_safeguarding_addressed: reason_safeguarding_addressed,
+      decision_makers_name: minister_name,
+      date_of_decision: date_of_decision
+    )
+
+    if revocation.valid?
+      revocation.save!
+      true
+    else
+      errors.add(:base, :check_answers)
+      false
+    end
+  end
+
+  private def at_least_one_reason
+    selected_reasons = reasons.filter_map { |reason| reason }
+
+    errors.add(:reasons, :at_least_one_reason) if selected_reasons.empty?
+  end
+
+  private def all_confirmed
+    errors.add(:base, :all_confirmed) unless confirm_minister_approved && confirm_letter_sent && confirm_letter_saved
+  end
+end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -28,6 +28,10 @@ class ProjectPolicy
     true
   end
 
+  def dao_revocation?
+    update?
+  end
+
   def check?
     edit?
   end

--- a/app/views/dao_revocations/change_date.html.erb
+++ b/app/views/dao_revocations/change_date.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title do %>
+  <%= page_title(t("dao_revocations.date.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_for @step_form, url: project_dao_revocation_update_change_step_path(@project, :date), method: :patch do |form| %>
+
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_date_field :date_of_decision, legend: {size: "xl"}, caption: {size: "xl"} %>
+
+      <%= form.govuk_submit t("dao_revocations.date.button") %>
+
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/dao_revocations/change_minister.html.erb
+++ b/app/views/dao_revocations/change_minister.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title do %>
+  <%= page_title(t("dao_revocations.minister.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_for @step_form, url: project_dao_revocation_update_change_step_path(@project, :minister), method: :patch do |form| %>
+
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_text_field :minister_name, label: {size: "xl"}, caption: {size: "xl"} %>
+
+      <%= form.govuk_submit t("dao_revocations.minister.button") %>
+
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/dao_revocations/change_reasons.html.erb
+++ b/app/views/dao_revocations/change_reasons.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title do %>
+  <%= page_title(t("dao_revocations.reasons.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_for @step_form, url: project_dao_revocation_update_change_step_path(@project, :reasons), method: :patch do |form| %>
+
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_check_boxes_fieldset :reasons, multiple: false, legend: {size: "xl"}, caption: {size: "xl"} do %>
+        <%= form.govuk_check_box :reason_school_rating_improved, 1, 0, multiple: false, label: {text: t("helpers.label.dao_revocation_stepped_form.reason_school_rating_improved")} %>
+
+        <%= form.govuk_check_box :reason_safeguarding_addressed, 1, 0, multiple: false, label: {text: t("helpers.label.dao_revocation_stepped_form.reason_safeguarding_addressed")} %>
+
+        <%= form.govuk_check_box :reason_school_closed, 1, 0, multiple: false, label: {text: t("helpers.label.dao_revocation_stepped_form.reason_school_closed")} %>
+
+      <% end %>
+
+      <%= form.govuk_submit t("dao_revocations.reasons.button") %>
+
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/dao_revocations/check.html.erb
+++ b/app/views/dao_revocations/check.html.erb
@@ -1,0 +1,62 @@
+<% content_for :page_title do %>
+  <%= page_title(t("dao_revocations.check.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= t("dao_revocations.check.caption") %></span>
+    <h1 class="govuk-heading-xl"><%= t("dao_revocations.check.title") %></h1>
+
+    <%= form_for @step_form, url: project_dao_revocation_check_path(@project, :date), method: :post do |form| %>
+
+      <%= form.govuk_error_summary %>
+
+      <%= govuk_summary_list do |summary_list| %>
+
+        <%= summary_list.with_row do |row| %>
+          <%= row.with_key { t("dao_revocations.check.summary.title.decision") } %>
+          <%= row.with_value { tag.span t("dao_revocations.check.summary.value.decision"), class: ["govuk-tag", "govuk-tag--red"] } %>
+        <% end %>
+
+        <%= summary_list.with_row do |row| %>
+          <%= row.with_key { t("dao_revocations.check.summary.title.reasons") } %>
+          <% if @step_form.reasons_empty? %>
+            <%= row.with_value { govuk_link_to "Enter reasons", project_dao_revocation_change_step_path(@project, :reasons) } %>
+          <% else %>
+            <%= row.with_value { @step_form.reasons.map { |reason| t("dao_revocations.check.summary.value.reasons.#{reason}") }.join("; ") } %>
+            <%= row.with_action(text: t("dao_revocations.check.summary.change.reasons"), href: project_dao_revocation_change_step_path(@project, :reasons), visually_hidden_text: t("dao_revocations.check.summary.title.reasons")) %>
+          <% end %>
+        <% end %>
+
+        <%= summary_list.with_row do |row| %>
+          <%= row.with_key { t("dao_revocations.check.summary.title.role") } %>
+          <%= row.with_value { "Minister" } %>
+        <% end %>
+
+        <%= summary_list.with_row do |row| %>
+          <%= row.with_key { t("dao_revocations.check.summary.title.minister_name") } %>
+          <% if @step_form.minister_name.blank? %>
+            <%= row.with_value { govuk_link_to "Enter minister's name", project_dao_revocation_change_step_path(@project, :minister) } %>
+          <% else %>
+            <%= row.with_value { @step_form.minister_name } %>
+            <%= row.with_action(text: t("dao_revocations.check.summary.change.minister_name"), href: project_dao_revocation_change_step_path(@project, :minister), visually_hidden_text: t("dao_revocations.check.summary.title.minister_name")) %>
+          <% end %>
+        <% end %>
+
+        <%= summary_list.with_row do |row| %>
+          <%= row.with_key { t("dao_revocations.check.summary.title.date_of_decision") } %>
+          <% if @step_form.date_of_decision.blank? %>
+            <%= row.with_value { govuk_link_to "Enter date of decision", project_dao_revocation_change_step_path(@project, :date) } %>
+          <% else %>
+            <%= row.with_value { @step_form.date_of_decision.to_fs(:govuk) } %>
+            <%= row.with_action(text: t("dao_revocations.check.summary.change.date_of_decision"), href: project_dao_revocation_change_step_path(@project, :date), visually_hidden_text: t("dao_revocations.check.summary.title.date_of_decision")) %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+    <%= form.govuk_submit t("dao_revocations.check.button") %>
+
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/dao_revocations/confirm.html.erb
+++ b/app/views/dao_revocations/confirm.html.erb
@@ -1,0 +1,42 @@
+<% content_for :page_title do %>
+  <%= page_title(t("dao_revocations.confirm.title")) %>
+<% end %>
+
+<% if @step_form.errors.any? %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_notification_banner title_text: t("dao_revocations.confirm.unconfirmed.title"),
+          text: t("dao_revocations.confirm.unconfirmed.body_html",
+            project_path: project_path(@project),
+            your_projects_path: in_progress_your_projects_path) %>
+  </div>
+</div>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= t("dao_revocations.confirm.caption") %></span>
+    <h1 class="govuk-heading-xl"><%= t("dao_revocations.confirm.title") %></h1>
+
+    <%= t("dao_revocations.confirm.body_html") %>
+
+    <%= form_for @step_form, url: project_dao_revocation_update_step_path(@project, :confirm), method: :post do |form| %>
+
+      <%= form.govuk_check_boxes_fieldset :confirm_minister_approved, multiple: false, legend: {text: t("helpers.legend.dao_revocation_stepped_form.confirm_minister_approved"), size: "l"} do %>
+        <%= form.govuk_check_box :confirm_minister_approved, 1, 0, multiple: false, label: {text: t("helpers.label.dao_revocation_stepped_form.confirm_minister_approved")} %>
+      <% end %>
+
+      <%= form.govuk_check_boxes_fieldset :confirm_letter_sent, multiple: false, legend: {text: t("helpers.legend.dao_revocation_stepped_form.confirm_letter_sent"), size: "l"} do %>
+        <%= form.govuk_check_box :confirm_letter_sent, 1, 0, multiple: false, label: {text: t("helpers.label.dao_revocation_stepped_form.confirm_letter_sent")} %>
+      <% end %>
+
+      <%= form.govuk_check_boxes_fieldset :confirm_letter_saved, multiple: false, legend: {text: t("helpers.legend.dao_revocation_stepped_form.confirm_letter_saved"), size: "l"} do %>
+        <%= form.govuk_check_box :confirm_letter_saved, 1, 0, multiple: false, label: {text: t("helpers.label.dao_revocation_stepped_form.confirm_letter_saved")} %>
+      <% end %>
+
+      <%= form.govuk_submit t("dao_revocations.confirm.button") %>
+
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/dao_revocations/date.html.erb
+++ b/app/views/dao_revocations/date.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title do %>
+  <%= page_title(t("dao_revocations.date.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_for @step_form, url: project_dao_revocation_update_step_path(@project, :date), method: :post do |form| %>
+
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_date_field :date_of_decision, legend: {size: "xl"}, caption: {size: "xl"} %>
+
+      <%= form.govuk_submit t("dao_revocations.date.button") %>
+
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/dao_revocations/minister.html.erb
+++ b/app/views/dao_revocations/minister.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title do %>
+  <%= page_title(t("dao_revocations.minister.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_for @step_form, url: project_dao_revocation_update_step_path(@project, :minister), method: :post do |form| %>
+
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_text_field :minister_name, label: {size: "xl"}, caption: {size: "xl"} %>
+
+      <%= form.govuk_submit t("dao_revocations.minister.button") %>
+
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/dao_revocations/reasons.html.erb
+++ b/app/views/dao_revocations/reasons.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title do %>
+  <%= page_title(t("dao_revocations.reasons.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_for @step_form, url: project_dao_revocation_update_step_path(@project, :reasons), method: :post do |form| %>
+
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_check_boxes_fieldset :reasons, multiple: false, legend: {size: "xl"}, caption: {size: "xl"} do %>
+        <%= form.govuk_check_box :reason_school_rating_improved, 1, 0, multiple: false, label: {text: t("helpers.label.dao_revocation_stepped_form.reason_school_rating_improved")} %>
+
+        <%= form.govuk_check_box :reason_safeguarding_addressed, 1, 0, multiple: false, label: {text: t("helpers.label.dao_revocation_stepped_form.reason_safeguarding_addressed")} %>
+
+        <%= form.govuk_check_box :reason_school_closed, 1, 0, multiple: false, label: {text: t("helpers.label.dao_revocation_stepped_form.reason_school_closed")} %>
+
+      <% end %>
+
+      <%= form.govuk_submit t("dao_revocations.reasons.button") %>
+
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/dao_revocations/start.html.erb
+++ b/app/views/dao_revocations/start.html.erb
@@ -1,0 +1,14 @@
+<% content_for :page_title do %>
+  <%= page_title(t("dao_revocations.start.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= @project.establishment.name %></span>
+    <h1 class="govuk-heading-xl"><%= t("dao_revocations.start.title") %></h1>
+
+    <%= t("dao_revocations.start.body_html") %>
+
+    <%= govuk_link_to t("dao_revocations.start.button"), project_dao_revocation_step_path(@project, :confirm), class: "govuk-button" %>
+  </div>
+</div>

--- a/config/locales/dao_revocations.en.yml
+++ b/config/locales/dao_revocations.en.yml
@@ -1,0 +1,14 @@
+en:
+  errors:
+    attributes:
+      base:
+        all_confirmed: You must complete all of the tasks
+        reason_required: You must select at least one reason
+        incorrect_project_type: A DAO revoked decision can only be recorded against a Conversion project with a Directive academy order
+        check_answers: Cannot record DAO revocation, check your answers
+      reasons:
+        at_least_one_reason: Select at least one reason
+      minister_name:
+        blank: Enter the name of the minister that approved the decision
+      date_of_decision:
+        blank: Enter a valid date the decision was made, like 27 3 2021

--- a/config/locales/dao_revocations.en.yml
+++ b/config/locales/dao_revocations.en.yml
@@ -1,4 +1,116 @@
 en:
+  dao_revocations:
+    start:
+      title: Record Directive Academy Order revocation
+      body_html:
+        <p>Revoking a DAO (Directive Academy Order) will end this conversion project.</p>
+        <p>This decision must be approved by a minister.</p>
+        <p>You must also send a letter confirming the decision to the school’s governing body, and save this in the school’s SharePoint folder.</p>
+        <p>If you choose to record the revocation of this project's Academy Order, you will need to enter information about:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>who made the decision</li>
+          <li>why they made the decision</li>
+          <li>when the decision was made</li>
+        </ul>
+      button: Continue
+
+    confirm:
+      title: Before you start
+      caption: Revoke Directive Academy Order
+      body_html:
+        <p>You cannot record a decision to revoke a DAO until you confirm that the following things have happened.</p>
+      button: Continue
+      unconfirmed:
+        title: Important
+        body_html:
+          <h2>You cannot record this decision yet</h2>
+          <p>Before you can record the decision to revoke an Academy Order:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>a minister must approve the decision</li>
+            <li>you must have sent the letter confirming the decision to the school</li>
+            <li>you must have saved a copy of the letter in SharePoint</li>
+          </ul>
+          <p>You can
+          <a class="govuk-notification-banner__link" href="%{project_path}">go back to the task list</a>
+          and continue working on this project, or
+          <a class="govuk-notification-banner__link" href="%{your_projects_path}">choose another project from your project list.</a></p>
+        button: Continue
+
+    reasons:
+      title: Why was the DAO revoked?
+      button: Continue
+
+    minister:
+      title: Minister’s name
+      button: Continue
+
+    date:
+      title: Date of decision
+      button: Continue
+
+    check:
+      title: Check your answers before recording this decision
+      caption: Revoke Directive Academy Order
+      button: Record DAO revocation
+      summary:
+        title:
+          decision: Decision
+          reasons: Reasons
+          role: Decision maker’s role
+          minister_name: Minister’s name
+          date_of_decision: Date of decision
+        value:
+          decision: DAO revoked
+          role: Minister
+          reasons:
+            reason_school_closed: School closed or closing
+            reason_school_rating_improved: School rated good or outstanding
+            reason_safeguarding_addressed: Safeguarding concerns addressed
+        change:
+          reasons: Change
+          minister_name: Change
+          date_of_decision: Change
+        empty:
+          reasons: Enter the reasons
+          minister_name: Enter the minister's name
+          date_of_decision: Enter the date of decision
+      successful: DAO revocation recorded successfully
+
+  helpers:
+    legend:
+      dao_revocation_stepped_form:
+        confirm_minister_approved: A minister has approved this decision
+        confirm_letter_sent: You have sent a letter confirming the revocation decision
+        confirm_letter_saved: You have saved a copy of the letter
+        reasons: Why was the DAO revoked?
+        date_of_decision: Date of decision
+    caption:
+      dao_revocation_stepped_form:
+        reasons: Revoke Directive Academy Order
+        minister_name: Revoke Directive Academy Order
+        date_of_decision: Revoke Directive Academy Order
+    label:
+      dao_revocation_stepped_form:
+        confirm_minister_approved: I confirm a minister has approved this decision
+        confirm_letter_sent: I confirm I have sent the letter confirming the revocation decision
+        confirm_letter_saved: I confirm I have saved a copy of the letter to the school’s SharePoint folder
+        reason_school_closed: School closed or closing
+        reason_school_rating_improved: School rated good or outstanding
+        reason_safeguarding_addressed: Safeguarding concerns addressed
+        minister_name: Minister’s name
+    hint:
+      dao_revocation_stepped_form:
+        confirm_minister_approved_html:
+          <p>The revocation of a DAO (Directive Academy Order) must be signed off by a minister. It cannot proceed without ministerial approval.</p>
+        confirm_letter_sent_html:
+          <p>You must write and send a letter to the school’s governing body to confirm the minister’s decision.</p>
+          <p>Use the letter templates in the revocation guidance (opens in a new tab) to help you.</p>
+        confirm_letter_saved_html:
+          <p>You must save a copy of the letter in the school’s SharePoint folder.</p>
+        reasons: Select all that apply.
+        minister_name: Enter the name of the minister who made the decision.
+        date_of_decision: For example, 27 3 2021
+
   errors:
     attributes:
       base:

--- a/config/locales/dao_revoked_decision.en.yml
+++ b/config/locales/dao_revoked_decision.en.yml
@@ -1,6 +1,0 @@
-en:
-  errors:
-    attributes:
-      base:
-        reason_required: You must select at least one reason
-        incorrect_project_type: A DAO revoked decision can only be recorded against a Conversion project with a Directive academy order

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,17 @@ Rails.application.routes.draw do
     patch "academy-urn", to: "conversions/academy_urn#update_academy_urn"
   end
 
+  concern :dao_revokable do
+    get "dao-revocation", to: "dao_revocations#start", as: :dao_revocation_start
+    get "dao-revocation/check", to: "dao_revocations#check", as: :dao_revocation_check
+    post "dao-revocation/check", to: "dao_revocations#save"
+
+    get "dao-revocation/:step", to: "dao_revocations#step", as: :dao_revocation_step
+    get "dao-revocation/:step/change", to: "dao_revocations#change_step", as: :dao_revocation_change_step
+    post "dao-revocation/:step", to: "dao_revocations#update_step", as: :dao_revocation_update_step
+    patch "dao-revocation/:step/change", to: "dao_revocations#update_change_step", as: :dao_revocation_update_change_step
+  end
+
   # A project
   constraints(id: VALID_UUID_REGEX) do
     resources :projects,
@@ -87,6 +98,7 @@ Rails.application.routes.draw do
         significant_date_historyable
         memberable
         academy_urn_updateable
+        dao_revokable
       ]
     resources :projects, except: :destroy do
       get "confirm_delete", on: :member, action: :confirm_delete, as: :confirm_delete

--- a/spec/features/dao_revocation/user_can_record_the_revocation_of_a_dao_from_a_project_spec.rb
+++ b/spec/features/dao_revocation/user_can_record_the_revocation_of_a_dao_from_a_project_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.feature "Users record the revocation of a DAO from a project" do
+  let(:user) { create(:user, :caseworker) }
+
+  before do
+    mock_all_academies_api_responses
+    sign_in_with_user(user)
+  end
+
+  scenario "by providing all of the details correctly" do
+    project = create(:conversion_project, directive_academy_order: true, assigned_to: user)
+
+    visit project_dao_revocation_start_path(project)
+
+    click_on "Continue"
+
+    check "I confirm a minister has approved this decision"
+    check "I confirm I have sent the letter confirming the revocation decision"
+    check "I confirm I have saved a copy of the letter to the school’s SharePoint folder"
+    click_button "Continue"
+
+    expect(page).to have_content "Why was the DAO revoked?"
+
+    check "School closed or closing"
+    check "Safeguarding concerns addressed"
+    click_button "Continue"
+
+    expect(page).to have_content "Minister’s name"
+    fill_in "Minister’s name", with: "Ministers Name"
+    click_button "Continue"
+
+    expect(page).to have_content "Date of decision"
+    fill_in "Day", with: 1
+    fill_in "Month", with: 1
+    fill_in "Year", with: 2024
+    click_button "Continue"
+
+    expect(page).to have_content "Check your answers before recording this decision"
+    click_button "Record DAO revocation"
+
+    expect(page).to have_content "DAO revocation recorded successfully"
+  end
+
+  scenario "they can change details before submitting" do
+    project = create(:conversion_project, directive_academy_order: true, assigned_to: user)
+
+    visit project_dao_revocation_start_path(project)
+
+    click_on "Continue"
+
+    check "I confirm a minister has approved this decision"
+    check "I confirm I have sent the letter confirming the revocation decision"
+    check "I confirm I have saved a copy of the letter to the school’s SharePoint folder"
+    click_button "Continue"
+
+    expect(page).to have_content "Why was the DAO revoked?"
+
+    check "School closed or closing"
+    check "Safeguarding concerns addressed"
+    click_button "Continue"
+
+    expect(page).to have_content "Minister’s name"
+    fill_in "Minister’s name", with: "Incorrect Name"
+    click_button "Continue"
+
+    expect(page).to have_content "Date of decision"
+    fill_in "Day", with: 1
+    fill_in "Month", with: 1
+    fill_in "Year", with: 2024
+    click_button "Continue"
+
+    expect(page).to have_content "Check your answers before recording this decision"
+
+    within ".govuk-summary-list__row:nth-of-type(4)" do
+      click_on "Change"
+    end
+
+    expect(page).to have_content "Minister’s name"
+    fill_in "Minister’s name", with: "Minister Name"
+    click_button "Continue"
+
+    expect(page).to have_content "Check your answers before recording this decision"
+
+    within ".govuk-summary-list__row:nth-of-type(4)" do
+      expect(page).to have_content "Minister Name"
+    end
+
+    expect(page).to have_content "Check your answers before recording this decision"
+    click_button "Record DAO revocation"
+
+    expect(page).to have_content "DAO revocation recorded successfully"
+  end
+end

--- a/spec/forms/dao_revocation_stepped_form_spec.rb
+++ b/spec/forms/dao_revocation_stepped_form_spec.rb
@@ -1,0 +1,313 @@
+require "rails_helper"
+
+RSpec.describe DaoRevocationSteppedForm, type: :model do
+  describe "steps" do
+    it "returns the correct steps in order" do
+      expect(described_class.steps).to eql [:confirm, :reasons, :minister, :date]
+    end
+
+    it "returns the first step" do
+      expect(described_class.first_step).to eql :confirm
+    end
+
+    it "returns the last step" do
+      expect(described_class.last_step).to eql :date
+    end
+  end
+
+  describe "validations" do
+    it "validates that all confirmations are checked on the confirm step" do
+      form = described_class.new(
+        confirm_minister_approved: true,
+        confirm_letter_sent: false,
+        confirm_letter_saved: true
+      )
+
+      expect(form).to be_invalid(:confirm)
+      expect(form.errors.messages_for(:base)).to include "You must complete all of the tasks"
+    end
+
+    it "validates that at least one reason is checked on the reasons step" do
+      form = described_class.new(
+        reason_school_closed: false,
+        reason_school_rating_improved: false,
+        reason_safeguarding_addressed: false
+      )
+
+      expect(form).to be_invalid(:reasons)
+      expect(form.errors.messages_for(:reasons)).to include "Select at least one reason"
+    end
+
+    it { is_expected.to validate_presence_of(:minister_name).on :minister }
+    it { is_expected.to validate_presence_of(:date_of_decision).on :date }
+
+    describe "date of decision" do
+      let(:valid_attributes) do
+        date_of_decision = Date.today
+        {
+          "date_of_decision(3i)": date_of_decision.day.to_s,
+          "date_of_decision(2i)": date_of_decision.month.to_s,
+          "date_of_decision(1i)": date_of_decision.year.to_s
+        }.with_indifferent_access
+      end
+
+      let(:form) { described_class.new }
+
+      it "shows a helpful error message when invalid" do
+        attributes = valid_attributes
+        attributes["date_of_decision(2i)"] = "13"
+
+        form.assign_attributes(attributes)
+
+        expect(form).to be_invalid(:date)
+        expect(form.errors.messages_for(:date_of_decision)).to include(
+          "Enter a valid date the decision was made, like 27 3 2021"
+        )
+      end
+
+      it "cannot be empty" do
+        attributes = valid_attributes
+        attributes["date_of_decision(3i)"] = ""
+        attributes["date_of_decision(2i)"] = ""
+        attributes["date_of_decision(1i)"] = ""
+
+        form.assign_attributes(attributes)
+
+        expect(form).to be_invalid(:date)
+      end
+
+      describe "day params" do
+        it "cannot be 0" do
+          attributes = valid_attributes
+          attributes[:"date_of_decision(2i)"] = "0"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid(:date)
+        end
+
+        it "cannot be less than 0" do
+          attributes = valid_attributes
+          attributes["date_of_decision(3i)"] = "-1"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid(:date)
+        end
+
+        it "cannot be more than 31" do
+          attributes = valid_attributes
+          attributes["date_of_decision(3i)"] = "32"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid(:date)
+        end
+
+        it "must be a number" do
+          attributes = valid_attributes
+          attributes["date_of_decision(3i)"] = "fourth"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid(:date)
+        end
+      end
+
+      describe "month params" do
+        it "cannot be 0" do
+          attributes = valid_attributes
+          attributes[:"date_of_decision(2i)"] = "0"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid(:date)
+        end
+
+        it "cannot be less than 0" do
+          attributes = valid_attributes
+          attributes["date_of_decision(2i)"] = "-1"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid(:date)
+        end
+
+        it "cannot be more than 12" do
+          attributes = valid_attributes
+          attributes["date_of_decision(2i)"] = "13"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid(:date)
+        end
+
+        it "must be a number" do
+          attributes = valid_attributes
+          attributes["date_of_decision(2i)"] = "fourth"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid(:date)
+        end
+      end
+
+      describe "year params" do
+        it "must be four digits" do
+          attributes = valid_attributes
+          attributes["date_of_decision(1i)"] = "25"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid(:date)
+        end
+
+        it "cannot be less than 2000" do
+          attributes = valid_attributes
+          attributes["date_of_decision(1i)"] = "1999"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid(:date)
+        end
+
+        it "cannot be more than 3000" do
+          attributes = valid_attributes
+          attributes["date_of_decision(1i)"] = "3001"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid(:date)
+        end
+
+        it "must be a number" do
+          attributes = valid_attributes
+          attributes["date_of_decision(2i)"] = "twenty twenty five"
+
+          form.assign_attributes(attributes)
+
+          expect(form).to be_invalid(:date)
+        end
+      end
+    end
+  end
+
+  describe "#reasons" do
+    it "returns an array of the reasons" do
+      form = described_class.new(
+        reason_school_closed: true,
+        reason_school_rating_improved: false,
+        reason_safeguarding_addressed: true
+      )
+
+      expect(form.reasons).to eql [:reason_school_closed, :reason_safeguarding_addressed]
+    end
+  end
+
+  describe "#reasons_empty?" do
+    it "returns true when all the reasons are false" do
+      form = described_class.new(
+        reason_school_closed: false,
+        reason_school_rating_improved: false,
+        reason_safeguarding_addressed: false
+      )
+
+      expect(form.reasons_empty?).to be true
+    end
+
+    it "returns false when any reason is true" do
+      form = described_class.new(
+        reason_school_closed: false,
+        reason_school_rating_improved: true,
+        reason_safeguarding_addressed: false
+      )
+
+      expect(form.reasons_empty?).to be false
+    end
+  end
+
+  describe "#checkable?" do
+    it "returns true when all the minimum required attributes are present" do
+      form = described_class.new(
+        reason_school_closed: true,
+        reason_school_rating_improved: false,
+        reason_safeguarding_addressed: false,
+        minister_name: "Minister Name",
+        date_of_decision: "2024-1-1"
+      )
+
+      expect(form.checkable?).to be true
+    end
+
+    it "returns false when any of the minimum required attributes are not present" do
+      form = described_class.new(
+        reason_school_closed: "",
+        reason_school_rating_improved: "",
+        reason_safeguarding_addressed: "",
+        minister_name: "",
+        date_of_decision: "2024-1-1"
+      )
+
+      expect(form.checkable?).to be false
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash of the attributes that need to be stored" do
+      form = described_class.new(
+        reason_school_closed: true,
+        reason_school_rating_improved: false,
+        reason_safeguarding_addressed: true,
+        minister_name: "Minister Name",
+        date_of_decision: Date.today
+      )
+
+      expect(form.to_h).to eql({
+        reason_school_closed: "true",
+        reason_school_rating_improved: "false",
+        reason_safeguarding_addressed: "true",
+        minister_name: "Minister Name",
+        date_of_decision: Date.today.to_s
+      })
+    end
+  end
+
+  describe "#save_to_project" do
+    before do
+      mock_all_academies_api_responses
+    end
+
+    let(:valid_form) do
+      described_class.new(
+        reason_school_closed: true,
+        reason_school_rating_improved: false,
+        reason_safeguarding_addressed: true,
+        minister_name: "Minister Name",
+        date_of_decision: Date.today
+      )
+    end
+
+    it "creates the DaoRevocation and saves it to the project returning true" do
+      project = create(:conversion_project, directive_academy_order: true)
+
+      result = valid_form.save_to_project(project)
+
+      expect(result).to be true
+      expect(DaoRevocation.count).to be 1
+
+      dao_revocation = DaoRevocation.last
+      expect(dao_revocation.reason_school_closed).to be true
+      expect(dao_revocation.decision_makers_name).to eql "Minister Name"
+      expect(dao_revocation.date_of_decision).to eql Date.today
+    end
+
+    it "returns false and adds an error when invalid" do
+      project = create(:conversion_project, directive_academy_order: false)
+
+      result = valid_form.save_to_project(project)
+
+      expect(result).to be false
+      expect(valid_form.errors.messages_for(:base)).to include "Cannot record DAO revocation, check your answers"
+    end
+  end
+end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -182,4 +182,14 @@ RSpec.describe ProjectPolicy do
       expect(subject).to permit(application_user, build(:conversion_project, assigned_to: application_user))
     end
   end
+
+  permissions :dao_revocation? do
+    it "grants access if the user is assigned to the project" do
+      expect(subject).to permit(application_user, build(:conversion_project, assigned_to: application_user))
+    end
+
+    it "denies access if the user is not assigned to the project" do
+      expect(subject).not_to permit(application_user, build(:conversion_project))
+    end
+  end
 end

--- a/spec/requests/dao_revocations_controller_spec.rb
+++ b/spec/requests/dao_revocations_controller_spec.rb
@@ -1,0 +1,230 @@
+require "rails_helper"
+
+RSpec.describe DaoRevocationsController, type: :request do
+  let(:user) { create(:user, :caseworker) }
+  let(:project) { create(:conversion_project, directive_academy_order: true, assigned_to: user) }
+
+  before do
+    sign_in_with(user)
+    mock_all_academies_api_responses
+  end
+
+  describe "#step" do
+    it "renders the template for the step" do
+      get project_dao_revocation_step_path(project, :reasons)
+
+      expect(response).to render_template "reasons"
+    end
+
+    it "renders 404 for unknown steps" do
+      get project_dao_revocation_step_path(project, :unknown_step)
+
+      expect(response).to render_template "page_not_found"
+      expect(response).to have_http_status :not_found
+    end
+
+    it "deleted the stored values on the first step" do
+      valid_params = {dao_revocation_stepped_form: {minister_name: "Minister Name"}}
+
+      post project_dao_revocation_update_step_path(project, :minister, params: valid_params)
+
+      expect(session["dao_revocation_#{project.id}"]).to be_truthy
+
+      get project_dao_revocation_step_path(project, :confirm)
+
+      expect(session["dao_revocation_#{project.id}"]).to be_nil
+    end
+  end
+
+  describe "#update_step" do
+    it "sets the values in the session when the form is valid" do
+      valid_params = {dao_revocation_stepped_form: {minister_name: "Minister Name"}}
+
+      post project_dao_revocation_update_step_path(project, :minister, params: valid_params)
+
+      expect(session["dao_revocation_#{project.id}"]).to eql(
+        {
+          reason_school_closed: "",
+          reason_school_rating_improved: "",
+          reason_safeguarding_addressed: "",
+          minister_name: "Minister Name",
+          date_of_decision: ""
+        }
+      )
+    end
+
+    it "shows an error when the form is invalid for the step" do
+      valid_params = {dao_revocation_stepped_form: {minister_name: ""}}
+
+      post project_dao_revocation_update_step_path(project, :minister, params: valid_params)
+
+      expect(response).to render_template "minister"
+      expect(response.body).to include "There is a problem"
+    end
+
+    it "redirects to the next step when the form is valid for the step" do
+      valid_params = {dao_revocation_stepped_form: {minister_name: "Minister Name"}}
+
+      post project_dao_revocation_update_step_path(project, :minister, params: valid_params)
+
+      expect(response).to redirect_to project_dao_revocation_step_path(project, :date)
+    end
+
+    it "redirects to the check answers view on the last step" do
+      valid_params = {dao_revocation_stepped_form: {date_of_decision: Date.yesterday}}
+
+      post project_dao_revocation_update_step_path(project, :date, params: valid_params)
+
+      expect(response).to redirect_to project_dao_revocation_check_path(project)
+    end
+  end
+
+  describe "#change_step" do
+    it "renders the change template for the step" do
+      get project_dao_revocation_change_step_path(project, :reasons)
+
+      expect(response).to render_template "change_reasons"
+    end
+
+    it "renders 404 for unknown steps" do
+      get project_dao_revocation_change_step_path(project, :unknown_step)
+
+      expect(response).to render_template "page_not_found"
+      expect(response).to have_http_status :not_found
+    end
+  end
+
+  describe "#update_change_step" do
+    it "sets the values in the session when the form is valid" do
+      valid_params = {dao_revocation_stepped_form: {minister_name: "Incorrect Name"}}
+
+      post project_dao_revocation_update_step_path(project, :minister, params: valid_params)
+
+      valid_params = {dao_revocation_stepped_form: {minister_name: "Minister Name"}}
+
+      patch project_dao_revocation_update_change_step_path(project, :minister, params: valid_params)
+
+      expect(session["dao_revocation_#{project.id}"]).to eql(
+        {
+          reason_school_closed: "",
+          reason_school_rating_improved: "",
+          reason_safeguarding_addressed: "",
+          minister_name: "Minister Name",
+          date_of_decision: ""
+        }
+      )
+    end
+
+    it "shows an error when the form is invalid for the step" do
+      valid_params = {dao_revocation_stepped_form: {minister_name: ""}}
+
+      patch project_dao_revocation_update_change_step_path(project, :minister, params: valid_params)
+
+      expect(response).to render_template "change_minister"
+      expect(response.body).to include "There is a problem"
+    end
+
+    it "redirects to the check answers view for every step" do
+      valid_params = {dao_revocation_stepped_form: {minister_name: "Minister Name"}}
+
+      patch project_dao_revocation_update_change_step_path(project, :minister, params: valid_params)
+
+      expect(response).to redirect_to project_dao_revocation_check_path(project)
+    end
+  end
+
+  describe "#check" do
+    let(:valid_params) do
+      {
+        dao_revocation_stepped_form:
+        {
+          date_of_decision: "2024-01-01",
+          reason_school_closed: "true",
+          reason_school_rating_improved: "false",
+          reason_safeguarding_addressed: "false",
+          minister_name: "Minister Name"
+        }
+      }
+    end
+
+    before do
+      patch project_dao_revocation_update_change_step_path(project, :minister, params: valid_params)
+    end
+
+    it "gets the stored values" do
+      get project_dao_revocation_check_path(project)
+
+      expect(session["dao_revocation_#{project.id}"]).to eql(
+        {
+          reason_school_closed: "true",
+          reason_school_rating_improved: "false",
+          reason_safeguarding_addressed: "false",
+          minister_name: "Minister Name",
+          date_of_decision: "2024-01-01"
+        }.with_indifferent_access
+      )
+    end
+
+    it "redirects to the start unless the form is checkable" do
+      not_checkable_params = {
+        dao_revocation_stepped_form:
+        {
+          date_of_decision: "",
+          reason_school_closed: "",
+          reason_school_rating_improved: "",
+          reason_safeguarding_addressed: "",
+          minister_name: "Minister Name"
+        }
+      }
+      patch project_dao_revocation_update_change_step_path(project, :minister, params: not_checkable_params)
+
+      get project_dao_revocation_check_path(project)
+
+      expect(response).to redirect_to project_dao_revocation_start_path(project)
+    end
+  end
+
+  describe "#save" do
+    let(:valid_params) do
+      {
+        dao_revocation_stepped_form:
+        {
+          reason_school_closed: "true",
+          reason_school_rating_improved: "false",
+          reason_safeguarding_addressed: "false",
+          minister_name: "Minister Name",
+          date_of_decision: "2024-1-1"
+        }
+      }
+    end
+
+    before do
+      patch project_dao_revocation_update_change_step_path(project, :minister, params: valid_params)
+    end
+
+    it "creates a new DAO Revocation record" do
+      expect { post project_dao_revocation_check_path(project) }.to change { DaoRevocation.count }
+    end
+
+    it "deletes the stored values" do
+      post project_dao_revocation_check_path(project)
+
+      expect(session["dao_revocation_#{project.id}"]).to be_nil
+    end
+
+    it "redirects to the project task page" do
+      post project_dao_revocation_check_path(project)
+
+      expect(response).to redirect_to project_path(project)
+    end
+
+    it "renders the check answers page and shows an error when invalid" do
+      allow_any_instance_of(DaoRevocation).to receive(:valid?).and_return(false)
+
+      post project_dao_revocation_check_path(project)
+
+      expect(response).to render_template "check"
+      expect(response.body).to include "Cannot record DAO revocation, check your answers"
+    end
+  end
+end


### PR DESCRIPTION
A DAO revocation is applied to a Conversion project that has a DAO applied to it.

The design is a 'check your answers' stepped form. This work delivers the basic flow but does not expose it in the application, that will follow.

There are four 'steps' here plus teh check your answers view:

- start page: infomation only
- confirm page: collects responses but does not save them
- reasons: collects up to three reasons for the revocation
- minister name: the name of the minister who approved the revocation
- date: the date on which the revocation was approved

We created a form object to handle everyting except the start page, which is just a action and view.

We do not want to create the actual DaoRevocation in the database until the check answers view is confirmed, so we store the temporay values in the session, we felt this was the right place as the confirmation page is framed as the user confirming they have taken the steps, so it is quite personal. Whilst orphaned data in the session is possible, the session should be deleted by the browser on close, so this is acceptable.

Coming back to the start, the session will be cleared and so the flow must be restarted. The values are stored in the session keyed by the project ID so multiple projects can be stored, there is a theoretical limit to the number of values that can be stored in the session, but as we only store five simple data types, we think this is fine, it's worh noting that DAO revocation at this stage in the overall project life cycle are unlikely.

We have the concept of 'checkable' which is the form being in an acceptable state for submission of changing, if the check answer view is requested before this state is reached, the user is redirected back to the start.

As a user could (however unlikely) make request to the steps manually, the check answer view handles an empty state and links to each steps so that a user can complete the task, although restarting is the preferred route.

We check at the start of the journey that no DaoRevocation is present on the current project, we do not check the project type or that a DAO is present - we may want to add this with the work that exposes this steps to users, we want to try and keep the complexity here down for review!

