### PR TITLE
Release 77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release-77][release-77]
+
 ### Added
 
 - Add the date an academy opened to the Grant management export for conversions
@@ -2025,7 +2027,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-76...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-77...HEAD
+[release-77]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-76...release-77
 [release-76]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-75...release-76
 [release-75]:


### PR DESCRIPTION
Added

- Add the date an academy opened to the Grant management export for conversions
- Add the team a project is assigned to to the RPA, SUG and FA letters export

Changed

- The RPA, SUG and FA letter export does not include conversion projects with a revoked DAO.
- The by month exports do not include conversion projects with a revoked DAO.
- The single by month view and export are now sorted by the conversion or transfer date only.
- The pre conversion grants export includes a new column that shows the DAO revocation state of a project as applicable.
- Once a project has it's DAO revoked, it can no longer be edited, except by Service Support.
- Conversion projects with a DAO (Directive Academy Order) can now be 'revoked' from the task list.
- DAO revocation is a stepped process which requires at least one reason, minister name and date of decision.
- Revoking DAO ends a project

Fixed

- The change conversion date and change transfer date buttons only appear on the appropriate project type.

