### PR TITLE
Release 82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release-82][release-82]
+
 ### Added
 
 - new conversion projects now collect the group reference number, used in the
@@ -2113,7 +2115,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-81...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-82...HEAD
+[release-82]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-81...release-82
 [release-81]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-80...release-81
 [release-80]:


### PR DESCRIPTION
Added

- new conversion projects now collect the group reference number, used in the Prepare application to group projects together for advisory board.
- new transfer projects now collect the group reference number, used in the Prepare application to group projects together for advisory board.
- the group reference number for a conversion or transfer can now be changed from the project information view.
- show an indicator when a project is part of a group
- a new index page listing all grouped projects
- a list of the project groups is shown on the index page
- individual project groups can now be viewed

Fixed

- the time for a date history item is now shown in the London timezone

Changed

- The feedback form link in the phase banner is now the same as the one in the footer
