### PR TITLE
Get a project's MP by postcode

### DIFF
--- a/app/controllers/member_of_parliament_controller.rb
+++ b/app/controllers/member_of_parliament_controller.rb
@@ -6,8 +6,8 @@ class MemberOfParliamentController < ApplicationController
 
   def show
     @member_name = fetch_member_name
-    @parliamentary_office = find_contact_detail(type_id: 1)
-    @member_email = find_contact_detail(type_id: 1).email
+    @member_email = contact_details.email
+    @parliamentary_office = contact_details
   end
 
   private def client
@@ -44,8 +44,8 @@ class MemberOfParliamentController < ApplicationController
     result
   end
 
-  private def find_contact_detail(type_id:)
-    member_contact_details.object.find { |details| details.type_id == type_id }
+  private def contact_details
+    member_contact_details.object
   end
 
   private def find_project

--- a/app/models/api/members_api/client.rb
+++ b/app/models/api/members_api/client.rb
@@ -71,10 +71,9 @@ class Api::MembersApi::Client
 
     case response.status
     when 200
-      contact_details = JSON.parse(response.body)["value"].map do |detail|
-        Api::MembersApi::MemberContactDetails.new.from_hash(detail)
-      end
-      Result.new(contact_details, nil)
+      contact_details = JSON.parse(response.body)["value"]
+      parliamentary_office = contact_details.find { |c| c["typeId"] == 1 }
+      Result.new(Api::MembersApi::MemberContactDetails.new.from_hash(parliamentary_office), nil)
     when 404
       Result.new(nil, NotFoundError.new(I18n.t("members_api.errors.member_not_found", member_id: member_id)))
     else

--- a/app/models/api/members_api/client.rb
+++ b/app/models/api/members_api/client.rb
@@ -11,32 +11,6 @@ class Api::MembersApi::Client
     @connection = connection || default_connection
   end
 
-  def constituency(search_term)
-    response = constituency_search(search_term)
-
-    case response.status
-    when 200
-      body = JSON.parse(response.body)
-      Result.new(body, nil)
-    else
-      Result.new(nil, Error.new(I18n.t("members_api.errors.other", search_term: search_term, status: response.status)))
-    end
-  end
-
-  def member_for_constituency(constituency)
-    member = member_id(constituency)
-
-    return Result.new(nil, member.error) if member.error.present?
-
-    member_id = member.object
-    member_name = member_name(member_id).object
-    contact_details = member_contact_details(member_id).object.find { |details| details.type_id == 1 }
-
-    Result.new(Api::MembersApi::MemberDetails.new(member_name, contact_details), nil)
-  rescue NoMethodError
-    Result.new(nil, Error.new(I18n.t("members_api.errors.contact_details_not_found", member_id: member_id)))
-  end
-
   def member_for_postcode(postcode)
     response = postcode_search(postcode)
 
@@ -62,35 +36,6 @@ class Api::MembersApi::Client
     Result.new(Api::MembersApi::MemberDetails.new(member_name, contact_details), nil)
   end
 
-  def member_id(search_term)
-    constituency_data = constituency(search_term)
-    if constituency_data.error.present?
-      return Result.new(nil, constituency_data.error)
-    end
-
-    if constituency_data.object["items"].count == 0
-      Result.new(nil, NotFoundError.new(NotFoundError.new(I18n.t("members_api.errors.search_term_not_found", constituency: search_term))))
-    elsif constituency_data.object["items"].count > 1
-      Result.new(nil, MultipleResultsError.new(I18n.t("members_api.errors.multiple", search_term: search_term)))
-    else
-      Result.new(member_id_from_constituency(constituency_data), nil)
-    end
-  end
-
-  def member_name(member_id)
-    response = member(member_id)
-
-    case response.status
-    when 200
-      result = JSON.parse(response.body)["value"]
-      Result.new(Api::MembersApi::MemberName.new.from_hash(result), nil)
-    when 404
-      Result.new(nil, NotFoundError.new(I18n.t("members_api.errors.member_not_found", member_id: member_id)))
-    else
-      Result.new(nil, Error.new(I18n.t("members_api.errors.other")))
-    end
-  end
-
   def member_contact_details(member_id)
     response = member_contact(member_id)
 
@@ -106,25 +51,8 @@ class Api::MembersApi::Client
     end
   end
 
-  private def constituency_search(search_term)
-    @connection.get("/api/Location/Constituency/Search", {searchText: search_term})
-  rescue Faraday::Error => error
-    raise Error.new(error)
-  end
-
   private def postcode_search(search_term)
     @connection.get("/api/Members/Search", {Location: search_term, House: 1, IsCurrentMember: true})
-  rescue Faraday::Error => error
-    raise Error.new(error)
-  end
-
-  private def member_id_from_constituency(constituency_data)
-    constituency = constituency_data.object["items"][0]["value"]
-    constituency.dig("currentRepresentation", "member", "value", "id")
-  end
-
-  private def member(member_id)
-    @connection.get("/api/Members/#{member_id}")
   rescue Faraday::Error => error
     raise Error.new(error)
   end

