### PR TITLE
(175119) Group reference number editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Prepare application to group projects together for advisory board.
 - new transfer projects now collect the group reference number, used in the
   Prepare application to group projects together for advisory board.
+- the group reference number for a conversion or transfer can now be changed
+  from the project information view.
 
 ## [Release-81][release-81]
 

--- a/app/controllers/conversions/projects_controller.rb
+++ b/app/controllers/conversions/projects_controller.rb
@@ -67,6 +67,7 @@ class Conversions::ProjectsController < ProjectsController
       :establishment_sharepoint_link,
       :incoming_trust_sharepoint_link,
       :incoming_trust_ukprn,
+      :group_id,
       :advisory_board_date,
       :advisory_board_conditions,
       :directive_academy_order,

--- a/app/controllers/transfers/projects_controller.rb
+++ b/app/controllers/transfers/projects_controller.rb
@@ -59,6 +59,7 @@ class Transfers::ProjectsController < ApplicationController
       :outgoing_trust_sharepoint_link,
       :outgoing_trust_ukprn,
       :incoming_trust_ukprn,
+      :group_id,
       :advisory_board_date,
       :advisory_board_conditions,
       :two_requires_improvement,

--- a/app/forms/conversion/edit_project_form.rb
+++ b/app/forms/conversion/edit_project_form.rb
@@ -9,6 +9,7 @@ class Conversion::EditProjectForm < EditProjectForm
       establishment_sharepoint_link: project.establishment_sharepoint_link,
       incoming_trust_sharepoint_link: project.incoming_trust_sharepoint_link,
       incoming_trust_ukprn: project.incoming_trust_ukprn,
+      group_id: project.group&.group_identifier,
       advisory_board_date: project.advisory_board_date,
       advisory_board_conditions: project.advisory_board_conditions,
       directive_academy_order: project.directive_academy_order,
@@ -47,6 +48,8 @@ class Conversion::EditProjectForm < EditProjectForm
     )
 
     ActiveRecord::Base.transaction do
+      project.group = group_id_to_group(group_id)
+
       project.save
       update_handover_note if handover_note_body.present?
       notify_team_leaders(project) if assigned_to_regional_caseworker_team

--- a/app/forms/conversion/edit_project_form.rb
+++ b/app/forms/conversion/edit_project_form.rb
@@ -1,32 +1,7 @@
-class Conversion::EditProjectForm
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-  include ActiveRecord::AttributeAssignment
-
-  attr_accessor :project, :user
-
-  attribute :establishment_sharepoint_link
-  attribute :incoming_trust_sharepoint_link
-  attribute :incoming_trust_ukprn
-  attribute :advisory_board_date, :date
-  attribute :advisory_board_conditions
+class Conversion::EditProjectForm < EditProjectForm
   attribute :directive_academy_order, :boolean
-  attribute :two_requires_improvement, :boolean
-  attribute :assigned_to_regional_caseworker_team, :boolean
-  attribute :handover_note_body
-
-  validates :establishment_sharepoint_link, presence: true, sharepoint_url: true
-  validates :incoming_trust_sharepoint_link, presence: true, sharepoint_url: true
-
-  validates :incoming_trust_ukprn, presence: true, ukprn: true
-  validates :incoming_trust_ukprn, trust_exists: true, if: -> { incoming_trust_ukprn.present? }
-
-  validates :advisory_board_date, presence: true
-  validates :advisory_board_date, date_in_the_past: true
 
   validates :directive_academy_order, inclusion: {in: [true, false]}
