### PR TITLE
(169471) DAO dao revocations in exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The by month exports do not include conversion projects with a revoked DAO.
 - The single by month view and export are now sorted by the conversion or
   transfer date only.
+- The pre conversion grants export includes a new column that shows the DAO
+  revocation state of a project as applicable.
 
 ## [Release-76][release-76]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add the date an academy opened to the Grant management export for conversions
 - Add the team a project is assigned to to the RPA, SUG and FA letters export
 
+### Changed
+
+- The RPA, SUG and FA letter export does not include conversion projects with a
+  revoked DAO.
+
 ## [Release-76][release-76]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The RPA, SUG and FA letter export does not include conversion projects with a
   revoked DAO.
+- The by month exports do not include conversion projects with a revoked DAO.
+- The single by month view and export are now sorted by the conversion or
+  transfer date only.
 
 ## [Release-76][release-76]
 

--- a/app/controllers/all/by_month/conversions/projects_controller.rb
+++ b/app/controllers/all/by_month/conversions/projects_controller.rb
@@ -48,7 +48,7 @@ class All::ByMonth::Conversions::ProjectsController < ApplicationController
     @year = year
     @date = "#{year}-#{month}-1"
 
-    @pager, @projects = pagy_array(ByMonthProjectFetcherService.new.conversion_projects_by_date(month, year))
+    @pager, @projects = pagy_array(ByMonthProjectFetcherService.new.conversion_projects_by_date_range(@date, @date))
   end
 
   private def redirect_if_dates_incorrect

--- a/app/controllers/all/by_month/transfers/projects_controller.rb
+++ b/app/controllers/all/by_month/transfers/projects_controller.rb
@@ -48,7 +48,7 @@ class All::ByMonth::Transfers::ProjectsController < ApplicationController
     @year = year
     @date = "#{year}-#{month}-1"
 
-    @pager, @projects = pagy_array(ByMonthProjectFetcherService.new.transfer_projects_by_date(month, year))
+    @pager, @projects = pagy_array(ByMonthProjectFetcherService.new.transfer_projects_by_date_range(@date, @date))
   end
 
   private def redirect_if_dates_incorrect

--- a/app/controllers/all/export/by_significant_date/conversions/all_data/projects_controller.rb
+++ b/app/controllers/all/export/by_significant_date/conversions/all_data/projects_controller.rb
@@ -1,30 +1,30 @@
 class All::Export::BySignificantDate::Conversions::AllData::ProjectsController < ApplicationController
+  include DateRangable
+
   def date_range_csv
     authorize Project, :index?
 
-    from_date = "#{params[:from_year]}-#{params[:from_month]}-1"
-    to_date = "#{params[:to_year]}-#{params[:to_month]}-1"
-    return redirect_if_dates_incorrect if Date.parse(to_date) < Date.parse(from_date)
+    return redirect_if_dates_incorrect if @to_date < @from_date
 
-    projects = ByMonthProjectFetcherService.new.conversion_projects_by_date_range(from_date, to_date)
-    csv = Export::Conversions::AllDataCsvExportService.new(projects).call
+    csv = create_csv
 
-    send_data csv, filename: "#{from_date}-#{to_date}_schools_due_to_convert.csv", type: :csv, disposition: "attachment"
+    send_data csv, filename: "#{@from_date}-#{@to_date}_schools_due_to_convert.csv", type: :csv, disposition: "attachment"
   end
 
   def single_month_csv
     authorize Project, :index?
 
-    month = params[:month]
-    year = params[:year]
+    csv = create_csv
 
-    projects = ByMonthProjectFetcherService.new.conversion_projects_by_date(month, year)
-    csv = Export::Conversions::AllDataCsvExportService.new(projects).call
-
-    send_data csv, filename: "#{month}-#{year}_schools_due_to_convert.csv", type: :csv, disposition: "attachment"
+    send_data csv, filename: "#{@from_date.month}-#{@from_date.year}_schools_due_to_convert.csv", type: :csv, disposition: "attachment"
   end
 
   private def redirect_if_dates_incorrect
     redirect_to date_range_this_month_all_by_month_conversions_projects_path, alert: I18n.t("project.date_range.date_form.from_date_before_to_date")
