### PR TITLE
Add Cancel links to the DAO Revocation steps

### DIFF
--- a/app/views/dao_revocations/change_date.html.erb
+++ b/app/views/dao_revocations/change_date.html.erb
@@ -11,7 +11,10 @@
 
       <%= form.govuk_date_field :date_of_decision, legend: {size: "xl"}, caption: {size: "xl"} %>
 
-      <%= form.govuk_submit t("dao_revocations.date.button") %>
+      <div class="govuk-button-group">
+        <%= form.govuk_submit t("dao_revocations.reasons.button") %>
+        <%= govuk_link_to t("cancel"), project_dao_revocation_check_path(@project) %>
+      </div>
 
     <% end %>
 

--- a/app/views/dao_revocations/change_minister.html.erb
+++ b/app/views/dao_revocations/change_minister.html.erb
@@ -11,7 +11,10 @@
 
       <%= form.govuk_text_field :minister_name, label: {size: "xl"}, caption: {size: "xl"} %>
 
-      <%= form.govuk_submit t("dao_revocations.minister.button") %>
+      <div class="govuk-button-group">
+        <%= form.govuk_submit t("dao_revocations.reasons.button") %>
+        <%= govuk_link_to t("cancel"), project_dao_revocation_check_path(@project) %>
+      </div>
 
     <% end %>
 

--- a/app/views/dao_revocations/change_reasons.html.erb
+++ b/app/views/dao_revocations/change_reasons.html.erb
@@ -18,7 +18,10 @@
 
       <% end %>
 
-      <%= form.govuk_submit t("dao_revocations.reasons.button") %>
+      <div class="govuk-button-group">
+        <%= form.govuk_submit t("dao_revocations.reasons.button") %>
+        <%= govuk_link_to t("cancel"), project_dao_revocation_check_path(@project) %>
+      </div>
 
     <% end %>
 

--- a/app/views/dao_revocations/check.html.erb
+++ b/app/views/dao_revocations/check.html.erb
@@ -54,7 +54,10 @@
         <% end %>
       <% end %>
 
-    <%= form.govuk_submit t("dao_revocations.check.button") %>
+      <div class="govuk-button-group">
+        <%= form.govuk_submit t("dao_revocations.check.button") %>
+        <%= govuk_link_to t("cancel"), project_path(@project) %>
+      </div>
 
     <% end %>
 

--- a/app/views/dao_revocations/confirm.html.erb
+++ b/app/views/dao_revocations/confirm.html.erb
@@ -34,7 +34,10 @@
         <%= form.govuk_check_box :confirm_letter_saved, 1, 0, multiple: false, label: {text: t("helpers.label.dao_revocation_stepped_form.confirm_letter_saved")} %>
       <% end %>
 
-      <%= form.govuk_submit t("dao_revocations.confirm.button") %>
+      <div class="govuk-button-group">
+        <%= form.govuk_submit t("dao_revocations.reasons.button") %>
+        <%= govuk_link_to t("cancel"), project_path(@project) %>
+      </div>
 
     <% end %>
 

--- a/app/views/dao_revocations/date.html.erb
+++ b/app/views/dao_revocations/date.html.erb
@@ -11,7 +11,10 @@
 
       <%= form.govuk_date_field :date_of_decision, legend: {size: "xl"}, caption: {size: "xl"} %>
 
-      <%= form.govuk_submit t("dao_revocations.date.button") %>
+      <div class="govuk-button-group">
+        <%= form.govuk_submit t("dao_revocations.reasons.button") %>
+        <%= govuk_link_to t("cancel"), project_path(@project) %>
+      </div>
 
     <% end %>
 

--- a/app/views/dao_revocations/minister.html.erb
+++ b/app/views/dao_revocations/minister.html.erb
@@ -11,7 +11,10 @@
 
       <%= form.govuk_text_field :minister_name, label: {size: "xl"}, caption: {size: "xl"} %>
 
