### PR TITLE
(172824) Allow users to edit the "Handover to RCS" field on projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- If a project is not assigned to RCS on creation, the assigned user can edit
+  the project in the usual way and assign it to RCS, along with adding a
+  handover note
 - Use of ADOP change to AOPU
 
 ## [Release-79][release-79]

--- a/app/controllers/conversions/projects_controller.rb
+++ b/app/controllers/conversions/projects_controller.rb
@@ -44,12 +44,12 @@ class Conversions::ProjectsController < ProjectsController
 
   def edit
     authorize project
-    @project_form = Conversion::EditProjectForm.new_from_project(project)
+    @project_form = Conversion::EditProjectForm.new_from_project(project, current_user)
   end
 
   def update
     authorize project
-    @project_form = Conversion::EditProjectForm.new_from_project(project)
+    @project_form = Conversion::EditProjectForm.new_from_project(project, current_user)
 
     if @project_form.update(edit_project_params)
       redirect_to project_information_path(project), notice: I18n.t("project.update.success")
@@ -70,7 +70,9 @@ class Conversions::ProjectsController < ProjectsController
       :advisory_board_date,
       :advisory_board_conditions,
       :directive_academy_order,
-      :two_requires_improvement
+      :two_requires_improvement,
+      :assigned_to_regional_caseworker_team,
+      :handover_note_body
     )
   end
 

--- a/app/controllers/transfers/projects_controller.rb
+++ b/app/controllers/transfers/projects_controller.rb
@@ -34,12 +34,12 @@ class Transfers::ProjectsController < ApplicationController
 
   def edit
     authorize project
-    @project_form = Transfer::EditProjectForm.new_from_project(project)
+    @project_form = Transfer::EditProjectForm.new_from_project(project, current_user)
   end
 
   def update
     authorize project
-    @project_form = Transfer::EditProjectForm.new_from_project(project)
+    @project_form = Transfer::EditProjectForm.new_from_project(project, current_user)
 
     if @project_form.update(edit_project_params)
       redirect_to project_information_path(project), notice: I18n.t("project.update.success")
@@ -64,7 +64,9 @@ class Transfers::ProjectsController < ApplicationController
       :two_requires_improvement,
       :inadequate_ofsted,
       :financial_safeguarding_governance_issues,
-      :outgoing_trust_to_close
+      :outgoing_trust_to_close,
+      :assigned_to_regional_caseworker_team,
+      :handover_note_body
     )
   end
 

--- a/app/forms/conversion/edit_project_form.rb
+++ b/app/forms/conversion/edit_project_form.rb
@@ -3,7 +3,7 @@ class Conversion::EditProjectForm
   include ActiveModel::Attributes
   include ActiveRecord::AttributeAssignment
 
-  attr_accessor :project
+  attr_accessor :project, :user
 
   attribute :establishment_sharepoint_link
   attribute :incoming_trust_sharepoint_link
@@ -12,6 +12,8 @@ class Conversion::EditProjectForm
   attribute :advisory_board_conditions
   attribute :directive_academy_order, :boolean
   attribute :two_requires_improvement, :boolean
+  attribute :assigned_to_regional_caseworker_team, :boolean
+  attribute :handover_note_body
 
   validates :establishment_sharepoint_link, presence: true, sharepoint_url: true
   validates :incoming_trust_sharepoint_link, presence: true, sharepoint_url: true
@@ -26,7 +28,7 @@ class Conversion::EditProjectForm
 
   validates :two_requires_improvement, inclusion: {in: [true, false], message: I18n.t("errors.conversion_project.attributes.two_requires_improvement.inclusion")}
 
-  def self.new_from_project(project)
+  def self.new_from_project(project, user)
     new(
       project: project,
       establishment_sharepoint_link: project.establishment_sharepoint_link,
@@ -35,7 +37,10 @@ class Conversion::EditProjectForm
       advisory_board_date: project.advisory_board_date,
       advisory_board_conditions: project.advisory_board_conditions,
       directive_academy_order: project.directive_academy_order,
-      two_requires_improvement: project.two_requires_improvement
+      two_requires_improvement: project.two_requires_improvement,
+      assigned_to_regional_caseworker_team: project.team.eql?("regional_casework_services"),
+      handover_note_body: project.handover_note&.body,
+      user: user
     )
   end
 
@@ -49,6 +54,10 @@ class Conversion::EditProjectForm
 
     return false unless valid?
 
