### PR TITLE
Add "project main contact" details to RPA/SUG report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- The "project main contact" (selected via a task) is output to the RPA/SUG
+  export
+
 ## [Release-80][release-80]
 
 ### Added

--- a/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
+++ b/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
@@ -42,6 +42,9 @@ class Export::Conversions::RpaSugAndFaLettersCsvExportService < Export::CsvExpor
     incoming_trust_main_contact_name
     incoming_trust_main_contact_role
     incoming_trust_main_contact_email
+    main_contact_name
+    main_contact_title
+    main_contact_email
     director_of_child_services_name
     director_of_child_services_role
     director_of_child_services_email

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -79,9 +79,9 @@ en:
           mp_address_2: MP address 2
           mp_address_3: MP address 3
           mp_address_postcode: MP postcode
-          main_contact_name: Main contact name
-          main_contact_email: Main contact email
-          main_contact_title: Main contact role
+          main_contact_name: Project main contact name
+          main_contact_email: Project main contact email
+          main_contact_title: Project main contact role
           link_to_project: Link to project
           region: Region
           outgoing_trust_name: Outgoing trust name


### PR DESCRIPTION
A user reported that they were adding a contact as the "Project main contact" but that contact was not being output to the RPA/SUG report. Despite the "select the main contact for a project" task
indicating that "this person will receive funding letters", the main contact for a project was not actually being included in the report.

As a temporary fix, add this contact into the RPA/SUG report. Also update the column name to make it (hopefully) more obvious this is the *Project* main contact. 

When we rework the contacts pages, this commit will become redundant, as users will be able to choose the contacts output to the RPA/SUG report.