--- a/app/models/api/members_api/client.rb
+++ b/app/models/api/members_api/client.rb
@@ -37,7 +37,7 @@ class Api::MembersApi::Client
   end
 
   def member_contact_details(member_id)
-    response = member_contact(member_id)
+    response = contact_details_search(member_id)
 
     case response.status
     when 200
@@ -57,7 +57,7 @@ class Api::MembersApi::Client
     raise Error.new(error)
   end
 
-  private def member_contact(member_id)
+  private def contact_details_search(member_id)
     @connection.get("/api/Members/#{member_id}/Contact")
   rescue Faraday::Error => error
     raise Error.new(error)

--- a/app/models/api/members_api/member_contact_details.rb
+++ b/app/models/api/members_api/member_contact_details.rb
@@ -34,15 +34,4 @@ class Api::MembersApi::MemberContactDetails < Api::BaseApiModel
       email: "email"
     }
   end
-
-  def address
-    [
-      line1,
-      line2,
-      line3,
-      line4,
-      line5,
-      postcode
-    ]
-  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -144,7 +144,7 @@ class Project < ApplicationRecord
 
   # :nocov:
   private def fetch_member_of_parliament
-    result = Api::MembersApi::Client.new.member_for_constituency(establishment.parliamentary_constituency)
+    result = Api::MembersApi::Client.new.member_for_postcode(establishment.address_postcode)
 
     if result.error.present?
       track_event(result.error.message)

--- a/app/views/member_of_parliament/show.html.erb
+++ b/app/views/member_of_parliament/show.html.erb
@@ -17,11 +17,9 @@
           row.with_key { t("member_of_parliament.show.rows.email") }
           row.with_value { mail_to(@member_email, @member_email) }
         end
-        if @parliamentary_office
-          summary_list.with_row do |row|
-            row.with_key { @parliamentary_office.type }
-            row.with_value { address_markup(@parliamentary_office.address) }
-          end
+        summary_list.with_row do |row|
+          row.with_key { t("member_of_parliament.show.rows.parliamentary_office") }
+          row.with_value { address_markup(@parliamentary_office.address) }
         end
       end %>
 </div>

--- a/app/views/member_of_parliament/show.html.erb
+++ b/app/views/member_of_parliament/show.html.erb
@@ -11,15 +11,15 @@
   <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
           row.with_key { t("member_of_parliament.show.rows.full_title") }
-          row.with_value { @member_name.object.name_full_title }
+          row.with_value { @member_of_parliament.name }
         end
         summary_list.with_row do |row|
           row.with_key { t("member_of_parliament.show.rows.email") }
-          row.with_value { mail_to(@member_email, @member_email) }
+          row.with_value { mail_to(@member_of_parliament.email, @member_of_parliament.email) }
         end
         summary_list.with_row do |row|
           row.with_key { t("member_of_parliament.show.rows.parliamentary_office") }
-          row.with_value { address_markup(@parliamentary_office.address) }
+          row.with_value { address_markup(@parliamentary_office) }
         end
       end %>
 </div>

--- a/config/locales/members_api.en.yml
+++ b/config/locales/members_api.en.yml
@@ -4,6 +4,7 @@ en:
       other: "[MEMBERS API] There was an error connecting to the Members API, status: %{status}, search_term: %{search_term}"
       multiple: "[MEMBERS API] Multiple results found for search term: %{search_term}"
       search_term_not_found: "[MEMBERS_API] Constituency not found: %{constituency}"
+      postcode_not_found: "[MEMBERS_API] Postcode not found or returned no results: %{postcode}"
       member_not_found: "[MEMBERS API] Member not found: %{member_id}"
       contact_details_not_found: "[MEMBERS API] Contact details not found for member %{member_id}"
     member:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -390,6 +390,7 @@ en:
       rows:
         full_title: Full title
         email: Email address
+        parliamentary_office: Parliamentary office
   project_completed:
     title: Project completed
     subtitle: You have completed the project for %{school_name} %{urn}.

--- a/spec/features/all_projects/export/academies_due_to_transfer_spec.rb
+++ b/spec/features/all_projects/export/academies_due_to_transfer_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Academies due to transfer" do
     user = create(:user, :service_support)
     sign_in_with_user(user)
     mock_all_academies_api_responses
-    mock_successful_member_details
+    mock_successful_members_api_postcode_search_response(member_contact_details: nil, member_name: nil)
     create(:conversion_project, conversion_date: Date.new(2024, 6, 1))
   end
 

--- a/spec/features/all_projects/export/pre_conversion_grants_spec.rb
+++ b/spec/features/all_projects/export/pre_conversion_grants_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Pre conversion grants" do
     user = create(:user, :service_support)
     sign_in_with_user(user)
     mock_all_academies_api_responses
-    mock_successful_member_details
+    mock_successful_members_api_postcode_search_response(member_contact_details: nil, member_name: nil)
     create(:conversion_project, conversion_date: Date.new(2024, 6, 1))
   end
 