-
-  validates :two_requires_improvement, inclusion: {in: [true, false], message: I18n.t("errors.conversion_project.attributes.two_requires_improvement.inclusion")}
 
   def self.new_from_project(project, user)
     new(
@@ -78,16 +53,5 @@ class Conversion::EditProjectForm
     end
 
     project
-  end
-
-  private def update_handover_note
-    note = Note.find_or_initialize_by(project: project, task_identifier: :handover, user: user)
-    note.update!(body: handover_note_body)
-  end
-
-  private def notify_team_leaders(project)
-    User.team_leaders.each do |team_leader|
-      TeamLeaderMailer.new_conversion_project_created(team_leader, project).deliver_later if team_leader.active
-    end
   end
 end

--- a/app/forms/create_project_form.rb
+++ b/app/forms/create_project_form.rb
@@ -22,8 +22,8 @@ class CreateProjectForm
   validates :urn, presence: true, urn: true
   validates :incoming_trust_ukprn, presence: true, ukprn: true, on: :existing_trust
   validates :incoming_trust_ukprn, trust_exists: true, on: :existing_trust, if: -> { incoming_trust_ukprn.present? }
-  validates :group_id, format: {with: /\AGRP_\d{8}\z/}, if: -> { group_id.present? }
-  validate :group_id_ukprn, if: -> { group_id.present? && incoming_trust_ukprn.present? }
+
+  validates_with GroupIdValidator
 
   validates :advisory_board_date, presence: true
   validates :advisory_board_date, date_in_the_past: true
@@ -74,11 +74,5 @@ class CreateProjectForm
 
   private def urn_unique_for_in_progress_transfers
     errors.add(:urn, :duplicate) if Transfer::Project.active.where(urn: urn).any?
-  end
-
-  private def group_id_ukprn
-    group = ProjectGroup.find_by_group_identifier(group_id)
-
-    errors.add(:group_id, :trust_ukprn) unless group.nil? || group.trust_ukprn.eql?(incoming_trust_ukprn)
   end
 end

--- a/app/forms/edit_project_form.rb
+++ b/app/forms/edit_project_form.rb
@@ -26,8 +26,7 @@ class EditProjectForm
 
   validates :two_requires_improvement, inclusion: {in: [true, false], message: I18n.t("errors.attributes.two_requires_improvement.inclusion")}
 
-  validates :group_id, format: {with: /\AGRP_\d{8}\z/}, if: -> { group_id.present? }
-  validate :group_id_ukprn, if: -> { group_id.present? && incoming_trust_ukprn.present? }
+  validates_with GroupIdValidator
 
   private def update_handover_note
     note = Note.find_or_initialize_by(project: project, task_identifier: :handover, user: user)
@@ -38,12 +37,6 @@ class EditProjectForm
     User.team_leaders.each do |team_leader|
       TeamLeaderMailer.new_conversion_project_created(team_leader, project).deliver_later if team_leader.active
     end
-  end
-
-  private def group_id_ukprn
-    group = ProjectGroup.find_by_group_identifier(group_id)
-
-    errors.add(:group_id, :trust_ukprn) unless group.nil? || group.trust_ukprn.eql?(incoming_trust_ukprn)
   end
 
   private def group_id_to_group(group_id)

--- a/app/forms/edit_project_form.rb
+++ b/app/forms/edit_project_form.rb
@@ -5,14 +5,15 @@ class EditProjectForm
 
   attr_accessor :project, :user
 
-  attribute :establishment_sharepoint_link
-  attribute :incoming_trust_sharepoint_link
-  attribute :incoming_trust_ukprn
+  attribute :establishment_sharepoint_link, :string
+  attribute :incoming_trust_sharepoint_link, :string
+  attribute :incoming_trust_ukprn, :integer
   attribute :advisory_board_date, :date
-  attribute :advisory_board_conditions
+  attribute :advisory_board_conditions, :string
   attribute :two_requires_improvement, :boolean
   attribute :assigned_to_regional_caseworker_team, :boolean
-  attribute :handover_note_body
+  attribute :handover_note_body, :string
+  attribute :group_id, :string
 
   validates :establishment_sharepoint_link, presence: true, sharepoint_url: true
   validates :incoming_trust_sharepoint_link, presence: true, sharepoint_url: true
@@ -23,7 +24,10 @@ class EditProjectForm
   validates :advisory_board_date, presence: true
   validates :advisory_board_date, date_in_the_past: true
 
-  validates :two_requires_improvement, inclusion: {in: [true, false], message: I18n.t("errors.conversion_project.attributes.two_requires_improvement.inclusion")}
+  validates :two_requires_improvement, inclusion: {in: [true, false], message: I18n.t("errors.attributes.two_requires_improvement.inclusion")}
+
+  validates :group_id, format: {with: /\AGRP_\d{8}\z/}, if: -> { group_id.present? }
+  validate :group_id_ukprn, if: -> { group_id.present? && incoming_trust_ukprn.present? }
 
   private def update_handover_note
     note = Note.find_or_initialize_by(project: project, task_identifier: :handover, user: user)
@@ -34,5 +38,20 @@ class EditProjectForm
     User.team_leaders.each do |team_leader|
       TeamLeaderMailer.new_conversion_project_created(team_leader, project).deliver_later if team_leader.active
     end
+  end
+
+  private def group_id_ukprn
+    group = ProjectGroup.find_by_group_identifier(group_id)
+
+    errors.add(:group_id, :trust_ukprn) unless group.nil? || group.trust_ukprn.eql?(incoming_trust_ukprn)
+  end
+
+  private def group_id_to_group(group_id)
+    return if group_id.blank?
+
+    project.group = ProjectGroup.find_or_create_by(
+      group_identifier: group_id,
+      trust_ukprn: incoming_trust_ukprn
+    )
   end
 end

--- a/app/forms/edit_project_form.rb
+++ b/app/forms/edit_project_form.rb
@@ -1,0 +1,38 @@
+class EditProjectForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
+  attr_accessor :project, :user
+
+  attribute :establishment_sharepoint_link
+  attribute :incoming_trust_sharepoint_link
+  attribute :incoming_trust_ukprn
+  attribute :advisory_board_date, :date
+  attribute :advisory_board_conditions
+  attribute :two_requires_improvement, :boolean
+  attribute :assigned_to_regional_caseworker_team, :boolean
+  attribute :handover_note_body
+
+  validates :establishment_sharepoint_link, presence: true, sharepoint_url: true
+  validates :incoming_trust_sharepoint_link, presence: true, sharepoint_url: true
+
+  validates :incoming_trust_ukprn, presence: true, ukprn: true
+  validates :incoming_trust_ukprn, trust_exists: true, if: -> { incoming_trust_ukprn.present? }
+
+  validates :advisory_board_date, presence: true
+  validates :advisory_board_date, date_in_the_past: true
+
+  validates :two_requires_improvement, inclusion: {in: [true, false], message: I18n.t("errors.conversion_project.attributes.two_requires_improvement.inclusion")}
+
+  private def update_handover_note
+    note = Note.find_or_initialize_by(project: project, task_identifier: :handover, user: user)
+    note.update!(body: handover_note_body)
+  end
+
+  private def notify_team_leaders(project)
+    User.team_leaders.each do |team_leader|
+      TeamLeaderMailer.new_conversion_project_created(team_leader, project).deliver_later if team_leader.active
+    end
+  end
+end

--- a/app/forms/transfer/edit_project_form.rb
+++ b/app/forms/transfer/edit_project_form.rb
@@ -1,40 +1,16 @@
-class Transfer::EditProjectForm
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-  include ActiveRecord::AttributeAssignment
-
-  attr_accessor :project, :user
-
-  attribute :establishment_sharepoint_link
+class Transfer::EditProjectForm < EditProjectForm
   attribute :outgoing_trust_sharepoint_link
-  attribute :incoming_trust_sharepoint_link
   attribute :outgoing_trust_ukprn
-  attribute :incoming_trust_ukprn
-  attribute :advisory_board_date, :date
-  attribute :advisory_board_conditions
-  attribute :two_requires_improvement, :boolean
   attribute :inadequate_ofsted, :boolean
   attribute :financial_safeguarding_governance_issues, :boolean
   attribute :outgoing_trust_to_close, :boolean
-  attribute :assigned_to_regional_caseworker_team, :boolean
-  attribute :handover_note_body
 
-  validates :establishment_sharepoint_link, presence: true, sharepoint_url: true
-  validates :incoming_trust_sharepoint_link, presence: true, sharepoint_url: true
   validates :outgoing_trust_sharepoint_link, presence: true, sharepoint_url: true
 
   validates :outgoing_trust_ukprn, presence: true, ukprn: true
   validates :outgoing_trust_ukprn, trust_exists: true, if: -> { outgoing_trust_ukprn.present? }
 
-  validates :incoming_trust_ukprn, presence: true, ukprn: true
-  validates :incoming_trust_ukprn, trust_exists: true, if: -> { incoming_trust_ukprn.present? }
-
   validates_with OutgoingIncomingTrustsUkprnValidator
-
-  validates :advisory_board_date, presence: true
-  validates :advisory_board_date, date_in_the_past: true
-
-  validates :two_requires_improvement, inclusion: {in: [true, false], message: I18n.t("errors.conversion_project.attributes.two_requires_improvement.inclusion")}
 
   validates :inadequate_ofsted, inclusion: {in: [true, false], message: I18n.t("errors.transfer_project.attributes.inadequate_ofsted.inclusion")}
 
@@ -102,16 +78,5 @@ class Transfer::EditProjectForm
     end
 
     project
-  end
-
-  private def update_handover_note
-    note = Note.find_or_initialize_by(project: project, task_identifier: :handover, user: user)
-    note.update!(body: handover_note_body)
-  end
-
-  private def notify_team_leaders(project)
-    User.team_leaders.each do |team_leader|
-      TeamLeaderMailer.new_conversion_project_created(team_leader, project).deliver_later if team_leader.active
-    end
   end
 end

--- a/app/forms/transfer/edit_project_form.rb
+++ b/app/forms/transfer/edit_project_form.rb
@@ -1,6 +1,6 @@
 class Transfer::EditProjectForm < EditProjectForm
-  attribute :outgoing_trust_sharepoint_link
-  attribute :outgoing_trust_ukprn
+  attribute :outgoing_trust_sharepoint_link, :string
+  attribute :outgoing_trust_ukprn, :integer
   attribute :inadequate_ofsted, :boolean
   attribute :financial_safeguarding_governance_issues, :boolean
   attribute :outgoing_trust_to_close, :boolean
@@ -24,6 +24,7 @@ class Transfer::EditProjectForm < EditProjectForm
       outgoing_trust_sharepoint_link: project.outgoing_trust_sharepoint_link,
       outgoing_trust_ukprn: project.outgoing_trust_ukprn,
       incoming_trust_ukprn: project.incoming_trust_ukprn,
+      group_id: project.group&.group_identifier,
       advisory_board_date: project.advisory_board_date,
       advisory_board_conditions: project.advisory_board_conditions,
       two_requires_improvement: project.two_requires_improvement,
@@ -71,6 +72,8 @@ class Transfer::EditProjectForm < EditProjectForm
     )
 
     ActiveRecord::Base.transaction do
