### PR TITLE
Fix flaky feature spec

### DIFF
--- a/spec/features/internal_contacts/users_can_edit_the_added_by_user_with_autocomplete_spec.rb
+++ b/spec/features/internal_contacts/users_can_edit_the_added_by_user_with_autocomplete_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Users change the assigned user", driver: :headless_firefox do
   after do
     sign_out
     # we need to wait after signing out otherwise we get flaking sessions
-    sleep(0.4)
+    sleep(0.2)
   end
 
   let(:project) { create(:conversion_project, regional_delivery_officer: user) }
@@ -103,8 +103,10 @@ RSpec.feature "Users change the assigned user", driver: :headless_firefox do
       end
 
       fill_in "Added by", with: user.first_name
+      # we wait to give the autcomplete time to render
+      sleep(0.05)
 
-      within(autocomplete_first_suggestion) do
+      within(autocomplete_first_suggestion(page)) do
         expect(page).to have_content("#{user.first_name} #{user.last_name} (#{user.email})")
       end
     end
@@ -117,8 +119,10 @@ RSpec.feature "Users change the assigned user", driver: :headless_firefox do
       end
 
       fill_in "Added by", with: user.last_name
+      # we wait to give the autcomplete time to render
+      sleep(0.05)
 
-      within(autocomplete_first_suggestion) do
+      within(autocomplete_first_suggestion(page)) do
         expect(page).to have_content("#{user.first_name} #{user.last_name} (#{user.email})")
       end
     end
@@ -131,8 +135,10 @@ RSpec.feature "Users change the assigned user", driver: :headless_firefox do
       end
 
       fill_in "Added by", with: user.email
+      # we wait to give the autcomplete time to render
+      sleep(0.05)
 
-      within(autocomplete_first_suggestion) do
+      within(autocomplete_first_suggestion(page)) do
         expect(page).to have_content("#{user.first_name} #{user.last_name} (#{user.email})")
       end
     end
@@ -145,6 +151,10 @@ RSpec.feature "Users change the assigned user", driver: :headless_firefox do
       end
 
       fill_in "Added by", with: "Jane"
+      # we wait to give the autcomplete time to render
+      sleep(0.05)
+
+      autocomplete_no_results = page.find("li.autocomplete__option--no-results")
 
       within(autocomplete_no_results) do
         expect(page).to have_content("No results found")
@@ -152,11 +162,7 @@ RSpec.feature "Users change the assigned user", driver: :headless_firefox do
     end
   end
 
-  def autocomplete_first_suggestion
+  def autocomplete_first_suggestion(page)
     page.find("li#user-autocomplete__option--0")
-  end
-
-  def autocomplete_no_results
-    page.find("li.autocomplete__option--no-results")
   end
 end


### PR DESCRIPTION
This autocomplete spec often fails in ci:

```
 Unable to find css "li#user-autocomplete__option--0"
```

This work is an attempt to make this less flaky by pausing briefly
after filling in the autocomplete to give it time to render.

We also pass the page object to the helper just in-case!

