### PR TITLE
Release 78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release-78][release-78]
+
 ### Changed
 
 - when changing the significant date for a conversion or transfer project the
@@ -2045,7 +2047,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-77...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-78...HEAD
+[release-78]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-77...release-78
 [release-77]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-76...release-77
 [release-76]:


### PR DESCRIPTION
## Changed

- when changing the significant date for a conversion or transfer project the
  revised date cannot be the same as the current date.
- the project information view now uses 'cards' to break the make the
  information clearer.
- the external contacts are now shown as 'cards' to make them clearer.
- The local authority contact in exports is now the "main" contact as selected
  in the UI. If none is selected, then the exported contact is the next contact
  with the category of "local authority"
- Users are now asked which type of project to add with an explanation of each
  type.

## Added

- Users can now indicate a local authority contact is the local authority main
  contact for a project