+    assigned_to = assigned_to_regional_caseworker_team ? nil : project.assigned_to
+    assigned_at = assigned_to_regional_caseworker_team ? nil : project.assigned_at
+    team = assigned_to_regional_caseworker_team ? "regional_casework_services" : project.team
+
     project.assign_attributes(
       establishment_sharepoint_link: establishment_sharepoint_link,
       incoming_trust_sharepoint_link: incoming_trust_sharepoint_link,
@@ -56,9 +65,29 @@ class Conversion::EditProjectForm
       advisory_board_date: advisory_board_date,
       advisory_board_conditions: advisory_board_conditions,
       directive_academy_order: directive_academy_order,
-      two_requires_improvement: two_requires_improvement
+      two_requires_improvement: two_requires_improvement,
+      team: team,
+      assigned_to: assigned_to,
+      assigned_at: assigned_at
     )
 
-    project.save!
+    ActiveRecord::Base.transaction do
+      project.save
+      update_handover_note if handover_note_body.present?
+      notify_team_leaders(project) if assigned_to_regional_caseworker_team
+    end
+
+    project
+  end
+
+  private def update_handover_note
+    note = Note.find_or_initialize_by(project: project, task_identifier: :handover, user: user)
+    note.update!(body: handover_note_body)
+  end
+
+  private def notify_team_leaders(project)
+    User.team_leaders.each do |team_leader|
+      TeamLeaderMailer.new_conversion_project_created(team_leader, project).deliver_later if team_leader.active
+    end
   end
 end

--- a/app/forms/transfer/edit_project_form.rb
+++ b/app/forms/transfer/edit_project_form.rb
@@ -3,7 +3,7 @@ class Transfer::EditProjectForm
   include ActiveModel::Attributes
   include ActiveRecord::AttributeAssignment
 
-  attr_accessor :project
+  attr_accessor :project, :user
 
   attribute :establishment_sharepoint_link
   attribute :outgoing_trust_sharepoint_link
@@ -16,6 +16,8 @@ class Transfer::EditProjectForm
   attribute :inadequate_ofsted, :boolean
   attribute :financial_safeguarding_governance_issues, :boolean
   attribute :outgoing_trust_to_close, :boolean
+  attribute :assigned_to_regional_caseworker_team, :boolean
+  attribute :handover_note_body
 
   validates :establishment_sharepoint_link, presence: true, sharepoint_url: true
   validates :incoming_trust_sharepoint_link, presence: true, sharepoint_url: true
@@ -38,7 +40,7 @@ class Transfer::EditProjectForm
 
   validates :outgoing_trust_to_close, inclusion: {in: [true, false], message: I18n.t("errors.transfer_project.attributes.outgoing_trust_to_close.inclusion")}
 
-  def self.new_from_project(project)
+  def self.new_from_project(project, user)
     new(
       project: project,
       establishment_sharepoint_link: project.establishment_sharepoint_link,
@@ -51,7 +53,10 @@ class Transfer::EditProjectForm
       two_requires_improvement: project.two_requires_improvement,
       inadequate_ofsted: project.tasks_data.inadequate_ofsted,
       financial_safeguarding_governance_issues: project.tasks_data.financial_safeguarding_governance_issues,
-      outgoing_trust_to_close: project.tasks_data.outgoing_trust_to_close
+      outgoing_trust_to_close: project.tasks_data.outgoing_trust_to_close,
+      assigned_to_regional_caseworker_team: project.team.eql?("regional_casework_services"),
+      handover_note_body: project.handover_note&.body,
+      user: user
     )
   end
 
@@ -65,6 +70,10 @@ class Transfer::EditProjectForm
 
     return false unless valid?
 
+    assigned_to = assigned_to_regional_caseworker_team ? nil : project.assigned_to
+    assigned_at = assigned_to_regional_caseworker_team ? nil : project.assigned_at
+    team = assigned_to_regional_caseworker_team ? "regional_casework_services" : project.team
+
     project.assign_attributes(
       establishment_sharepoint_link: establishment_sharepoint_link,
       incoming_trust_sharepoint_link: incoming_trust_sharepoint_link,
@@ -73,7 +82,10 @@ class Transfer::EditProjectForm
       incoming_trust_ukprn: incoming_trust_ukprn,
       advisory_board_date: advisory_board_date,
       advisory_board_conditions: advisory_board_conditions,
-      two_requires_improvement: two_requires_improvement
+      two_requires_improvement: two_requires_improvement,
+      team: team,
+      assigned_to: assigned_to,
+      assigned_at: assigned_at
     )
 
     project.tasks_data.assign_attributes(
@@ -82,9 +94,24 @@ class Transfer::EditProjectForm
       outgoing_trust_to_close: outgoing_trust_to_close
     )
 
-    if valid?
+    ActiveRecord::Base.transaction do
       project.save!
       project.tasks_data.save!
