### PR TITLE
Correcting grant payment certificate references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the project in the usual way and assign it to RCS, along with adding a
   handover note
 - Use of ADOP change to AOPU
-- Corrected references in content to the grant payment certificate in conversions
-  to declaration of expenditure certificate
+- Corrected references in content to the grant payment certificate in
+  conversions to declaration of expenditure certificate
 
 ## [Release-79][release-79]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the project in the usual way and assign it to RCS, along with adding a
   handover note
 - Use of ADOP change to AOPU
+- Corrected references in content to the grant payment certificate in conversions
+  to declaration of expenditure certificate
 
 ## [Release-79][release-79]
 

--- a/config/locales/conversion/tasks/receive_grant_payment_certificate.en.yml
+++ b/config/locales/conversion/tasks/receive_grant_payment_certificate.en.yml
@@ -2,30 +2,30 @@ en:
   conversion:
     task:
       receive_grant_payment_certificate:
-        title: Receive grant payment certificate
+        title: Receive declaration of expenditure certificate
         hint:
-          html: <p>Remind the school and trust to complete the grant payment certificate.</p>
-        guidance_link: What to do if you have not received the grant payment certificate
+          html: <p>Remind the school and trust to complete and return the declaration of expenditure certificate.</p>
+        guidance_link: Update the grant assurance spreadsheet
         guidance:
           html:
-            <p>If you do not receive the grant certificate, you should keep reminding the school and trust to send it to you.</p>
-            <p>Regional Casework Services must also <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&action=default&mobileredirect=true" target="_blank">update the support grant assurance report spreadsheet (opens in new tab)</a>. Do not update this grant assurance report spreadsheet if you work in a team in one of the Regions.</p>
+            <p>Regional Casework Services team members must <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&action=default&mobileredirect=true" target="_blank">update the support grant assurance report spreadsheet (opens in new tab)</a>.</p> 
+            <p>Do not update this grant assurance report spreadsheet if you work in a team in one of the Regions.</p>
         check_certificate:
-          title: Check the grant payment certificate is correct
+          title: Check the declaration of expenditure certificate is correct
           hint:
             html: <p>Once they have sent it to you, check they've used the right template and there is no missing information.</p>
           guidance_link: Using the right certificate
           guidance:
             html:
-              <p>If the school only received the £25,000 converter grant, they need to download and <a href="https://www.gov.uk/government/publications/academy-support-grant" target="_blank">complete the academy conversions, support grant certificate (opens in new tab)</a>.</p>
+              <p>If the school only received the £25,000 pre-opening support grant, they need to download and <a href="https://www.gov.uk/government/publications/academy-support-grant" target="_blank">complete the academy conversions, support grant certificate (opens in new tab)</a>.</p>
               <p>If the school or trust received a sponsored grant, they need to <a href="https://www.gov.uk/government/publications/sponsored-academies-funding-guidance-for-sponsors" target="_blank">complete the certificate in Annex 2 of the Sponsored academies funding - advice for sponsors PDF (opens in a new tab)</a>.</p>
         save_certificate:
-          title: Save the grant payment certificate in the academy's SharePoint folder
+          title: Save the declaration of expenditure certificate in the academy's SharePoint folder
         date_received:
-          title: Enter the date you received the grant payment certificate
+          title: Enter the date you received the declaration of expenditure certificate
           hint:
             html: <p>For example, 27 5 2007</p>
           received_info:
-            html: DfE received the grant payment certificate on %{date}.
+            html: DfE received the declaration of expenditure certificate on %{date}.
           errors:
             invalid: Enter a valid date, like 1 1 2025

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -55,7 +55,7 @@ en:
         <ul>
         <li>The conversion date has been confirmed and is in the past</li>
         <li>The confirm all conditions have been met task is completed</li>
-        <li>The receive grant payment certificate task is completed</li>
+        <li>The receive declaration of expenditure certificate task is completed</li>
         <li>The confirm the date the academy opened task is completed</li>
         </ul>
     form_a_mat:

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -249,7 +249,7 @@ RSpec.feature "Users can complete conversion tasks" do
     context "when the task does not have a date" do
       scenario "they can add a date" do
         visit project_tasks_path(project)
-        click_on "Receive grant payment certificate"
+        click_on "Receive declaration of expenditure certificate"
         page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
         fill_in "Day", with: "1"
         fill_in "Month", with: "1"
@@ -266,9 +266,9 @@ RSpec.feature "Users can complete conversion tasks" do
 
       scenario "they see the date on the page but cannot add a new one" do
         visit project_tasks_path(project)
-        click_on "Receive grant payment certificate"
-        expect(page).to have_content("DfE received the grant payment certificate on 1 January 2024.")
-        expect(page).to_not have_content("Enter the date you received the grant payment certificate")
+        click_on "Receive declaration of expenditure certificate"
+        expect(page).to have_content("DfE received the declaration of expenditure certificate on 1 January 2024.")
+        expect(page).to_not have_content("Enter the date you received the declaration of expenditure certificate")
       end
     end
   end


### PR DESCRIPTION
## Changes

This work replaces references in content the grant payment certificate with declaration of expenditure certificate

### Before 

![Screenshot 2024-07-17 at 3 17 18 PM](https://github.com/user-attachments/assets/8a00f9a1-bb02-4fa7-a3e9-0edff7329283)

![Screenshot 2024-07-17 at 3 16 47 PM](https://github.com/user-attachments/assets/ef88cfd7-0428-42e4-8b1e-454ca5931460)

![test complete education gov uk_projects_B4B736FE-32A9-4698-9244-DEBF1A006385_tasks_receive_grant_payment_certificate](https://github.com/user-attachments/assets/12826bc8-efae-4ceb-934f-d3aa0cd871a8)

### After

![Screenshot 2024-07-17 at 3 16 24 PM](https://github.com/user-attachments/assets/2dbf076f-a162-43e6-85b7-02cf24f863eb)

![Screenshot 2024-07-17 at 3 17 30 PM](https://github.com/user-attachments/assets/621e4841-7c52-464f-9696-4641b792fd08)

![localhost_3000_projects_4F3D2844-9DA6-4F0D-AAA6-C65ED52A64D3_tasks_receive_grant_payment_certificate](https://github.com/user-attachments/assets/a87e71f5-0150-448d-9a54-3bbeccdf6017)

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
