### PR TITLE
Change tag for environment banner

### DIFF
--- a/app/views/shared/_environment_banner.html.erb
+++ b/app/views/shared/_environment_banner.html.erb
@@ -1,3 +1,3 @@
 <% unless environment_banner.nil? %>
-  <div id="environment-banner" aria-label="environment banner" role="complementary"><%= environment_banner %></div>
+  <aside id="environment-banner" aria-label="environment banner"><%= environment_banner %></aside>
 <% end %>


### PR DESCRIPTION
This banner is not shown in production so this doesn't strictly matter,
but SonarCloud is complaining about it.

We can use an aside tag which has an implicit role of 'complimentary',
so let's do that and get the SonarCloud green tick back.