-      <%= form.govuk_submit t("dao_revocations.minister.button") %>
+      <div class="govuk-button-group">
+        <%= form.govuk_submit t("dao_revocations.reasons.button") %>
+        <%= govuk_link_to t("cancel"), project_path(@project) %>
+      </div>
 
     <% end %>
 

--- a/app/views/dao_revocations/reasons.html.erb
+++ b/app/views/dao_revocations/reasons.html.erb
@@ -18,8 +18,10 @@
 
       <% end %>
 
-      <%= form.govuk_submit t("dao_revocations.reasons.button") %>
-
+      <div class="govuk-button-group">
+        <%= form.govuk_submit t("dao_revocations.reasons.button") %>
+        <%= govuk_link_to t("cancel"), project_path(@project) %>
+      </div>
     <% end %>
 
   </div>

--- a/app/views/dao_revocations/start.html.erb
+++ b/app/views/dao_revocations/start.html.erb
@@ -9,6 +9,9 @@
 
     <%= t("dao_revocations.start.body_html") %>
 
-    <%= govuk_link_to t("dao_revocations.start.button"), project_dao_revocation_step_path(@project, :confirm), class: "govuk-button" %>
+    <div class="govuk-button-group">
+      <%= govuk_link_to t("dao_revocations.start.button"), project_dao_revocation_step_path(@project, :confirm), class: "govuk-button" %>
+      <%= govuk_link_to t("cancel"), project_path(@project) %>
+    </div>
   </div>
 </div>

--- a/spec/features/dao_revocation/user_can_record_the_revocation_of_a_dao_from_a_project_spec.rb
+++ b/spec/features/dao_revocation/user_can_record_the_revocation_of_a_dao_from_a_project_spec.rb
@@ -103,4 +103,64 @@ RSpec.feature "Users record the revocation of a DAO from a project" do
 
     expect(page).to have_content "DAO revocation recorded successfully"
   end
+
+  scenario "the Cancel buttons go to the correct places" do
+    project = create(:conversion_project, directive_academy_order: true, assigned_to: user)
+
+    visit project_path(project)
+
+    click_on "Revoke a Directive Academy Order"
+
+    click_on "Record DAO revocation"
+
+    expect(page).to have_content "Record Directive Academy Order revocation"
+
+    click_on "Continue"
+
+    check "I confirm a minister has approved this decision"
+    check "I confirm I have sent the letter confirming the revocation decision"
+    check "I confirm I have saved a copy of the letter to the school’s SharePoint folder"
+    click_button "Continue"
+
+    click_on "Cancel"
+
+    expect(page).to have_content("Task list")
+
+    click_on "Revoke a Directive Academy Order"
+
+    click_on "Record DAO revocation"
+
+    expect(page).to have_content "Record Directive Academy Order revocation"
+
+    click_on "Continue"
+
+    check "I confirm a minister has approved this decision"
+    check "I confirm I have sent the letter confirming the revocation decision"
+    check "I confirm I have saved a copy of the letter to the school’s SharePoint folder"
+    click_button "Continue"
+
+    check "School closed or closing"
+    check "Safeguarding concerns addressed"
+    click_button "Continue"
+
+    expect(page).to have_content "Minister’s name"
+    fill_in "Minister’s name", with: "Incorrect Name"
+    click_button "Continue"
+
+    expect(page).to have_content "Date of decision"
+    fill_in "Day", with: 1
+    fill_in "Month", with: 1
+    fill_in "Year", with: 2024
+    click_button "Continue"
+
+    expect(page).to have_content "Check your answers before recording this decision"
+
+    within ".govuk-summary-list__row:nth-of-type(4)" do
+      click_on "Change"
+    end
+
+    click_on "Cancel"
+
+    expect(page).to have_content "Check your answers before recording this decision"
+  end
 end


### PR DESCRIPTION
The DAO Revocation steps need cancel links. 

The Cancel links on the initial steps just take you back to the task list. 

The Cancel links on the "Change" steps (ie. if you are changing a value from the "Confirm" page) take you back to the Confirm page.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