+      update_handover_note if handover_note_body.present?
+      notify_team_leaders(project) if assigned_to_regional_caseworker_team
+    end
+
+    project
+  end
+
+  private def update_handover_note
+    note = Note.find_or_initialize_by(project: project, task_identifier: :handover, user: user)
+    note.update!(body: handover_note_body)
+  end
+
+  private def notify_team_leaders(project)
+    User.team_leaders.each do |team_leader|
+      TeamLeaderMailer.new_conversion_project_created(team_leader, project).deliver_later if team_leader.active
     end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -142,6 +142,10 @@ class Project < ApplicationRecord
     is_a?(Conversion::Project) && directive_academy_order?
   end
 
+  def handover_note
+    notes.find_by(task_identifier: :handover)
+  end
+
   # :nocov:
   private def fetch_member_of_parliament
     result = Api::MembersApi::Client.new.member_for_constituency(establishment.parliamentary_constituency)

--- a/app/views/conversions/project_information/_assignment.html.erb
+++ b/app/views/conversions/project_information/_assignment.html.erb
@@ -1,0 +1,16 @@
+<div id="assignment" class="govuk-summary-card">
+  <div class="govuk-summary-card__title-wrapper">
+    <h3 class="govuk-summary-card__title">
+      <%= t("project_information.show.reasons_for.assignment.title") %>
+    </h3>
+  </div>
+  <div class="govuk-summary-card__content">
+    <%= govuk_summary_list do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key { t("project_information.show.reasons_for.handing_over.title") }
+            row.with_value { t("project_information.show.reasons_for.handing_over.#{project.team.eql?("regional_casework_services")}") }
+            row.with_action(text: "Change", href: conversions_edit_path(@project, anchor: "project-assignment"), visually_hidden_text: "the project assignment")
+          end
+        end %>
+  </div>
+</div>

--- a/app/views/conversions/project_information/_information_list.erb
+++ b/app/views/conversions/project_information/_information_list.erb
@@ -2,6 +2,8 @@
 
 <%= render partial: "shared/project_information/project_details", locals: { project: @project } %>
 
+<%= render partial: "assignment", locals: { project: @project } %>
+
 <%= render partial: "reasons_for_conversion", locals: { project: @project } %>
 
 <%= render partial: "shared/project_information/advisory_board_details", locals: { project: @project } %>

--- a/app/views/conversions/projects/edit.html.erb
+++ b/app/views/conversions/projects/edit.html.erb
@@ -18,6 +18,17 @@
       </div>
 
       <div class="govuk-form-group">
+        <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team,
+              yes_no_responses,
+              :id,
+              :name,
+              legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")},
+              form_group: {id: "project-assignment"} %>
+        <%= form.govuk_text_area :handover_note_body,
+              label: {text: t("project.new.handover_comments_label"), size: "m"} %>
+      </div>
+
+      <div class="govuk-form-group">
         <%= form.govuk_collection_radio_buttons :directive_academy_order,
               directive_academy_order_responses,
               :id,

--- a/app/views/transfers/project_information/_assignment.html.erb
+++ b/app/views/transfers/project_information/_assignment.html.erb
@@ -1,0 +1,16 @@
+<div id="assignment" class="govuk-summary-card">
+  <div class="govuk-summary-card__title-wrapper">
+    <h3 class="govuk-summary-card__title">
+      <%= t("project_information.show.reasons_for.assignment.title") %>
+    </h3>
+  </div>
+  <div class="govuk-summary-card__content">
+    <%= govuk_summary_list do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key { t("project_information.show.reasons_for.handing_over.title") }
+            row.with_value { t("project_information.show.reasons_for.handing_over.#{project.team.eql?("regional_casework_services")}") }
+            row.with_action(text: "Change", href: transfers_edit_path(@project, anchor: "project-assignment"), visually_hidden_text: "the project assignment")
+          end
+        end %>
+  </div>
+</div>

--- a/app/views/transfers/project_information/_information_list.erb
+++ b/app/views/transfers/project_information/_information_list.erb
@@ -2,6 +2,8 @@
 
 <%= render partial: "shared/project_information/project_details", locals: { project: @project } %>
 
+<%= render partial: "assignment", locals: { project: @project } %>
+
 <%= render partial: "project_information/reasons_for_transfer", locals: { project: @project } %>
 
 <%= render partial: "shared/project_information/advisory_board_details", locals: { project: @project } %>

--- a/app/views/transfers/projects/edit.html.erb
+++ b/app/views/transfers/projects/edit.html.erb
@@ -49,6 +49,17 @@
               form_group: {id: "outgoing-trust-to-close"} %>
       </div>
 