+      project.group = group_id_to_group(group_id)
+
       project.save!
       project.tasks_data.save!
       update_handover_note if handover_note_body.present?

--- a/app/validators/group_id_validator.rb
+++ b/app/validators/group_id_validator.rb
@@ -1,0 +1,14 @@
+class GroupIdValidator < ActiveModel::Validator
+  def validate(record)
+    group_id = record.group_id
+
+    return unless group_id.present?
+
+    record.errors.add(:group_id, :invalid) unless group_id.match?(/\AGRP_\d{8}\z/)
+
+    if record.incoming_trust_ukprn.present?
+      group = ProjectGroup.find_by_group_identifier(group_id)
+      record.errors.add(:group_id, :trust_ukprn) unless group.nil? || group.trust_ukprn.eql?(record.incoming_trust_ukprn)
+    end
+  end
+end

--- a/app/views/conversions/projects/edit.html.erb
+++ b/app/views/conversions/projects/edit.html.erb
@@ -7,6 +7,10 @@
         <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m"}, width: 10, autocomplete: :off %>
       </div>
 
+      <div class="govuk-form-group" id="group-reference-number">
+        <%= form.govuk_text_field :group_id, label: {size: "m"}, width: 10, autocomplete: :off %>
+      </div>
+
       <div class="govuk-form-group" id="advisory-board">
         <%= form.govuk_date_field :advisory_board_date, legend: {text: t("helpers.legend.project.advisory_board_date")}, form_group: {id: "advisory-board-date"}, hint: {text: t("helpers.hint.project.advisory_board_date").html_safe} %>
         <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m", text: t("helpers.label.conversion_project.advisory_board_conditions")} %>

