### PR TITLE
(Fix) Correct text for transfer stakeholder kick off task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The task list includes a link to the completing a project section.
 
+### Fixed
+
+- Corrected the note text created when a user confirms the Transfer date as part
+  of the stakeholder kick off task - it said "Conversion" when it should say
+  "Transfer"
+
 ## [Release-75][release-75]
 
 ### Added

--- a/app/forms/conversion/task/stakeholder_kick_off_task_form.rb
+++ b/app/forms/conversion/task/stakeholder_kick_off_task_form.rb
@@ -62,6 +62,6 @@ class Conversion::Task::StakeholderKickOffTaskForm < ::BaseTaskForm
   end
 
   private def stakeholder_kick_off_reason
-    [{type: :stakeholder_kick_off, note_text: "Conversion date confirmed as part of the External stakeholder kick off task."}]
+    [{type: :stakeholder_kick_off, note_text: I18n.t("conversion.task.stakeholder_kick_off.confirmed_conversion_date.note")}]
   end
 end

--- a/app/forms/transfer/task/stakeholder_kick_off_task_form.rb
+++ b/app/forms/transfer/task/stakeholder_kick_off_task_form.rb
@@ -60,6 +60,6 @@ class Transfer::Task::StakeholderKickOffTaskForm < BaseTaskForm
   end
 
   private def stakeholder_kick_off_reason
-    [{type: :stakeholder_kick_off, note_text: "Conversion date confirmed as part of the External stakeholder kick off task."}]
+    [{type: :stakeholder_kick_off, note_text: I18n.t("transfer.task.stakeholder_kick_off.confirmed_transfer_date.note")}]
   end
 end

--- a/config/locales/conversion/tasks/stakeholder_kick_off.en.yml
+++ b/config/locales/conversion/tasks/stakeholder_kick_off.en.yml
@@ -47,7 +47,7 @@ en:
           errors:
             format: Enter a valid confirmed conversion date
             in_the_future: Conversion date must be in the future
-          note: Conversion date confirmed as part of external stakeholder kick off task.
+          note: Conversion date confirmed as part of the external stakeholder kick off task.
         setup_meeting:
           title: Send invites to the kick-off meeting or call
           hint:

--- a/config/locales/transfer/tasks/stakeholder_kick_off.en.yml
+++ b/config/locales/transfer/tasks/stakeholder_kick_off.en.yml
@@ -52,3 +52,4 @@ en:
           errors:
             format: Enter a valid confirmed transfer date
             in_the_future: Transfer date must be in the future
+          note: Transfer date confirmed as part of the external stakeholder kick off task.


### PR DESCRIPTION
When creating a date change note for a transfer project as part of the stakeholder kick off task, the text in the note said "Conversion". This should be "Transfer".

The existing notes themselves will be fixed up separately. 

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
