### PR TITLE
Correcting acronym for APOU from ADOP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Use of ADOP change to AOPU
+
 ## [Release-79][release-79]
 
 ### Added

--- a/config/locales/conversion/tasks/academy_details.en.yml
+++ b/config/locales/conversion/tasks/academy_details.en.yml
@@ -12,6 +12,6 @@ en:
           html:
             <p>Make sure the school and trust agree on the academy name.</p>
             <p>It must be confirmed at least 40 days before the academy opens.</p>
-            <p>If the name needs to change after that point, you must email ADOP (Academy Delivery Operational Policy) as they will use this information to create the academy's URN (Unique Reference Number) and funding letters.</p>
+            <p>If the name needs to change after that point, you must email AOPU (Academies Operational Practice Unit) as they will use this information to create the academy's URN (Unique Reference Number) and funding letters.</p>
         name:
           title: Enter the academy name

--- a/config/locales/conversion/tasks/conditions_met.en.yml
+++ b/config/locales/conversion/tasks/conditions_met.en.yml
@@ -5,7 +5,7 @@ en:
         title: Confirm all conditions have been met
         hint:
           html:
-            "The deadline for meeting all conditions is in the email you got from the ADOP (Academies Delivery Operational Practice) team. All conditions must be met before the deadline or the school will not be able to convert on %{date}."
+            "The deadline for meeting all conditions is in the email you got from the AOPU (Academies Operational Practice Unit) team. All conditions must be met before the deadline or the school will not be able to convert on %{date}."
         guidance_link: How to check all conditions have been met
         guidance:
           html:
@@ -20,7 +20,7 @@ en:
           title: Confirm all conditions are met
           hint:
             html:
-              <p>This will change the conversion's status on the "By month" project list. ADOP use that list to prepare funding agreement letters.</p>
+              <p>This will change the conversion's status on the "By month" project list. AOPU use that list to prepare funding agreement letters.</p>
           guidance_link: What to do if conditions are not met
           guidance:
             html:


### PR DESCRIPTION
## Changes

This work removes uses of ADOP (Academy Delivery Operational Policy) and ADOP (Academies Delivery Operational Practice) and replaces it with the correct AOPU (Academies Operational Practice Unit)

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