--- a/app/views/shared/project_information/_project_details.html.erb
+++ b/app/views/shared/project_information/_project_details.html.erb
@@ -26,6 +26,14 @@
             row.with_key { t("project_information.show.project_details.rows.region") }
             row.with_value { project.establishment.region_name }
           end
+          summary_list.with_row do |row|
+            row.with_key { t("project_information.show.project_details.rows.group") }
+            if project.group.present?
+              row.with_value { project.group.group_identifier }
+            else
+              row.with_value { t("project_information.show.project_details.values.no_group") }
+            end
+          end
         end %>
   </div>
 </div>

--- a/app/views/shared/project_information/_project_details.html.erb
+++ b/app/views/shared/project_information/_project_details.html.erb
@@ -33,6 +33,12 @@
             else
               row.with_value { t("project_information.show.project_details.values.no_group") }
             end
+            if project.is_a?(Transfer::Project)
+              row.with_action(text: "Change", href: transfers_edit_path(@project, anchor: "group-reference-number"), visually_hidden_text: "the group reference number")
+            end
+            if project.is_a?(Conversion::Project)
+              row.with_action(text: "Change", href: conversions_edit_path(@project, anchor: "group-reference-number"), visually_hidden_text: "the group reference number")
+            end
           end
         end %>
   </div>

