### PR TITLE
DAO revocation reasons model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- When revoking a DAO, details for each reason must now be supplied.
+
 ## [Release-78][release-78]
 
 ### Changed

--- a/app/controllers/dao_revocations_controller.rb
+++ b/app/controllers/dao_revocations_controller.rb
@@ -72,7 +72,7 @@ class DaoRevocationsController < ApplicationController
     authorize @project, :dao_revocation?
     @step_form = DaoRevocationSteppedForm.new(get_store)
 
-    if @step_form.save_to_project(@project)
+    if @step_form.save(@project, current_user)
       delete_store
       redirect_to project_path(@project), notice: I18n.t("dao_revocations.check.successful")
     else
@@ -103,6 +103,9 @@ class DaoRevocationsController < ApplicationController
         :reason_school_closed,
         :reason_school_rating_improved,
         :reason_safeguarding_addressed,
+        :reason_school_closed_note,
+        :reason_school_rating_improved_note,
+        :reason_safeguarding_addressed_note,
         :minister_name,
         :date_of_decision,
         :confirm_minister_approved,

--- a/app/models/dao_revocation.rb
+++ b/app/models/dao_revocation.rb
@@ -1,15 +1,16 @@
 class DaoRevocation < ApplicationRecord
   belongs_to :project
+  has_many :reasons,
+    -> { order :reason_type },
+    foreign_key: :dao_revocation_id,
+    class_name: "DaoRevocationReason",
+    dependent: :destroy
+  has_many :notes, through: :reasons
 
   validates :date_of_decision, :decision_makers_name, presence: true
   validate :conversion_project_with_dao
-  validate :at_least_one_reason
 
   after_destroy :update_project_state
-
-  private def at_least_one_reason
-    errors.add(:base, :reason_required) unless reason_school_closed || reason_school_rating_improved || reason_safeguarding_addressed
-  end
 
   private def conversion_project_with_dao
     errors.add(:base, :incorrect_project_type) unless project.is_a?(Conversion::Project) && project.directive_academy_order

--- a/app/models/dao_revocation_reason.rb
+++ b/app/models/dao_revocation_reason.rb
@@ -1,0 +1,13 @@
+class DaoRevocationReason < ApplicationRecord
+  belongs_to :dao_revocation
+  has_one :note, as: :notable, dependent: :destroy
+
+  validates :note, presence: true
+  validates :reason_type, presence: true
+
+  enum :reason_type, {
+    school_closed: "school_closed",
+    school_rating_improved: "school_rating_improved",
+    safeguarding_addressed: "safeguarding_addressed"
+  }
+end

--- a/app/models/dao_revocation_reason.rb
+++ b/app/models/dao_revocation_reason.rb
@@ -6,8 +6,8 @@ class DaoRevocationReason < ApplicationRecord
   validates :reason_type, presence: true
 
   enum :reason_type, {
-    school_closed: "school_closed",
-    school_rating_improved: "school_rating_improved",
-    safeguarding_addressed: "safeguarding_addressed"
+    reason_school_closed: "school_closed",
+    reason_school_rating_improved: "school_rating_improved",
+    reason_safeguarding_addressed: "safeguarding_addressed"
   }
 end

--- a/app/views/dao_revocations/change_reasons.html.erb
+++ b/app/views/dao_revocations/change_reasons.html.erb
@@ -10,11 +10,30 @@
       <%= form.govuk_error_summary %>
 
       <%= form.govuk_check_boxes_fieldset :reasons, multiple: false, legend: {size: "xl"}, caption: {size: "xl"} do %>
-        <%= form.govuk_check_box :reason_school_rating_improved, 1, 0, multiple: false, label: {text: t("helpers.label.dao_revocation_stepped_form.reason_school_rating_improved")} %>
+        <%= form.govuk_check_box :reason_school_rating_improved,
+              1,
+              0,
+              multiple: false,
+              label: {text: t("helpers.label.dao_revocation_stepped_form.reason_school_rating_improved")} do %>
+              <%= form.govuk_text_area :reason_school_rating_improved_note %>
 
-        <%= form.govuk_check_box :reason_safeguarding_addressed, 1, 0, multiple: false, label: {text: t("helpers.label.dao_revocation_stepped_form.reason_safeguarding_addressed")} %>
+        <% end %>
 
