### PR TITLE
Model key contacts

### DIFF
--- a/app/models/key_contacts.rb
+++ b/app/models/key_contacts.rb
@@ -1,0 +1,4 @@
+class KeyContacts < ApplicationRecord
+  belongs_to :project
+  belongs_to :headteacher, class_name: "Contact", optional: true
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,6 +15,7 @@ class Project < ApplicationRecord
   has_many :contacts, class_name: "Contact::Project", inverse_of: :project, dependent: :destroy
   has_many :date_history, class_name: "SignificantDateHistory", inverse_of: :project, dependent: :destroy
   has_one :dao_revocation, class_name: "DaoRevocation", inverse_of: :project, dependent: :destroy
+  has_one :key_contacts, dependent: :destroy
 
   belongs_to :main_contact, inverse_of: :main_contact_for_project, dependent: :destroy, class_name: "Contact", optional: true
   belongs_to :establishment_main_contact, inverse_of: :main_contact_for_establishment, dependent: :destroy, class_name: "Contact", optional: true

--- a/db/migrate/20240808094556_add_key_contacts.rb
+++ b/db/migrate/20240808094556_add_key_contacts.rb
@@ -1,0 +1,9 @@
+class AddKeyContacts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :key_contacts, id: :uuid do |t|
+      t.uuid :project_id, index: true
+      t.uuid :headteacher_id, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_01_080056) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_08_094556) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -241,6 +241,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_01_080056) do
     t.index ["group_identifier"], name: "index_gias_groups_on_group_identifier"
     t.index ["ukprn"], name: "index_gias_groups_on_ukprn"
     t.index ["unique_group_identifier"], name: "index_gias_groups_on_unique_group_identifier", unique: true
+  end
+
+  create_table "key_contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+    t.uuid "project_id"
+    t.uuid "headteacher_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["headteacher_id"], name: "index_key_contacts_on_headteacher_id"
+    t.index ["project_id"], name: "index_key_contacts_on_project_id"
   end
 
   create_table "local_authorities", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/models/key_contacts_spec.rb
+++ b/spec/models/key_contacts_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe KeyContacts do
+  before do
+    mock_all_academies_api_responses
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:project).required(true) }
+    it { is_expected.to belong_to(:headteacher).optional(true) }
+  end
+
+  describe "headteacher" do
+    it "can be a project contact" do
+      contact = create(:project_contact)
+
+      project = create(:conversion_project)
+      key_contacts = described_class.create!(project: project, headteacher: contact)
+
+      expect(key_contacts.headteacher).to be contact
+    end
+
+    it "can be an establishment contact" do
+      contact = create(:establishment_contact)
+
+      project = create(:conversion_project)
+      key_contacts = described_class.create!(project: project, headteacher: contact)
+
+      expect(key_contacts.headteacher).to be contact
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to belong_to(:local_authority_main_contact).optional(true) }
     it { is_expected.to have_one(:dao_revocation).dependent(:destroy) }
     it { is_expected.to belong_to(:group).optional(true) }
+    it { is_expected.to have_one(:key_contacts).dependent(:destroy) }
 
     describe "delete related entities" do
       context "when the project is deleted" do


### PR DESCRIPTION
Key contacts are those used by data consumers to send important
communications to those involved in projects.

They fill DfE defined roles in the project:

- headteacher
- chair of governors
- incoming trust CEO
- outgoing trust CEO
- director of children services
- member of parliament

These roles are not the contact job title.

We want to encapsulate these into a model that sits outside of Project
(to keep Project as clean as we can).

We settled on `key_contacts` which is a simple joining model between the
project and the contacts.

Here we are only adding headteacher, but the others will follow.

We have no referential integrity here as:

- a project will destroy its own key_contacts
- we want a contact to be deleted even if referenced from a key_contact,
  which will then return `nil`, which is the expected behaviour

There is also no need for polymorphic associations here as Contact use
single table inheritance so that Rails can identify the class of the
contact that is returned on the association.

This approach is a similar to `TasksData` which we use to keep all the
task related attributes out of the project model and table.
