### PR TITLE
Make Contact::Parliament a "real" contact type

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -13,7 +13,8 @@ class Contact < ApplicationRecord
     local_authority: 3,
     solicitor: 5,
     diocese: 4,
-    other: 0
+    other: 0,
+    member_of_parliament: 7
   }
 
   scope :by_name, -> { order(:name) }

--- a/app/models/contact/parliament.rb
+++ b/app/models/contact/parliament.rb
@@ -1,44 +1,18 @@
-class Contact::Parliament
-  attr_reader :name, :email
-
-  def initialize(constituency:)
-    client = Api::MembersApi::Client.new
-    member = client.member_id(constituency)
-
-    raise member.error if member.error.present?
-
-    member_id = member.object
-    member_name = client.member_name(member_id).object
-    contact_details = client.member_contact_details(member_id).object.find { |details| details.type_id == 1 }
-
-    details = Api::MembersApi::MemberDetails.new(member_name, contact_details)
-
-    @constituency = constituency
-    @name = details.name
-    @email = details.email
+class Contact::Parliament < Contact
+  def self.policy_class
+    ContactPolicy
   end
 
-  def id
-    nil
-  end
+  attribute :category, default: 7
+  attribute :organisation_name, default: "HM Government"
+
+  validates :parliamentary_constituency, presence: true
 
   def editable?
     false
   end
 
-  def category
-    "other"
-  end
-
   def title
-    I18n.t("members_api.member.title", constituency: @constituency)
-  end
-
-  def phone
-    nil
-  end
-
-  def organisation_name
-    nil
+    I18n.t("members_api.member.title", constituency: parliamentary_constituency&.titleize)
   end
 end

--- a/db/migrate/20240718133823_add_constituency_to_contact.rb
+++ b/db/migrate/20240718133823_add_constituency_to_contact.rb
@@ -1,0 +1,5 @@
+class AddConstituencyToContact < ActiveRecord::Migration[7.0]
+  def change
+    add_column :contacts, :parliamentary_constituency, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_15_115518) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_18_133823) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -32,6 +32,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_15_115518) do
     t.string "type"
     t.uuid "local_authority_id"
     t.integer "establishment_urn"
+    t.string "parliamentary_constituency"
     t.index ["category"], name: "index_contacts_on_category"
     t.index ["establishment_urn"], name: "index_contacts_on_establishment_urn"
     t.index ["project_id"], name: "index_contacts_on_project_id"

--- a/spec/models/contact/parliament_spec.rb
+++ b/spec/models/contact/parliament_spec.rb
@@ -1,74 +1,42 @@
 require "rails_helper"
 
 RSpec.describe Contact::Parliament do
-  let(:client) { Api::MembersApi::Client }
-  let(:client_instance) { double }
-  let(:name) { double(Api::MembersApi::MemberName, name_display_as: "Joe Bloggs") }
-  let(:contact_details) { double(find: Api::MembersApi::MemberContactDetails.new.from_hash({email: "joe.bloggs@email.com", line1: "Houses of Parliment", postcode: "SW1A 0AA"})) }
+  describe "Validations" do
+    it { should validate_presence_of(:parliamentary_constituency) }
+  end
 
-  around do |spec|
-    ClimateControl.modify(
-      MEMBERS_API_HOST: "https://members-api.test"
-    ) do
-      spec.run
+  describe ".policy_class" do
+    it "uses the ContactPolicy" do
+      expect(described_class.policy_class).to eq(ContactPolicy)
     end
   end
 
-  before do
-    allow(client).to receive(:new).and_return(client_instance)
-    allow(client_instance).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(4744, nil))
-    allow(client_instance).to receive(:member_name).and_return(Api::MembersApi::Client::Result.new(name, nil))
-    allow(client_instance).to receive(:member_contact_details).and_return(Api::MembersApi::Client::Result.new(contact_details, nil))
-  end
+  describe "#editable" do
+    it "always returns false" do
+      contact = described_class.new
 
-  describe "#initialize" do
-    it "initializes a new instance with the member details" do
-      member_of_parliament = described_class.new(constituency: "St Albans")
-
-      expect(member_of_parliament.name).to eq("Joe Bloggs")
-      expect(member_of_parliament.title).to eq("Member of Parliament for St Albans")
-      expect(member_of_parliament.category).to eq("other")
-      expect(member_of_parliament.id).to be_nil
-      expect(member_of_parliament.organisation_name).to be_nil
+      expect(contact.editable?).to be false
     end
   end
 
-  describe "#editable?" do
-    it "is always false" do
-      expect(described_class.new(constituency: "St Albans").editable?).to be false
+  describe "category" do
+    it "returns member_of_parliament" do
+      contact = described_class.new
+      expect(contact.category).to eq("member_of_parliament")
     end
   end
 
-  context "when the Member of Parliament is not found" do
-    before do
-      allow(client).to receive(:new).and_return(client_instance)
-      allow(client_instance).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::NotFoundError.new))
-    end
-
-    it "raises a not found error" do
-      expect { described_class.new(constituency: "Nowhereville") }.to raise_error(Api::MembersApi::Client::NotFoundError)
+  describe "title" do
+    it "returns 'Member of Parliament for' in title case" do
+      contact = described_class.new(parliamentary_constituency: "east ham")
+      expect(contact.title).to eq("Member of Parliament for East Ham")
     end
   end
 
-  context "when the Members API returns multiple results for the constituency" do
-    before do
-      allow(client).to receive(:new).and_return(client_instance)
-      allow(client_instance).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::MultipleResultsError.new))
-    end
-
-    it "raises a a multiple results error" do
-      expect { described_class.new(constituency: "Middlesbrough") }.to raise_error(Api::MembersApi::Client::MultipleResultsError)
-    end
-  end
-
-  context "when the Members API returns an error response" do
-    before do
-      allow(client).to receive(:new).and_return(client_instance)
-      allow(client_instance).to receive(:member_id).and_return(Api::MembersApi::Client::Result.new(nil, Api::MembersApi::Client::Error.new))
-    end
-
-    it "raises a generic error" do
-      expect { described_class.new(constituency: "Westminster") }.to raise_error(Api::MembersApi::Client::Error)
+  describe "organisation_name" do
+    it "returns HM Government" do
+      contact = described_class.new
+      expect(contact.organisation_name).to eq("HM Government")
     end
   end
 end


### PR DESCRIPTION
We're going to have to store the MP details in our app because the Members API is too inefficient to use on the fly. First step, turn the transient Contact::Parliament model into a "real" ActiveRecord model so we have somewhere to store our MP details.

Note that the `parliamentary_constituency` has to be a string because we're going to link Establishments and MPs together by constituency. The constituencies on GIAS do have IDs, but they're not the same ID as the ones used on the Members API. So we have to do the matching by constituency name.

## Changes

_Add a summary of the changes in this pull request_

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
