### PR TITLE
Set the HSTS header

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,7 @@ module DfeCompleteConversionsTransfersAndChanges
 
     # set the X-Frame-Options header
     config.action_dispatch.default_headers["X-Frame-Options"] = "DENY"
+    # set the HSTS header
+    config.action_dispatch.default_headers["Strict-Transport-Security"] = "preload"
   end
 end


### PR DESCRIPTION
Our June 2024 IT Health Check recommends we set the HSTS, or Strict
transport security header to preload.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
