### PR TITLE
Introduce notable association on note

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -2,6 +2,7 @@ class Note < ApplicationRecord
   belongs_to :project
   belongs_to :user
   belongs_to :significant_date_history, class_name: "SignificantDateHistory", optional: true
+  belongs_to :notable, polymorphic: true, optional: true
 
   validates :body, presence: true, allow_blank: false
 

--- a/app/models/significant_date_history_reason.rb
+++ b/app/models/significant_date_history_reason.rb
@@ -1,6 +1,6 @@
 class SignificantDateHistoryReason < ApplicationRecord
-  belongs_to :significant_date_history, class_name: "SignificantDateHistory"
-  has_one :note, required: true, dependent: :destroy, foreign_key: :significant_date_history_reason_id
+  belongs_to :significant_date_history
+  has_one :note, as: :notable, dependent: :destroy
 
   validates :reason_type, presence: true
 

--- a/app/policies/note_policy.rb
+++ b/app/policies/note_policy.rb
@@ -18,7 +18,7 @@ class NotePolicy
   end
 
   def destroy?
-    return false if @note.significant_date_history_id.present?
+    return false if @note.notable.present?
 
     edit?
   end

--- a/db/migrate/20240709090855_add_notable_to_note.rb
+++ b/db/migrate/20240709090855_add_notable_to_note.rb
@@ -1,0 +1,23 @@
+class AddNotableToNote < ActiveRecord::Migration[7.0]
+  def up
+    change_table :notes do |t|
+      t.rename :significant_date_history_reason_id, :notable_id
+      t.string :notable_type
+      t.index [:notable_id, :notable_type]
+    end
+
+    Note.all.each do |note|
+      if note.notable_id.present?
+        note.update! notable_type: "SignificantDateHistoryReason"
+      end
+    end
+  end
+
+  def down
+    change_table :notes do |t|
+      t.rename :notable_id, :significant_date_history_reason_id
+    end
+
+    remove_column :notes, :notable_type
+  end
+end

--- a/db/migrate/20240709115448_remove_significant_date_history_from_note.rb
+++ b/db/migrate/20240709115448_remove_significant_date_history_from_note.rb
@@ -1,0 +1,5 @@
+class RemoveSignificantDateHistoryFromNote < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :notes, :significant_date_history_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_09_090855) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_09_115448) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -261,7 +261,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_09_090855) do
     t.datetime "updated_at", null: false
     t.string "task_identifier"
     t.uuid "notable_id"
-    t.uuid "significant_date_history_id"
     t.string "notable_type"
     t.index ["notable_id", "notable_type"], name: "index_notes_on_notable_id_and_notable_type"
     t.index ["project_id"], name: "index_notes_on_project_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_03_142240) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_09_090855) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -260,8 +260,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_03_142240) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "task_identifier"
+    t.uuid "notable_id"
     t.uuid "significant_date_history_id"
-    t.uuid "significant_date_history_reason_id"
+    t.string "notable_type"
+    t.index ["notable_id", "notable_type"], name: "index_notes_on_notable_id_and_notable_type"
     t.index ["project_id"], name: "index_notes_on_project_id"
     t.index ["user_id"], name: "index_notes_on_user_id"
   end

--- a/spec/factories/conversion/date_history_factory.rb
+++ b/spec/factories/conversion/date_history_factory.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
   end
 
   factory :date_history_reason, class: SignificantDateHistoryReason do
-    significant_date_history { association :conversion_date_history }
+    significant_date_history { association :date_history }
     reason_type { :legacy_reason }
     note { association :note }
   end

--- a/spec/factories/conversion/date_history_factory.rb
+++ b/spec/factories/conversion/date_history_factory.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     project { association :conversion_project }
     previous_date { Date.today.at_beginning_of_month - 1.month }
     revised_date { previous_date + 2.months }
-    note { association :note }
   end
 
   factory :date_history_reason, class: SignificantDateHistoryReason do

--- a/spec/factories/note_factory.rb
+++ b/spec/factories/note_factory.rb
@@ -10,8 +10,8 @@ FactoryBot.define do
       body { "I really enjoyed performing this task" }
     end
 
-    trait :for_significant_date_history do
-      significant_date_history_id { association :date_history }
+    trait :for_significant_date_history_reason do
+      notable { association :date_history_reason }
       body { "This is the reason the conversion date has changed" }
     end
   end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Note, type: :model do
   describe "Relationships" do
     it { is_expected.to belong_to(:project) }
     it { is_expected.to belong_to(:user) }
-    it { is_expected.to belong_to(:significant_date_history).optional(true) }
+    it { is_expected.to belong_to(:notable).optional(true) }
   end
 
   describe "Validations" do

--- a/spec/models/significant_date_history_spec.rb
+++ b/spec/models/significant_date_history_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe SignificantDateHistory do
   end
 
   describe "Associations" do
-    it { is_expected.to have_one(:note).dependent(:destroy) }
     it { is_expected.to have_many(:reasons).order(:reason_type).dependent(:destroy).class_name("SignificantDateHistoryReason") }
     it { is_expected.to belong_to(:project).required(true) }
     it { is_expected.to belong_to(:user) }

--- a/spec/policies/note_policy_spec.rb
+++ b/spec/policies/note_policy_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe NotePolicy do
   context "when the note is from a conversion date history" do
     permissions :edit?, :update? do
       it "allows if the note is from a date history" do
-        note = build(:note, :for_significant_date_history, user: application_user)
-        allow(note).to receive(:significant_date_history_id).and_return("uuid")
+        note = build(:note, :for_significant_date_history_reason, user: application_user)
+        allow(note).to receive(:notable_id).and_return("uuid")
 
         expect(subject).to permit(application_user, note)
       end
@@ -44,8 +44,8 @@ RSpec.describe NotePolicy do
 
     permissions :destroy? do
       it "denies all actions if the note is from a date history" do
-        note = build(:note, :for_significant_date_history, user: application_user)
-        allow(note).to receive(:significant_date_history_id).and_return("uuid")
+        note = build(:note, :for_significant_date_history_reason, user: application_user)
+        allow(note).to receive(:notable_id).and_return("uuid")
 
         expect(subject).not_to permit(application_user, note)
       end


### PR DESCRIPTION
This works lays the foundation for adding free text to the DAO
revocation reasons. We want to store the free text as Notes just like we do for
the reasons on the SignificantDateHistoryReason.

We change the existing column to be the notable_id and add the notable_type to
store the parents class.

We then clean up some leftover parts of the prior association to
SignificantDateHistory.