--- a/spec/features/all_projects/export/pre_transfer_grants_export_spec.rb
+++ b/spec/features/all_projects/export/pre_transfer_grants_export_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Pre transfer grants export" do
     user = create(:user, :service_support)
     sign_in_with_user(user)
     mock_all_academies_api_responses
-    mock_successful_member_details
+    mock_successful_members_api_postcode_search_response(member_contact_details: nil, member_name: nil)
     create(:conversion_project, conversion_date: Date.new(2024, 6, 1))
   end
 

--- a/spec/features/all_projects/export/rpa_sug_and_fa_letters_export_spec.rb
+++ b/spec/features/all_projects/export/rpa_sug_and_fa_letters_export_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "RPA, SUG and FA letters export" do
     user = create(:user, :service_support)
     sign_in_with_user(user)
     mock_all_academies_api_responses
-    mock_successful_member_details
+    mock_successful_members_api_postcode_search_response(member_contact_details: nil, member_name: nil)
     create(:conversion_project, conversion_date: Date.new(2024, 6, 1))
   end
 

--- a/spec/models/api/members_api/client_spec.rb
+++ b/spec/models/api/members_api/client_spec.rb
@@ -51,14 +51,14 @@ RSpec.describe Api::MembersApi::Client do
       allow(fake_client).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(4744, nil))
       fake_name = double(Api::MembersApi::MemberName, name_display_as: "Joe Bloggs")
       allow(fake_client).to receive(:member_name).and_return(Api::MembersApi::Client::Result.new(fake_name, nil))
-      fake_contact_details = double(find: Api::MembersApi::MemberContactDetails.new.from_hash({email: "joe.bloggs@email.com", line1: "Houses of Parliment", postcode: "SW1A 0AA"}))
+      fake_contact_details = double(find: Api::MembersApi::MemberContactDetails.new.from_hash({email: "joe.bloggs@email.com", line1: "House of Commons", postcode: "SW1A 0AA"}))
       allow(fake_client).to receive(:member_contact_details).and_return(Api::MembersApi::Client::Result.new(fake_contact_details, nil))
 
       response = fake_client.member_for_constituency("St Albans").object
 
       expect(response.name).to eq("Joe Bloggs")
       expect(response.email).to eq("joe.bloggs@email.com")
-      expect(response.address.line1).to eq("Houses of Parliment")
+      expect(response.address.line1).to eq("House of Commons")
       expect(response.address.postcode).to eq("SW1A 0AA")
     end
 
@@ -245,11 +245,11 @@ RSpec.describe Api::MembersApi::Client do
         }.to_json]
       end
 
-      it "returns a Result with the JSON response body and no error" do
-        expect(subject.object).to be_a(Array)
-        expect(subject.object[0]).to be_a(Api::MembersApi::MemberContactDetails)
-        expect(subject.object[0].line1).to eq("House of Commons")
-        expect(subject.object[0].postcode).to eq("SW1A 0AA")
+      it "returns a Result with the Parliamentary office details *only* and no error" do
+        expect(subject.object).to be_a(Api::MembersApi::MemberContactDetails)
+        expect(subject.object.line1).to eq("House of Commons")
+        expect(subject.object.postcode).to eq("SW1A 0AA")
+        expect(subject.object.email).to eq("daisy.cooper.mp@parliament.uk")
         expect(subject.error).to be_nil
       end
     end

--- a/spec/models/api/members_api/client_spec.rb
+++ b/spec/models/api/members_api/client_spec.rb
@@ -91,6 +91,103 @@ RSpec.describe Api::MembersApi::Client do
     end
   end
 
