### PR TITLE
Configure the Rails cache to use Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ code straight forward for those that would like to use them.
 - [Developer scripts](/doc/developer-scripts.md)
 - [GOV.UK Notify](/doc/govuk-notify.md)
 - [Information banner](/doc/information-banner.md)
+- [Redis](/doc/redis.md")
 
 ## Errors and monitoring
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,10 @@ module DfeCompleteConversionsTransfersAndChanges
 
     config.support_email = "regionalservices.rg@education.gov.uk"
 
-    # use the cookie session and set the name of the cookie
+    # setup Redis cache in all environments
+    config.cache_store = :redis_cache_store, {url: ENV["REDIS_URL"]}
+
+    # use the cookies for the session and set the name of the cookie
     config.session_store :cookie_store, key: "SESSION"
 
     # set the X-Frame-Options header

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,18 +19,17 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
+  #
+  # We have enabled the Redis cache store in config/application.rb
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
   end
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,10 +28,9 @@ Rails.application.configure do
     "Cache-Control" => "public, max-age=#{1.hour.to_i}"
   }
 
-  # Show full error reports and disable caching.
+  # Show full error reports and disable caching
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/doc/decisions/0026-storing-temporary-data-for-stepped-forms.md
+++ b/doc/decisions/0026-storing-temporary-data-for-stepped-forms.md
@@ -1,0 +1,41 @@
+# 26. Storing temporary data for stepped forms
+
+Date: 2024-07-11
+
+## Status
+
+Accepted
+
+## Context
+
+Stepped forms or multi step forms are a common pattern in GOV.UK services.
+
+The concept is that a user builds up the data in a given object over a series of
+forms. Generally we do not want to create the objects in the database until all
+steps are completed.
+
+This leaves the issue of how to store the 'temporary' data before submission.
+
+The session is a good place to store this data, but we have to use the cookie
+store which has a hard 4kb limit which may not be suitable for forms that have
+free text responses.
+
+A good next best option is the cache store. This is abstracted by `Rails.cache`
+and can be backed by various services.
+
+## Decision
+
+We'll use the Rails cache store and write our temporary values there.
+
+The store will be backed by Redis as we already have a dependency on it.
+
+We will use unique keys for the values in the store so that they do not clash,
+the key should include a unique value for each user.
+
+We will set a timeout on the values stored with a default of one hour, we should
+handle the case when the values have expired.
+
+## Consequences
+
+- Complexity in the application increases
+- dependent on Redis in ALL environments

--- a/doc/redis.md
+++ b/doc/redis.md
@@ -1,0 +1,11 @@
+# Redis
+
+The application depends on Redis:
+
+- for the Sidekiq queue
+- to store temporary values in stepped (multi step) forms
+
+Redis is required in all environments.
+
+Redis config is in `config/application.rb` and the Redis server URL is stored in
+the `REDIS_URL` environment variable.


### PR DESCRIPTION
Whilst we do not use the Rails cache for caching, we want to use it to
store temporary values on our stepped forms.

This work configures the cache to use Redis and enable it in all
environments.

In development caching can be toggled on and off and we have retained
this behaviour.

You will need to be running Redis locally and have the REDIS_URL
variable set in .env.development.local from this point forwards.