-        <%= form.govuk_check_box :reason_school_closed, 1, 0, multiple: false, label: {text: t("helpers.label.dao_revocation_stepped_form.reason_school_closed")} %>
+        <%= form.govuk_check_box :reason_safeguarding_addressed,
+              1,
+              0,
+              multiple: false,
+              label: {text: t("helpers.label.dao_revocation_stepped_form.reason_safeguarding_addressed")} do %>
+              <%= form.govuk_text_area :reason_safeguarding_addressed_note %>
+            <% end %>
+
+        <%= form.govuk_check_box :reason_school_closed,
+              1,
+              0,
+              multiple: false,
+              label: {text: t("helpers.label.dao_revocation_stepped_form.reason_school_closed")} do %>
+              <%= form.govuk_text_area :reason_school_closed_note %>
+        <% end %>
 
       <% end %>
 

--- a/app/views/dao_revocations/check.html.erb
+++ b/app/views/dao_revocations/check.html.erb
@@ -23,7 +23,16 @@
           <% if @step_form.reasons_empty? %>
             <%= row.with_value { govuk_link_to "Enter reasons", project_dao_revocation_change_step_path(@project, :reasons) } %>
           <% else %>
-            <%= row.with_value { @step_form.reasons.map { |reason| t("dao_revocations.check.summary.value.reasons.#{reason}") }.join("; ") } %>
+            <%= row.with_value do %>
+              <% @step_form.reasons.each do |reason| %>
+                <div class="govuk-!-padding-bottom-3">
+                  <h6 class="govuk-heading-xxs"><%= t("dao_revocations.check.summary.value.reasons.#{reason}") %>:</h6>
+                  <div class="govuk-body">
+                    <%= simple_format(@step_form.public_send(:"#{reason}_note")) %>
+                  </div>
+                </div>
+              <% end %>
+            <% end %>
             <%= row.with_action(text: t("dao_revocations.check.summary.change.reasons"), href: project_dao_revocation_change_step_path(@project, :reasons), visually_hidden_text: t("dao_revocations.check.summary.title.reasons")) %>
           <% end %>
         <% end %>

--- a/app/views/dao_revocations/reasons.html.erb
+++ b/app/views/dao_revocations/reasons.html.erb
@@ -10,11 +10,30 @@
       <%= form.govuk_error_summary %>
 
       <%= form.govuk_check_boxes_fieldset :reasons, multiple: false, legend: {size: "xl"}, caption: {size: "xl"} do %>
-        <%= form.govuk_check_box :reason_school_rating_improved, 1, 0, multiple: false, label: {text: t("helpers.label.dao_revocation_stepped_form.reason_school_rating_improved")} %>
+        <%= form.govuk_check_box :reason_school_rating_improved,
+              1,
+              0,
+              multiple: false,
+              label: {text: t("helpers.label.dao_revocation_stepped_form.reason_school_rating_improved")} do %>
+              <%= form.govuk_text_area :reason_school_rating_improved_note %>
 
-        <%= form.govuk_check_box :reason_safeguarding_addressed, 1, 0, multiple: false, label: {text: t("helpers.label.dao_revocation_stepped_form.reason_safeguarding_addressed")} %>
+        <% end %>
 
-        <%= form.govuk_check_box :reason_school_closed, 1, 0, multiple: false, label: {text: t("helpers.label.dao_revocation_stepped_form.reason_school_closed")} %>
+        <%= form.govuk_check_box :reason_safeguarding_addressed,
+              1,
+              0,
+              multiple: false,
+              label: {text: t("helpers.label.dao_revocation_stepped_form.reason_safeguarding_addressed")} do %>
+              <%= form.govuk_text_area :reason_safeguarding_addressed_note %>
+            <% end %>
+
+        <%= form.govuk_check_box :reason_school_closed,
+              1,
+              0,
+              multiple: false,
+              label: {text: t("helpers.label.dao_revocation_stepped_form.reason_school_closed")} do %>
+              <%= form.govuk_text_area :reason_school_closed_note %>
+        <% end %>
 
       <% end %>
 

--- a/config/locales/dao_revocations.en.yml
+++ b/config/locales/dao_revocations.en.yml
@@ -103,6 +103,9 @@ en:
         reason_school_closed: School closed or closing
         reason_school_rating_improved: School rated good or outstanding
         reason_safeguarding_addressed: Safeguarding concerns addressed
