### PR TITLE
Annotate releases in App Insights for all environments

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -64,7 +64,7 @@ jobs:
         RAILS_ENV=development
         CURRENT_GIT_SHA="${{ needs.set-env.outputs.checked-out-sha }}"
         TIME_OF_BUILD="${{ needs.set-env.outputs.date }}"
-      annotate-release: ${{ needs.set-env.outputs.environment == 'development' && matrix.suffix == '' }}
+      annotate-release: ${{ matrix.suffix == '' }}
     secrets:
       azure-acr-credentials: ${{ secrets.ACR_CREDENTIALS }}
       azure-acr-name: ${{ secrets.ACR_NAME }}


### PR DESCRIPTION
* The condition ensures that when the worker container deploys there is not an additional marker in app insights. We dont want this to happen because they are both deployed at the same time using the same image tag so it is not necessary to do it twice