--- a/app/views/transfers/projects/edit.html.erb
+++ b/app/views/transfers/projects/edit.html.erb
@@ -11,6 +11,10 @@
         <%= form.govuk_text_field :incoming_trust_ukprn, label: {size: "m", text: t("helpers.label.transfer_project.incoming_trust_ukprn")}, hint: {text: t("helpers.hint.transfer_project.incoming_trust_ukprn").html_safe}, width: 10, autocomplete: :off %>
       </div>
 
+      <div class="govuk-form-group" id="group-reference-number">
+        <%= form.govuk_text_field :group_id, label: {size: "m"}, width: 10, autocomplete: :off %>
+      </div>
+
       <div class="govuk-form-group">
         <%= form.govuk_date_field :advisory_board_date, legend: {text: t("helpers.legend.transfer_project.advisory_board_date")}, form_group: {id: "advisory-board-date"}, hint: {text: t("helpers.hint.project.advisory_board_date").html_safe} %>
         <%= form.govuk_text_area :advisory_board_conditions, label: {size: "m", text: t("helpers.label.transfer_project.advisory_board_conditions")} %>

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -66,6 +66,7 @@ en:
     label:
       conversion_edit_project_form:
         incoming_trust_ukprn: Incoming trust UKPRN (UK Provider Reference Number)
+        group_id: Group reference number
       conversion_create_project_form:
         urn: School URN (Unique Reference Number)
         incoming_trust_ukprn: Incoming trust UKPRN (UK Provider Reference Number)
@@ -89,6 +90,9 @@ en:
         incoming_trust_ukprn_html:
           <p>A UKPRN is an 8-digit number that always starts with a 1.</p>
           <p><a href="https://www.get-information-schools.service.gov.uk/Search?SelectedTab=Groups" class="govuk-link" rel="noreferrer noopener" target="_blank">Search GIAS to find the incoming trust's UKPRN (opens in a new tab)</a>.</p>
+        group_id_html:
+          <p>If this school is converting as part of a group, enter the group reference number.</p>
+          <p>The reference number begins with the letters GRP and contains up to 8 numbers, like GRP_XXXXXXXX. You can find this on the group’s page in Prepare conversions and transfers.</p>
       conversion_create_project_form:
         establishment_sharepoint_link_html:
           <p>If the school applied to convert, you must save the application form in the Schools' SharePoint folder.</p>

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -130,7 +130,3 @@ en:
         must_be_in_the_future: Provisional conversion date must be in the future
       academy_urn:
         matching_school_urn: Academy URN cannot be the same as the school URN
