### PR TITLE
Fix notable migration

### DIFF
--- a/db/migrate/20240709090855_add_notable_to_note.rb
+++ b/db/migrate/20240709090855_add_notable_to_note.rb
@@ -8,7 +8,8 @@ class AddNotableToNote < ActiveRecord::Migration[7.0]
 
     Note.all.each do |note|
       if note.notable_id.present?
-        note.update! notable_type: "SignificantDateHistoryReason"
+        note.notable_type = "SignificantDateHistoryReason"
+        note.save(validate: false)
       end
     end
   end


### PR DESCRIPTION
We got this migration through dev and test but it failed in prod as
there are 'deleted' projects which are excluded by a `default_scope`.

This means the notes for these projects return nil for their project
making them invalid and so not saving.

Our plan is to rollback the migrations in dev and test and redeploy this
fix.

