### PR TITLE
(174872) include form a mat in by trust view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - content changes to articles of association task in conversions and transfers
   to describe the process more accurately
 - addition of 1 checkbox to articles tasks in conversions and transfers
+- the all project by trust view now includes 'form a multi academy trusts'
 
 ## [Release-80][release-80]
 

--- a/app/controllers/all/trusts/projects_controller.rb
+++ b/app/controllers/all/trusts/projects_controller.rb
@@ -11,12 +11,40 @@ class All::Trusts::ProjectsController < ApplicationController
     authorize Project, :index?
 
     @trust = Api::AcademiesApi::Client.new.get_trust(incoming_trust_ukprn).object
-    @pager, @projects = pagy(Project.active.by_trust_ukprn(@trust.ukprn).ordered_by_significant_date.includes(:assigned_to))
+    @pager, @projects = pagy(
+      Project.active.by_trust_ukprn(@trust.ukprn).ordered_by_significant_date.includes(:assigned_to)
+    )
 
     AcademiesApiPreFetcherService.new.call!(@projects)
   end
 
+  def show_by_reference
+    authorize Project, :index?
+
+    @trust = build_trust_from_reference_number(trust_reference_number)
+    @pager, @projects = pagy(
+      Project.active.where(
+        new_trust_reference_number: trust_reference_number
+      ).ordered_by_significant_date.includes(:assigned_to)
+    )
+
+    AcademiesApiPreFetcherService.new.call!(@projects)
+    render "show"
+  end
+
   private def incoming_trust_ukprn
     params[:trust_ukprn]
+  end
+
+  private def trust_reference_number
+    params[:trust_reference_number]
+  end
+
+  private def build_trust_from_reference_number(reference)
+    project = Project.find_by_new_trust_reference_number!(reference)
+
+    Api::AcademiesApi::Trust.new.from_hash(
+      {referenceNumber: project.new_trust_reference_number, name: project.new_trust_name}
+    )
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -71,6 +71,7 @@ class Project < ApplicationRecord
   }
 
   scope :not_form_a_mat, -> { where.not(incoming_trust_ukprn: nil) }