-    conversion_project:
-      attributes:
-        two_requires_improvement:
-          inclusion: State if the conversion is due to 2RI. Choose yes or no

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -481,3 +481,7 @@ en:
       group_id:
         invalid: A group group reference number must start GRP_ and contain 8 numbers, like GRP_00000001
         trust_ukprn: The group reference number must be for the same trust as all other group members, check the group reference number and incoming trust UKPRN
+    conversion_project:
+      attributes:
+        two_requires_improvement:
+          inclusion: State if the conversion is due to 2RI. Choose yes or no

--- a/config/locales/project_information.en.yml
+++ b/config/locales/project_information.en.yml
@@ -19,9 +19,11 @@ en:
             transfer_project: Transfer date
           local_authority: Local authority
           region: Region
+          group: Group reference number
         values:
           conversion_project: Conversion
           transfer_project: Transfer
+          no_group: Not grouped
       reasons_for:
         conversion:
           title: Reasons for the conversion

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -47,6 +47,8 @@ en:
         new_trust_reference_number: Trust reference number (TRN)
         new_trust_name: Trust name
         group_id: Group reference number
+      transfer_edit_project_form:
+        group_id: Group reference number
     legend:
       transfer_project:
         advisory_board_date: Date of advisory board
@@ -87,6 +89,10 @@ en:
             <li>any financial package that has been finalised and agreed</li>
           </ul>
         two_requires_improvement: If an academy receives 2 or more requires improvement ratings (2RI) from Ofsted, it can be transferred to a different trust to improve performance.
+      transfer_edit_project_form:
+        group_id_html:
+          <p>If this academy is transfering  as part of a group, enter the group reference number.</p>
+          <p>The reference number begins with the letters GRP and contains up to 8 numbers, like GRP_XXXXXXXX. You can find this on the group’s page in Prepare conversions and transfers.</p>
       transfer_create_project_form:
         new_trust_name: Enter the proposed name for the new trust. This can be changed later on if necessary.
         new_trust_reference_number_html:
@@ -108,6 +114,9 @@ en:
           <li>who the Schools Financial Support and Oversight lead is</li>
           <li>any financial package that has been finalised and agreed</li>
           </ul>
+        group_id_html:
+          <p>If this academy is transfering  as part of a group, enter the group reference number.</p>
+          <p>The reference number begins with the letters GRP and contains up to 8 numbers, like GRP_XXXXXXXX. You can find this on the group’s page in Prepare conversions and transfers.</p>
   errors:
     attributes:
       provisional_transfer_date:

--- a/spec/features/conversions/users_can_edit_project_details_spec.rb
+++ b/spec/features/conversions/users_can_edit_project_details_spec.rb
@@ -202,4 +202,36 @@ RSpec.feature "Users can edit conversion project details" do
 
     expect(page).to have_content "Not assigned to project"
   end
+
+  scenario "they can change and unset the group reference number" do
+    create(:project_group, group_identifier: "GRP_12345678", trust_ukprn: project.incoming_trust_ukprn)
+    visit project_information_path(project)
+
+    row = find("#projectDetails .govuk-summary-list__row:nth-child(6)")
+
+    within(row) do
+      expect(page).to have_content("Not grouped")
+      click_link "Change"
+    end
+
+    fill_in "Group reference number", with: "GRP_12345678"
+
+    click_on "Continue"
+
+    within(row) do
+      expect(page).to have_content("GRP_12345678")
+    end
+
+    within(row) do
+      click_link "Change"
+    end
+
+    fill_in "Group reference number", with: ""
+
+    click_on "Continue"
+
+    within(row) do
+      expect(page).to have_content("Not grouped")
+    end
+  end
 end

--- a/spec/features/project_information/users_can_view_project_details_spec.rb
+++ b/spec/features/project_information/users_can_view_project_details_spec.rb
@@ -21,4 +21,23 @@ RSpec.feature "Users can view project details" do
       expect(page).to have_content("Yes")
     end
   end