+  describe "#member_for_postcode" do
+    let(:client) { described_class.new(connection: fake_successful_postcode_search_connection(fake_response)) }
+
+    context "when there is an MP for the postcode" do
+      let(:fake_response) { [200, nil, {items: [{value: {id: "12345", nameDisplayAs: "Joe Bloggs", nameFullTitle: "Joe Bloggs MP"}}]}.to_json] }
+
+      before do
+        fake_contact_details = Api::MembersApi::MemberContactDetails.new.from_hash({email: "joe.bloggs@email.com", line1: "House of Commons", postcode: "SW1A 0AA"})
+        allow(client).to receive(:member_contact_details).and_return(Api::MembersApi::Client::Result.new(fake_contact_details, nil))
+      end
+
+      it "returns the MP name and details" do
+        response = client.member_for_postcode("W1A1AA")
+
+        expect(response.object.name).to eq("Joe Bloggs")
+        expect(response.object.email).to eq("joe.bloggs@email.com")
+        expect(response.object.address.line1).to eq("House of Commons")
+        expect(response.object.address.postcode).to eq("SW1A 0AA")
+      end
+    end
+
+    context "when the MP is found but the call to get contact details fails" do
+      let(:fake_response) { [200, nil, {items: [{value: {id: "12345", nameDisplayAs: "Joe Bloggs", nameFullTitle: "Joe Bloggs MP"}}]}.to_json] }
+
+      before do
+        allow(client).to receive(:member_contact_details).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::NotFoundError))
+      end
+
+      it "returns the MP name" do
+        response = client.member_for_postcode("W1A1AA")
+
+        expect(response.object.name).to eq("Joe Bloggs")
+        expect(response.object.email).to be_nil
+        expect(response.object.address.line1).to be_nil
+        expect(response.object.address.postcode).to be_nil
+      end
+    end
+
+    context "when there is no MP for the postcode, or the postcode is not found" do
+      let(:fake_response) { [200, nil, {items: []}.to_json] }
+
+      it "returns an error" do
+        response = client.member_for_postcode("W1A1AA")
+
+        expect(response.error).to be_a(Api::MembersApi::Client::NotFoundError)
+      end
+
+      it "does not try to get the contact details" do
+        client.member_for_postcode("W1A1AA")
+        expect(client).to_not receive(:member_contact)
+      end
+    end
+
+    context "when there are multiple results for a postcode" do
+      let(:fake_response) { [200, nil, {items: [{value: {id: "12345"}}, {value: {id: "56789"}}]}.to_json] }
+
+      it "returns an error" do
+        response = client.member_for_postcode("W1A1AA")
+
+        expect(response.object).to be_nil
+        expect(response.error).to be_a(Api::MembersApi::Client::MultipleResultsError)
+      end
+    end
+
+    context "when the response returns a 404" do
+      # We believe the API will return a 200 when there are no results, but anticipate a 404 anyway
+      let(:fake_response) { [404, nil, nil] }
+
+      it "returns an error" do
+        response = client.member_for_postcode("W1A1AA")
+
+        expect(response.object).to be_nil
+        expect(response.error).to be_a(Api::MembersApi::Client::NotFoundError)
+      end
+    end
+
+    context "when the response returns any other error" do
+      let(:fake_response) { [500, nil, nil] }
+
+      it "returns an error" do
+        response = client.member_for_postcode("W1A1AA")
+
+        expect(response.object).to be_nil
+        expect(response.error).to be_a(Api::MembersApi::Client::Error)
+        expect(response.error.message).to eq("[MEMBERS API] There was an error connecting to the Members API, status: 500, search_term: W1A1AA")
+      end
+    end
+
+    context "when the connection fails" do
+      let(:client) { described_class.new(connection: fake_failed_postcode_search_connection) }
+
+      it "raises an Error" do
+        expect { client.member_for_postcode("W1A1AA") }.to raise_error(Api::MembersApi::Client::Error)
+      end
+    end
+  end
+
   describe "#member_id" do
     let(:client) { described_class.new(connection: fake_successful_constituency_search_connection(fake_response)) }
 
@@ -283,10 +380,30 @@ RSpec.describe Api::MembersApi::Client do
     end
   end
 
+  def fake_successful_postcode_search_connection(response)
+    Faraday.new do |builder|
+      builder.adapter :test do |stub|
+        stub.get("/api/Members/Search") do |_env|
+          response
+        end
+      end
+    end
+  end
+
   def fake_failed_constituency_search_connection
     Faraday.new do |builder|
       builder.adapter :test do |stub|
         stub.get("/api/Location/Constituency/Search") do |_env|
+          raise Faraday::Error
+        end
+      end
+    end
+  end
+
+  def fake_failed_postcode_search_connection
+    Faraday.new do |builder|
+      builder.adapter :test do |stub|
+        stub.get("/api/Members/Search") do |_env|
           raise Faraday::Error
         end
       end

--- a/spec/models/api/members_api/client_spec.rb
+++ b/spec/models/api/members_api/client_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Api::MembersApi::Client do
 
       it "does not try to get the contact details" do
         client.member_for_postcode("W1A1AA")
-        expect(client).to_not receive(:member_contact)
+        expect(client).to_not receive(:contact_details_search)
       end
     end
 

--- a/spec/models/api/members_api/client_spec.rb
+++ b/spec/models/api/members_api/client_spec.rb
@@ -12,85 +12,6 @@ RSpec.describe Api::MembersApi::Client do
     end
   end
 