+  end
+
+  private def create_csv
+    projects = ByMonthProjectFetcherService.new.conversion_projects_by_date_range(@from_date.to_s, @to_date.to_s)
+    Export::Conversions::AllDataCsvExportService.new(projects).call
   end
 end

--- a/app/controllers/all/export/by_significant_date/transfers/all_data/projects_controller.rb
+++ b/app/controllers/all/export/by_significant_date/transfers/all_data/projects_controller.rb
@@ -1,27 +1,24 @@
 class All::Export::BySignificantDate::Transfers::AllData::ProjectsController < ApplicationController
+  include DateRangable
+
   def date_range_csv
     authorize Project, :index?
 
-    from_date = "#{params[:from_year]}-#{params[:from_month]}-1"
-    to_date = "#{params[:to_year]}-#{params[:to_month]}-1"
-    return redirect_if_dates_incorrect if Date.parse(to_date) < Date.parse(from_date)
+    return redirect_if_dates_incorrect if @to_date < @from_date
 
-    projects = ByMonthProjectFetcherService.new.transfer_projects_by_date_range(from_date, to_date)
+    projects = ByMonthProjectFetcherService.new.transfer_projects_by_date_range(@from_date.to_s, @to_date.to_s)
     csv = Export::Transfers::AllDataCsvExportService.new(projects).call
 
-    send_data csv, filename: "#{from_date}-#{to_date}_academies_due_to_transfer.csv", type: :csv, disposition: "attachment"
+    send_data csv, filename: "#{@from_date}-#{@to_date}_academies_due_to_transfer.csv", type: :csv, disposition: "attachment"
   end
 
   def single_month_csv
     authorize Project, :index?
 
-    month = params[:month]
-    year = params[:year]
-
-    projects = ByMonthProjectFetcherService.new.transfer_projects_by_date(month, year)
+    projects = ByMonthProjectFetcherService.new.transfer_projects_by_date_range(@from_date.to_s, @to_date.to_s)
     csv = Export::Transfers::AllDataCsvExportService.new(projects).call
 
-    send_data csv, filename: "#{month}-#{year}_academies_due_to_transfer.csv", type: :csv, disposition: "attachment"
+    send_data csv, filename: "#{@from_date.month}-#{@from_date.year}_academies_due_to_transfer.csv", type: :csv, disposition: "attachment"
   end
 
   private def redirect_if_dates_incorrect

--- a/app/controllers/concerns/date_rangable.rb
+++ b/app/controllers/concerns/date_rangable.rb
@@ -1,0 +1,28 @@
+module DateRangable
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_from_and_to_date
+  end
+
+  private def set_from_and_to_date
+    if ranged_params?
+      from_year = params[:from_year]
+      from_month = params[:from_month]
+      to_year = params[:to_year]
+      to_month = params[:to_month]
+    else
+      from_year = params[:year]
+      from_month = params[:month]
+      to_year = params[:year]
+      to_month = params[:month]
+    end
+
+    @from_date = Date.new(from_year.to_i, from_month.to_i).at_beginning_of_month
+    @to_date = Date.new(to_year.to_i, to_month.to_i).at_end_of_month
+  end
+
+  private def ranged_params?
+    params[:from_year].present? && params[:from_month].present? && params[:to_year].present? && params[:to_month].present?
+  end
+end

--- a/app/forms/export/new_rpa_sug_and_fa_letters_form.rb
+++ b/app/forms/export/new_rpa_sug_and_fa_letters_form.rb
@@ -1,6 +1,6 @@
 class Export::NewRpaSugAndFaLettersForm < Export::BaseForm
   def export
-    projects = Project.conversions.significant_date_in_range(from_date.to_s, to_date.to_s)
+    projects = Project.active.or(Project.completed).conversions.significant_date_in_range(from_date.to_s, to_date.to_s)
     pre_fetched_projects = AcademiesApiPreFetcherService.new.call!(projects)
 
     Export::Conversions::RpaSugAndFaLettersCsvExportService.new(pre_fetched_projects).call

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -43,7 +43,7 @@ class Project < ApplicationRecord
   scope :transfers, -> { where(type: "Transfer::Project") }
 
   scope :ordered_by_completed_date, -> { completed.order(completed_at: :desc) }