+
+  context "when the project is grouped with others" do
+    let(:group) { create(:project_group, group_identifier: "GRP_12345678") }
+    let(:project) { create(:conversion_project, group: group) }
+
+    scenario "they can see the group reference number" do
+      within "#projectDetails" do
+        expect(page).to have_content(group.group_identifier)
+      end
+    end
+  end
+
+  context "when the project is not grouped with others" do
+    scenario "they can see an indicator" do
+      within "#projectDetails" do
+        expect(page).to have_content("Not grouped")
+      end
+    end
+  end
 end

--- a/spec/forms/conversion/edit_project_form_spec.rb
+++ b/spec/forms/conversion/edit_project_form_spec.rb
@@ -180,5 +180,35 @@ RSpec.describe Conversion::EditProjectForm, type: :model do
                                 .with("TeamLeaderMailer", "new_conversion_project_created", "deliver_now", args: [team_leader, project]))
       end
     end
+
+    describe "the group reference number" do
+      context "when the group does not exist" do
+        it "creates the group and associate the project" do
+          expect { subject.update({group_id: "GRP_12345678"}) }.to change { ProjectGroup.count }.by(1)
+
+          expect(project.group.group_identifier).to eql "GRP_12345678"
+        end
+      end
+
+      context "when the group exists" do
+        it "associates the project" do
+          create(:project_group, group_identifier: "GRP_12345678", trust_ukprn: project.incoming_trust_ukprn)
+
+          expect { subject.update({group_id: "GRP_12345678"}) }.not_to change { ProjectGroup.count }
+
+          expect(project.group.group_identifier).to eql "GRP_12345678"
+        end
+      end
+
+      context "when set to empty" do
+        it "un-sets the project association" do
+          create(:project_group, group_identifier: "GRP_12345678", trust_ukprn: project.incoming_trust_ukprn)
+
+          expect { subject.update({group_id: ""}) }.not_to change { ProjectGroup.count }
+
+          expect(project.group).to be_nil
+        end
+      end
+    end
   end
 end

--- a/spec/validators/group_id_validator_spec.rb
+++ b/spec/validators/group_id_validator_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe GroupIdValidator do
+  subject { GroupIdValidatorTest.new }
+
+  context "when the group id format is correct" do
+    it "is valid" do
+      subject.group_id = "GRP_12345678"
+
+      expect(subject).to be_valid
+    end
+  end
+
+  context "when the group id format is incorrect" do
+    it "is invalid" do
+      ["GRP12345678", "grp_12345678", "GRP_12345"].each do |incorrect_group_id|
+        subject.group_id = incorrect_group_id
+
+        expect(subject).to be_invalid
+      end
+    end
+  end
+
+  context "when the group exists" do
+    context "and the incoming_trust_ukprn matches" do
+      it "is valid" do
+        create(:project_group, group_identifier: "GRP_12345678", trust_ukprn: 1234567)
+
+        subject.group_id = "GRP_12345678"
+        subject.incoming_trust_ukprn = 1234567
+
+        expect(subject).to be_valid
+      end
+    end
+
+    context "and the incoming_trust_ukprn does not match" do
+      it "is invalid" do
+        create(:project_group, group_identifier: "GRP_12345678", trust_ukprn: 1234567)
+
+        subject.group_id = "GRP_12345678"
+        subject.incoming_trust_ukprn = 7654321
+
+        expect(subject).to be_invalid
+      end
+    end
+  end
+end
+
+class GroupIdValidatorTest
+  include ActiveModel::Validations
+  attr_accessor :incoming_trust_ukprn
+  attr_accessor :group_id
+
+  validates_with GroupIdValidator
+end


### PR DESCRIPTION
Whilst users have to supply the group reference number, there is a chance it
could be incorrect, so we want to allow it to be changed.

We already have a pattern for this with the concept of 'edit project form' for
both conversion and transfers.

This work extracts the common behaviour across those forms and then adds in the
group reference number for editing.

Editing the group reference number needs to allow it to be set to nothing, i.e.
the association to the group cancelled, this is achieved by submitting an empty
value.
