### PR TITLE
Update Google Tag Manager

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -24,3 +24,6 @@ if (addedByTarget) {
     'Added by'
   )
 }
+
+// set the js-enabled class on the body if JS is enabled
+document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled')

--- a/app/javascript/google-tag-manager.js
+++ b/app/javascript/google-tag-manager.js
@@ -1,0 +1,34 @@
+function googleTagManagerScript (window, document, script, datalayer, id) {
+  // Retrieve datalayer array from window scope or create an empty array if it doesn't exist
+  window[datalayer] = window[datalayer] || []
+
+  // Push a timestamped event for GTM initialisation
+  window[datalayer].push({
+    'gtm.start': new Date().getTime(),
+    event: 'gtm.js'
+  })
+
+  // Get the first script included on the page
+  const firstScript = document.getElementsByTagName(script)[0]
+
+  // Create a script element
+  const gtmScript = document.createElement(script)
+
+  // Optionally prepare the query parameter string for the datalayer name
+  const dataLayerParam = datalayer !== 'dataLayer' ? '&l=' + datalayer : ''
+
+  // Enable asynchronous loading for the GTM script
+  gtmScript.async = true
+
+  // Finalise link to GTM script
+  gtmScript.src = '//www.googletagmanager.com/gtm.js?id=' + id + dataLayerParam
+
+  // Insert new script element into DOM
+  firstScript.parentNode.insertBefore(gtmScript, firstScript)
+}
+
+// Get the id form the meta tag
+const tagManagerId = document.head.querySelector('meta[name="google-tag-manager-connection"]').content
+
+// load the Tag Manager script and fire it
+googleTagManagerScript(window, document, 'script', 'datalayer', tagManagerId)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="theme-color" content="#0b0c0c">
     <%= tag :meta, name: "application-insights-connection", content: ENV["ApplicationInsights__ConnectionString"] if enable_application_insights? %>
+    <%= tag :meta, name: "google-tag-manager-connection", content: ENV["GOOGLE_TAG_MANAGER_ID"] if enable_google_tag_manager? %>
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -22,11 +23,11 @@
     <%= stylesheet_link_tag "application" %>
 
     <%= javascript_include_tag "application-insights" if enable_application_insights? %>
+    <%= javascript_include_tag "google-tag-manager" if enable_google_tag_manager? %>
     <%= javascript_include_tag "govuk-frontend/govuk/all" %>
     <%= javascript_include_tag "dfefrontend" %>
     <%= javascript_include_tag "application", defer: true %>
 
-    <%= render partial: "shared/google_tag_manager" if enable_google_tag_manager? %>
   </head>
 
   <body class="govuk-template__body ">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,10 +30,6 @@
   </head>
 
   <body class="govuk-template__body ">
-    <script nonce="<%= content_security_policy_nonce %>">
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
-
     <%= render partial: "shared/environment_banner" %>
 
     <%= render partial: "cookies/banner" unless optional_cookies_set? %>

--- a/app/views/shared/_google_tag_manager.html.erb
+++ b/app/views/shared/_google_tag_manager.html.erb
@@ -1,6 +1,0 @@
-<script nonce='<%= content_security_policy_nonce %>'>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;var n=d.querySelector('[nonce]');
-n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','<%= ENV["GOOGLE_TAG_MANAGER_ID"] %>');</script>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,21 +6,12 @@
 
 Rails.application.configure do
   config.content_security_policy do |policy|
-    policy.default_src :self, "https://region1.google-analytics.com"
-    policy.font_src :self
-    policy.img_src :self, "https://region1.google-analytics.com"
-    policy.connect_src :self, "https://js.monitor.azure.com", "https://westeurope-5.in.applicationinsights.azure.com"
-    policy.object_src :none
-    policy.script_src :self, "https://www.googletagmanager.com/gtm.js"
-    policy.style_src :self
-    # Specify URI for violation reports
-    # policy.report_uri "/csp-violation-report-endpoint"
+    policy.default_src :self
+    policy.script_src :self,
+      "www.googletagmanager.com"
+    policy.connect_src :self,
+      "region1.google-analytics.com",
+      "https://js.monitor.azure.com",
+      "https://westeurope-5.in.applicationinsights.azure.com"
   end
-
-  # Generate session nonces for permitted importmap and inline scripts
-  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-  config.content_security_policy_nonce_directives = %w[script-src]
-
-  # Report violations without enforcing the policy.
-  # config.content_security_policy_report_only = true
 end


### PR DESCRIPTION
Around 13 June we stopped getting Google Analytics data via Tag manager. This may have been when we added Applicaiton Insights?

This is hard to debug as we only run Tag Manger in production.

We've made the two approaches consistent across Tag Manager and Application Insights and tried to simplify the content security policy, see the commit for details.