+        reason_school_closed_note: Details
+        reason_school_rating_improved_note: Details
+        reason_safeguarding_addressed_note: Details
         minister_name: Minister’s name
     hint:
       dao_revocation_stepped_form:

--- a/db/migrate/20240709143301_add_dao_revocation_reasons.rb
+++ b/db/migrate/20240709143301_add_dao_revocation_reasons.rb
@@ -1,0 +1,8 @@
+class AddDaoRevocationReasons < ActiveRecord::Migration[7.0]
+  def change
+    create_table :dao_revocation_reasons, id: :uuid do |t|
+      t.uuid :dao_revocation_id, index: true
+      t.string :reason_type
+    end
+  end
+end

--- a/db/migrate/20240715115518_remove_reasons_from_dao_revocation.rb
+++ b/db/migrate/20240715115518_remove_reasons_from_dao_revocation.rb
@@ -1,0 +1,7 @@
+class RemoveReasonsFromDaoRevocation < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :dao_revocations, :reason_school_closed, :boolean
+    remove_column :dao_revocations, :reason_school_rating_improved, :boolean
+    remove_column :dao_revocations, :reason_safeguarding_addressed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_09_143301) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_15_115518) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -170,9 +170,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_09_143301) do
     t.datetime "updated_at", null: false
     t.date "date_of_decision"
     t.string "decision_makers_name"
-    t.boolean "reason_school_closed"
-    t.boolean "reason_school_rating_improved"
-    t.boolean "reason_safeguarding_addressed"
     t.uuid "project_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_09_115448) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_09_143301) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -157,6 +157,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_09_115448) do
     t.boolean "receive_grant_payment_certificate_check_certificate"
     t.date "confirm_date_academy_opened_date_opened"
     t.string "risk_protection_arrangement_reason"
+  end
+
+  create_table "dao_revocation_reasons", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+    t.uuid "dao_revocation_id"
+    t.string "reason_type"
+    t.index ["dao_revocation_id"], name: "index_dao_revocation_reasons_on_dao_revocation_id"
   end
 
   create_table "dao_revocations", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/factories/dao_revocation_factory.rb
+++ b/spec/factories/dao_revocation_factory.rb
@@ -1,10 +1,23 @@
 FactoryBot.define do
   factory :dao_revocation do
-    project { association :conversion_project }
-    decision_makers_name { "Minister Name" }
+    project { association :conversion_project, directive_academy_order: true }
+    decision_makers_name { "Education Minister" }
     date_of_decision { Date.today - 1.week }
-    reason_school_rating_improved { false }
-    reason_safeguarding_addressed { false }
-    reason_school_closed { true }
+
+    after(:create) do |dao_revocation, context|
+      create(:dao_revocation_reason, dao_revocation: dao_revocation)
+    end
+  end
+
+  factory :dao_revocation_reason do
+    dao_revocation { association :dao_revocation }
+    reason_type { :reason_school_closed }
+    note {
+      association :note,
+        project: dao_revocation.project,
+        notable: instance,
+        user: dao_revocation.project.assigned_to,
+        body: "Details of why the school is closing."
+    }
   end
 end

--- a/spec/features/dao_revocation/user_can_record_the_revocation_of_a_dao_from_a_project_spec.rb
+++ b/spec/features/dao_revocation/user_can_record_the_revocation_of_a_dao_from_a_project_spec.rb
@@ -29,7 +29,15 @@ RSpec.feature "Users record the revocation of a DAO from a project" do
     expect(page).to have_content "Why was the DAO revoked?"
 
     check "School closed or closing"
+    within "#dao-revocation-stepped-form-reason-school-closed-1-conditional" do
+      fill_in "Details", with: "Details of school closing."
+    end
+
     check "Safeguarding concerns addressed"
+    within "#dao-revocation-stepped-form-reason-safeguarding-addressed-1-conditional" do
+      fill_in "Details", with: "Details of safeguarding concerns addressed."
+    end
+
     click_button "Continue"
 
     expect(page).to have_content "Minister’s name"
@@ -69,7 +77,15 @@ RSpec.feature "Users record the revocation of a DAO from a project" do
     expect(page).to have_content "Why was the DAO revoked?"
 
     check "School closed or closing"
