### PR TITLE
Configuration for HSTS Header

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,6 @@ module DfeCompleteConversionsTransfersAndChanges
     # set the X-Frame-Options header
     config.action_dispatch.default_headers["X-Frame-Options"] = "DENY"
     # set the HSTS header
-    config.action_dispatch.default_headers["Strict-Transport-Security"] = "preload"
+    config.action_dispatch.default_headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains; preload"
   end
 end


### PR DESCRIPTION
The HSTS Header requires that we set the max-age property when using preload. Additionally, the 2024 ITHC recommends we also add the includeSubDomains property too.