### PR TITLE
(fix) CookiesForm do not load responses

### DIFF
--- a/app/forms/cookies_form.rb
+++ b/app/forms/cookies_form.rb
@@ -4,9 +4,7 @@ class CookiesForm
 
   attribute :accept_optional_cookies, :boolean
 
-  RESPONSES = [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")]
-
   def responses
-    RESPONSES
+    [OpenStruct.new(id: true, name: "Yes"), OpenStruct.new(id: false, name: "No")]
   end
 end

--- a/spec/forms/cookies_form_spec.rb
+++ b/spec/forms/cookies_form_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 RSpec.describe CookiesForm, type: :model do
   it "returns the responses using the form" do
     cookie_form = CookiesForm.new
-    expect(cookie_form.responses).to eq(CookiesForm::RESPONSES)
+    expect(cookie_form.responses.first.id).to be true
+    expect(cookie_form.responses.last.id).to be false
   end
 
   it "has accept_optional_cookies attribute" do


### PR DESCRIPTION
We keep seeing deployments fail with this error:

```
/srv/app/app/forms/cookies_form.rb:7:in `<class:CookiesForm>': uninitialized constant CookiesForm::OpenStruct (NameError)
```

So far this only seems to happen when we update the Standardrb gem and
backing that out has consistently fixed the issue, although it could
just be a coincidence!

We cannot reproduce the issue locally either.

If the failure is this OpenStruct in CookiesForm the only thing unusual
about it is the assignment to a const, there is really no need to do
this, so let's try it without and see how we get on.