### PR TITLE
Use the "main" Local Authority contact in exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - the project information view now uses 'cards' to break the make the
   information clearer.
 - the external contacts are now shown as 'cards' to make them clearer.
+- The local authority contact in exports is now the "main" contact as selected
+  in the UI. If none is selected, then the exported contact is the next contact
+  with the category of "local authority"
 
 ### Added
 

--- a/app/presenters/export/csv/local_authority_presenter_module.rb
+++ b/app/presenters/export/csv/local_authority_presenter_module.rb
@@ -12,17 +12,11 @@ module Export::Csv::LocalAuthorityPresenterModule
   end
 
   def local_authority_contact_name
-    contacts = @contacts_fetcher.all_project_contacts_grouped
-    return if contacts["local_authority"].blank?
-
-    contacts["local_authority"].pluck(:name).join(",")
+    local_authority_contact&.name
   end
 
   def local_authority_contact_email
-    contacts = @contacts_fetcher.all_project_contacts_grouped
-    return if contacts["local_authority"].blank?
-
-    contacts["local_authority"].pluck(:email).join(",")
+    local_authority_contact&.email
   end
 
   def local_authority_address_1
@@ -59,5 +53,9 @@ module Export::Csv::LocalAuthorityPresenterModule
     return unless @local_authority.present?
 
     @local_authority.address_postcode
+  end
+
+  private def local_authority_contact
+    @contacts_fetcher.local_authority_contact
   end
 end

--- a/app/services/contacts_fetcher_service.rb
+++ b/app/services/contacts_fetcher_service.rb
@@ -5,8 +5,8 @@ class ContactsFetcherService
     @project = project
     @project_contacts = @project.contacts
     @establishment_contacts = Contact::Establishment.find_by(establishment_urn: @project.urn)
-    @all_contacts = all_project_contacts_grouped
     @director_of_child_services = @project.director_of_child_services
+    @all_contacts = all_project_contacts_grouped
   end
 
   def all_project_contacts
@@ -53,6 +53,16 @@ class ContactsFetcherService
       @all_contacts["incoming_trust"].find { |c| c.id == @project.incoming_trust_main_contact_id }
     else
       @all_contacts["incoming_trust"].first
+    end
+  end
+
+  def local_authority_contact
+    return if @all_contacts["local_authority"].nil?
+
+    if @project.local_authority_main_contact_id.present?
+      @all_contacts["local_authority"].find { |c| c.id == @project.local_authority_main_contact_id }
+    else
+      @all_contacts["local_authority"].first
     end
   end
 

--- a/spec/presenters/export/csv/local_authority_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/local_authority_presenter_module_spec.rb
@@ -37,18 +37,6 @@ RSpec.describe Export::Csv::LocalAuthorityPresenterModule do
     expect(subject.local_authority_contact_email).to eql "jake@example.com"
   end
 
-  context "when there is more than one local authority contact" do
-    let!(:local_authority_main_contact) { create(:project_contact, category: "local_authority", name: "Bob Contact", email: "local_authority_contact@email.com", project: project) }
-
-    it "presents the local authority contact names" do
-      expect(subject.local_authority_contact_name).to eql "Bob Contact,Jake Example"
-    end
-
-    it "presents the local authority contact emails" do
-      expect(subject.local_authority_contact_email).to eql "local_authority_contact@email.com,jake@example.com"
-    end
-  end
-
   def known_local_authority
     double(
       LocalAuthority,

--- a/spec/services/contacts_fetcher_service_spec.rb
+++ b/spec/services/contacts_fetcher_service_spec.rb
@@ -171,6 +171,26 @@ RSpec.describe ContactsFetcherService do
     end
   end
 
+  describe "#local_authority_contact" do
+    let!(:contact) { create(:project_contact, project: project, category: "local_authority") }
+
+    context "when there is a local_authority_main_contact_id" do
+      before { allow(project).to receive(:local_authority_main_contact_id).and_return(contact.id) }
+
+      it "returns the contact with that id" do
+        expect(described_class.new(project).local_authority_contact).to eq(contact)
+      end
+    end
+
+    context "when there is NOT a local_authority_main_contact_id" do
+      before { allow(project).to receive(:local_authority_main_contact_id).and_return(nil) }
+
+      it "returns the next matching contact" do
+        expect(described_class.new(project).local_authority_contact).to eq(contact)
+      end
+    end
+  end
+
   describe "#other_contact" do
     let!(:contact) { create(:project_contact, project: project, category: "other") }
 


### PR DESCRIPTION
## Changes

Now that we can choose a "main" contact for the local authority in the application, export that contact in exports under the "Local authority contact" column (as opposed to just outputting *all* local authority contacts).

If no contact is chosen as the "main" contact, export the next contact with the local authority category.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