-  describe "#constituency_search" do
-    let(:client) { described_class.new(connection: fake_successful_constituency_search_connection(fake_response)) }
-
-    subject { client.constituency("St Albans") }
-
-    context "when there is a result" do
-      let(:fake_response) { [200, nil, {items: [{value: {name: "St Albans", id: 12345}}]}.to_json] }
-
-      it "returns a Result with the JSON response body and no error" do
-        expect(subject.object).to eql("items" => [{"value" => {"name" => "St Albans", "id" => 12345}}])
-        expect(subject.error).to be_nil
-      end
-    end
-
-    context "when there is any other error" do
-      let(:fake_response) { [500, nil, nil] }
-
-      it "returns a Result with an Error" do
-        expect(subject.object).to be_nil
-        expect(subject.error).to be_a(Api::MembersApi::Client::Error)
-        expect(subject.error.message).to eq(I18n.t("members_api.errors.other", search_term: "St Albans", status: 500))
-      end
-    end
-
-    context "when the connection fails" do
-      let(:client) { described_class.new(connection: fake_failed_constituency_search_connection) }
-
-      it "raises an Error" do
-        expect { subject }.to raise_error(Api::MembersApi::Client::Error)
-      end
-    end
-  end
-
-  describe "#member_for_constituency" do
-    it "returns a hash when successful" do
-      fake_client = Api::MembersApi::Client.new
-      allow(fake_client).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(4744, nil))
-      fake_name = double(Api::MembersApi::MemberName, name_display_as: "Joe Bloggs")
-      allow(fake_client).to receive(:member_name).and_return(Api::MembersApi::Client::Result.new(fake_name, nil))
-      fake_contact_details = double(find: Api::MembersApi::MemberContactDetails.new.from_hash({email: "joe.bloggs@email.com", line1: "House of Commons", postcode: "SW1A 0AA"}))
-      allow(fake_client).to receive(:member_contact_details).and_return(Api::MembersApi::Client::Result.new(fake_contact_details, nil))
-
-      response = fake_client.member_for_constituency("St Albans").object
-
-      expect(response.name).to eq("Joe Bloggs")
-      expect(response.email).to eq("joe.bloggs@email.com")
-      expect(response.address.line1).to eq("House of Commons")
-      expect(response.address.postcode).to eq("SW1A 0AA")
-    end
-
-    it "raises an error if the member_contact_details is nil" do
-      fake_client = Api::MembersApi::Client.new
-      allow(fake_client).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(4744, nil))
-      fake_name = double(Api::MembersApi::MemberName, name_display_as: "Joe Bloggs")
-      allow(fake_client).to receive(:member_name).and_return(Api::MembersApi::Client::Result.new(fake_name, nil))
-      allow(fake_client).to receive(:member_contact_details).and_return(Api::MembersApi::Client::Result.new(nil, nil))
-
-      response = fake_client.member_for_constituency("St Albans")
-
-      expect(response.object).to be_nil
-      expect(response.error).to be_a(Api::MembersApi::Client::Error)
-      expect(response.error.message).to eq(I18n.t("members_api.errors.contact_details_not_found", member_id: 4744))
-    end
-
-    it "logs a warning if there are multiple contact details, and returns a nil object" do
-      ClimateControl.modify(
-        APPLICATION_INSIGHTS_KEY: "fake-key-1234"
-      ) do
-        fake_client = Api::MembersApi::Client.new
-        allow(fake_client).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::MultipleResultsError.new(I18n.t("members_api.errors.multiple", search_term: "St Albans"))))
-        allow(fake_client).to receive(:member_name).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::Error.new))
-        allow(fake_client).to receive(:member_contact_details).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::Error.new))
-
-        response = fake_client.member_for_constituency("St Albans")
-        expect(response.object).to be_nil
-      end
-    end
-  end
-
   describe "#member_for_postcode" do
     let(:client) { described_class.new(connection: fake_successful_postcode_search_connection(fake_response)) }
 
@@ -188,122 +109,6 @@ RSpec.describe Api::MembersApi::Client do
     end
   end
 
-  describe "#member_id" do
-    let(:client) { described_class.new(connection: fake_successful_constituency_search_connection(fake_response)) }
-
-    context "when there is one result" do
-      subject { client.member_id("St Albans") }
-
-      let(:fake_response) do
-        [
-          200,
-          nil,
-          {
-            items: [{
-              value: {
-                name: "St Albans", currentRepresentation: {
-                  member: {
-                    value: {
-                      id: 12345
-                    }
-                  }
-                }
-              }
-            }]
-          }.to_json
-        ]
-      end
-
-      it "returns a the ID" do
-        expect(subject.object).to eql(12345)
-      end
-    end
-
-    context "when there is more than one result" do
-      subject { client.member_id("St A") }
-
-      let(:fake_response) { [200, nil, {items: [{value: {name: "St Albans"}}, {value: {name: "Lewisham West and Penge"}}]}.to_json] }
-
-      it "returns a MultipleResultsError" do
-        expect(subject.object).to be_nil
-        expect(subject.error).to be_a(Api::MembersApi::Client::MultipleResultsError)
-        expect(subject.error.message).to eq(I18n.t("members_api.errors.multiple", search_term: "St A"))
-      end
-    end
-
-    context "when there are no results" do
-      subject { client.member_id("Mars") }
-
-      let(:fake_response) { [200, nil, {items: []}.to_json] }
-
-      it "returns a NotFoundError" do
-        expect(subject.object).to be_nil
-        expect(subject.error).to be_a(Api::MembersApi::Client::NotFoundError)
-        expect(subject.error.message).to eq(I18n.t("members_api.errors.search_term_not_found", constituency: "Mars"))
-      end
-    end
-
-    context "when there is any other error" do
-      subject { client.member_id("nonexistent place") }
-
-      let(:fake_response) { [404, nil] }
-
-      it "returns an Error" do
-        expect(subject.object).to be_nil
-        expect(subject.error).to be_a(Api::MembersApi::Client::Error)
-        expect(subject.error.message).to eq(I18n.t("members_api.errors.other", search_term: "nonexistent place", status: 404))
-      end
-    end
-  end
-
-  describe "#member_name" do
-    let(:client) { described_class.new(connection: fake_successful_member_connection(1234, fake_response)) }
-
-    subject { client.member_name(1234) }
-
-    context "when the member id is not found" do
-      let(:fake_response) { [404, nil, nil] }
-
-      it "returns a Result with a NotFoundError" do
-        expect(subject.object).to be_nil
-        expect(subject.error).to be_a(Api::MembersApi::Client::NotFoundError)
-        expect(subject.error.message).to eq(I18n.t("members_api.errors.member_not_found", member_id: 1234))
-      end
-    end
-
-    context "when the member id is found" do
-      let(:fake_response) do
-        [200, nil, {"value" =>
-                       {"id" => 4679,
-                        "nameAddressAs" => "Neil O'Brien"}}.to_json]
-      end
-
-      it "returns a Result with the JSON response body and no error" do
-        expect(subject.object).to be_a(Api::MembersApi::MemberName)
-        expect(subject.object.name_address_as).to eq("Neil O'Brien")
-        expect(subject.error).to be_nil
-      end
-    end
-
-    context "when the connection fails" do
-      let(:client) { described_class.new(connection: fake_failed_member_connection) }
-
-      it "raises an Error" do
-        expect { subject }.to raise_error(Api::MembersApi::Client::Error)
-      end
-    end
-
-    context "when where is any other error" do
-      let(:fake_response) { [500, nil, nil] }
-
-      it "returns a Result with an Error" do
-        expect(subject.object).to be_nil
-        expect(subject.error).to be_a(Api::MembersApi::Client::Error)
-        expect(subject.error.message).to eq(I18n.t("members_api.errors.other"))
-      end
-    end
-  end
-
   describe "#member_contact_details" do
     let(:client) { described_class.new(connection: fake_successful_member_contact_connection(1234, fake_response)) }
 
