### PR TITLE
Update X-Frame-Options header

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,8 @@ module DfeCompleteConversionsTransfersAndChanges
 
     # use the cookie session and set the name of the cookie
     config.session_store :cookie_store, key: "SESSION"
+
+    # set the X-Frame-Options header
+    config.action_dispatch.default_headers["X-Frame-Options"] = "DENY"
   end
 end


### PR DESCRIPTION
Our June 2024 IT Health Check recommends we set the X-Frame-Options
header to DENY, we are already SAMEORIGIN, so not really at risk, but
here is the change to DENY.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
