### PR TITLE
Release 80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release-80][release-80]
+
 ### Added
 
 - details component and content to explain when to use a deed of termination to
@@ -2075,7 +2077,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-79...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-80...HEAD
+[release-80]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-79...release-80
 [release-79]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-78...release-79
 [release-78]:


### PR DESCRIPTION
Added

- details component and content to explain when to use a deed of termination to end a master funding agreement in a transfer project
- a count of the number of DAO conversion projects has been added to the statistics page.

Changed

- If a project is not assigned to RCS on creation, the assigned user can edit the project in the usual way and assign it to RCS, along with adding a handover note
- Use of ADOP change to AOPU
- Corrected references in content to the grant payment certificate in conversions to declaration of expenditure certificate
- To complete a transfer project users will have to ensure that the following:
  - The transfer date has been confirmed and is in the past
  - The confirm this transfer has authority to proceed task is completed
  - The receive declaration of expenditure certificate task is completed
  - The confirm the date the academy transferred task is completed
- Update the feedback form link in the footer

