### PR TITLE
Update optional cookies cookie

### DIFF
--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -6,7 +6,11 @@ class CookiesController < ApplicationController
 
   def update
     accept_optional_cookies = cookies_params[:accept_optional_cookies]
-    cookies[:ACCEPT_OPTIONAL_COOKIES] = {value: accept_optional_cookies, expires: 1.year} unless accept_optional_cookies.nil?
+
+    unless accept_optional_cookies.nil?
+      cookies[:ACCEPT_OPTIONAL_COOKIES] =
+        {value: accept_optional_cookies, expires: 1.year, httponly: true}
+    end
 
     redirect_back_or_to(cookies_path, notice: I18n.t("cookies.updated_message.#{accept_optional_cookies}"))
   end


### PR DESCRIPTION
During the June 2024 IT Health check it was raised that our
`ACCEPT_OPTIONAL_COOKIES` should be httponly.

This change will not take effect for users who already have the cookie
set, until they delete the existing cookie or it expires.

Clearing cookies for the application will set the new cookie and is
recommended.