+    within "#dao-revocation-stepped-form-reason-school-closed-1-conditional" do
+      fill_in "Details", with: "Details of school closing."
+    end
+
     check "Safeguarding concerns addressed"
+    within "#dao-revocation-stepped-form-reason-safeguarding-addressed-1-conditional" do
+      fill_in "Details", with: "Details of safeguarding concerns addressed."
+    end
+
     click_button "Continue"
 
     expect(page).to have_content "Minister’s name"
@@ -140,7 +156,15 @@ RSpec.feature "Users record the revocation of a DAO from a project" do
     click_button "Continue"
 
     check "School closed or closing"
+    within "#dao-revocation-stepped-form-reason-school-closed-1-conditional" do
+      fill_in "Details", with: "Details of school closing."
+    end
+
     check "Safeguarding concerns addressed"
+    within "#dao-revocation-stepped-form-reason-safeguarding-addressed-1-conditional" do
+      fill_in "Details", with: "Details of safeguarding concerns addressed."
+    end
+
     click_button "Continue"
 
     expect(page).to have_content "Minister’s name"

--- a/spec/features/users_can_view_a_project_spec.rb
+++ b/spec/features/users_can_view_a_project_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Users can view a project" do
 
   context "when the project is a conversion with a DAO revocation" do
     let(:project) { create(:conversion_project, state: :dao_revoked, directive_academy_order: true) }
-    let!(:dao_revocation) { DaoRevocation.create!(project_id: project.id, date_of_decision: Date.today, decision_makers_name: "Minister Name", reason_school_closed: true) }
+    let!(:dao_revocation) { DaoRevocation.create!(project_id: project.id, date_of_decision: Date.today, decision_makers_name: "Minister Name") }
 
     scenario "they can see the tag in the summary" do
       visit project_path(project)

--- a/spec/models/dao_revocation_reason_spec.rb
+++ b/spec/models/dao_revocation_reason_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe DaoRevocationReason do
+  describe "attributes" do
+    it do
+      should define_enum_for(:reason_type)
+        .with_values(
+          school_closed: "school_closed",
+          school_rating_improved: "school_rating_improved",
+          safeguarding_addressed: "safeguarding_addressed"
+        )
+        .backed_by_column_of_type(:string)
+    end
+  end
+
+  describe "associations" do
+    it { should belong_to(:dao_revocation) }
+    it { should have_one(:note) }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of(:reason_type) }
+    it { should validate_presence_of(:note) }
+  end
+end

--- a/spec/models/dao_revocation_reason_spec.rb
+++ b/spec/models/dao_revocation_reason_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe DaoRevocationReason do
     it do
       should define_enum_for(:reason_type)
         .with_values(
-          school_closed: "school_closed",
-          school_rating_improved: "school_rating_improved",
-          safeguarding_addressed: "safeguarding_addressed"
+          reason_school_closed: "school_closed",
+          reason_school_rating_improved: "school_rating_improved",
+          reason_safeguarding_addressed: "safeguarding_addressed"
         )
         .backed_by_column_of_type(:string)
     end

--- a/spec/models/dao_revocation_spec.rb
+++ b/spec/models/dao_revocation_spec.rb
@@ -13,18 +13,6 @@ RSpec.describe DaoRevocation do
     it { is_expected.to validate_presence_of(:date_of_decision) }
     it { is_expected.to validate_presence_of(:decision_makers_name) }
 
-    describe "#at_least_one_reason" do
-      it "validates that at least one reason is checked" do
-        project = build(:conversion_project, directive_academy_order: true)
-        decision = described_class.new(date_of_decision: Date.today, decision_makers_name: "Bob Smith", project: project)
-        expect(decision.valid?).to be false
-        expect(decision.errors[:base]).to include("You must select at least one reason")
-
-        decision = described_class.new(date_of_decision: Date.today, decision_makers_name: "Bob Smith", project: project, reason_school_closed: true)
-        expect(decision.valid?).to be true
-      end
-    end
-
     describe "#conversion_project_with_dao" do
       it "is invalid if it is associated with a transfer project" do
         project = build(:transfer_project)
@@ -44,6 +32,7 @@ RSpec.describe DaoRevocation do
 
   describe "Associations" do
     it { is_expected.to belong_to(:project) }
+    it { is_expected.to have_many(:reasons).order(:reason_type) }
   end
 
   describe "Callbacks" do

