### PR TITLE
Add task list link to completion section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- The task list includes a link to the completing a project section.
+
 ## [Release-75][release-75]
 
 ### Added

--- a/app/views/projects/show/_complete.html.erb
+++ b/app/views/projects/show/_complete.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <%= form_with url: project_complete_path(@project), method: :put do |form| %>
+    <%= form_with url: project_complete_path(@project), method: :put, id: "completing-a-project" do |form| %>
       <h3 class="govuk-heading-m"><%= t("project.complete.heading") %></h3>
       <p class="govuk-body"><%= t("project.complete.guidance.html") %></p>
 

--- a/app/views/shared/projects/_task_list.html.erb
+++ b/app/views/shared/projects/_task_list.html.erb
@@ -7,6 +7,10 @@
           <% @task_list.sections.each do |section| %>
             <%= render partial: "shared/side_navigation_item", locals: {name: t("#{section.locales_path}.title"), path: "##{section.identifier}"} %>
           <% end %>
+
+          <% unless @project.completed? %>
+            <li><%= link_to t("project.show.completing_a_project_link"), "#completing-a-project", class: "govuk-link govuk-link--no-visited-state" %></li>
+          <% end %>
         </ul>
       </nav>
     </div>

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -14,6 +14,7 @@ en:
       title: Task list
       edit_button:
         text: Edit
+      completing_a_project_link: Completing a project
     all:
       in_progress:
         title: All projects in progress

--- a/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
+++ b/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
@@ -28,6 +28,8 @@ RSpec.feature "Users can complete a conversion project" do
     scenario "the project is completed successfully" do
       visit project_path(project)
 
+      click_on "Completing a project"
+
       click_on I18n.t("project.complete.submit_button")
 
       expect(page).to have_content("Project completed")

--- a/spec/features/transfers/users_can_complete_a_transfer_project_spec.rb
+++ b/spec/features/transfers/users_can_complete_a_transfer_project_spec.rb
@@ -19,6 +19,8 @@ RSpec.feature "Users can complete a transfer project" do
     scenario "the project is completed successfully" do
       visit project_path(project)
 
+      click_on "Completing a project"
+
       click_on I18n.t("project.complete.submit_button")
 
       expect(page).to have_content("Project completed")


### PR DESCRIPTION
Marking the project as complete could be seen as the final section of
the task list so here we add a jump to link for access to it.

![image](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/assets/480578/afe2b38c-47e0-4cbb-8af0-bb56c6df9fce)

