### PR TITLE
(167653) Allow users to add a local authority main contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   information clearer.
 - the external contacts are now shown as 'cards' to make them clearer.
 
+### Added
+
+- Users can now indicate a local authority contact is the local authority main
+  contact for a project
+
 ## [Release-77][release-77]
 
 ### Added

--- a/app/forms/contact/create_project_contact_form.rb
+++ b/app/forms/contact/create_project_contact_form.rb
@@ -6,7 +6,8 @@ class Contact::CreateProjectContactForm
   CATEGORIES_WITH_PRIMARY_CONTACT = [
     "school_or_academy",
     "incoming_trust",
-    "outgoing_trust"
+    "outgoing_trust",
+    "local_authority"
   ].freeze
 
   attribute :category
@@ -79,6 +80,8 @@ class Contact::CreateProjectContactForm
       @contact.incoming_trust_main_contact
     when "outgoing_trust"
       @contact.outgoing_trust_main_contact
+    when "local_authority"
+      @contact.local_authority_main_contact
     end
   end
 
@@ -90,6 +93,8 @@ class Contact::CreateProjectContactForm
       @project.incoming_trust_main_contact_id = primary_contact_for_category ? @contact.id : nil
     when "outgoing_trust"
       @project.outgoing_trust_main_contact_id = primary_contact_for_category ? @contact.id : nil
+    when "local_authority"
+      @project.local_authority_main_contact_id = primary_contact_for_category ? @contact.id : nil
     end
   end
 end

--- a/app/models/contact/project.rb
+++ b/app/models/contact/project.rb
@@ -8,6 +8,7 @@ class Contact::Project < Contact
   has_one :main_contact_for_establishment, class_name: "::Project", inverse_of: :establishment_main_contact
   has_one :main_contact_for_incoming_trust, class_name: "::Project", inverse_of: :incoming_trust_main_contact
   has_one :main_contact_for_outgoing_trust, class_name: "::Project", inverse_of: :outgoing_trust_main_contact
+  has_one :main_contact_for_local_authority, class_name: "::Project", inverse_of: :local_authority_main_contact
   has_one :contact_for_chair_of_governors, class_name: "Conversion::Project", inverse_of: :chair_of_governors_contact
 
   def establishment_main_contact
@@ -20,5 +21,9 @@ class Contact::Project < Contact
 
   def outgoing_trust_main_contact
     project.outgoing_trust_main_contact_id == id
+  end
+
+  def local_authority_main_contact
+    project.local_authority_main_contact_id == id
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -20,6 +20,7 @@ class Project < ApplicationRecord
   belongs_to :establishment_main_contact, inverse_of: :main_contact_for_establishment, dependent: :destroy, class_name: "Contact::Project", optional: true
   belongs_to :incoming_trust_main_contact, inverse_of: :main_contact_for_incoming_trust, dependent: :destroy, class_name: "Contact::Project", optional: true
   belongs_to :outgoing_trust_main_contact, inverse_of: :main_contact_for_outgoing_trust, dependent: :destroy, class_name: "Contact::Project", optional: true
+  belongs_to :local_authority_main_contact, inverse_of: :main_contact_for_local_authority, dependent: :destroy, class_name: "Contact::Project", optional: true
 
   validates :urn, presence: true
   validates :urn, urn: true

--- a/app/views/external_contacts/_contact_group.html.erb
+++ b/app/views/external_contacts/_contact_group.html.erb
@@ -67,6 +67,12 @@
                   row.with_value { t("yes") }
                 end
               end
+              if contact.local_authority_main_contact
+                summary_list.with_row do |row|
+                  row.with_key { t("contact.details.local_authority_main_contact") }
+                  row.with_value { t("yes") }
+                end
+              end
             end
           end %>
     </div>

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -21,6 +21,7 @@ en:
       establishment_main_contact: Primary contact for school or academy?
       incoming_trust_main_contact: Primary contact for incoming trust?
       outgoing_trust_main_contact: Primary contact for outgoing trust?
+      local_authority_main_contact: Primary contact for local authority?
     new:
       title: Add contact
       save_contact_button: Add contact

--- a/db/migrate/20240703142240_local_authority_main_contact_id.rb
+++ b/db/migrate/20240703142240_local_authority_main_contact_id.rb
@@ -1,0 +1,5 @@
+class LocalAuthorityMainContactId < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :local_authority_main_contact_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_03_133114) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_03_142240) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -302,6 +302,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_03_133114) do
     t.uuid "chair_of_governors_contact_id"
     t.integer "state", default: 0, null: false
     t.integer "prepare_id"
+    t.uuid "local_authority_main_contact_id"
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["incoming_trust_ukprn"], name: "index_projects_on_incoming_trust_ukprn"

--- a/spec/models/contact/project_spec.rb
+++ b/spec/models/contact/project_spec.rb
@@ -70,4 +70,26 @@ RSpec.describe Contact::Project do
       expect(contact.outgoing_trust_main_contact).to be false
     end
   end
+
+  describe "#local_authority_main_contact" do
+    before do
+      mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    end
+
+    it "returns true if the contact is the local_authority_main_contact for its project" do
+      project = create(:conversion_project)
+      contact = create(:project_contact, project: project)
+      project.local_authority_main_contact_id = contact.id
+      project.save
+
+      expect(contact.reload.local_authority_main_contact).to be true
+    end
+
+    it "returns false if the contact is NOT the local_authority_main_contact for its project" do
+      project = create(:conversion_project, local_authority_main_contact_id: SecureRandom.uuid)
+      contact = create(:project_contact, project: project)
+
+      expect(contact.local_authority_main_contact).to be false
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to belong_to(:establishment_main_contact).optional(true) }
     it { is_expected.to belong_to(:incoming_trust_main_contact).optional(true) }
     it { is_expected.to belong_to(:outgoing_trust_main_contact).optional(true) }
+    it { is_expected.to belong_to(:local_authority_main_contact).optional(true) }
     it { is_expected.to have_one(:dao_revocation).dependent(:destroy) }
 
     describe "delete related entities" do
@@ -126,6 +127,24 @@ RSpec.describe Project, type: :model do
         project.update(outgoing_trust_main_contact: outgoing_trust_main_contact)
 
         expect(project.outgoing_trust_main_contact).to eql(outgoing_trust_main_contact)
+      end
+    end
+
+    describe "#local_authority_contact" do
+      it "returns nil when no association exists, but there are project contacts" do
+        project = create(:conversion_project)
+        create_list(:project_contact, 3, project: project)
+
+        expect(project.local_authority_main_contact).to be_nil
+      end
+
+      it "returns the contact when one is set" do
+        project = create(:conversion_project)
+        local_authority_contact = create(:project_contact)
+
+        project.update(local_authority_main_contact: local_authority_contact)
+
+        expect(project.local_authority_main_contact).to eql(local_authority_contact)
       end
     end
   end


### PR DESCRIPTION
## Changes

Users have requested the ability to set a local authority contact as the main
local authority contact, should a project have multiple local authority
contacts.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
