### PR TITLE
(Chore) Remove funding agreement contact ID

### DIFF
--- a/app/models/contact/project.rb
+++ b/app/models/contact/project.rb
@@ -8,7 +8,6 @@ class Contact::Project < Contact
   has_one :main_contact_for_establishment, class_name: "::Project", inverse_of: :establishment_main_contact
   has_one :main_contact_for_incoming_trust, class_name: "::Project", inverse_of: :incoming_trust_main_contact
   has_one :main_contact_for_outgoing_trust, class_name: "::Project", inverse_of: :outgoing_trust_main_contact
-  has_one :main_contact_for_funding_agreement, class_name: "::Project", inverse_of: :funding_agreement_contact
   has_one :contact_for_chair_of_governors, class_name: "Conversion::Project", inverse_of: :chair_of_governors_contact
 
   def establishment_main_contact

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -20,7 +20,6 @@ class Project < ApplicationRecord
   belongs_to :establishment_main_contact, inverse_of: :main_contact_for_establishment, dependent: :destroy, class_name: "Contact::Project", optional: true
   belongs_to :incoming_trust_main_contact, inverse_of: :main_contact_for_incoming_trust, dependent: :destroy, class_name: "Contact::Project", optional: true
   belongs_to :outgoing_trust_main_contact, inverse_of: :main_contact_for_outgoing_trust, dependent: :destroy, class_name: "Contact::Project", optional: true
-  belongs_to :funding_agreement_contact, inverse_of: :main_contact_for_funding_agreement, dependent: :destroy, class_name: "Contact::Project", optional: true
 
   validates :urn, presence: true
   validates :urn, urn: true

--- a/db/migrate/20240703133114_remove_funding_agreement_letters_contact.rb
+++ b/db/migrate/20240703133114_remove_funding_agreement_letters_contact.rb
@@ -1,0 +1,5 @@
+class RemoveFundingAgreementLettersContact < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :projects, :funding_agreement_contact_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_18_140233) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_03_133114) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -288,7 +288,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_18_140233) do
     t.integer "academy_urn"
     t.uuid "tasks_data_id"
     t.string "tasks_data_type"
-    t.uuid "funding_agreement_contact_id"
     t.integer "outgoing_trust_ukprn"
     t.string "team"
     t.boolean "two_requires_improvement", default: false

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe Project, type: :model do
     it { is_expected.to belong_to(:assigned_to).required(false) }
     it { is_expected.to belong_to(:tasks_data).required(true) }
     it { is_expected.to belong_to(:main_contact).optional(true) }
-    it { is_expected.to belong_to(:funding_agreement_contact).optional(true) }
     it { is_expected.to belong_to(:establishment_main_contact).optional(true) }
     it { is_expected.to belong_to(:incoming_trust_main_contact).optional(true) }
     it { is_expected.to belong_to(:outgoing_trust_main_contact).optional(true) }
@@ -127,24 +126,6 @@ RSpec.describe Project, type: :model do
         project.update(outgoing_trust_main_contact: outgoing_trust_main_contact)
 
         expect(project.outgoing_trust_main_contact).to eql(outgoing_trust_main_contact)
-      end
-    end
-
-    describe "#funding_agreement_contact" do
-      it "returns nil when no association exists, but there are project contacts" do
-        project = create(:conversion_project)
-        create_list(:project_contact, 3, project: project)
-
-        expect(project.funding_agreement_contact).to be_nil
-      end
-
-      it "returns the contact when one is set" do
-        project = create(:conversion_project)
-        funding_agreement_contact = create(:project_contact)
-
-        project.update(funding_agreement_contact: funding_agreement_contact)
-
-        expect(project.funding_agreement_contact).to eql(funding_agreement_contact)
       end
     end
   end


### PR DESCRIPTION
This association hasn't been used for a long time. Remove it to keep the codebase tidy.