+      <div class="govuk-form-group">
+        <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team,
+              yes_no_responses,
+              :id,
+              :name,
+              legend: {text: t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team")},
+              form_group: {id: "project-assignment"} %>
+        <%= form.govuk_text_area :handover_note_body,
+              label: {text: t("project.new.handover_comments_label"), size: "m"} %>
+      </div>
+
       <%= form.govuk_submit do %>
         <%= govuk_link_to "Cancel", project_information_path(@project) %>
       <% end %>

--- a/config/locales/project_information.en.yml
+++ b/config/locales/project_information.en.yml
@@ -27,6 +27,12 @@ en:
           title: Reasons for the conversion
         transfer:
           title: Reasons for the transfer
+        handing_over:
+          title: Are you handing this project over to RCS (Regional Casework Services)?
+          "true": "Yes"
+          "false": "No"
+        assignment:
+          title: Project assignment
         directive_academy_order:
           title: Has a directive academy order been issued?
           "true": "Yes"

--- a/spec/features/conversions/users_can_edit_project_details_spec.rb
+++ b/spec/features/conversions/users_can_edit_project_details_spec.rb
@@ -173,4 +173,33 @@ RSpec.feature "Users can edit conversion project details" do
       expect(page).to have_content("No")
     end
   end
+
+  scenario "they can hand the project over to RCS" do
+    visit project_information_path(project)
+
+    row = find("#assignment .govuk-summary-list__row:nth-child(1)")
+
+    within(row) do
+      expect(page).to have_content("No")
+      click_link "Change"
+    end
+
+    within("#project-assignment") do
+      choose("Yes")
+    end
+
+    fill_in "Handover comments", with: "Handover reasons go here"
+
+    click_on "Continue"
+
+    within(row) do
+      expect(page).to have_content("Yes")
+    end
+
+    expect(project.reload.assigned_to).to be_nil
+    expect(project.team).to eql("regional_casework_services")
+    expect(project.notes.find_by(task_identifier: :handover).body).to eq("Handover reasons go here")
+
+    expect(page).to have_content "Not assigned to project"
+  end
 end

--- a/spec/features/transfers/users_can_edit_project_details_spec.rb
+++ b/spec/features/transfers/users_can_edit_project_details_spec.rb
@@ -289,4 +289,33 @@ RSpec.feature "Users can edit transfer project details" do
       expect(page).to have_content("No")
     end
   end
+
+  scenario "they can hand the project over to RCS" do
+    visit project_information_path(project)
+
+    row = find("#assignment .govuk-summary-list__row:nth-child(1)")
+
+    within(row) do
+      expect(page).to have_content("No")
+      click_link "Change"
+    end
+
+    within("#project-assignment") do
+      choose("Yes")
+    end
+
+    fill_in "Handover comments", with: "Handover reasons go here"
+
+    click_on "Continue"
+
+    within(row) do
+      expect(page).to have_content("Yes")
+    end
+
+    expect(project.reload.assigned_to).to be_nil
+    expect(project.team).to eql("regional_casework_services")
+    expect(project.notes.find_by(task_identifier: :handover).body).to eq("Handover reasons go here")
+
+    expect(page).to have_content "Not assigned to project"
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -911,6 +911,17 @@ RSpec.describe Project, type: :model do
     end
   end
 
+  describe "#handover_note" do
+    it "returns the associated Note with the `handover` task identifier" do
+      mock_successful_api_responses(urn: any_args, ukprn: any_args)
+      project = build(:conversion_project)
+      handover_note = create(:note, task_identifier: :handover, body: "Handover body", user: build(:user), project: project)
+      _other_note = create(:note, task_identifier: :stakeholder_kick_off, body: "Another body", user: build(:user), project: project)
+
+      expect(project.handover_note).to eq(handover_note)
+    end
+  end
+
   describe "delegation" do
     it "delegates local_authority to establishment" do
       local_authotity = double(code: 100)


### PR DESCRIPTION
## Changes

The RCS team have reported that users creating projects, intending to hand them
over to RCS, are not filling out the project creation form correctly and
instead keeping the projects assigned to themselves. The RCS team are then
having to spend time every day informing users how to reassign projects
via the Internal Contacts tab. Additionally, you cannot assign the project to
"no one" in the internal contacts tab, and the RCS team use a list of unassigned
projects in their workflow.

In order to try to mitigate this, make the "Handover to Regional casework
services" field on the Edit project form editable. This field is not actually
an attribute on the project, it adjusts who and to which team a project
is assigned to.

The user can now assign the project to RCS via the edit project form. This does
however mean they will no longer be able to edit the project, as the project
is no longer assigned to them (!). But this should hopefully reduce confusion
and give the RCS team less daily work.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
