### PR TITLE
(171855) Validate the significant date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- when changing the significant date for a conversion or transfer project the
+  revised date cannot be the same as the current date.
+
 ## [Release-77][release-77]
 
 ### Added

--- a/app/forms/new_date_history_form.rb
+++ b/app/forms/new_date_history_form.rb
@@ -8,6 +8,7 @@ class NewDateHistoryForm
   attribute :revised_date, :date
 
   validates :project, :user, :revised_date, presence: true
+  validate :revised_date_not_previous_date, if: -> { project.present? }
 
   def assign_attributes(attributes)
     if GovukDateFieldParameters.new(:revised_date, attributes, without_day: true).invalid?
@@ -17,5 +18,9 @@ class NewDateHistoryForm
     end
 
     super
+  end
+
+  private def revised_date_not_previous_date
+    errors.add(:revised_date, :same_as_previous_date) if revised_date.eql?(project.significant_date)
   end
 end

--- a/config/locales/conversion_date_history.en.yml
+++ b/config/locales/conversion_date_history.en.yml
@@ -1,6 +1,6 @@
 en:
   conversion_new_date_history_form:
-    title: Conversion Date
+    title: Conversion date
     current_date_html: <p>The current conversion date is <span class="govuk-body govuk-!-font-weight-bold">%{date}</span>.</p>
     revised_date_html: <p>The new proposed conversion date is <span class="govuk-body govuk-!-font-weight-bold">%{date}</span>.</p>
     form:

--- a/config/locales/date_history.en.yml
+++ b/config/locales/date_history.en.yml
@@ -1,0 +1,10 @@
+en:
+  errors:
+    attributes:
+      revised_date:
+        format: Enter a valid month and year
+        transaction: Revised date could not be saved
+        blank: Enter a valid month and year for the revised date, like 9 2024
+        same_as_previous_date: The new date cannot be the same as the current date. Check you have entered the correct date.
+      note_body:
+        blank: Enter a reason

--- a/config/locales/transfer_date_history.en.yml
+++ b/config/locales/transfer_date_history.en.yml
@@ -29,11 +29,3 @@ en:
         <p>You can change the transfer date as many times as you need to.</p>
         <p>Enter the transfer date again if this change was not right.</p>
         <p>You can alter the transfer date at any time if there are changes to the project in the future.</p>
-  errors:
-    attributes:
-      revised_date:
-        format: Enter a valid month and year
-        transaction: Revised date could not be saved
-        blank: Enter a valid month and year for the revised date, like 9 2024
-      note_body:
-        blank: Enter a reason

--- a/config/locales/transfer_date_history.en.yml
+++ b/config/locales/transfer_date_history.en.yml
@@ -1,6 +1,6 @@
 en:
   transfer_new_date_history_form:
-    title: Transfer Date
+    title: Transfer date
     current_date_html: <p>The current transfer date is <span class="govuk-body govuk-!-font-weight-bold">%{date}</span>.</p>
     revised_date_html: <p>The new proposed transfer date is <span class="govuk-body govuk-!-font-weight-bold">%{date}</span>.</p>
     form:

--- a/spec/forms/new_date_form_spec.rb
+++ b/spec/forms/new_date_form_spec.rb
@@ -51,6 +51,16 @@ RSpec.describe NewDateHistoryForm, type: :model do
         expect(form).to be_invalid
       end
 
+      it "cannot be the same as the current date" do
+        attributes = valid_attributes
+        form.assign_attributes(attributes)
+        form.project = build(:conversion_project, significant_date: Date.today)
+        form.revised_date = Date.today
+
+        expect(form).to be_invalid
+        expect(form.errors.messages_for(:revised_date)).to include("The new date cannot be the same as the current date. Check you have entered the correct date.")
+      end
+
       describe "month params" do
         it "cannot be 0" do
           attributes = valid_attributes


### PR DESCRIPTION
When changing the significant date it should not be the same date.

This validation prevents that from happening.

We used a lower case D for the word 'date' as mentioned here: https://ukgovernmentdfe.slack.com/archives/C05UBB0EZ43/p1719838553779419