### PR TITLE
(173735) Remove and refactor default scope for deleted projects

### DIFF
--- a/app/forms/export/new_academies_due_to_transfer_form.rb
+++ b/app/forms/export/new_academies_due_to_transfer_form.rb
@@ -1,6 +1,6 @@
 class Export::NewAcademiesDueToTransferForm < Export::BaseForm
   def export
-    projects = Project.transfers.significant_date_in_range(from_date.to_s, to_date.to_s)
+    projects = Project.not_deleted.transfers.significant_date_in_range(from_date.to_s, to_date.to_s)
     pre_fetched_projects = AcademiesApiPreFetcherService.new.call!(projects)
 
     Export::Transfers::AcademiesDueToTransferCsvExportService.new(pre_fetched_projects).call

--- a/app/forms/export/new_pre_conversion_grants_form.rb
+++ b/app/forms/export/new_pre_conversion_grants_form.rb
@@ -1,6 +1,7 @@
 class Export::NewPreConversionGrantsForm < Export::BaseForm
   def export
-    projects = Project.conversions.advisory_board_date_in_range(from_date.to_s, to_date.to_s)
+    projects = Project.not_deleted.conversions.advisory_board_date_in_range(from_date.to_s, to_date.to_s)
+
     pre_fetched_projects = AcademiesApiPreFetcherService.new.call!(projects)
 
     Export::Conversions::PreConversionGrantsCsvExportService.new(pre_fetched_projects).call

--- a/app/forms/export/new_pre_transfer_grants_form.rb
+++ b/app/forms/export/new_pre_transfer_grants_form.rb
@@ -1,6 +1,6 @@
 class Export::NewPreTransferGrantsForm < Export::BaseForm
   def export
-    projects = Project.transfers.advisory_board_date_in_range(from_date.to_s, to_date.to_s)
+    projects = Project.not_deleted.transfers.advisory_board_date_in_range(from_date.to_s, to_date.to_s)
     pre_fetched_projects = AcademiesApiPreFetcherService.new.call!(projects)
 
     Export::Transfers::PreTransferGrantsCsvExportService.new(pre_fetched_projects).call

--- a/app/forms/export/new_rpa_sug_and_fa_letters_form.rb
+++ b/app/forms/export/new_rpa_sug_and_fa_letters_form.rb
@@ -1,6 +1,6 @@
 class Export::NewRpaSugAndFaLettersForm < Export::BaseForm
   def export
-    projects = Project.active.or(Project.completed).conversions.significant_date_in_range(from_date.to_s, to_date.to_s)
+    projects = Project.not_deleted.not_dao_revoked.conversions.significant_date_in_range(from_date.to_s, to_date.to_s)
     pre_fetched_projects = AcademiesApiPreFetcherService.new.call!(projects)
 
     Export::Conversions::RpaSugAndFaLettersCsvExportService.new(pre_fetched_projects).call

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -72,8 +72,6 @@ class Project < ApplicationRecord
 
   scope :not_form_a_mat, -> { where.not(incoming_trust_ukprn: nil) }
 
