### PR TITLE
Add the headteacher contact to exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   also have to add it
 - transfer project also have a new 'confirm the headteacher contact' task that
   works the same as for conversions.
+- the confirmed headteacher contact details are now included in exports where
+  needed.
 
 ## [Release-82][release-82]
 

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -108,6 +108,24 @@ module Export::Csv::SchoolPresenterModule
     school_or_academy_contact&.title
   end
 
+  def headteacher_contact_name
+    return unless @project.key_contacts&.headteacher.present?
+
+    @project.key_contacts.headteacher.name
+  end
+
+  def headteacher_contact_role
+    return unless @project.key_contacts&.headteacher.present?
+
+    @project.key_contacts.headteacher.title
+  end
+
+  def headteacher_contact_email
+    return unless @project.key_contacts&.headteacher.present?
+
+    @project.key_contacts.headteacher.email
+  end
+
   private def school_or_academy_contact
     @contacts_fetcher.school_or_academy_contact
   end

--- a/app/services/export/conversions/all_data_csv_export_service.rb
+++ b/app/services/export/conversions/all_data_csv_export_service.rb
@@ -49,6 +49,9 @@ class Export::Conversions::AllDataCsvExportService < Export::CsvExportService
     assigned_to_name
     team_managing_the_project
     main_contact_name
+    headteacher_contact_name
+    headteacher_contact_role
+    headteacher_contact_email
     local_authority_contact_name
     local_authority_contact_email
     incoming_trust_main_contact_name

--- a/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
+++ b/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
@@ -14,6 +14,9 @@ class Export::Conversions::RpaSugAndFaLettersCsvExportService < Export::CsvExpor
     school_main_contact_name
     school_main_contact_role
     school_main_contact_email
+    headteacher_contact_name
+    headteacher_contact_role
+    headteacher_contact_email
     chair_of_governors_name
     chair_of_governors_email
     academy_urn

--- a/app/services/export/transfers/academies_due_to_transfer_csv_export_service.rb
+++ b/app/services/export/transfers/academies_due_to_transfer_csv_export_service.rb
@@ -27,6 +27,9 @@ class Export::Transfers::AcademiesDueToTransferCsvExportService < Export::CsvExp
     main_contact_name
     main_contact_email
     main_contact_title
+    headteacher_contact_name
+    headteacher_contact_role
+    headteacher_contact_email
   ]
 
   def initialize(projects)

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -137,6 +137,9 @@ en:
           school_main_contact_email: School contact email
           school_main_contact_name: School contact name
           school_main_contact_role: School contact role
+          headteacher_contact_name: Headteacher name
+          headteacher_contact_role: Headteacher role
+          headteacher_contact_email: Headteacher email
           other_contact_name: Other contact name
           other_contact_email: Other contact email
           other_contact_role: Other contact role

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -105,6 +105,26 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
     end
   end
 
+  describe "headteacher contact" do
+    context "when the headteacher contact is confirmed" do
+      it "shows the contact details" do
+        KeyContacts.new(project: project, headteacher: contact)
+
+        expect(subject.headteacher_contact_name).to eql "Jo Example"
+        expect(subject.headteacher_contact_role).to eql "CEO of Learning"
+        expect(subject.headteacher_contact_email).to eql "jo@example.com"
+      end
+    end
+
+    context "when the headteacher contact is not confirmed" do
+      it "shows nothing" do
+        expect(subject.headteacher_contact_name).to be_nil
+        expect(subject.headteacher_contact_role).to be_nil
+        expect(subject.headteacher_contact_email).to be_nil
+      end
+    end
+  end
+
   def known_establishment
     double(
       Api::AcademiesApi::Establishment,


### PR DESCRIPTION
We recently added new tasks for conversions and transfers to confirm the
headteacher contact details.

This work exposes that data, if available in the exports.

