### PR TITLE
Adding guidance to master funding agreement task in transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- details component and content to explain when to use a deed of termination to
+  end a master funding agreement in a transfer project
+
 ### Changed
 
 - If a project is not assigned to RCS on creation, the assigned user can edit

--- a/config/locales/transfer/tasks/master_funding_agreement.en.yml
+++ b/config/locales/transfer/tasks/master_funding_agreement.en.yml
@@ -6,6 +6,12 @@ en:
         hint:
           html: <p>Update the master funding agreement to a new version if the incoming trust uses one from before 2018.</p>
                 <p>Use a deed of termination to end the master funding agreement for the outgoing trust if it will close after this transfer.</p>
+        guidance_link: When to sign a deed of termination
+        guidance:
+          html:      
+              <p>A deed of termination can only be signed when both the:</p>
+              <li>outgoing trust submit their financial accounts</li>
+              <li>finance reporting team confirm the master funding agreement can be terminated</li>
 
         clear_section:
           title: Check and clear the master funding agreement


### PR DESCRIPTION
## Changes

This work adds a small piece of additional content to the master funding agreement task in a transfer following some user feedback.

### Previous version

<img width="830" alt="Screenshot 2024-07-17 at 2 04 57 PM" src="https://github.com/user-attachments/assets/f9838b09-ce59-45a2-9a4a-8331b355f1f4">

### New version

<img width="835" alt="Screenshot 2024-07-17 at 2 04 35 PM" src="https://github.com/user-attachments/assets/b18e621d-06f9-4637-9904-f4b3ffa6a22b">

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
