### PR TITLE
(168448) DAO revoked projects cannot be edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   transfer date only.
 - The pre conversion grants export includes a new column that shows the DAO
   revocation state of a project as applicable.
+- Once a project has it's DAO revoked, it can no longer be edited, except by
+  Service Support.
 
 ## [Release-76][release-76]
 


### PR DESCRIPTION
Project is our primary model and this policy for it has grown over time.

This work adds changes for the new `dao_revoked` project state (a
conversion project with a DAO that has been revoked) and also attempts
to refactor.

Generally speaking:

- service support can edit anything except a deleted project
- the user assigned to a project can edit it
- any recognised user can add notes or contact unless the project is
  'finsihed' i.e. completed, deleted or dao_revoked

The change significant date methods are really just aliases for
conversions and transfers and have been updated.

There are still some other policies here that are pretty opaque so I've
added a comment to indicate what they are doing.

Base on top of #1701 