-  default_scope { where.not(state: :deleted) }
-
   enum :region, {
     london: "H",
     south_east: "J",

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -43,7 +43,7 @@ class Project < ApplicationRecord
   scope :transfers, -> { where(type: "Transfer::Project") }
 
   scope :ordered_by_completed_date, -> { completed.order(completed_at: :desc) }
-  scope :in_progress, -> { where(state: :active).assigned }
+  scope :in_progress, -> { active.assigned }
 
   scope :assigned, -> { where.not(assigned_to: nil) }
   scope :assigned_to_caseworker, ->(user) { where(assigned_to: user).or(where(caseworker: user)) }

--- a/app/models/statistics/project_statistics.rb
+++ b/app/models/statistics/project_statistics.rb
@@ -122,14 +122,17 @@ class Statistics::ProjectStatistics
     hash = {}
     (1..6).each do |i|
       date = Date.today + i.month
-      hash["#{date.month}/#{date.year}"] = {conversions: Conversion::Project.confirmed.filtered_by_significant_date(date.month, date.year).count, transfers: Transfer::Project.confirmed.filtered_by_significant_date(date.month, date.year).count}
+      hash["#{date.month}/#{date.year}"] = {
+        conversions: @conversion_projects.confirmed.filtered_by_significant_date(date.month, date.year).count,
+        transfers: @transfer_projects.confirmed.filtered_by_significant_date(date.month, date.year).count
+      }
     end
     hash
   end
 
   def new_projects_this_month
-    transfers_count = Transfer::Project.where("created_at >= ?", Time.now.beginning_of_month).where("created_at <= ?", Time.now.end_of_month).count
-    conversions_count = Conversion::Project.where("created_at >= ?", Time.now.beginning_of_month).where("created_at <= ?", Time.now.end_of_month).count
+    transfers_count = @transfer_projects.where("created_at >= ?", Time.now.beginning_of_month).where("created_at <= ?", Time.now.end_of_month).count
+    conversions_count = @conversion_projects.where("created_at >= ?", Time.now.beginning_of_month).where("created_at <= ?", Time.now.end_of_month).count
 
     OpenStruct.new(
       total: transfers_count + conversions_count,

--- a/app/models/statistics/project_statistics.rb
+++ b/app/models/statistics/project_statistics.rb
@@ -1,11 +1,11 @@
 class Statistics::ProjectStatistics
   def initialize
-    @projects = Conversion::Project.all
+    @conversion_projects = Conversion::Project.all
     @transfer_projects = Transfer::Project.all
   end
 
   def total_number_of_conversion_projects
-    @projects.count
+    @conversion_projects.count
   end
 
   def total_number_of_transfer_projects
@@ -13,7 +13,7 @@ class Statistics::ProjectStatistics
   end
 
   def total_number_of_in_progress_conversion_projects
-    @projects.in_progress.count
+    @conversion_projects.in_progress.count
   end
 
   def total_number_of_in_progress_transfer_projects
@@ -21,7 +21,7 @@ class Statistics::ProjectStatistics
   end
 
   def total_number_of_unassigned_conversion_projects
-    @projects.unassigned_to_user.count
+    @conversion_projects.unassigned_to_user.count
   end
 
   def total_number_of_unassigned_transfer_projects
@@ -29,7 +29,7 @@ class Statistics::ProjectStatistics
   end
 
   def total_number_of_completed_conversion_projects
-    @projects.completed.count
+    @conversion_projects.completed.count
   end
 
   def total_number_of_completed_transfer_projects
@@ -37,7 +37,7 @@ class Statistics::ProjectStatistics
   end
 
   def total_conversion_projects_with_regional_casework_services
-    @projects.assigned_to_regional_caseworker_team.count
+    @conversion_projects.assigned_to_regional_caseworker_team.count
   end
 
   def total_transfer_projects_with_regional_casework_services
@@ -45,7 +45,7 @@ class Statistics::ProjectStatistics
   end
 
   def in_progress_conversion_projects_with_regional_casework_services
-    @projects.assigned_to_regional_caseworker_team.in_progress.count
+    @conversion_projects.assigned_to_regional_caseworker_team.in_progress.count
   end
 
   def in_progress_transfer_projects_with_regional_casework_services
@@ -53,7 +53,7 @@ class Statistics::ProjectStatistics
   end
 
   def completed_conversion_projects_with_regional_casework_services
-    @projects.assigned_to_regional_caseworker_team.completed.count
+    @conversion_projects.assigned_to_regional_caseworker_team.completed.count
   end
 
   def completed_transfer_projects_with_regional_casework_services
@@ -61,7 +61,7 @@ class Statistics::ProjectStatistics
   end
 
   def unassigned_conversion_projects_with_regional_casework_services
-    @projects.assigned_to_regional_caseworker_team.unassigned_to_user.count
+    @conversion_projects.assigned_to_regional_caseworker_team.unassigned_to_user.count
   end
 
   def unassigned_transfer_projects_with_regional_casework_services
@@ -69,7 +69,7 @@ class Statistics::ProjectStatistics
   end
 
   def total_conversion_projects_not_with_regional_casework_services
-    @projects.not_assigned_to_regional_caseworker_team.count
+    @conversion_projects.not_assigned_to_regional_caseworker_team.count
   end
 
   def total_transfer_projects_not_with_regional_casework_services
@@ -77,7 +77,7 @@ class Statistics::ProjectStatistics
   end
 
   def in_progress_conversion_projects_not_with_regional_casework_services
-    @projects.not_assigned_to_regional_caseworker_team.in_progress.count
+    @conversion_projects.not_assigned_to_regional_caseworker_team.in_progress.count
   end
 
   def in_progress_transfer_projects_not_with_regional_casework_services
@@ -85,7 +85,7 @@ class Statistics::ProjectStatistics
   end
 
   def completed_conversion_projects_not_with_regional_casework_services
-    @projects.not_assigned_to_regional_caseworker_team.completed.count
+    @conversion_projects.not_assigned_to_regional_caseworker_team.completed.count
   end
 
   def completed_transfer_projects_not_with_regional_casework_services
@@ -93,7 +93,7 @@ class Statistics::ProjectStatistics
   end
 
   def unassigned_conversion_projects_not_with_regional_casework_services
-    @projects.not_assigned_to_regional_caseworker_team.unassigned_to_user.count
+    @conversion_projects.not_assigned_to_regional_caseworker_team.unassigned_to_user.count
   end
 
   def unassigned_transfer_projects_not_with_regional_casework_services
@@ -102,10 +102,10 @@ class Statistics::ProjectStatistics
 
   def conversion_project_statistics_for_region(region)
     OpenStruct.new(
-      total: @projects.by_region(region).count,
-      in_progress: @projects.by_region(region).in_progress.count,
-      completed: @projects.by_region(region).completed.count,
-      unassigned: @projects.by_region(region).unassigned_to_user.count
+      total: @conversion_projects.by_region(region).count,
+      in_progress: @conversion_projects.by_region(region).in_progress.count,
+      completed: @conversion_projects.by_region(region).completed.count,
+      unassigned: @conversion_projects.by_region(region).unassigned_to_user.count
     )
   end
 

--- a/app/models/statistics/project_statistics.rb
+++ b/app/models/statistics/project_statistics.rb
@@ -1,7 +1,7 @@
 class Statistics::ProjectStatistics
   def initialize
-    @conversion_projects = Conversion::Project.all
-    @transfer_projects = Transfer::Project.all
+    @conversion_projects = Conversion::Project.not_deleted
+    @transfer_projects = Transfer::Project.not_deleted
   end
 
   def total_number_of_conversion_projects

--- a/app/services/by_region_project_fetcher_service.rb
+++ b/app/services/by_region_project_fetcher_service.rb
@@ -10,7 +10,7 @@ class ByRegionProjectFetcherService
   end
 
   def regional_casework_services_projects(region)
-    Project.by_region(region).assigned_to_regional_caseworker_team.includes(:assigned_to).ordered_by_significant_date
+    Project.active.by_region(region).assigned_to_regional_caseworker_team.includes(:assigned_to).ordered_by_significant_date
   end
 
   private def projects_by_region

--- a/app/services/by_team_project_fetcher_service.rb
+++ b/app/services/by_team_project_fetcher_service.rb
@@ -43,9 +43,9 @@ class ByTeamProjectFetcherService
     return [] if @team.nil?
 
     projects = if @team.eql?("regional_casework_services")
-      Project.assigned_to_regional_caseworker_team.unassigned_to_user.ordered_by_significant_date
+      Project.active.assigned_to_regional_caseworker_team.unassigned_to_user.ordered_by_significant_date
     else
-      Project.by_region(@team).unassigned_to_user.ordered_by_significant_date
+      Project.active.by_region(@team).unassigned_to_user.ordered_by_significant_date
     end
 
     AcademiesApiPreFetcherService.new.call!(projects)

--- a/app/services/by_trust_project_fetcher_service.rb
+++ b/app/services/by_trust_project_fetcher_service.rb
@@ -12,7 +12,7 @@ class ByTrustProjectFetcherService
   end
 
   private def projects_by_trust
-    projects = Project.not_form_a_mat.not_completed
+    projects = Project.active.not_form_a_mat
     return false unless projects.any?
 
     projects.group_by(&:incoming_trust_ukprn)

--- a/app/services/by_user_project_fetcher_service.rb
+++ b/app/services/by_user_project_fetcher_service.rb
@@ -7,7 +7,7 @@ class ByUserProjectFetcherService
   end
 
   private def projects_by_user
-    projects = Project.assigned.not_completed
+    projects = Project.assigned.active
     return false unless projects.any?
 
     projects.group_by(&:assigned_to_id)

--- a/spec/forms/export/new_academies_due_to_transfer_form_spec.rb
+++ b/spec/forms/export/new_academies_due_to_transfer_form_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe Export::NewAcademiesDueToTransferForm, type: :model do
       to_date = Date.new(2024, 4, 1)
       form = described_class.new(from_date: from_date, to_date: to_date)
 
-      allow(Project).to receive(:transfers).and_call_original
+      allow(Project).to receive(:not_deleted).and_call_original
       allow(Project).to receive(:significant_date_in_range).and_call_original
 
       form.export
 
-      expect(Project).to have_received(:transfers)
+      expect(Project).to have_received(:not_deleted)
       expect(Project).to have_received(:significant_date_in_range).with(from_date.to_s, to_date.to_s)
     end
 
@@ -43,6 +43,33 @@ RSpec.describe Export::NewAcademiesDueToTransferForm, type: :model do
 
       expect(Export::Transfers::AcademiesDueToTransferCsvExportService).to have_received(:new).once
       expect(fake_csv_export_service).to have_received(:call).once
+    end
+
+    describe "includes the right projects" do
+      before do
+        mock_all_academies_api_responses
+      end
+
+      let(:from_date) { Date.new(2024, 1, 1) }
+      let(:to_date) { Date.new(2024, 4, 1) }
+
+      let!(:active_project) { create(:transfer_project, :active, transfer_date: Date.new(2024, 2, 1), urn: 111111) }
+      let!(:completed_project) { create(:transfer_project, :completed, transfer_date: Date.new(2024, 2, 1), urn: 222222) }
+      let!(:deleted_project) { create(:transfer_project, :deleted, transfer_date: Date.new(2024, 2, 1), urn: 333333) }
+
+      subject { described_class.new(from_date: from_date, to_date: to_date).export }
+
+      it "includes active projects" do
+        expect(subject).to include active_project.urn.to_s
+      end
+
+      it "includes completed projects" do
+        expect(subject).to include completed_project.urn.to_s
+      end
+
+      it "does not include deleted projects" do
+        expect(subject).not_to include deleted_project.urn.to_s
+      end
     end
   end
 end

--- a/spec/forms/export/new_pre_transfer_grants_form_spec.rb
+++ b/spec/forms/export/new_pre_transfer_grants_form_spec.rb
@@ -22,11 +22,13 @@ RSpec.describe Export::NewPreTransferGrantsForm, type: :model do
       to_date = Date.new(2024, 4, 1)
       form = described_class.new(from_date: from_date, to_date: to_date)
 
+      allow(Project).to receive(:not_deleted).and_call_original
       allow(Project).to receive(:transfers).and_call_original
       allow(Project).to receive(:advisory_board_date_in_range).and_call_original
 
       form.export
 
+      expect(Project).to have_received(:not_deleted)
       expect(Project).to have_received(:transfers)
       expect(Project).to have_received(:advisory_board_date_in_range).with(from_date.to_s, to_date.to_s)
     end
@@ -43,6 +45,33 @@ RSpec.describe Export::NewPreTransferGrantsForm, type: :model do
 
       expect(Export::Transfers::PreTransferGrantsCsvExportService).to have_received(:new).once
       expect(fake_csv_export_service).to have_received(:call).once
+    end
+
+    describe "includes the right projects" do
+      before do
+        mock_all_academies_api_responses
+      end
+
+      let(:from_date) { Date.new(2024, 1, 1) }
+      let(:to_date) { Date.new(2024, 4, 1) }
+
+      let!(:active_project) { create(:transfer_project, :active, advisory_board_date: Date.new(2024, 2, 1)) }
+      let!(:completed_project) { create(:transfer_project, :completed, advisory_board_date: Date.new(2024, 1, 1)) }
+      let!(:deleted_project) { create(:transfer_project, :deleted, advisory_board_date: Date.new(2024, 2, 1)) }
+
+      subject { described_class.new(from_date: from_date, to_date: to_date).export }
+
+      it "includes active projects" do
+        expect(subject).to include active_project.id.to_s
+      end
+
+      it "includes completed projects" do
+        expect(subject).to include completed_project.id.to_s
+      end
+
+      it "does not include deleted projects" do
+        expect(subject).not_to include deleted_project.id.to_s
+      end
     end
   end
 end

--- a/spec/forms/export/new_rpa_sug_and_fa_letters_form_spec.rb
+++ b/spec/forms/export/new_rpa_sug_and_fa_letters_form_spec.rb
@@ -22,15 +22,13 @@ RSpec.describe Export::NewRpaSugAndFaLettersForm, type: :model do
       to_date = Date.new(2024, 4, 1)
       form = described_class.new(from_date: from_date, to_date: to_date)
 
-      allow(Project).to receive(:active).and_call_original
-      allow(Project).to receive(:completed).and_call_original
+      allow(Project).to receive(:not_deleted).and_call_original
       allow(Project).to receive(:conversions).and_call_original
       allow(Project).to receive(:significant_date_in_range).and_call_original
 
       form.export
 
-      expect(Project).to have_received(:active)
-      expect(Project).to have_received(:completed)
+      expect(Project).to have_received(:not_deleted)
       expect(Project).to have_received(:conversions)
       expect(Project).to have_received(:significant_date_in_range).with(from_date.to_s, to_date.to_s)
     end
@@ -47,6 +45,38 @@ RSpec.describe Export::NewRpaSugAndFaLettersForm, type: :model do
 
       expect(Export::Conversions::RpaSugAndFaLettersCsvExportService).to have_received(:new).once
       expect(fake_csv_export_service).to have_received(:call).once
+    end
+
+    describe "includes the right projects" do
+      before do
+        mock_all_academies_api_responses
+      end
+
+      let(:from_date) { Date.new(2024, 1, 1) }
+      let(:to_date) { Date.new(2024, 4, 1) }
+
+      let!(:active_project) { create(:conversion_project, :active, conversion_date: Date.new(2024, 2, 1), urn: 111111) }
+      let!(:completed_project) { create(:conversion_project, :completed, conversion_date: Date.new(2024, 1, 1), urn: 222222) }
+      let!(:dao_revoked_project) { create(:conversion_project, :dao_revoked, conversion_date: Date.new(2024, 1, 1), urn: 333333) }
+      let!(:deleted_project) { create(:conversion_project, :deleted, conversion_date: Date.new(2024, 2, 1), urn: 444444) }
+
+      subject { described_class.new(from_date: from_date, to_date: to_date).export }
+
+      it "includes active projects" do
+        expect(subject).to include active_project.urn.to_s
+      end
+
+      it "includes completed projects" do
+        expect(subject).to include completed_project.urn.to_s
+      end
+
+      it "does not include DAO revoked projects" do
+        expect(subject).not_to include dao_revoked_project.urn.to_s
+      end
+
+      it "does not include deleted projects" do
+        expect(subject).not_to include deleted_project.urn.to_s
+      end
     end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -474,21 +474,6 @@ RSpec.describe Project, type: :model do
   end
 
   describe "Scopes" do
-    describe "default scope" do
-      before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
-
-      it "does not return deleted (state = 2) projects by default" do
-        in_progress_project = create(:conversion_project, state: 0)
-        completed_project = create(:conversion_project, completed_at: Date.today - 1.year, state: 1)
-        deleted_project = create(:conversion_project, state: 2)
-
-        projects = Project.all
-
-        expect(projects).to include(in_progress_project, completed_project)
-        expect(projects).to_not include(deleted_project)
-      end
-    end
-
     describe "conversions" do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 

--- a/spec/services/by_region_project_fetcher_service_spec.rb
+++ b/spec/services/by_region_project_fetcher_service_spec.rb
@@ -54,5 +54,14 @@ RSpec.describe ByRegionProjectFetcherService do
 
       expect(described_class.new.regional_casework_services_projects(user.team)).to match_array []
     end
+
+    it "does not include completed, deleted or dao_revoked projects" do
+      user = create(:user, team: "london")
+      _completed_project = create(:conversion_project, :completed, region: "london", team: "regional_casework_services")
+      _deleted_project = create(:conversion_project, :deleted, region: "north_west", team: "regional_casework_services")
+      _dao_revoked_project = create(:conversion_project, :dao_revoked, region: "north_west", team: "regional_casework_services")
+
+      expect(described_class.new.regional_casework_services_projects(user.team)).to match_array []
+    end
   end
 end

--- a/spec/services/by_team_project_fetcher_service_spec.rb
+++ b/spec/services/by_team_project_fetcher_service_spec.rb
@@ -153,6 +153,16 @@ RSpec.describe ByTeamProjectFetcherService do
         result = described_class.new(user.team).unassigned
         expect(result).to include(conversion_project_rcs, conversion_project_london, transfer_project_rcs, transfer_project_london)
       end
+
+      it "does not include completed, deleted or DAO revoked projects" do
+        user = build(:user, team: "regional_casework_services")
+        completed_project = create(:conversion_project, :completed, team: "regional_casework_services", assigned_to: nil)
+        deleted_project = create(:conversion_project, :deleted, team: "regional_casework_services", assigned_to: nil)
+        dao_revoked_project = create(:conversion_project, :dao_revoked, team: "regional_casework_services", assigned_to: nil)
+
+        result = described_class.new(user.team).unassigned
+        expect(result).not_to include(completed_project, deleted_project, dao_revoked_project)
+      end
     end
 
     context "when the user's team is a region" do

--- a/spec/services/by_trust_project_fetcher_service_spec.rb
+++ b/spec/services/by_trust_project_fetcher_service_spec.rb
@@ -61,4 +61,28 @@ RSpec.describe ByTrustProjectFetcherService do
   it "returns an empty array when there are no projects to source trusts" do
     expect(described_class.new.call).to eql []
   end
+
+  it "returns the expected count of active conversion projects" do
+    mock_all_academies_api_responses
+    create(:conversion_project, :active)
+    create(:conversion_project, :deleted)
+    create(:conversion_project, :completed)
+    create(:conversion_project, :dao_revoked)
+
+    result = described_class.new.call.first
+
+    expect(result.conversion_count).to be 1
+  end
+
+  it "returns the expected count of active transfer projects" do
+    mock_all_academies_api_responses
+    create(:transfer_project, :active)
+    create(:transfer_project, :deleted)
+    create(:transfer_project, :completed)
+    create(:transfer_project, :dao_revoked)
+
+    result = described_class.new.call.first
+
+    expect(result.transfer_count).to be 1
+  end
 end

--- a/spec/services/by_user_project_fetcher_service_spec.rb
+++ b/spec/services/by_user_project_fetcher_service_spec.rb
@@ -38,4 +38,42 @@ RSpec.describe ByUserProjectFetcherService do
   it "returns an empty array when there are no projects to source trusts" do
     expect(described_class.new.call).to eql []
   end
+
+  it "returns the expected count of active conversion projects" do
+    mock_all_academies_api_responses
+    user = create(:user)
+    _deleted_project = create(:conversion_project, :deleted, assigned_to: user)
+    _completed_project = create(:conversion_project, :completed, assigned_to: user)
+    _dao_revoked_project = create(:conversion_project, :dao_revoked, assigned_to: user)
+
+    result = described_class.new.call
+
+    expect(result).to be_empty
+
+    _active_project = create(:conversion_project, :active, assigned_to: user)
+
+    result = described_class.new.call
+
+    expect(result).not_to be_empty
+    expect(result.first.conversion_count).to be 1
+  end
+
+  it "returns the expected count of active transfer projects" do
+    mock_all_academies_api_responses
+    user = create(:user)
+    _deleted_project = create(:transfer_project, :deleted, assigned_to: user)
+    _completed_project = create(:transfer_project, :completed, assigned_to: user)
+    _dao_revoked_project = create(:transfer_project, :dao_revoked, assigned_to: user)
+
+    result = described_class.new.call
+
+    expect(result).to be_empty
+
+    _active_project = create(:transfer_project, :active, assigned_to: user)
+
+    result = described_class.new.call
+
+    expect(result).not_to be_empty
+    expect(result.first.transfer_count).to be 1
+  end
 end


### PR DESCRIPTION
We introduced a default scope to exclude deleted projects everywhere. This
became a problem with the `project` association on Note (don't use default
scopes for anything other than ordering?!?!)

This work removes the default scope and takes the steps to ensure that the
application continues to work as expected.

We rely on the `state` enum and the `in_progress` scope, which uses the `active`
state internally.

In summary we have a state machine, where projects are:

- active
- in progress (assigned to a user)
- completed *
- deleted * 
- DAO revoked *

* all of these result in the project essentially being over
