### PR TITLE
(175111) Add ProjectGroup model

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -22,6 +22,8 @@ class Project < ApplicationRecord
   belongs_to :outgoing_trust_main_contact, inverse_of: :main_contact_for_outgoing_trust, dependent: :destroy, class_name: "Contact::Project", optional: true
   belongs_to :local_authority_main_contact, inverse_of: :main_contact_for_local_authority, dependent: :destroy, class_name: "Contact::Project", optional: true
 
+  belongs_to :group, inverse_of: :projects, class_name: "ProjectGroup", optional: true
+
   validates :urn, presence: true
   validates :urn, urn: true
   validates :incoming_trust_ukprn, presence: true, unless: -> { new_trust_reference_number.present? }

--- a/app/models/project_group.rb
+++ b/app/models/project_group.rb
@@ -1,0 +1,3 @@
+class ProjectGroup < ApplicationRecord
+  has_many :projects, foreign_key: :group_id
+end

--- a/db/migrate/20240801080056_add_project_groups.rb
+++ b/db/migrate/20240801080056_add_project_groups.rb
@@ -1,0 +1,11 @@
+class AddProjectGroups < ActiveRecord::Migration[7.0]
+  def change
+    create_table :project_groups, id: :uuid do |t|
+      t.string :group_identifier, index: true
+      t.integer :trust_ukprn, index: true
+      t.timestamps
+    end
+
+    add_column :projects, :group_id, :uuid, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_25_110919) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_01_080056) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -271,6 +271,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_25_110919) do
     t.index ["user_id"], name: "index_notes_on_user_id"
   end
 
+  create_table "project_groups", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+    t.string "group_identifier"
+    t.integer "trust_ukprn"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_identifier"], name: "index_project_groups_on_group_identifier"
+    t.index ["trust_ukprn"], name: "index_project_groups_on_trust_ukprn"
+  end
+
   create_table "projects", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.integer "urn", null: false
     t.datetime "created_at", null: false
@@ -308,6 +317,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_25_110919) do
     t.integer "state", default: 0, null: false
     t.integer "prepare_id"
     t.uuid "local_authority_main_contact_id"
+    t.uuid "group_id"
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["incoming_trust_ukprn"], name: "index_projects_on_incoming_trust_ukprn"

--- a/spec/models/project_group_spec.rb
+++ b/spec/models/project_group_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe ProjectGroup, type: :model do
+  describe "columns" do
+    it { is_expected.to have_db_column(:trust_ukprn).of_type :integer }
+    it { is_expected.to have_db_column(:group_identifier).of_type :string }
+  end
+
+  describe "associations" do
+    it { is_expected.to have_many(:projects) }
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to belong_to(:outgoing_trust_main_contact).optional(true) }
     it { is_expected.to belong_to(:local_authority_main_contact).optional(true) }
     it { is_expected.to have_one(:dao_revocation).dependent(:destroy) }
+    it { is_expected.to belong_to(:group).optional(true) }
 
     describe "delete related entities" do
       context "when the project is deleted" do


### PR DESCRIPTION
Conversions and transfers are 'grouped' together at advisory board to
join the same trust and doing so opens the door to funding under new
policies.

We need to support this grouping of projects, but will not originate the
groups as this is done pre-advisory board (so in the Prepare
applications).

A project can only belong to one group, but a trust could have multiple
groups over time.

Right now a group will always relate to a Trust, for now we will capture
the incoming trust UKPRN to make this connection.

This work sets up a basic model to handle this.

