### PR TITLE
Add confirm headteacher contact to transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - a new 'confirm the headteacher contact' task has been added, users need to
   choose the appropriate contact from those available to the project, they may
   also have to add it
+- transfer project also have a new 'confirm the headteacher contact' task that
+  works the same as for conversions.
 
 ## [Release-82][release-82]
 

--- a/app/forms/transfer/task/confirm_headteacher_contact_task_form.rb
+++ b/app/forms/transfer/task/confirm_headteacher_contact_task_form.rb
@@ -1,0 +1,21 @@
+class Transfer::Task::ConfirmHeadteacherContactTaskForm < BaseTaskForm
+  attribute :headteacher_contact_id, :string
+
+  def initialize(tasks_data, user)
+    @tasks_data = tasks_data
+    @user = user
+    @project = @tasks_data.project
+    @key_contacts = KeyContacts.find_or_create_by(project: @project)
+
+    super(@tasks_data, @user)
+    self.headteacher_contact_id = @key_contacts.headteacher_id
+  end
+
+  def save
+    @key_contacts.update!(headteacher_id: headteacher_contact_id)
+  end
+
+  private def completed?
+    @key_contacts.headteacher.present?
+  end
+end

--- a/app/models/transfer/task_list.rb
+++ b/app/models/transfer/task_list.rb
@@ -6,6 +6,7 @@ class Transfer::TaskList < ::BaseTaskList
         tasks: [
           Transfer::Task::HandoverTaskForm,
           Transfer::Task::StakeholderKickOffTaskForm,
+          Transfer::Task::ConfirmHeadteacherContactTaskForm,
           Transfer::Task::MainContactTaskForm,
           Transfer::Task::RequestNewUrnAndRecordTaskForm,
           Transfer::Task::SponsoredSupportGrantTaskForm,

--- a/app/views/transfers/tasks/confirm_headteacher_contact/edit.html.erb
+++ b/app/views/transfers/tasks/confirm_headteacher_contact/edit.html.erb
@@ -1,0 +1,53 @@
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.confirm_headteacher_contact.title")) %>
+<% end %>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-9">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @project.establishment.name %></span>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
+      <%= t("transfer.task.confirm_headteacher_contact.title") %>
+    </h1>
+
+    <div class="app-task-hint">
+      <%= t("transfer.task.confirm_headteacher_contact.hint.html", contacts_path: project_contacts_path(@project)) %>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <% if @project.contacts.school_or_academy.empty? %>
+
+      <h2 class="govuk-heading-l"><%= t("transfer.task.confirm_headteacher_contact.no_contacts.title") %></h2>
+      <%= govuk_inset_text(text: t("transfer.task.confirm_headteacher_contact.no_contacts.hint.html")) %>
+      <%= link_to "Add a contact", new_project_contact_path(@project), class: "govuk-button", data: {module: "govuk-button"}, draggable: "false" %>
+
+    <% else %>
+
+      <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
+        <%= form.govuk_error_summary %>
+
+        <%= form.govuk_collection_radio_buttons :headteacher_contact_id,
+              @project.contacts.school_or_academy,
+              :id,
+              :name,
+              :email_and_phone,
+              legend: {text: t("transfer.task.confirm_headteacher_contact.choose_a_contact.title"), size: "l"},
+              hint: {text: t("transfer.task.confirm_headteacher_contact.choose_a_contact.hint.html")},
+              form_group: {id: "who-is-the-headteacher"} %>
+
+        <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/config/locales/transfer/tasks/confirm_headteacher_contact.en.yml
+++ b/config/locales/transfer/tasks/confirm_headteacher_contact.en.yml
@@ -1,0 +1,20 @@
+en:
+  transfer:
+    task:
+      confirm_headteacher_contact:
+        title: Confirm the headteacher’s details
+        hint:
+          html:
+            <p>Check the contact details are correct, <a href="%{contacts_path}">edit incorrect contact
+            details and add missing contacts</a>. You may need to contact the person
+            who previously worked on the project to verify this.</p>
+        no_contacts:
+          title: Who is the headteacher?
+          hint:
+            html: <p>No contacts have been added to the project.</p>
+        choose_a_contact:
+          title: Who is the headteacher?
+          hint:
+            html:
+              <p>Choose the relevant person from the list of contacts. You may need to add a new contact if the person you are looking for is not in the list.</p>
+              <p>Their job title may be slightly different to the role described here. Choose the person whose role most closely matches the headteacher.</p>

--- a/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
+++ b/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
@@ -36,6 +36,7 @@ RSpec.feature "Users can complete transfer tasks" do
   tasks_with_collected_data = %w[
     stakeholder_kick_off
     conditions_met
+    confirm_headteacher_contact
     main_contact
     bank_details_changing
     check_and_confirm_financial_information

--- a/spec/features/transfers/users_can_confirm_the_headteacher_contact_spec.rb
+++ b/spec/features/transfers/users_can_confirm_the_headteacher_contact_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.feature "Users can confirm the headteacher contact" do
+  let(:user) { create(:user, :caseworker) }
+  let(:project) { create(:transfer_project, assigned_to: user) }
+
+  before do
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  context "when there are no contacts for the project" do
+    scenario "they see a helpful message and a link to the contacts tab" do
+      visit project_path(project)
+      click_link "Confirm the headteacher’s details"
+
+      expect(page).to have_content "No contacts have been added to the project."
+      expect(page).to have_link href: project_contacts_path(project), text: "edit incorrect contact details and add missing contacts"
+    end
+  end
+
+  context "when there are contacts but they are not in the correct category" do
+    let!(:contact) { create(:project_contact, category: :incoming_trust, project: project) }
+
+    scenario "they see a helpful message and a link to the contacts tab" do
+      visit project_path(project)
+      click_link "Confirm the headteacher’s details"
+
+      expect(page).to have_content "No contacts have been added to the project."
+      expect(page).to have_link href: project_contacts_path(project), text: "edit incorrect contact details and add missing contacts"
+    end
+  end
+
+  context "when there are contacts and they are in the correct category" do
+    let!(:contact) { create(:project_contact, category: :school_or_academy, project: project) }
+
+    scenario "they can choose the contact" do
+      visit project_path(project)
+      click_link "Confirm the headteacher’s details"
+
+      expect(page).to have_content contact.name
+      expect(page).to have_content contact.email
+      expect(page).to have_content contact.phone
+
+      choose contact.name
+
+      click_button "Save and return"
+
+      within ".app-task-list li:nth-of-type(1) li:nth-of-type(3)" do
+        expect(page).to have_content "Completed"
+      end
+    end
+  end
+end

--- a/spec/models/transfer/task_list_spec.rb
+++ b/spec/models/transfer/task_list_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Transfer::TaskList do
       transfer_task_list_identifiers = [
         :handover,
         :stakeholder_kick_off,
+        :confirm_headteacher_contact,
         :main_contact,
         :request_new_urn_and_record,
         :sponsored_support_grant,
@@ -53,7 +54,7 @@ RSpec.describe Transfer::TaskList do
       project = create(:transfer_project)
       task_list = described_class.new(project, user)
 
-      expect(task_list.tasks.count).to eql 25
+      expect(task_list.tasks.count).to eql 26
       expect(task_list.tasks.first).to be_a Transfer::Task::HandoverTaskForm
       expect(task_list.tasks.last).to be_a Transfer::Task::DeclarationOfExpenditureCertificateTaskForm
     end


### PR DESCRIPTION
Just like conversions, we want to explicitly ask the user to confirm
which contact is the headteacher. The information is important to
downstream data users.

This work is a repeat of the conversions work.

