### PR TITLE
Allow img-src from Google tag manager

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -9,6 +9,8 @@ Rails.application.configure do
     policy.default_src :self
     policy.script_src :self,
       "www.googletagmanager.com"
+    policy.img_src :self,
+      "www.googletagmanager.com"
     policy.connect_src :self,
       "region1.google-analytics.com",
       "https://js.monitor.azure.com",


### PR DESCRIPTION
As mentioned here:

https://developers.google.com/tag-platform/security/guides/csp

Once you have tag manager/analytics working, you'll need to allow this
img_src (assume they use a hidden gif to track).