--- a/spec/models/dao_revocation_spec.rb
+++ b/spec/models/dao_revocation_spec.rb
@@ -4,9 +4,6 @@ RSpec.describe DaoRevocation do
   describe "Attributes" do
     it { is_expected.to have_db_column(:date_of_decision).of_type :date }
     it { is_expected.to have_db_column(:decision_makers_name).of_type :string }
-    it { is_expected.to have_db_column(:reason_school_closed).of_type :boolean }
-    it { is_expected.to have_db_column(:reason_school_rating_improved).of_type :boolean }
-    it { is_expected.to have_db_column(:reason_safeguarding_addressed).of_type :boolean }
   end
 
   describe "Validations" do
@@ -39,7 +36,7 @@ RSpec.describe DaoRevocation do
     it "updates the state of the associated project after destruction" do
       mock_successful_api_response_to_create_any_project
       project = create(:conversion_project, directive_academy_order: true, state: :dao_revoked)
-      decision = described_class.new(date_of_decision: Date.today, decision_makers_name: "Bob Smith", reason_school_closed: true, project: project)
+      decision = described_class.new(date_of_decision: Date.today, decision_makers_name: "Bob Smith", project: project)
 
       decision.destroy!
       expect(project.state).to eq("active")

--- a/spec/requests/dao_revocations_controller_spec.rb
+++ b/spec/requests/dao_revocations_controller_spec.rb
@@ -75,8 +75,11 @@ RSpec.describe DaoRevocationsController, type: :request do
       expect(cache_store_value(project, user)).to eql(
         {
           reason_school_closed: "",
+          reason_school_closed_note: "",
           reason_school_rating_improved: "",
+          reason_school_rating_improved_note: "",
           reason_safeguarding_addressed: "",
+          reason_safeguarding_addressed_note: "",
           minister_name: "Minister Name",
           date_of_decision: ""
         }
@@ -137,8 +140,11 @@ RSpec.describe DaoRevocationsController, type: :request do
       expect(cache_store_value(project, user)).to eql(
         {
           reason_school_closed: "",
+          reason_school_closed_note: "",
           reason_school_rating_improved: "",
+          reason_school_rating_improved_note: "",
           reason_safeguarding_addressed: "",
+          reason_safeguarding_addressed_note: "",
           minister_name: "Minister Name",
           date_of_decision: ""
         }
@@ -170,8 +176,11 @@ RSpec.describe DaoRevocationsController, type: :request do
         {
           date_of_decision: "2024-01-01",
           reason_school_closed: "true",
+          reason_school_closed_note: "Details of the school closing.",
           reason_school_rating_improved: "false",
+          reason_school_rating_improved_note: nil,
           reason_safeguarding_addressed: "false",
+          reason_safeguarding_addressed_note: nil,
           minister_name: "Minister Name"
         }
       }
@@ -187,8 +196,11 @@ RSpec.describe DaoRevocationsController, type: :request do
       expect(cache_store_value(project, user)).to eql(
         {
           reason_school_closed: "true",
+          reason_school_closed_note: "Details of the school closing.",
           reason_school_rating_improved: "false",
+          reason_school_rating_improved_note: "",
           reason_safeguarding_addressed: "false",
+          reason_safeguarding_addressed_note: "",
           minister_name: "Minister Name",
           date_of_decision: "2024-01-01"
         }
@@ -220,8 +232,11 @@ RSpec.describe DaoRevocationsController, type: :request do
         dao_revocation_stepped_form:
         {
           reason_school_closed: "true",
+          reason_school_closed_note: "Details fo the schoool closing.",
           reason_school_rating_improved: "false",
+          reason_school_rating_improved_note: nil,
           reason_safeguarding_addressed: "false",
+          reason_safeguarding_addressed_note: nil,
           minister_name: "Minister Name",
           date_of_decision: "2024-1-1"
         }


### PR DESCRIPTION
We want to collect details about each reason for a DAO being revoked. Our approach to this is the same as the reasons on a SignificantDateHistory, a joining 'reason' model that links the revocation to a note which lets us keep all 'notes' in one table.

With the model inplace we move on to update the form objects, views and controllers and finally drop the columns that used to store the reasons on DaoRevocation - there are no DaoRevocations in production and if one is added before this work is deployed we will deal with it manually (DAO Revocation is very rare).

