### PR TITLE
(173677) Update transfer completion logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use of ADOP change to AOPU
 - Corrected references in content to the grant payment certificate in
   conversions to declaration of expenditure certificate
+- To complete a transfer project users will have to ensure that the following:
+  - The transfer date has been confirmed and is in the past
+  - The confirm this transfer has authority to proceed task is completed
+  - The receive declaration of expenditure certificate task is completed
+  - The confirm the date the academy transferred task is completed
 
 ## [Release-79][release-79]
 

--- a/app/models/transfer/project.rb
+++ b/app/models/transfer/project.rb
@@ -10,10 +10,27 @@ class Transfer::Project < Project
   validates :outgoing_trust_ukprn, ukprn: true
 
   MANDATORY_CONDITIONS = [
-    :confirmed_date_and_in_the_past?
+    :confirmed_date_and_in_the_past?,
+    :authority_to_proceed?,
+    :declaration_of_expenditure_certificate_task_completed?,
+    :confirm_date_academy_transferred_task_completed?
   ]
 
   alias_attribute :authority_to_proceed, :all_conditions_met
+
+  def declaration_of_expenditure_certificate_task_completed?
+    user = assigned_to
+    tasks = Transfer::Task::DeclarationOfExpenditureCertificateTaskForm.new(tasks_data, user)
+    return true if tasks.status.eql?(:completed) || tasks.status.eql?(:not_applicable)
+    false
+  end
+
+  def confirm_date_academy_transferred_task_completed?
+    user = assigned_to
+    tasks = Transfer::Task::ConfirmDateAcademyTransferredTaskForm.new(tasks_data, user)
+    return true if tasks.status.eql?(:completed)
+    false
+  end
 
   def outgoing_trust
     @outgoing_trust ||= fetch_trust(outgoing_trust_ukprn)

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -13,7 +13,10 @@ en:
       unable_to_complete_html:
         <p>This project cannot be completed until:</p>
         <ul>
-        <li>The transfer date has been confirmed and is in the past</li>
+          <li>The transfer date has been confirmed and is in the past</li>
+          <li>The confirm this transfer has authority to proceed task is completed</li>
+          <li>The receive declaration of expenditure certificate task is completed</li>
+          <li>The confirm the date the academy transferred task is completed</li>
         </ul>
     summary_card:
       type: Type

--- a/spec/features/transfers/users_can_complete_a_transfer_project_spec.rb
+++ b/spec/features/transfers/users_can_complete_a_transfer_project_spec.rb
@@ -9,11 +9,20 @@ RSpec.feature "Users can complete a transfer project" do
   end
 
   context "when the academy has transferred" do
+    let(:tasks_data) {
+      create(:transfer_tasks_data,
+        declaration_of_expenditure_certificate_date_received: Date.today - 4.months,
+        declaration_of_expenditure_certificate_correct: true,
+        declaration_of_expenditure_certificate_saved: true,
+        confirm_date_academy_transferred_date_transferred: Date.today - 3.months)
+    }
     let(:project) {
       create(:transfer_project,
         assigned_to: user,
         significant_date: 2.months.ago.at_beginning_of_month,
-        significant_date_provisional: false)
+        significant_date_provisional: false,
+        authority_to_proceed: true,
+        tasks_data: tasks_data)
     }
 
     scenario "the project is completed successfully" do

--- a/spec/models/transfer/project_spec.rb
+++ b/spec/models/transfer/project_spec.rb
@@ -23,20 +23,120 @@ RSpec.describe Transfer::Project do
   end
 
   describe "#completable?" do
-    before { mock_successful_api_response_to_create_any_project }
+    let(:project) { create(:transfer_project) }
+
+    before do
+      mock_successful_api_response_to_create_any_project
+
+      allow(project).to receive(:confirmed_date_and_in_the_past?).and_return(true)
+      allow(project).to receive(:authority_to_proceed?).and_return(true)
+      allow(project).to receive(:declaration_of_expenditure_certificate_task_completed?).and_return(true)
+      allow(project).to receive(:confirm_date_academy_transferred_task_completed?).and_return(true)
+    end
 
     it "returns true when all the mandatory conditions are completed" do
