### PR TITLE
(175117) Collect group reference number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - new conversion projects now collect the group reference number, used in the
   Prepare application to group projects together for advisory board.
+- new transfer projects now collect the group reference number, used in the
+  Prepare application to group projects together for advisory board.
 
 ## [Release-81][release-81]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- new conversion projects now collect the group reference number, used in the
+  Prepare application to group projects together for advisory board.
+
 ## [Release-81][release-81]
 
 ### Added

--- a/app/controllers/conversions/projects_controller.rb
+++ b/app/controllers/conversions/projects_controller.rb
@@ -90,7 +90,8 @@ class Conversions::ProjectsController < ProjectsController
       :directive_academy_order,
       :two_requires_improvement,
       :new_trust_name,
-      :new_trust_reference_number
+      :new_trust_reference_number,
+      :group_id
     )
   end
 end

--- a/app/controllers/transfers/projects_controller.rb
+++ b/app/controllers/transfers/projects_controller.rb
@@ -88,7 +88,8 @@ class Transfers::ProjectsController < ApplicationController
       :financial_safeguarding_governance_issues,
       :outgoing_trust_to_close,
       :new_trust_name,
-      :new_trust_reference_number
+      :new_trust_reference_number,
+      :group_id
     )
   end
 end

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -65,7 +65,15 @@ class Conversion::CreateProjectForm < CreateProjectForm
     return nil unless valid?(context)
 
     ActiveRecord::Base.transaction do
+      if group_id.present?
+        @project.group = ProjectGroup.find_or_create_by(
+          group_identifier: group_id,
+          trust_ukprn: incoming_trust_ukprn
+        )
+      end
+
       @project.save
+
       @note = Note.create(body: handover_note_body, project: @project, user: user, task_identifier: :handover) if handover_note_body
       notify_team_leaders(@project) if assigned_to_regional_caseworker_team
       Event.log(grouping: :project, user: user, with: @project, message: "Project created.")

--- a/app/forms/create_project_form.rb
+++ b/app/forms/create_project_form.rb
@@ -17,10 +17,13 @@ class CreateProjectForm
   attribute :new_trust_reference_number
   attribute :new_trust_name
   attribute :advisory_board_date, :date
+  attribute :group_id, :string
 
   validates :urn, presence: true, urn: true
   validates :incoming_trust_ukprn, presence: true, ukprn: true, on: :existing_trust
   validates :incoming_trust_ukprn, trust_exists: true, on: :existing_trust, if: -> { incoming_trust_ukprn.present? }
+  validates :group_id, format: {with: /\AGRP_\d{8}\z/}, if: -> { group_id.present? }
+  validate :group_id_ukprn, if: -> { group_id.present? && incoming_trust_ukprn.present? }
 
   validates :advisory_board_date, presence: true
   validates :advisory_board_date, date_in_the_past: true
@@ -71,5 +74,11 @@ class CreateProjectForm
 
   private def urn_unique_for_in_progress_transfers
     errors.add(:urn, :duplicate) if Transfer::Project.active.where(urn: urn).any?
+  end
+
+  private def group_id_ukprn
+    group = ProjectGroup.find_by_group_identifier(group_id)
+
+    errors.add(:group_id, :trust_ukprn) unless group.nil? || group.trust_ukprn.eql?(incoming_trust_ukprn)
   end
 end

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -62,6 +62,13 @@ class Transfer::CreateProjectForm < CreateProjectForm
     return nil unless valid?(context)
 
     ActiveRecord::Base.transaction do
