### PR TITLE
(Fix) Update Project state after DaoRevocation destruction

### DIFF
--- a/app/models/dao_revocation.rb
+++ b/app/models/dao_revocation.rb
@@ -5,11 +5,17 @@ class DaoRevocation < ApplicationRecord
   validate :conversion_project_with_dao
   validate :at_least_one_reason
 
+  after_destroy :update_project_state
+
   private def at_least_one_reason
     errors.add(:base, :reason_required) unless reason_school_closed || reason_school_rating_improved || reason_safeguarding_addressed
   end
 
   private def conversion_project_with_dao
     errors.add(:base, :incorrect_project_type) unless project.is_a?(Conversion::Project) && project.directive_academy_order
+  end
+
+  private def update_project_state
+    project.update(state: :active)
   end
 end

--- a/spec/models/dao_revocation_spec.rb
+++ b/spec/models/dao_revocation_spec.rb
@@ -45,4 +45,15 @@ RSpec.describe DaoRevocation do
   describe "Associations" do
     it { is_expected.to belong_to(:project) }
   end
+
+  describe "Callbacks" do
+    it "updates the state of the associated project after destruction" do
+      mock_successful_api_response_to_create_any_project
+      project = create(:conversion_project, directive_academy_order: true, state: :dao_revoked)
+      decision = described_class.new(date_of_decision: Date.today, decision_makers_name: "Bob Smith", reason_school_closed: true, project: project)
+
+      decision.destroy!
+      expect(project.state).to eq("active")
+    end
+  end
 end


### PR DESCRIPTION
When fiddling with test data, we realised that if a DaoRevocation is destroyed, it causes the parent project to become unavailable in the UI, because the DaoRevocation does not exist but the project's state is still :dao_revoked.

This is a rare occurrence as DaoRevocations probably won't be deleted, but it may happen if we're asked to remove one manually. This ensures the parent project does not become inaccessible.