-  scope :in_progress, -> { where(state: 0).assigned }
+  scope :in_progress, -> { where(state: :active).assigned }
 
   scope :assigned, -> { where.not(assigned_to: nil) }
   scope :assigned_to_caseworker, ->(user) { where(assigned_to: user).or(where(caseworker: user)) }

--- a/app/presenters/export/csv/project_presenter.rb
+++ b/app/presenters/export/csv/project_presenter.rb
@@ -332,6 +332,16 @@ class Export::Csv::ProjectPresenter
     @project.tasks_data.declaration_of_expenditure_certificate_date_received.to_fs(:csv)
   end
 
+  def dao_revoked
+    return I18n.t("export.csv.project.values.not_applicable") unless @project.dao_revokable?
+
+    if @project.dao_revoked?
+      @project.dao_revocation.date_of_decision.to_fs(:csv)
+    else
+      I18n.t("export.csv.project.values.no")
+    end
+  end
+
   private def other_contact
     @contacts_fetcher.other_contact
   end

--- a/app/services/by_month_project_fetcher_service.rb
+++ b/app/services/by_month_project_fetcher_service.rb
@@ -4,32 +4,14 @@ class ByMonthProjectFetcherService
   end
 
   def conversion_projects_by_date_range(from_date, to_date)
-    projects = Project.conversions.in_progress.confirmed.significant_date_in_range(from_date, to_date)
+    projects = Project.active.conversions.in_progress.confirmed.significant_date_in_range(from_date, to_date)
 
     AcademiesApiPreFetcherService.new.call!(projects) if @pre_fetch_academies_api
   end
 
   def transfer_projects_by_date_range(from_date, to_date)
-    projects = Project.transfers.in_progress.confirmed.significant_date_in_range(from_date, to_date)
+    projects = Project.active.transfers.in_progress.confirmed.significant_date_in_range(from_date, to_date)
 
     AcademiesApiPreFetcherService.new.call!(projects) if @pre_fetch_academies_api
-  end
-
-  def conversion_projects_by_date(month, year)
-    projects = Project.conversions.confirmed.filtered_by_significant_date(month, year)
-
-    AcademiesApiPreFetcherService.new.call!(projects) if @pre_fetch_academies_api
-    sort_by_conditions_met_and_name(projects)
-  end
-
-  def transfer_projects_by_date(month, year)
-    projects = Project.transfers.confirmed.filtered_by_significant_date(month, year)
-
-    AcademiesApiPreFetcherService.new.call!(projects) if @pre_fetch_academies_api
-    sort_by_conditions_met_and_name(projects)
-  end
-
-  private def sort_by_conditions_met_and_name(projects)
-    projects.sort_by { |p| [p.all_conditions_met? ? 0 : 1, p.establishment.name] }
   end
 end

--- a/app/services/export/conversions/pre_conversion_grants_csv_export_service.rb
+++ b/app/services/export/conversions/pre_conversion_grants_csv_export_service.rb
@@ -14,6 +14,7 @@ class Export::Conversions::PreConversionGrantsCsvExportService < Export::CsvExpo
     conversion_date
     date_academy_opened
     academy_order_type
+    dao_revoked
     completed_grant_payment_certificate_received
     two_requires_improvement
     sponsored_grant_type

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -12,6 +12,7 @@ en:
           risk_protection_arrangement_reason: Reason for commercial insurance
           advisory_board_date: Advisory board date
           academy_order_type: Academy order type
+          dao_revoked: Directive academy order revoked
           reception_to_six_years: Proposed capacity for pupils in reception to year 6
           seven_to_eleven_years: Proposed capacity for pupils in years 7 to 11
           twelve_or_above_years: Proposed capacity for students in year 12 or above