+  scope :form_a_mat, -> { where(incoming_trust_ukprn: nil) }
 
   enum :region, {
     london: "H",

--- a/app/services/by_trust_project_fetcher_service.rb
+++ b/app/services/by_trust_project_fetcher_service.rb
@@ -26,10 +26,6 @@ class ByTrustProjectFetcherService
     @trusts + @form_a_mat_trusts
   end
 
-  private def all_projects_grouped_by_identifier
-    @all_projects_grouped_by_ukprn.merge(@all_projects_grouped_by_trust_reference_number)
-  end
-
   private def projects_grouped_by_ukprn
     Project.active.not_form_a_mat.group_by(&:incoming_trust_ukprn)
   end

--- a/app/services/by_trust_project_fetcher_service.rb
+++ b/app/services/by_trust_project_fetcher_service.rb
@@ -1,21 +1,41 @@
 class ByTrustProjectFetcherService
-  def call
-    projects = projects_by_trust
+  def initialize
+    @all_projects_grouped_by_ukprn = []
+    @all_projects_grouped_by_trust_reference_number = []
 
-    if projects
-      trusts = get_trusts(projects.keys)
-
-      sort_trust_objects_by_name(build_trust_objects(trusts, projects))
-    else
-      []
-    end
+    @trusts = []
+    @form_a_mat_trusts = []
   end
 
-  private def projects_by_trust
-    projects = Project.active.not_form_a_mat
-    return false unless projects.any?
+  def call
+    @all_projects_grouped_by_ukprn = projects_grouped_by_ukprn
+    @all_projects_grouped_by_trust_reference_number = projects_grouped_by_trust_reference_number
 
-    projects.group_by(&:incoming_trust_ukprn)
+    if @all_projects_grouped_by_ukprn.any?
+      @trusts = get_trusts(@all_projects_grouped_by_ukprn.keys)
+    end
+
+    if @all_projects_grouped_by_trust_reference_number.any?
+      @form_a_mat_trusts = build_form_a_mat_trusts
+    end
+
+    sort_trust_objects_by_name(build_trust_objects)
+  end
+
+  private def all_trusts
+    @trusts + @form_a_mat_trusts
+  end
+
+  private def all_projects_grouped_by_identifier
+    @all_projects_grouped_by_ukprn.merge(@all_projects_grouped_by_trust_reference_number)
+  end
+
+  private def projects_grouped_by_ukprn
+    Project.active.not_form_a_mat.group_by(&:incoming_trust_ukprn)
+  end
+
+  private def projects_grouped_by_trust_reference_number
+    Project.active.form_a_mat.group_by(&:new_trust_reference_number)
   end
 
   private def get_trusts(ukprns)
@@ -23,16 +43,28 @@ class ByTrustProjectFetcherService
     client.get_trusts(ukprns).object
   end
 
-  private def build_trust_objects(trusts, projects)
-    return [] unless trusts.present? && projects
+  private def build_form_a_mat_trusts
+    the_projects = Project.active.where(incoming_trust_ukprn: nil).pluck(:new_trust_reference_number, :new_trust_name).to_h
 
-    trusts.map do |trust|
+    the_projects.map do |project|
+      Api::AcademiesApi::Trust.new.from_hash({referenceNumber: project.first, name: project.last})
+    end
+  end
+
+  private def build_trust_objects
+    all_trusts.map do |trust|
+      trust_projects = if trust.ukprn.present?
+        @all_projects_grouped_by_ukprn.fetch(trust.ukprn.to_i)
+      else
+        @all_projects_grouped_by_trust_reference_number.fetch(trust.group_identifier)
+      end
+
       OpenStruct.new(
         name: trust.name,
         ukprn: trust.ukprn,
         group_id: trust.group_identifier,
-        conversion_count: projects.fetch(trust.ukprn.to_i).count { |p| p.type == "Conversion::Project" },
-        transfer_count: projects.fetch(trust.ukprn.to_i).count { |p| p.type == "Transfer::Project" }
+        conversion_count: trust_projects.count { |p| p.type == "Conversion::Project" },
+        transfer_count: trust_projects.count { |p| p.type == "Transfer::Project" }
       )
     end
   end

--- a/app/views/all/trusts/projects/_trust_table.html.erb
+++ b/app/views/all/trusts/projects/_trust_table.html.erb
@@ -15,7 +15,11 @@
     <% trusts.each do |trust| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__header govuk-table__cell">
-          <%= link_to trust.name, by_trust_all_trusts_projects_path(trust.ukprn), class: "govuk-link govuk-link--no-visited-state" %>
+          <% if trust.ukprn.present? %>
+            <%= link_to trust.name, by_trust_ukprn_all_trusts_projects_path(trust.ukprn), class: "govuk-link govuk-link--no-visited-state" %>
+          <% else %>
+            <%= link_to trust.name, by_trust_reference_all_trusts_projects_path(trust.group_id), class: "govuk-link govuk-link--no-visited-state" %>
+          <% end %>
         </td>
         <td class="govuk-table__cell"><%= trust.group_id %></td>
         <td class="govuk-table__cell"><%= trust.conversion_count %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,7 +176,8 @@ Rails.application.routes.draw do
           end
           namespace :trusts do
             get "/", to: "projects#index"
-            get ":trust_ukprn", to: "projects#show", as: :by_trust
+            get "/ukprn/:trust_ukprn", to: "projects#show", as: :by_trust_ukprn
+            get "/reference/:trust_reference_number", to: "projects#show_by_reference", as: :by_trust_reference
           end
           namespace :local_authorities, path: "local-authorities" do
             get "/", to: "projects#index"

--- a/spec/factories/academies_api/trust.rb
+++ b/spec/factories/academies_api/trust.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :academies_api_trust, class: "Api::AcademiesApi::Trust" do
     ukprn { "10061021" }
+    group_identifier { "TR100610" }
     original_name { "THE ROMERO CATHOLIC ACADEMY" }
     companies_house_number { "09702162" }
     address_street { "The Street" }

--- a/spec/features/projects/trusts/users_can_view_a_list_of_projects_for_a_given_from_a_mat_trust_spec.rb
+++ b/spec/features/projects/trusts/users_can_view_a_list_of_projects_for_a_given_from_a_mat_trust_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.feature "Users can view a list of projects for a given form a MAT trust" do
+  before do
+    sign_in_with_user(user)
+  end
+
+  let(:user) { create(:user, email: "user@education.gov.uk") }
+
+  context "when a trust has no projects i.e. the trust does not exist!" do
+    scenario "it returns not found" do
+      visit by_trust_reference_all_trusts_projects_path("TR12345")
+
+      expect(page).to have_http_status :not_found
+    end
+  end
+
+  context "when a trust has a project" do
+    scenario "they see the project listed" do
+      mock_all_academies_api_responses
+      project = create(
+        :conversion_project,
+        new_trust_name: "THE BIG TRUST",
+        new_trust_reference_number: "TR12345",
+        incoming_trust_ukprn: nil
+      )
+
+      visit by_trust_reference_all_trusts_projects_path("TR12345")
+
+      expect(page).to have_content("Projects for The Big Trust")
+      expect(page).to have_content(project.establishment.name)
+    end
+  end
+end

--- a/spec/features/projects/trusts/users_can_view_a_list_of_projects_for_a_given_trust_spec.rb
+++ b/spec/features/projects/trusts/users_can_view_a_list_of_projects_for_a_given_trust_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Users can view a list of projects for a given trust" do
 
   context "when a trust has no projects" do
     scenario "they see an empty message" do
-      visit by_trust_all_trusts_projects_path(10010010)
+      visit by_trust_ukprn_all_trusts_projects_path(10010010)
 
       expect(page).to have_content("Projects for Trust Name")
       expect(page).to have_content("There are no projects for Trust Name")
@@ -22,7 +22,7 @@ RSpec.feature "Users can view a list of projects for a given trust" do
       project = create(:conversion_project, incoming_trust_ukprn: 10010010, urn: 123456)
       completed_project = create(:conversion_project, :completed, completed_at: Date.today, incoming_trust_ukprn: 10010010, urn: 165432)
 
-      visit by_trust_all_trusts_projects_path(10010010)
+      visit by_trust_ukprn_all_trusts_projects_path(10010010)
 
       expect(page).to have_content("Projects for Trust Name")
       expect(page).to have_content(project.urn)
@@ -34,7 +34,7 @@ RSpec.feature "Users can view a list of projects for a given trust" do
     scenario "they see the project listed" do
       project = create(:conversion_project, incoming_trust_ukprn: 10010010, urn: 123456, assigned_to: nil)
 
-      visit by_trust_all_trusts_projects_path(10010010)
+      visit by_trust_ukprn_all_trusts_projects_path(10010010)
 
       expect(page).to have_content("Projects for Trust Name")
       expect(page).to have_content(project.urn)

--- a/spec/features/projects/trusts/users_can_view_projects_by_trust_spec.rb
+++ b/spec/features/projects/trusts/users_can_view_projects_by_trust_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.feature "Users can view a list trusts" do
   before do
     sign_in_with_user(user)
-    mock_academies_api_client_get_establishments_and_trusts
   end
 
   let(:user) { create(:user, email: "user@education.gov.uk") }
@@ -18,45 +17,37 @@ RSpec.feature "Users can view a list trusts" do
 
   context "when there are projects to fetch trusts for" do
     scenario "they see the trust listed and a link" do
-      project = create(:conversion_project, incoming_trust_ukprn: 10010010)
+      mock_all_academies_api_responses
+      create(:conversion_project, incoming_trust_ukprn: 10061021)
+      create(:conversion_project, incoming_trust_ukprn: nil, new_trust_reference_number: "TR12345", new_trust_name: "BIG NEW TRUST")
 
       visit all_trusts_projects_path
 
       within("tbody > tr:first-child") do
-        expect(page).to have_content("Trust Name")
-        expect(page).to have_content("TR100100")
+        expect(page).to have_content("Big New Trust")
+        expect(page).to have_content("TR12345")
         expect(page).to have_content("1")
-        expect(page).to have_link(project.incoming_trust.name, href: by_trust_all_trusts_projects_path(10010010))
+        expect(page).to have_link("Big New Trust", href: by_trust_reference_all_trusts_projects_path("TR12345"))
+      end
+
+      within("tbody > tr:last-child") do
+        expect(page).to have_content("The Romero Catholic Academy")
+        expect(page).to have_content("TR100610")
+        expect(page).to have_content("1")
+        expect(page).to have_link("The Romero Catholic Academy", href: by_trust_ukprn_all_trusts_projects_path(10061021))
       end
     end
 
     scenario "when there are enough projects to page they see a pager" do
-      mock_academies_api_client_get_establishments_and_trusts
+      mock_all_academies_api_responses
 
       21.times do
-        create(:conversion_project, incoming_trust_ukprn: 10010010)
+        create(:conversion_project, incoming_trust_ukprn: 10061021)
       end
 
-      visit by_trust_all_trusts_projects_path(10010010)
+      visit by_trust_ukprn_all_trusts_projects_path(10061021)
 
       expect(page).to have_css(".govuk-pagination")
     end
-  end
-
-  def mock_academies_api_client_get_establishments_and_trusts
-    api_client = Api::AcademiesApi::Client.new
-
-    establishment = double("Establishment", name: "Establishment Name", urn: "123456")
-    trust = double("Trust", name: "Trust Name", ukprn: "10010010", group_identifier: "TR100100")
-
-    allow(Api::AcademiesApi::Client).to receive(:new).and_return(api_client)
-
-    allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new([establishment], nil))
-    allow(api_client).to receive(:get_trusts).and_return(Api::AcademiesApi::Client::Result.new([trust], nil))
-
-    allow(api_client).to receive(:get_trust).and_return(Api::AcademiesApi::Client::Result.new(trust, nil))
-    allow(api_client).to receive(:get_establishment).and_return(Api::AcademiesApi::Client::Result.new(establishment, nil))
-
-    api_client
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -770,6 +770,18 @@ RSpec.describe Project, type: :model do
         expect(Project.not_form_a_mat).to include(single_converter_project)
       end
     end
