### PR TITLE
Add a count of DAO revoked projects to statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - details component and content to explain when to use a deed of termination to
   end a master funding agreement in a transfer project
+- a count of the number of DAO conversion projects has been added to the
+  statistics page.
 
 ### Changed
 

--- a/app/models/statistics/project_statistics.rb
+++ b/app/models/statistics/project_statistics.rb
@@ -36,6 +36,10 @@ class Statistics::ProjectStatistics
     @transfer_projects.completed.count
   end
 
+  def total_number_of_dao_revoked_conversion_projects
+    @projects.dao_revoked.count
+  end
+
   def total_conversion_projects_with_regional_casework_services
     @projects.assigned_to_regional_caseworker_team.count
   end

--- a/app/views/all/statistics/statistics/index.html.erb
+++ b/app/views/all/statistics/statistics/index.html.erb
@@ -58,6 +58,11 @@
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_number_of_unassigned_conversion_projects %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_number_of_unassigned_transfer_projects %></td>
           </tr>
+          <tr class="govuk-table__row" id="dao_revoked">
+            <th scope="row" class="govuk-table__cell">DAO revoked projects</th>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_number_of_dao_revoked_conversion_projects %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric">NA</td>
+          </tr>
           <tr class="govuk-table__row" id="all_projects">
             <th scope="row" class="govuk-table__cell">All projects</th>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= @project_statistics.total_number_of_conversion_projects %></td>

--- a/spec/models/statistics/project_statistics_spec.rb
+++ b/spec/models/statistics/project_statistics_spec.rb
@@ -62,6 +62,13 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
       end
     end
 
+    describe "#total_number_of_dao_revoked_conversion_projects" do
+      it "returns the total number of all dao revoked conversion projects" do
+        create(:conversion_project, :dao_revoked)
+        expect(subject.total_number_of_dao_revoked_conversion_projects).to eql(1)
+      end
+    end
+
     context "when there are deleted projects" do
       before do
         create(:transfer_project, :deleted)


### PR DESCRIPTION
This work adds the number of DAO conversion projects to the statistics page.

Transfers cannot be issued a DAO so can never have one revoked.
