### PR TITLE
DAO Revocation change project state

### DIFF
--- a/app/forms/dao_revocation_stepped_form.rb
+++ b/app/forms/dao_revocation_stepped_form.rb
@@ -89,6 +89,7 @@ class DaoRevocationSteppedForm
 
     if revocation.valid?
       revocation.save!
+      project.update!(state: :dao_revoked)
       true
     else
       errors.add(:base, :check_answers)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -138,6 +138,10 @@ class Project < ApplicationRecord
     ContactsFetcherService.new(self).all_project_contacts
   end
 
+  def dao_revokable?
+    is_a?(Conversion::Project) && directive_academy_order?
+  end
+
   # :nocov:
   private def fetch_member_of_parliament
     result = Api::MembersApi::Client.new.member_for_constituency(establishment.parliamentary_constituency)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -91,7 +91,8 @@ class Project < ApplicationRecord
   enum :state, {
     active: 0,
     completed: 1,
-    deleted: 2
+    deleted: 2,
+    dao_revoked: 3
   }
 
   def establishment

--- a/app/views/conversions/shared/_project_summary.html.erb
+++ b/app/views/conversions/shared/_project_summary.html.erb
@@ -22,6 +22,18 @@
 
 <%= project_notification_banner(@project, current_user) %>
 
+<% if @project.dao_revoked? %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_notification_banner(
+          title_text: t("conversion_project.dao_revoked.notification.title"),
+          text: t("conversion_project.dao_revoked.notification.body_html", revocation_date: @project.dao_revocation.date_of_decision.to_fs(:govuk)),
+          html_attributes: {id: "notification-dao-revoked"}
+        ) %>
+  </div>
+</div>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <%= govuk_summary_list(actions: false, html_attributes: {id: "project-summary", class: "dfe-summary-list--project-summary"}) do |summary_list|

--- a/app/views/conversions/shared/_project_summary.html.erb
+++ b/app/views/conversions/shared/_project_summary.html.erb
@@ -7,8 +7,13 @@
     <span class="govuk-caption-l">
       <%= t("project.summary.heading.conversion", urn: @project.urn) %>
       <%= govuk_tag(text: t("project.summary.type.conversion"), colour: "purple") %>
+
       <% if @project.form_a_mat? %>
         <%= govuk_tag(text: t("project.summary.type.form_a_mat"), colour: "pink") %>
+      <% end %>
+
+      <% if @project.dao_revoked? %>
+        <%= govuk_tag(text: t("project.summary.type.dao_revoked"), colour: "red") %>
       <% end %>
     </span>
     <h1 class="govuk-heading-xl"><%= @project.establishment.name %></h1>

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -26,6 +26,13 @@ en:
           <p class="govuk-body">This will help the person continuing this project to organise the kick-off meeting.</p>
           <h2 class="govuk-heading-l">What happens next</h2>
           <p class="govuk-body">Another person will be assigned to this project.</p>
+    dao_revoked:
+      notification:
+        title: Important
+        body_html:
+          <p>This project’s Directive Academy Order was revoked on %{revocation_date}.</p>
+          <p>Only Service Support team members can make changes to this project.</p>
+
     summary_card:
       type: Type
       incoming_trust: Incoming trust

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -133,6 +133,7 @@ en:
         conversion: Conversion
         transfer: Transfer
         form_a_mat: Form a MAT
+        dao_revoked: DAO revoked
       incoming_trust:
         title: Incoming trust
       outgoing_trust:

--- a/spec/features/users_can_view_a_project_spec.rb
+++ b/spec/features/users_can_view_a_project_spec.rb
@@ -38,4 +38,17 @@ RSpec.feature "Users can view a project" do
       end
     end
   end
+
+  context "when the project is a conversion with a DAO revocation" do
+    let(:project) { create(:conversion_project, state: :dao_revoked, directive_academy_order: true) }
+    let!(:dao_revocation) { DaoRevocation.create!(project_id: project.id, date_of_decision: Date.today, decision_makers_name: "Minister Name", reason_school_closed: true) }
+
+    scenario "they can see the tag in the summary" do
+      visit project_path(project)
+
+      within(".govuk-caption-l .govuk-tag--red") do
+        expect(page).to have_content("DAO revoked")
+      end
+    end
+  end
 end

--- a/spec/features/users_can_view_a_project_spec.rb
+++ b/spec/features/users_can_view_a_project_spec.rb
@@ -50,5 +50,14 @@ RSpec.feature "Users can view a project" do
         expect(page).to have_content("DAO revoked")
       end
     end
+
+    scenario "they can see the notification banner" do
+      visit project_path(project)
+
+      within("#notification-dao-revoked") do
+        expect(page).to have_content("This project’s Directive Academy Order was revoked on")
+        expect(page).to have_content(Date.today.to_fs(:govuk))
+      end
+    end
   end
 end

--- a/spec/forms/dao_revocation_stepped_form_spec.rb
+++ b/spec/forms/dao_revocation_stepped_form_spec.rb
@@ -301,6 +301,14 @@ RSpec.describe DaoRevocationSteppedForm, type: :model do
       expect(dao_revocation.date_of_decision).to eql Date.today
     end
 
+    it "updates the project state to dao_revoked" do
+      project = create(:conversion_project, directive_academy_order: true)
+
+      valid_form.save_to_project(project)
+
+      expect(project.reload.state).to eql "dao_revoked"
+    end
+
     it "returns false and adds an error when invalid" do
       project = create(:conversion_project, directive_academy_order: false)
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -895,6 +895,22 @@ RSpec.describe Project, type: :model do
     end
   end
 
+  describe "#dao_revokable?" do
+    it "returns true when the project is a conversion with a DAO applied" do
+      project = build(:conversion_project, directive_academy_order: true)
+
+      expect(project.dao_revokable?).to be true
+    end
+
+    it "returns false when the project is not appropriate" do
+      conversion_project = build(:conversion_project, directive_academy_order: false)
+      transfer_project = build(:transfer_project)
+
+      expect(conversion_project.dao_revokable?).to be false
+      expect(transfer_project.dao_revokable?).to be false
+    end
+  end
+
   describe "delegation" do
     it "delegates local_authority to establishment" do
       local_authotity = double(code: 100)


### PR DESCRIPTION
This work updates the `DaoRevocationSteppedForm` to update the project state
once the DAO Revocation is saved. At the point of saving we should have a valid
`DaoRevocation` and `Project` so we bang(!) to raise any unexpected errors.

We move on to show when a project has its DAO revoked, showing a red 'DAO
REVOKE' tag and notification banner as per the design.

Lastly we add a helper method to project to tell us if a project is appropriate
for DAO revocation i.e. it is a conversion with an DAO applied - we'll use this
helper soon to allow users to actually revoke DAOs in the application.
