### PR TITLE
(Fix) Allow all Contact types to be a "project main contact"

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -6,6 +6,13 @@ class Contact < ApplicationRecord
   validates :title, presence: true, allow_blank: false
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}, allow_blank: true
 
+  has_one :main_contact_for_project, class_name: "::Project", inverse_of: :main_contact
+  has_one :main_contact_for_establishment, class_name: "::Project", inverse_of: :establishment_main_contact
+  has_one :main_contact_for_incoming_trust, class_name: "::Project", inverse_of: :incoming_trust_main_contact
+  has_one :main_contact_for_outgoing_trust, class_name: "::Project", inverse_of: :outgoing_trust_main_contact
+  has_one :main_contact_for_local_authority, class_name: "::Project", inverse_of: :local_authority_main_contact
+  has_one :contact_for_chair_of_governors, class_name: "::Project", inverse_of: :chair_of_governors_contact
+
   enum category: {
     school_or_academy: 1,
     incoming_trust: 2,

--- a/app/models/contact/project.rb
+++ b/app/models/contact/project.rb
@@ -4,12 +4,6 @@ class Contact::Project < Contact
   end
 
   belongs_to :project, class_name: "::Project"
-  has_one :main_contact_for_project, class_name: "::Project", inverse_of: :main_contact
-  has_one :main_contact_for_establishment, class_name: "::Project", inverse_of: :establishment_main_contact
-  has_one :main_contact_for_incoming_trust, class_name: "::Project", inverse_of: :incoming_trust_main_contact
-  has_one :main_contact_for_outgoing_trust, class_name: "::Project", inverse_of: :outgoing_trust_main_contact
-  has_one :main_contact_for_local_authority, class_name: "::Project", inverse_of: :local_authority_main_contact
-  has_one :contact_for_chair_of_governors, class_name: "Conversion::Project", inverse_of: :chair_of_governors_contact
 
   def establishment_main_contact
     project.establishment_main_contact_id == id

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -5,8 +5,6 @@ class Conversion::Project < Project
 
   has_one :chair_of_governors, class_name: "Contact::Project", inverse_of: :project
 
-  belongs_to :chair_of_governors_contact, inverse_of: :contact_for_chair_of_governors, dependent: :destroy, class_name: "Contact::Project", optional: true
-
   attr_writer :academy
 
   alias_attribute :conversion_date, :significant_date

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -16,11 +16,12 @@ class Project < ApplicationRecord
   has_many :date_history, class_name: "SignificantDateHistory", inverse_of: :project, dependent: :destroy
   has_one :dao_revocation, class_name: "DaoRevocation", inverse_of: :project, dependent: :destroy
 
-  belongs_to :main_contact, inverse_of: :main_contact_for_project, dependent: :destroy, class_name: "Contact::Project", optional: true
-  belongs_to :establishment_main_contact, inverse_of: :main_contact_for_establishment, dependent: :destroy, class_name: "Contact::Project", optional: true
-  belongs_to :incoming_trust_main_contact, inverse_of: :main_contact_for_incoming_trust, dependent: :destroy, class_name: "Contact::Project", optional: true
-  belongs_to :outgoing_trust_main_contact, inverse_of: :main_contact_for_outgoing_trust, dependent: :destroy, class_name: "Contact::Project", optional: true
-  belongs_to :local_authority_main_contact, inverse_of: :main_contact_for_local_authority, dependent: :destroy, class_name: "Contact::Project", optional: true
+  belongs_to :main_contact, inverse_of: :main_contact_for_project, dependent: :destroy, class_name: "Contact", optional: true
+  belongs_to :establishment_main_contact, inverse_of: :main_contact_for_establishment, dependent: :destroy, class_name: "Contact", optional: true
+  belongs_to :incoming_trust_main_contact, inverse_of: :main_contact_for_incoming_trust, dependent: :destroy, class_name: "Contact", optional: true
+  belongs_to :outgoing_trust_main_contact, inverse_of: :main_contact_for_outgoing_trust, dependent: :destroy, class_name: "Contact", optional: true
+  belongs_to :local_authority_main_contact, inverse_of: :main_contact_for_local_authority, dependent: :destroy, class_name: "Contact", optional: true
+  belongs_to :chair_of_governors_contact, inverse_of: :contact_for_chair_of_governors, dependent: :destroy, class_name: "Contact::Project", optional: true
 
   belongs_to :group, inverse_of: :projects, class_name: "ProjectGroup", optional: true
 

--- a/spec/presenters/export/csv/project_presenter_spec.rb
+++ b/spec/presenters/export/csv/project_presenter_spec.rb
@@ -605,6 +605,18 @@ RSpec.describe Export::Csv::ProjectPresenter do
     expect(presenter.main_contact_title).to eql "Very important person"
   end
 
+  context "when the main contact is a Contact::Establishment" do
+    it "presents the main contact email" do
+      user = create(:establishment_contact, email: "establishment.contact@education.gov.uk")
+      project = build(:conversion_project, main_contact_id: user.id)
+      user.establishment_urn = project.urn
+
+      presenter = described_class.new(project)
+
+      expect(presenter.main_contact_email).to eql "establishment.contact@education.gov.uk"
+    end
+  end
+
   it "handles a project without a main contact" do
     project = build(:conversion_project, main_contact: nil)
 

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -97,6 +97,14 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
     expect(subject.school_main_contact_role).to eq("CEO of Learning")
   end
 
+  context "when the school main contact is a Contact::Establishment" do
+    let(:contact) { create(:establishment_contact, email: "headteacher@school.com", establishment_urn: project.urn) }
+
+    it "presents the school main contact email" do
+      expect(subject.school_main_contact_email).to eq("headteacher@school.com")
+    end
+  end
+
   def known_establishment
     double(
       Api::AcademiesApi::Establishment,


### PR DESCRIPTION
When testing PR #1780 in development, we realised that any Contact type other than Contact::Project, when selected for the "main contact for the project" (Project.main_contact), was not showing in the exports.

This was because the contact type for project main contact was set to Contact::Project, but the "Choose a main contact for the project" task allows *any* contact type to be selected.

Additionally, when fixing this issue we realised that the Chair of Governors contact association was only on the Conversion Project type, when we allow Transfer projects to choose a Chair of Governors as well.

Fix both of these by moving the associations into the base Contact and Project classes.

