### PR TITLE
Fix missing reason type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Corrected the note text created when a user confirms the Transfer date as part
   of the stakeholder kick off task - it said "Conversion" when it should say
   "Transfer"
+- Added 'voluntary deferral' to the list of allowed reasons for a change of
+  date.
 
 ## [Release-75][release-75]
 

--- a/app/models/significant_date_history_reason.rb
+++ b/app/models/significant_date_history_reason.rb
@@ -26,6 +26,7 @@ class SignificantDateHistoryReason < ApplicationRecord
     buildings: "buildings",
     legal_documents: "legal_documents",
     commercial_transfer_agreement: "commercial_transfer_agreement",
-    advisory_board_conditions: "advisory_board_conditions"
+    advisory_board_conditions: "advisory_board_conditions",
+    voluntary_deferral: "voluntary_deferral"
   }
 end

--- a/spec/models/significant_date_history_reason_spec.rb
+++ b/spec/models/significant_date_history_reason_spec.rb
@@ -3,6 +3,18 @@ require "rails_helper"
 RSpec.describe SignificantDateHistoryReason do
   describe "Attributes" do
     it { is_expected.to have_db_column(:reason_type).of_type :string }
+
+    describe "reason_type" do
+      it "contains all the values used by the forms" do
+        earlier_values = DateHistory::Reasons::NewEarlierForm::REASONS_LIST
+        later_conversion_values = DateHistory::Reasons::NewLaterForm::CONVERSION_REASONS_LIST
+        later_transfer_values = DateHistory::Reasons::NewLaterForm::TRANSFER_REASONS_LIST
+
+        all_form_values = (earlier_values + later_transfer_values + later_conversion_values).map(&:to_s).uniq.sort
+
+        expect(all_form_values.to_set.subset?(SignificantDateHistoryReason.reason_types.keys.sort.to_set)).to be true
+      end
+    end
   end
 
   describe "Validations" do


### PR DESCRIPTION
When adding the new date history reasons we missed 'voluntary deferral',
this fix adds it in and ensures that all of the form values are in the
`reason_type` enum with a spec.
