### PR TITLE
Add the Date the academy opened to the Grant Management report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Add the date an academy opened to the Grant management export for conversions
+
 ## [Release-76][release-76]
 
 ### Added

--- a/app/services/export/conversions/pre_conversion_grants_csv_export_service.rb
+++ b/app/services/export/conversions/pre_conversion_grants_csv_export_service.rb
@@ -12,6 +12,7 @@ class Export::Conversions::PreConversionGrantsCsvExportService < Export::CsvExpo
     advisory_board_date
     provisional_conversion_date
     conversion_date
+    date_academy_opened
     academy_order_type
     completed_grant_payment_certificate_received
     two_requires_improvement


### PR DESCRIPTION
## Changes

The date an academy transferred is already on the GMFU export for transfers. Add the date an academy opened to the same report for conversions.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