@@ -370,16 +175,6 @@ RSpec.describe Api::MembersApi::Client do
     end
   end
 
-  def fake_successful_constituency_search_connection(response)
-    Faraday.new do |builder|
-      builder.adapter :test do |stub|
-        stub.get("/api/Location/Constituency/Search") do |_env|
-          response
-        end
-      end
-    end
-  end
-
   def fake_successful_postcode_search_connection(response)
     Faraday.new do |builder|
       builder.adapter :test do |stub|
@@ -390,40 +185,10 @@ RSpec.describe Api::MembersApi::Client do
     end
   end
 
-  def fake_failed_constituency_search_connection
-    Faraday.new do |builder|
-      builder.adapter :test do |stub|
-        stub.get("/api/Location/Constituency/Search") do |_env|
-          raise Faraday::Error
-        end
-      end
-    end
-  end
-
   def fake_failed_postcode_search_connection
     Faraday.new do |builder|
       builder.adapter :test do |stub|
         stub.get("/api/Members/Search") do |_env|
-          raise Faraday::Error
-        end
-      end
-    end
-  end
-
-  def fake_successful_member_connection(id, response)
-    Faraday.new do |builder|
-      builder.adapter :test do |stub|
-        stub.get("/api/Members/#{id}") do |_env|
-          response
-        end
-      end
-    end
-  end
-
-  def fake_failed_member_connection
-    Faraday.new do |builder|
-      builder.adapter :test do |stub|
-        stub.get("/api/Members/1234") do |_env|
           raise Faraday::Error
         end
       end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -388,7 +388,7 @@ RSpec.describe Project, type: :model do
     end
 
     it "returns nil when the API returns nothing" do
-      mock_nil_member_for_constituency_response
+      mock_nil_member_for_postcode_response
 
       project = build(:conversion_project)
       allow(project).to receive(:establishment).and_return(build(:academies_api_establishment))
@@ -404,7 +404,7 @@ RSpec.describe Project, type: :model do
         telemetry_client = double(ApplicationInsights::TelemetryClient, track_event: true, flush: true)
         allow(ApplicationInsights::TelemetryClient).to receive(:new).and_return(telemetry_client)
 
-        mock_nil_member_for_constituency_response
+        mock_nil_member_for_postcode_response
 
         project = build(:conversion_project)
         allow(project).to receive(:establishment).and_return(build(:academies_api_establishment))

--- a/spec/presenters/export/csv/mp_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/mp_presenter_module_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Export::Csv::MpPresenterModule do
   end
 
   it "presents nil values when there is no MP to show" do
-    mock_nil_member_for_constituency_response
+    mock_nil_member_for_postcode_response
     mock_all_academies_api_responses
 
     project = build(:conversion_project)

--- a/spec/requests/member_of_parliament_controller_spec.rb
+++ b/spec/requests/member_of_parliament_controller_spec.rb
@@ -19,28 +19,28 @@ RSpec.describe MemberOfParliamentController, type: :request do
 
     context "when the Member of Parliament is found" do
       before do
-        mock_successful_members_api_responses(member_name: member_name, member_contact_details: member_parliamentary_office)
+        mock_successful_members_api_postcode_search_response(member_name: member_name, member_contact_details: member_parliamentary_office)
         perform_request
       end
 
       subject { response.body }
 
       it "returns the MP's name" do