-      project = create(:transfer_project)
-      allow(project).to receive(:confirmed_date_and_in_the_past?).and_return(true)
-
       expect(project.completable?).to eq true
     end
 
-    it "returns false if any of the mandatory conditions are not completed" do
-      project = create(:transfer_project)
+    it "returns false if the transfer date is in the future" do
       allow(project).to receive(:confirmed_date_and_in_the_past?).and_return(false)
 
       expect(project.completable?).to eq false
+    end
+
+    it "returns false if the the project has not got authority to proceed" do
+      allow(project).to receive(:authority_to_proceed?).and_return(false)
+
+      expect(project.completable?).to eq false
+    end
+
+    it "returns false if the declaration of expenditure task is incomplete" do
+      allow(project).to receive(:declaration_of_expenditure_certificate_task_completed?).and_return(false)
+
+      expect(project.completable?).to eq false
+    end
+
+    it "returns false if the confirm date academy openend task is incomplete" do
+      allow(project).to receive(:confirm_date_academy_transferred_task_completed?).and_return(false)
+
+      expect(project.completable?).to eq false
+    end
+  end
+
+  describe "#declaration_of_expenditure_certificate_task_completed?" do
+    before do
+      mock_all_academies_api_responses
+    end
+
+    let(:user) { create(:user) }
+    let(:tasks_data) {
+      create(:transfer_tasks_data,
+        declaration_of_expenditure_certificate_date_received: Date.today,
+        declaration_of_expenditure_certificate_correct: true,
+        declaration_of_expenditure_certificate_saved: true,
+        declaration_of_expenditure_certificate_not_applicable: false)
+    }
+    let(:project) { create(:transfer_project, tasks_data: tasks_data) }
+
+    context "when the task is completed" do
+      it "returns true" do
+        expect(project.declaration_of_expenditure_certificate_task_completed?).to be true
+      end
+    end
+
+    context "when the task is not applicable" do
+      before do
+        allow(tasks_data)
+          .to receive(:declaration_of_expenditure_certificate_not_applicable)
+          .and_return(true)
+      end
+
+      it "returns true" do
+        expect(project.declaration_of_expenditure_certificate_task_completed?).to be true
+      end
+    end
+
+    context "when the task is not completed" do
+      before do
+        allow(tasks_data)
+          .to receive(:declaration_of_expenditure_certificate_date_received)
+          .and_return(nil)
+      end
+
+      it "returns false" do
+        expect(project.declaration_of_expenditure_certificate_task_completed?).to be false
+      end
+    end
+  end
+
+  describe "#confirm_date_academy_transferred_task_completed?" do
+    before do
+      mock_all_academies_api_responses
+    end
+
+    let(:user) { create(:user) }
+    let(:tasks_data) {
+      create(:transfer_tasks_data,
+        confirm_date_academy_transferred_date_transferred: Date.today)
+    }
+    let(:project) { create(:transfer_project, tasks_data: tasks_data) }
+
+    context "when the task is completed" do
+      it "returns true" do
+        expect(project.confirm_date_academy_transferred_task_completed?).to be true
+      end
+    end
+
+    context "when the task is NOT completed" do
+      before do
+        allow(tasks_data)
+          .to receive(:confirm_date_academy_transferred_date_transferred)
+          .and_return(nil)
+      end
+
+      it "returns false" do
+        expect(project.confirm_date_academy_transferred_task_completed?).to be false
+      end
     end
   end
 end


### PR DESCRIPTION
This work updates the logic that controls when a user can complete a transfer
project.

The following must have been completed:

- The transfer date has been confirmed and is in the past
- The confirm this transfer has authority to proceed task is completed
- The receive declaration of expenditure certificate task is completed
- The confirm the date the academy transferred task is completed