+
+    describe "form_a_mat scope" do
+      it "returns only form a MAT projects" do
+        mock_successful_api_responses(urn: any_args, ukprn: any_args)
+
+        form_a_mat_project = create(:conversion_project, :form_a_mat)
+        single_converter_project = create(:conversion_project)
+
+        expect(Project.form_a_mat).to include(form_a_mat_project)
+        expect(Project.form_a_mat).not_to include(single_converter_project)
+      end
+    end
   end
 
   describe "region" do

--- a/spec/services/by_trust_project_fetcher_service_spec.rb
+++ b/spec/services/by_trust_project_fetcher_service_spec.rb
@@ -85,4 +85,32 @@ RSpec.describe ByTrustProjectFetcherService do
 
     expect(result.transfer_count).to be 1
   end
+
+  describe "form a multi academy trust projects" do
+    it "includes a form a MAT trust with the correct counts and details" do
+      mock_successful_api_establishment_response(urn: 123456)
+
+      create(:transfer_project, :active, incoming_trust_ukprn: nil, new_trust_reference_number: "TR12345", new_trust_name: "BRAND NEW TRUST")
+      create(:conversion_project, :active, incoming_trust_ukprn: nil, new_trust_reference_number: "TR12345", new_trust_name: "BRAND NEW TRUST")
+      create(:conversion_project, :active, incoming_trust_ukprn: nil, new_trust_reference_number: "TR54321", new_trust_name: "A DIFFERENT BRAND NEW TRUST")
+
+      result = described_class.new.call
+
+      expect(result.count).to be 2
+
+      brand_new_trust = result.last
+      a_different_brand_new_trust = result.first
+
+      expect(a_different_brand_new_trust.name).to eql "A Different Brand New Trust"
+      expect(a_different_brand_new_trust.group_id).to eql "TR54321"
+      expect(a_different_brand_new_trust.conversion_count).to be 1
+      expect(a_different_brand_new_trust.transfer_count).to be 0
+
+
+      expect(brand_new_trust.name).to eql "Brand New Trust"
+      expect(brand_new_trust.group_id).to eql "TR12345"
+      expect(brand_new_trust.conversion_count).to be 1
+      expect(brand_new_trust.transfer_count).to be 1
+    end
+  end
 end

--- a/spec/services/by_trust_project_fetcher_service_spec.rb
+++ b/spec/services/by_trust_project_fetcher_service_spec.rb
@@ -106,7 +106,6 @@ RSpec.describe ByTrustProjectFetcherService do
       expect(a_different_brand_new_trust.conversion_count).to be 1
       expect(a_different_brand_new_trust.transfer_count).to be 0
 
-
       expect(brand_new_trust.name).to eql "Brand New Trust"
       expect(brand_new_trust.group_id).to eql "TR12345"
       expect(brand_new_trust.conversion_count).to be 1


### PR DESCRIPTION
Users want to see both 'regular' trusts and 'form a multi academy' trusts in the all projects by trust view.

This is a little messy because we do not model the form a MAT trust, it is simply an attribute of a `Project`.

We did not want to change this by adding a model at this point, so we work around it. Full details are in the commit, but in summary we treat each type differently and combine them before sorting, this requires adding more code to handle this in actions, routes and views.