-        expect(subject).to include(member_name.name_full_title)
-      end
-
-      it "returns the MP's address formatted correctly" do
-        expect(subject).to include("#{member_parliamentary_office.line1}<br/>#{member_parliamentary_office.line2}<br/>#{member_parliamentary_office.postcode}")
+        expect(subject).to include(member_name.name_display_as)
       end
 
       it "returns the MP's email address as a mailto link" do
         expect(subject).to include('<a href="mailto:jane.smith.mp@parliament.uk">jane.smith.mp@parliament.uk</a>')
       end
+
+      it "returns the House of Commons address" do
+        expect(subject).to include("House of Commons<br/>London")
+      end
     end
 
-    context "when the constituency search returns multiple results" do
+    context "when the postcode search returns multiple results" do
       before do
-        mock_members_api_multiple_constituencies_response
+        mock_members_api_multiple_postcodes_response
         perform_request
       end
 
@@ -53,10 +53,7 @@ RSpec.describe MemberOfParliamentController, type: :request do
 
     context "when the Member of Parliament is not found" do
       before do
-        mock_successful_constituency_search_response
-        mock_successful_member_id_response
         mock_member_not_found_response
-        mock_contact_details_not_found_response
         perform_request
       end
 

--- a/spec/requests/member_of_parliament_controller_spec.rb
+++ b/spec/requests/member_of_parliament_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe MemberOfParliamentController, type: :request do
 
     context "when the Member of Parliament is found" do
       before do
-        mock_successful_members_api_responses(member_name: member_name, member_contact_details: [member_parliamentary_office])
+        mock_successful_members_api_responses(member_name: member_name, member_contact_details: member_parliamentary_office)
         perform_request
       end
 

--- a/spec/services/export/conversions/by_month_csv_export_service_spec.rb
+++ b/spec/services/export/conversions/by_month_csv_export_service_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Export::Conversions::AllDataCsvExportService do
   describe "#call" do
     before do
       mock_all_academies_api_responses
-      mock_successful_member_details
+      mock_successful_members_api_postcode_search_response(member_contact_details: nil, member_name: nil)
     end
 
     it "returns a csv with headers and values" do

--- a/spec/services/export/conversions/pre_conversion_grants_csv_export_service_spec.rb
+++ b/spec/services/export/conversions/pre_conversion_grants_csv_export_service_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Export::Conversions::PreConversionGrantsCsvExportService do
   describe "#call" do
     before do
       mock_successful_api_response_to_create_any_project
-      mock_successful_member_details
+      mock_successful_members_api_postcode_search_response(member_contact_details: nil, member_name: nil)
     end
 
     it "returns a csv with headers and values" do

--- a/spec/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service_spec.rb
+++ b/spec/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Export::Conversions::RpaSugAndFaLettersCsvExportService do
 
     it "returns a row of data" do
       mock_all_academies_api_responses
-      mock_successful_members_api_responses(member_name: build(:members_api_name), member_contact_details: [build(:members_api_contact_details)])
+      mock_successful_members_api_postcode_search_response(member_contact_details: nil, member_name: nil)
       project = build(:conversion_project)
       projects = [project]
 

--- a/spec/services/export/transfers/by_month_csv_export_services_spec.rb
+++ b/spec/services/export/transfers/by_month_csv_export_services_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Export::Transfers::AllDataCsvExportService do
   describe "#call" do
     before do
       mock_all_academies_api_responses
-      mock_successful_member_details
+      mock_successful_members_api_postcode_search_response(member_contact_details: nil, member_name: nil)
     end
 
     it "returns a csv with headers and values" do

--- a/spec/services/export/transfers/pre_transfer_grants_csv_export_service_spec.rb
+++ b/spec/services/export/transfers/pre_transfer_grants_csv_export_service_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Export::Transfers::PreTransferGrantsCsvExportService do
   describe "#call" do
     before do
       mock_successful_api_response_to_create_any_project
-      mock_successful_member_details
+      mock_successful_members_api_postcode_search_response(member_contact_details: nil, member_name: nil)
     end
 
     it "returns a csv with headers and values" do

--- a/spec/support/members_api_helpers.rb
+++ b/spec/support/members_api_helpers.rb
@@ -1,110 +1,42 @@
 module MembersApiHelpers
-  def mock_successful_members_api_responses(member_name:, member_contact_details:)
-    mock_successful_constituency_search_response
-    mock_successful_member_id_response
-    mock_successful_member_name_response(member_name: member_name)
-    mock_successful_member_contact_details_response(member_contact_details: member_contact_details)
-  end
+  def mock_successful_members_api_postcode_search_response(member_name:, member_contact_details:)
+    member_name ||= build(:members_api_name)
+    member_contact_details ||= build(:members_api_contact_details)
+    member_details = Api::MembersApi::MemberDetails.new(member_name, member_contact_details)
 
