### PR TITLE
Remove extra horizontal line in footer

### DIFF
--- a/app/views/shared/_dfe_footer.html.erb
+++ b/app/views/shared/_dfe_footer.html.erb
@@ -34,7 +34,6 @@
         </ul>
       </div>
     </div>
-    <hr class="govuk-footer__section-break">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow dfe-footer__meta-item--grow">
         <h2 class="govuk-visually-hidden">Support links</h2>


### PR DESCRIPTION
This is in line with the [RSD footer design pattern](https://design-system-rsd-c10b0db1a3a1.herokuapp.com/design-system/rsd-design-system/design-patterns/footer).


