### PR TITLE
Articles of association content changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - content changes to articles of association task in conversions and transfers
   to describe the process more accurately
+- addition of 1 checkbox to articles tasks in conversions and transfers
 
 ## [Release-80][release-80]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The "project main contact" (selected via a task) is output to the RPA/SUG
   export
 
+### Changed
+
+- content changes to articles of association task in conversions and transfers
+  to describe the process more accurately
+
 ## [Release-80][release-80]
 
 ### Added

--- a/app/forms/conversion/task/articles_of_association_task_form.rb
+++ b/app/forms/conversion/task/articles_of_association_task_form.rb
@@ -3,4 +3,5 @@ class Conversion::Task::ArticlesOfAssociationTaskForm < ::BaseOptionalTaskForm
   attribute :cleared, :boolean
   attribute :signed, :boolean
   attribute :saved, :boolean
+  attribute :sent, :boolean
 end

--- a/app/forms/transfer/task/articles_of_association_task_form.rb
+++ b/app/forms/transfer/task/articles_of_association_task_form.rb
@@ -3,4 +3,5 @@ class Transfer::Task::ArticlesOfAssociationTaskForm < BaseOptionalTaskForm
   attribute :cleared, :boolean
   attribute :signed, :boolean
   attribute :saved, :boolean
+  attribute :sent, :boolean
 end

--- a/app/views/conversions/tasks/articles_of_association/edit.html.erb
+++ b/app/views/conversions/tasks/articles_of_association/edit.html.erb
@@ -30,6 +30,7 @@
 
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :received)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :cleared)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :sent)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
       </div>

--- a/app/views/transfers/tasks/articles_of_association/edit.html.erb
+++ b/app/views/transfers/tasks/articles_of_association/edit.html.erb
@@ -30,6 +30,7 @@
 
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :received)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :cleared)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :sent)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
       </div>

--- a/config/locales/conversion/tasks/articles_of_association.en.yml
+++ b/config/locales/conversion/tasks/articles_of_association.en.yml
@@ -30,6 +30,8 @@ en:
           title: Received
         cleared:
           title: Cleared
+        sent:
+          title: Sent cleared version to trust's solicitors
         signed:
           title: Checked with solicitors that incoming trust have signed the articles
           hint:

--- a/config/locales/conversion/tasks/articles_of_association.en.yml
+++ b/config/locales/conversion/tasks/articles_of_association.en.yml
@@ -4,7 +4,18 @@ en:
       articles_of_association:
         title: Articles of association
         hint:
-          html: <p>The articles of association must be updated if the trust currently uses a version from February 2016 or earlier.</p>
+          html:
+            <p>You must update the articles of association if any of the following statements are true:</p>
+            <ul>
+            <li>the trust currently uses a version from February 2016 or earlier</li>
+            <li>a different type of academy is joining the trust. For example, a faith school joining a trust containing only community academies</li>
+            <li>it is a condition of the advisory board's decision</li>
+            </ul>
+            <p>You do not always need to update the articles but it is strongly advised, even when not required.</p>
+        guidance_link: Partially updating articles of association
+        guidance:
+          html: <p>Trusts do not have to adopt the latest version of the articles entirely. Although this is DfE's preferred option.</p>
+                <p>They can choose to just add the missing clauses in their existing articles.</p>
         clear_section:
           title: Check and clear the articles of association
           hint:
@@ -20,8 +31,10 @@ en:
         cleared:
           title: Cleared
         signed:
-          title: Signed by school or trust
+          title: Checked with solicitors that incoming trust have signed the articles
+          hint:
+            html: <p>It can be helpful to check the <a href="https://find-and-update.company-information.service.gov.uk/" target="_blank">Companies House website (opens in a new tab)</a> to make sure the signed articles have been uploaded</p>
         saved:
-          title: Saved in the school's SharePoint folder
+          title: Saved copy of articles in the school and trust's SharePoint folders
         not_applicable:
           title: Not applicable

--- a/config/locales/transfer/tasks/articles_of_association.en.yml
+++ b/config/locales/transfer/tasks/articles_of_association.en.yml
@@ -8,10 +8,14 @@ en:
             <p>You must update the articles of association if any of the following statements are true:</p>
             <ul>
             <li>the trust currently uses a version from February 2016 or earlier</li>
-            <li>a different type of academy is joining the trust (for example, a Church of England academy joining a trust containing only community academies)</li>
+            <li>a different type of academy is joining the trust. For example, a faith academy joining a trust containing only community academies</li>
             <li>it is a condition of the advisory board's decision</li>
             </ul>
             <p>You do not always need to update the articles but it is strongly advised, even when not required.</p>
+        guidance_link: Partially updating articles of association
+        guidance:
+          html: <p>Trusts do not have to adopt the latest version of the articles entirely. Although this is DfE's preferred option.</p>
+                <p>They can choose to just add the missing clauses in their existing articles.</p>
         clear_section:
           title: Check and clear the articles of association
           hint:
@@ -27,8 +31,10 @@ en:
         cleared:
           title: Cleared
         signed:
-          title: Signed by academy or incoming trust
+          title: Checked with solicitors that incoming trust have signed the articles
+          hint:
+            html: <p>It can be helpful to check the <a href="https://find-and-update.company-information.service.gov.uk/" target="_blank">Companies House website (opens in a new tab)</a> to make sure the signed articles have been uploaded</p>
         saved:
-          title: Saved in the academy SharePoint folder
+          title: Saved copy of articles in the school and trust's SharePoint folders
         not_applicable:
           title: Not applicable

--- a/config/locales/transfer/tasks/articles_of_association.en.yml
+++ b/config/locales/transfer/tasks/articles_of_association.en.yml
@@ -30,6 +30,8 @@ en:
           title: Received
         cleared:
           title: Cleared
+        sent:
+          title: Sent cleared version to trust's solicitors
         signed:
           title: Checked with solicitors that incoming trust have signed the articles
           hint:

--- a/db/migrate/20240725110919_add_sent_field_to_articles_of_association_task.rb
+++ b/db/migrate/20240725110919_add_sent_field_to_articles_of_association_task.rb
@@ -1,0 +1,6 @@
+class AddSentFieldToArticlesOfAssociationTask < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversion_tasks_data, :articles_of_association_sent, :boolean
+    add_column :transfer_tasks_data, :articles_of_association_sent, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_15_115518) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_25_110919) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -157,6 +157,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_15_115518) do
     t.boolean "receive_grant_payment_certificate_check_certificate"
     t.date "confirm_date_academy_opened_date_opened"
     t.string "risk_protection_arrangement_reason"
+    t.boolean "articles_of_association_sent"
   end
 
   create_table "dao_revocation_reasons", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
@@ -444,6 +445,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_15_115518) do
     t.boolean "conditions_met_check_any_information_changed"
     t.boolean "conditions_met_baseline_sheet_approved"
     t.boolean "form_m_not_applicable"
+    t.boolean "articles_of_association_sent"
   end
 
   create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/forms/conversion/tasks/articles_of_association_task_form_spec.rb
+++ b/spec/forms/conversion/tasks/articles_of_association_task_form_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe Conversion::Task::ArticlesOfAssociationTaskForm do
         task_form.saved = true
         task_form.cleared = true
         task_form.signed = true
+        task_form.sent = true
 
         expect(task_form.status).to eql :completed
       end


### PR DESCRIPTION
## Changes

Add a new "sent" field to the Articles of Association tasks for both Conversions and Transfers. Amend the content to reflect the process more accurately.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