-  def mock_successful_constituency_search_response
-    fake_body = {"items" => [{"value" => {"name" => "St Albans", "id" => 12345}}]}
-    fake_result = Api::MembersApi::Client::Result.new(fake_body, nil)
+    fake_result = Api::MembersApi::Client::Result.new(member_details, nil)
     test_client = Api::MembersApi::Client.new
 
-    allow(test_client).to receive(:constituency).and_return(fake_result)
+    allow(test_client).to receive(:member_for_postcode).and_return(fake_result)
     allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
   end
 
-  def mock_successful_member_id_response
-    test_client = Api::MembersApi::Client.new
-    fake_result = Api::MembersApi::Client::Result.new("12345", nil)
-
-    allow(test_client).to receive(:member_id).and_return(fake_result)
-    allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
-  end
-
-  def mock_successful_member_name_response(member_name:)
-    member_name = build(:members_api_name) if member_name.nil?
-
-    fake_result = Api::MembersApi::Client::Result.new(member_name, nil)
+  def mock_members_api_multiple_postcodes_response
+    fake_result = Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::MultipleResultsError.new)
     test_client = Api::MembersApi::Client.new
 
-    allow(test_client).to receive(:member_name).and_return(fake_result)
-    allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
-  end
-
-  def mock_successful_member_contact_details_response(member_contact_details:)
-    member_contact_details = [build(:members_api_contact_details)] if member_contact_details.nil?
-
-    fake_result = Api::MembersApi::Client::Result.new(member_contact_details, nil)
-    test_client = Api::MembersApi::Client.new
-
-    allow(test_client).to receive(:member_contact_details).and_return(fake_result)
-    allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
-  end
-
-  def mock_successful_member_details
-    address = double(
-      "MP address",
-      line1: "House of Commons",
-      line2: "London",
-      line3: "",
-      postcode: "SW1A 0AA"
-    )
-    member_details = double(
-      Api::MembersApi::MemberDetails,
-      name: "Member Parliament",
-      email: "member.parliament@parliament.uk",
-      address: address
-    )
-    result = Api::MembersApi::Client::Result.new(member_details, nil)
-
-    members_client = double(Api::MembersApi::Client, member_for_constituency: result)
-    allow(Api::MembersApi::Client).to receive(:new).and_return(members_client)
-    members_client
-  end
-
-  def mock_members_api_multiple_constituencies_response
-    fake_body = {"items" => [
-      {"value" => {"name" => "St Albans", "id" => 12345}},
-      {"value" => {"name" => "Lewisham West and Penge", "id" => 67890}}
-    ]}
-
-    fake_result = Api::MembersApi::Client::Result.new(fake_body, nil)
-    test_client = Api::MembersApi::Client.new
-
-    allow(test_client).to receive(:constituency).and_return(fake_result)
+    allow(test_client).to receive(:member_for_postcode).and_return(fake_result)
     allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
   end
 
   def mock_member_not_found_response
     test_client = Api::MembersApi::Client.new
     not_found_result = Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::NotFoundError.new)
-    allow(test_client).to receive(:member_name).and_return(not_found_result)
-    allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
-  end
-
-  def mock_contact_details_not_found_response
-    test_client = Api::MembersApi::Client.new
-    not_found_result = Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::NotFoundError.new)
-
-    allow(test_client).to receive(:member_contact_details).and_return(not_found_result)
-    allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
-  end
-
-  def mock_nil_member_for_constituency_response
-    test_client = Api::MembersApi::Client.new
-    empty_result = Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::NotFoundError.new)
-    allow(test_client).to receive(:member_for_constituency).and_return(empty_result)
+    allow(test_client).to receive(:member_for_postcode).and_return(not_found_result)
     allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
   end
 
   def mock_members_api_unavailable_response
     test_client = Api::MembersApi::Client.new
     error_result = Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::Error.new)
-    allow(test_client).to receive(:constituency).and_return(error_result)
-    allow(test_client).to receive(:member_name).and_return(error_result)
-    allow(test_client).to receive(:member_contact_details).and_return(error_result)
+    allow(test_client).to receive(:member_for_postcode).and_return(error_result)
+    allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
+  end
+
+  def mock_nil_member_for_postcode_response
+    test_client = Api::MembersApi::Client.new
+    empty_result = Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::NotFoundError.new)
+    allow(test_client).to receive(:member_for_postcode).and_return(empty_result)
     allow(Api::MembersApi::Client).to receive(:new).and_return(test_client)
   end
 end


### PR DESCRIPTION
## Changes

On May 31st 2024 constituency boundaries changed in the UK.

We previously retrieved an MP for a project by the establishment's constituency. We get the constituency from GIAS. There are currently no plans to update the constituencies in GIAS for establishments. This breaks our ability to get an MP by constituency.

Instead, we can get an MP for an establishment using the establishment's postcode. 

Refactor the Members API work to retrieve an MP for a project by establishment postcode.

Note that the MP details are not currently being exported due to performance concerns with the Parliamentary Members API, so none of this is user-facing work. 

To view an MP for a project, you can manually change the URL for a project to be `<project_id>/mp` and see the correct MP for an establishment.