--- a/spec/factories/dao_revocation_factory.rb
+++ b/spec/factories/dao_revocation_factory.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :dao_revocation do
+    project { association :conversion_project }
+    decision_makers_name { "Minister Name" }
+    date_of_decision { Date.today - 1.week }
+    reason_school_rating_improved { false }
+    reason_safeguarding_addressed { false }
+    reason_school_closed { true }
+  end
+end

--- a/spec/features/all_projects/by_month/users_can_view_projects_by_month_spec.rb
+++ b/spec/features/all_projects/by_month/users_can_view_projects_by_month_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Users can view projects by month" do
       click_on "Apply"
 
       click_on "download a more detailed version of the data as a CSV file"
-      expect(page.response_headers["Content-Disposition"]).to include("2023-1-1-2023-12-1_schools_due_to_convert.csv")
+      expect(page.response_headers["Content-Disposition"]).to include("2023-01-01-2023-12-31_schools_due_to_convert.csv")
     end
 
     scenario "the user can download a CSV of transfer projects" do
@@ -33,7 +33,7 @@ RSpec.feature "Users can view projects by month" do
       click_on "Apply"
 
       click_on "download a more detailed version of the data as a CSV file"
-      expect(page.response_headers["Content-Disposition"]).to include("2023-1-1-2023-12-1_academies_due_to_transfer.csv")
+      expect(page.response_headers["Content-Disposition"]).to include("2023-01-01-2023-12-31_academies_due_to_transfer.csv")
     end
   end
 

--- a/spec/forms/export/new_rpa_sug_and_fa_letters_form_spec.rb
+++ b/spec/forms/export/new_rpa_sug_and_fa_letters_form_spec.rb
@@ -22,11 +22,15 @@ RSpec.describe Export::NewRpaSugAndFaLettersForm, type: :model do
       to_date = Date.new(2024, 4, 1)
       form = described_class.new(from_date: from_date, to_date: to_date)
 
+      allow(Project).to receive(:active).and_call_original
+      allow(Project).to receive(:completed).and_call_original
       allow(Project).to receive(:conversions).and_call_original
       allow(Project).to receive(:significant_date_in_range).and_call_original
 
       form.export
 
+      expect(Project).to have_received(:active)
+      expect(Project).to have_received(:completed)
       expect(Project).to have_received(:conversions)
       expect(Project).to have_received(:significant_date_in_range).with(from_date.to_s, to_date.to_s)
     end

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -955,4 +955,37 @@ RSpec.describe Export::Csv::ProjectPresenter do
       end
     end
   end
+
+  describe "#dao_revoked" do
+    it "presents not applicable when dao revocation does not apply" do
+      project = build(:transfer_project)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.dao_revoked).to eql "not applicable"
+
+      project = build(:conversion_project, directive_academy_order: false)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.dao_revoked).to eql "not applicable"
+    end
+
+    it "presents 'no' when the dao has not be revoked" do
+      project = build(:conversion_project, directive_academy_order: true)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.dao_revoked).to eql "no"
+    end
+
+    it "presents the date of the decision to revoke when it has been" do
+      project = build(:conversion_project, directive_academy_order: true, state: :dao_revoked)
+      dao_revocation = create(:dao_revocation, project: project)
+
+      presenter = described_class.new(project)
+
+      expect(presenter.dao_revoked).to eql dao_revocation.date_of_decision.to_fs(:csv)
+    end
+  end
 end


### PR DESCRIPTION
This is the next step in supporting converison projects with a DAO that gets revoked. Once revoked the project is essentially over, similar to completion. Our first step is to ensure the project only show up in the exports when they are of value, otherwise they should not be included.

This requires work for both exports that will not include them and those that do, because `dao_revoked` is a new `state`
we have to deal with them pretty much everywhere as they are not `completed` nor are they `active` or `deleted` (the other states).

This work sets at to resolve the exports, following this logic/understanding:

- The by month exports do not include the DAO revoked conversions.
- The pre conversion grant export includes DAO revoked conversion projects and we have added a column to indicate those projects: 'Directive academy order revoked', which shows not applicable, no or the date of the decision.
- The RPA, SUG and FA letter export does not include the DAO revoked projects, but continue to inlcude the completed projects.