+      if group_id.present?
+        @project.group = ProjectGroup.find_or_create_by(
+          group_identifier: group_id,
+          trust_ukprn: incoming_trust_ukprn
+        )
+      end
+
       @project.save
       @note = Note.create(body: handover_note_body, project: @project, user: user, task_identifier: :handover) if handover_note_body
       @project.tasks_data.update!(

--- a/app/views/conversions/projects/new.html.erb
+++ b/app/views/conversions/projects/new.html.erb
@@ -20,6 +20,10 @@
       </div>
 
       <div class="govuk-form-group">
+        <%= form.govuk_text_field :group_id, label: {size: "m"}, width: 10, autocomplete: :off %>
+      </div>
+
+      <div class="govuk-form-group">
         <%= form.govuk_date_field :advisory_board_date, legend: {text: t("helpers.legend.project.advisory_board_date")}, form_group: {id: "advisory-board-date"}, hint: {text: t("helpers.hint.project.advisory_board_date").html_safe} %>
         <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m", text: t("helpers.label.conversion_project.advisory_board_conditions")} %>
       </div>

--- a/app/views/transfers/projects/new.html.erb
+++ b/app/views/transfers/projects/new.html.erb
@@ -21,6 +21,10 @@
       </div>
 
       <div class="govuk-form-group">
+        <%= form.govuk_text_field :group_id, label: {size: "m"}, width: 10, autocomplete: :off %>
+      </div>
+
+      <div class="govuk-form-group">
         <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.establishment_sharepoint_link")} %>
         <%= form.govuk_text_field :incoming_trust_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.incoming_trust_sharepoint_link")} %>
         <%= form.govuk_text_field :outgoing_trust_sharepoint_link, label: {size: "m", text: t("helpers.label.transfer_project.outgoing_trust_sharepoint_link")} %>

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -73,6 +73,7 @@ en:
         incoming_trust_sharepoint_link: Incoming trust SharePoint link
         new_trust_reference_number: Trust reference number (TRN)
         new_trust_name: Trust name
+        group_id: Group reference number
       conversion_project:
         caseworker_id: Caseworker
         regional_delivery_officer_id: Regional delivery officer
@@ -102,6 +103,9 @@ en:
         new_trust_name: Enter the proposed name for the new trust. This can be changed later on if necessary.
         new_trust_reference_number_html:
           <p>You can find the TRN in the <a href="https://educationgovuk.sharepoint.com/:x:/s/TrustandAcademyManagementServiceTRAMSPrivateBeta/ETyRXN0eIYxOmCVHTqWxSLYBQvHdfWicu7NybUaDeiz88g" class="govuk-link" rel="noreferrer noopener" target="_blank">new trusts spreadsheet (opens in new tab)</a>.</p>
+        group_id_html:
+          <p>If this school is converting as part of a group, enter the group reference number.</p>
+          <p>The reference number begins with the letters GRP and contains up to 8 numbers, like GRP_XXXXXXXX. You can find this on the group’s page in Prepare conversions and transfers.</p>
       conversion_project:
         provisional_conversion_date: You can find this in the advisory board template.
         advisory_board_conditions: Enter details of conditions that must be met before the school can convert.

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -478,3 +478,6 @@ en:
         not_matching: A trust with this TRN already exists. It is called %{trust_name}. Check the trust name you have entered for this conversion/transfer
       prepare_id:
         blank: You must supply a Prepare ID when creating a project via the API
+      group_id:
+        invalid: A group group reference number must start GRP_ and contain 8 numbers, like GRP_00000001
+        trust_ukprn: The group reference number must be for the same trust as all other group members, check the group reference number and incoming trust UKPRN

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -46,6 +46,7 @@ en:
       transfer_create_project_form:
         new_trust_reference_number: Trust reference number (TRN)
         new_trust_name: Trust name
+        group_id: Group reference number
     legend:
       transfer_project:
         advisory_board_date: Date of advisory board
@@ -93,6 +94,10 @@ en:
         establishment_sharepoint_link: Provide a link to the SharePoint folder for this academy. This is where you save all the relevant academy documents.
         incoming_trust_sharepoint_link: Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.
         outgoing_trust_sharepoint_link: Provide a link to the SharePoint folder for the outgoing trust. This is where you save all the relevant trust documents.
+        group_id_html:
+          <p>If this academy is transferring  as part of a group, enter the group reference number.</p>
+          <p>The reference number begins with the letters GRP and contains up to 8 numbers, like GRP_XXXXXXXX. You can find this on the group’s page in Prepare conversions and transfers.</p>
+
         advisory_board_conditions: Enter details of conditions that must be met before the school or academy can transfer.
         handover_note_body_html:
           <p>You must describe how the project has progressed so far and highlight any issues or concerns.</p>

--- a/spec/factories/project_group_factory.rb
+++ b/spec/factories/project_group_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :project_group do
+    trust_ukprn { 1234567 }
+    group_identifier { "GRP_12345678" }
+  end
+end

--- a/spec/features/conversions/users_can_create_converison_projects_in_a_group_spec.rb
+++ b/spec/features/conversions/users_can_create_converison_projects_in_a_group_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.feature "Users can create new conversion projects in a group" do
+  let(:regional_delivery_officer) { create(:user, :regional_delivery_officer) }
+  let(:urn) { 123456 }
+  let(:ukprn) { 10061021 }
+
+  before do
+    sign_in_with_user(regional_delivery_officer)
+  end
+
+  scenario "by supplying the group reference number" do
+    mock_successful_api_response_to_create_any_project
+
+    visit conversions_new_path
+
+    fill_in_new_conversion_project_form(urn, ukprn)
+
+    fill_in "Group reference number", with: "GRP_12345678"
+    click_button("Continue")
+
+    within ".govuk-notification-banner" do
+      expect(page).to have_content "Success"
+    end
+
+    expect(Project.first.group.group_identifier).to eql "GRP_12345678"
+  end
+end

--- a/spec/features/conversions/users_can_create_conversion_projects_spec.rb
+++ b/spec/features/conversions/users_can_create_conversion_projects_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Users can create new conversion projects" do
       choose "Conversion"
       click_button "Continue"
 
-      fill_in_form
+      fill_in_new_conversion_project_form(urn, ukprn)
 
       click_button("Continue")
 
@@ -38,39 +38,6 @@ RSpec.feature "Users can create new conversion projects" do
       click_button "Continue"
 
       expect(page).to have_content(I18n.t("helpers.hint.conversion_project.assigned_to_regional_caseworker_team"))
-    end
-  end
-
-  def fill_in_form
-    fill_in "School URN", with: urn
-    fill_in "Incoming trust UKPRN (UK Provider Reference Number)", with: ukprn
-
-    within("#provisional-conversion-date") do
-      completion_date = Date.today + 1.year
-      fill_in "Month", with: completion_date.month
-      fill_in "Year", with: completion_date.year
-    end
-
-    fill_in "School or academy SharePoint link", with: "https://educationgovuk-my.sharepoint.com/school-folder"
-    fill_in "Incoming trust SharePoint link", with: "https://educationgovuk-my.sharepoint.com/trust-folder"
-
-    within("#advisory-board-date") do
-      fill_in "Day", with: two_weeks_ago.day
-      fill_in "Month", with: two_weeks_ago.month
-      fill_in "Year", with: two_weeks_ago.year
-    end
-
-    fill_in "Advisory board conditions", with: "This school must:\n1. Do this\n2. And that"
-
-    fill_in "Handover comments", with: "A new handover comment"
-    within("#assigned-to-regional-caseworker-team") do
-      choose("No")
-    end
-    within("#directive-academy-order") do
-      choose "Academy order"
-    end
-    within("#two-requires-improvement") do
-      choose "No"
     end
   end
 end

--- a/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
+++ b/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
@@ -14,8 +14,6 @@ RSpec.feature "Users can create new transfer projects" do
       let(:incoming_ukprn) { 10061021 }
       let(:outgoing_ukprn) { 10090252 }
       let(:new_trust_reference_number) { nil }
-      let(:two_weeks_ago) { Date.today - 2.weeks }
-      let(:two_months_time) { Date.today + 2.months }
 
       before { mock_all_academies_api_responses }
 
@@ -24,7 +22,7 @@ RSpec.feature "Users can create new transfer projects" do
         choose "Transfer"
         click_button "Continue"
 
-        fill_in_form
+        fill_in_new_transfer_project_form(urn, incoming_ukprn, outgoing_ukprn)
 
         click_button("Continue")
 
@@ -57,9 +55,6 @@ RSpec.feature "Users can create new transfer projects" do
       let(:urn) { 123456 }
       let(:outgoing_ukprn) { 10090252 }
       let(:incoming_ukprn) { nil }
-      let(:new_trust_reference_number) { "TR12345" }
-      let(:two_weeks_ago) { Date.today - 2.weeks }
-      let(:two_months_time) { Date.today + 2.months }
 
       before { mock_all_academies_api_responses }
 
@@ -68,7 +63,9 @@ RSpec.feature "Users can create new transfer projects" do
         choose "Form a MAT transfer"
         click_button "Continue"
 
-        fill_in_form
+        fill_in_new_transfer_project_form(urn, nil, outgoing_ukprn)
+        fill_in "Trust reference number (TRN)", with: "TR12345"
+        fill_in "Trust name", with: "New Trust Name"
 
         click_button("Continue")
 
@@ -87,51 +84,6 @@ RSpec.feature "Users can create new transfer projects" do
 
         expect(page).to have_content("There is a problem")
       end
-    end
-  end
-
-  def fill_in_form
-    fill_in "Academy URN", with: urn
-    fill_in "Incoming trust UKPRN", with: incoming_ukprn if incoming_ukprn
-    fill_in "Trust reference number (TRN)", with: new_trust_reference_number if new_trust_reference_number
-    fill_in "Trust name", with: "New Trust" if new_trust_reference_number
-    fill_in "Outgoing trust UKPRN (UK Provider Reference Number)", with: outgoing_ukprn
-
-    fill_in "Academy SharePoint link", with: "https://educationgovuk-my.sharepoint.com/school-folder"
-    fill_in "Incoming trust SharePoint link", with: "https://educationgovuk-my.sharepoint.com/incoming-trust-folder"
-    fill_in "Outgoing trust SharePoint link", with: "https://educationgovuk-my.sharepoint.com/outgoing-trust-folder"
-
-    within("#advisory-board-date") do
-      fill_in "Day", with: two_weeks_ago.day
-      fill_in "Month", with: two_weeks_ago.month
-      fill_in "Year", with: two_weeks_ago.year
-    end
-
-    within("#two-requires-improvement") do
-      choose "No"
-    end
-
-    within("#inadequate-ofsted") do
-      choose "No"
-    end
-
-    within("#financial-safeguarding-governance-issues") do
-      choose "No"
-    end
-
-    within("#outgoing-trust-to-close") do
-      choose "No"
-    end
-
-    fill_in "Handover comments", with: "This is a handover note."
-
-    within("#provisional-transfer-date") do
-      fill_in "Month", with: two_months_time.month
-      fill_in "Year", with: two_months_time.year
-    end
-
-    within "#assigned-to-regional-caseworker-team" do
-      choose "No"
     end
   end
 end

--- a/spec/features/transfers/users_can_create_transfer_projects_in_a_group_spec.rb
+++ b/spec/features/transfers/users_can_create_transfer_projects_in_a_group_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.feature "Users can create new transfer projects in a group" do
+  let(:regional_delivery_officer) { create(:user, :regional_delivery_officer) }
+  let(:urn) { 123456 }
+  let(:incoming_ukprn) { 10061021 }
+  let(:outgoing_ukprn) { 10090252 }
+
+  before do
+    sign_in_with_user(regional_delivery_officer)
+  end
+
+  scenario "by supplying the group reference number" do
+    mock_successful_api_response_to_create_any_project
+
+    visit transfers_new_path
+
+    fill_in_new_transfer_project_form(urn, incoming_ukprn, outgoing_ukprn)
+
+    fill_in "Group reference number", with: "GRP_12345678"
+    click_button("Continue")
+
+    within ".govuk-notification-banner" do
+      expect(page).to have_content "Success"
+    end
+
+    expect(Project.first.group.group_identifier).to eql "GRP_12345678"
+  end
+end

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -323,6 +323,41 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
         expect(form.errors.messages[:new_trust_name].first).to include "The big trust"
       end
     end
+
+    describe "group id" do
+      context "when there is a group reference number" do
+        context "when the group is a new one" do
+          it "creates the group and makes the association to the project" do
+            form = build(
+              :create_transfer_project_form,
+              group_id: "GRP_12345678"
+            )
+
+            project = form.save
+            expect(ProjectGroup.count).to be 1
+
+            group = ProjectGroup.first
+            expect(project.group).to eql(group)
+          end
+        end
+
+        context "when the group exists" do
+          it "makes the association to the project" do
+            group = create(:project_group, group_identifier: "GRP_12345678", trust_ukprn: 1234567)
+            form = build(
+              :create_transfer_project_form,
+              incoming_trust_ukprn: 1234567,
+              group_id: "GRP_12345678"
+            )
+
+            project = form.save
+            expect(ProjectGroup.count).to be 1
+
+            expect(project.group).to eql(group)
+          end
+        end
+      end
+    end
   end
 
   describe "urn" do

--- a/spec/support/project_helpers.rb
+++ b/spec/support/project_helpers.rb
@@ -5,4 +5,38 @@ module ProjectHelpers
     project.save!
     project
   end
+
+  def fill_in_new_conversion_project_form(urn, ukprn)
+    fill_in "School URN", with: urn
+    fill_in "Incoming trust UKPRN (UK Provider Reference Number)", with: ukprn
+
+    within("#provisional-conversion-date") do
+      completion_date = Date.today + 1.year
+      fill_in "Month", with: completion_date.month
+      fill_in "Year", with: completion_date.year
+    end
+
+    fill_in "School or academy SharePoint link", with: "https://educationgovuk-my.sharepoint.com/school-folder"
+    fill_in "Incoming trust SharePoint link", with: "https://educationgovuk-my.sharepoint.com/trust-folder"
+
+    within("#advisory-board-date") do
+      advisory_board_date = Date.today - 2.weeks
+      fill_in "Day", with: advisory_board_date.day
+      fill_in "Month", with: advisory_board_date.month
+      fill_in "Year", with: advisory_board_date.year
+    end
+
+    fill_in "Advisory board conditions", with: "This school must:\n1. Do this\n2. And that"
+
+    fill_in "Handover comments", with: "A new handover comment"
+    within("#assigned-to-regional-caseworker-team") do
+      choose("No")
+    end
+    within("#directive-academy-order") do
+      choose "Academy order"
+    end
+    within("#two-requires-improvement") do
+      choose "No"
+    end
+  end
 end

--- a/spec/support/project_helpers.rb
+++ b/spec/support/project_helpers.rb
@@ -39,4 +39,49 @@ module ProjectHelpers
       choose "No"
     end
   end
+
+  def fill_in_new_transfer_project_form(urn, incoming_ukprn, outgoing_ukprn)
+    fill_in "Academy URN", with: urn
+    fill_in "Incoming trust UKPRN", with: incoming_ukprn if incoming_ukprn
+    fill_in "Outgoing trust UKPRN (UK Provider Reference Number)", with: outgoing_ukprn
+
+    fill_in "Academy SharePoint link", with: "https://educationgovuk-my.sharepoint.com/school-folder"
+    fill_in "Incoming trust SharePoint link", with: "https://educationgovuk-my.sharepoint.com/incoming-trust-folder"
+    fill_in "Outgoing trust SharePoint link", with: "https://educationgovuk-my.sharepoint.com/outgoing-trust-folder"
+
+    within("#advisory-board-date") do
+      advisory_board_date = Date.today - 2.weeks
+      fill_in "Day", with: advisory_board_date.day
+      fill_in "Month", with: advisory_board_date.month
+      fill_in "Year", with: advisory_board_date.year
+    end
+
+    within("#two-requires-improvement") do
+      choose "No"
+    end
+
+    within("#inadequate-ofsted") do
+      choose "No"
+    end
+
+    within("#financial-safeguarding-governance-issues") do
+      choose "No"
+    end
+
+    within("#outgoing-trust-to-close") do
+      choose "No"
+    end
+
+    fill_in "Handover comments", with: "This is a handover note."
+
+    within("#provisional-transfer-date") do
+      completion_date = Date.today + 1.year
+      fill_in "Month", with: completion_date.month
+      fill_in "Year", with: completion_date.year
+    end
+
+    within "#assigned-to-regional-caseworker-team" do
+      choose "No"
+    end
+  end
 end


### PR DESCRIPTION
Projects can be grouped together for advisory board to receive additional funding.

This work adds the group reference number to both create conversion and transfer
projects. The group reference number originates in the Prepare application and
so, for now is a matter of copy and pasting the value from one application to
the other (one day the applications should be connected).

We validate the group reference number format and that the project incoming
trust UKPRN matches that of the group (this grouping is by trust).

As the behaviour is shared, we add it to the base `create_project_form`.

Right now, we do not think form a MAT projects needs this behaviour.
