### PR TITLE
(176162 and 176163) Incoming trust CEO contact task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - a new 'confirm the incoming trust CEO contact' task has been added to
   conversion projects, users need to choose the appropriate contact from those
   available to the project, they may also have to add it
+- a new 'confirm the incoming trust CEO contact' task has been added to transfer
+  projects, users need to choose the appropriate contact from those available to
+  the project, they may also have to add it
 
 ## [Release-82][release-82]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   needed.
 - a new task 'confirm the chair of governors' task has been added to conversion
   projects, users must supply and indicate which contact fills this role.
+- a new 'confirm the incoming trust CEO contact' task has been added to
+  conversion projects, users need to choose the appropriate contact from those
+  available to the project, they may also have to add it
 
 ## [Release-82][release-82]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - a new 'confirm the incoming trust CEO contact' task has been added to transfer
   projects, users need to choose the appropriate contact from those available to
   the project, they may also have to add it
+- the confirmed incoming trust CEO contacts now appear in export where
+  appropriate.
 
 ## [Release-82][release-82]
 

--- a/app/forms/conversion/task/confirm_incoming_trust_ceo_contact_task_form.rb
+++ b/app/forms/conversion/task/confirm_incoming_trust_ceo_contact_task_form.rb
@@ -1,0 +1,21 @@
+class Conversion::Task::ConfirmIncomingTrustCeoContactTaskForm < BaseTaskForm
+  attribute :incoming_trust_ceo_contact_id, :string
+
+  def initialize(tasks_data, user)
+    @tasks_data = tasks_data
+    @user = user
+    @project = @tasks_data.project
+    @key_contacts = KeyContacts.find_or_create_by(project: @project)
+
+    super(@tasks_data, @user)
+    self.incoming_trust_ceo_contact_id = @key_contacts.incoming_trust_ceo_id
+  end
+
+  def save
+    @key_contacts.update!(incoming_trust_ceo_id: incoming_trust_ceo_contact_id)
+  end
+
+  private def completed?
+    @key_contacts.incoming_trust_ceo.present?
+  end
+end

--- a/app/forms/transfer/task/confirm_incoming_trust_ceo_contact_task_form.rb
+++ b/app/forms/transfer/task/confirm_incoming_trust_ceo_contact_task_form.rb
@@ -1,0 +1,21 @@
+class Transfer::Task::ConfirmIncomingTrustCeoContactTaskForm < BaseTaskForm
+  attribute :incoming_trust_ceo_contact_id, :string
+
+  def initialize(tasks_data, user)
+    @tasks_data = tasks_data
+    @user = user
+    @project = @tasks_data.project
+    @key_contacts = KeyContacts.find_or_create_by(project: @project)
+
+    super(@tasks_data, @user)
+    self.incoming_trust_ceo_contact_id = @key_contacts.incoming_trust_ceo_id
+  end
+
+  def save
+    @key_contacts.update!(incoming_trust_ceo_id: incoming_trust_ceo_contact_id)
+  end
+
+  private def completed?
+    @key_contacts.incoming_trust_ceo.present?
+  end
+end

--- a/app/models/conversion/task_list.rb
+++ b/app/models/conversion/task_list.rb
@@ -13,6 +13,7 @@ class Conversion::TaskList < ::BaseTaskList
           Conversion::Task::AcademyDetailsTaskForm,
           Conversion::Task::ConfirmHeadteacherContactTaskForm,
           Conversion::Task::ConfirmChairOfGovernorsContactTaskForm,
+          Conversion::Task::ConfirmIncomingTrustCeoContactTaskForm,
           Conversion::Task::MainContactTaskForm,
           Conversion::Task::ProposedCapacityOfTheAcademyTaskForm
         ]

--- a/app/models/key_contacts.rb
+++ b/app/models/key_contacts.rb
@@ -2,4 +2,5 @@ class KeyContacts < ApplicationRecord
   belongs_to :project
   belongs_to :headteacher, class_name: "Contact", optional: true
   belongs_to :chair_of_governors, class_name: "Contact", optional: true
+  belongs_to :incoming_trust_ceo, class_name: "Contact", optional: true
 end

--- a/app/models/transfer/task_list.rb
+++ b/app/models/transfer/task_list.rb
@@ -7,6 +7,7 @@ class Transfer::TaskList < ::BaseTaskList
           Transfer::Task::HandoverTaskForm,
           Transfer::Task::StakeholderKickOffTaskForm,
           Transfer::Task::ConfirmHeadteacherContactTaskForm,
+          Transfer::Task::ConfirmIncomingTrustCeoContactTaskForm,
           Transfer::Task::MainContactTaskForm,
           Transfer::Task::RequestNewUrnAndRecordTaskForm,
           Transfer::Task::SponsoredSupportGrantTaskForm,

--- a/app/presenters/export/csv/incoming_trust_presenter_module.rb
+++ b/app/presenters/export/csv/incoming_trust_presenter_module.rb
@@ -71,6 +71,24 @@ module Export::Csv::IncomingTrustPresenterModule
     incoming_trust_contact&.email
   end
 
+  def incoming_trust_ceo_contact_name
+    return unless @project.key_contacts&.incoming_trust_ceo.present?
+
+    @project.key_contacts.incoming_trust_ceo.name
+  end
+
+  def incoming_trust_ceo_contact_role
+    return unless @project.key_contacts&.incoming_trust_ceo.present?
+
+    @project.key_contacts.incoming_trust_ceo.title
+  end
+
+  def incoming_trust_ceo_contact_email
+    return unless @project.key_contacts&.incoming_trust_ceo.present?
+
+    @project.key_contacts.incoming_trust_ceo.email
+  end
+
   def incoming_trust_sharepoint_link
     return unless @project.incoming_trust_sharepoint_link.present?
 

--- a/app/services/export/conversions/all_data_csv_export_service.rb
+++ b/app/services/export/conversions/all_data_csv_export_service.rb
@@ -58,6 +58,9 @@ class Export::Conversions::AllDataCsvExportService < Export::CsvExportService
     incoming_trust_main_contact_email
     outgoing_trust_main_contact_name
     outgoing_trust_main_contact_email
+    incoming_trust_ceo_contact_name
+    incoming_trust_ceo_contact_role
+    incoming_trust_ceo_contact_email
     solicitor_contact_name
     solicitor_contact_email
     diocese_contact_name

--- a/app/services/export/transfers/all_data_csv_export_service.rb
+++ b/app/services/export/transfers/all_data_csv_export_service.rb
@@ -61,6 +61,9 @@ class Export::Transfers::AllDataCsvExportService < Export::CsvExportService
     incoming_trust_main_contact_email
     outgoing_trust_main_contact_name
     outgoing_trust_main_contact_email
+    incoming_trust_ceo_contact_name
+    incoming_trust_ceo_contact_role
+    incoming_trust_ceo_contact_email
     solicitor_contact_name
     solicitor_contact_email
     diocese_contact_name

--- a/app/views/conversions/tasks/confirm_incoming_trust_ceo_contact/edit.html.erb
+++ b/app/views/conversions/tasks/confirm_incoming_trust_ceo_contact/edit.html.erb
@@ -1,0 +1,53 @@
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("conversion.task.confirm_incoming_trust_ceo_contact.title")) %>
+<% end %>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-9">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @project.establishment.name %></span>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
+      <%= t("conversion.task.confirm_incoming_trust_ceo_contact.title") %>
+    </h1>
+
+    <div class="app-task-hint">
+      <%= t("conversion.task.confirm_incoming_trust_ceo_contact.hint.html", contacts_path: project_contacts_path(@project)) %>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <% if @project.contacts.incoming_trust.empty? %>
+
+      <h2 class="govuk-heading-l"><%= t("conversion.task.confirm_incoming_trust_ceo_contact.no_contacts.title") %></h2>
+      <%= govuk_inset_text(text: t("conversion.task.confirm_incoming_trust_ceo_contact.no_contacts.hint.html")) %>
+      <%= link_to "Add a contact", new_project_contact_path(@project), class: "govuk-button", data: {module: "govuk-button"}, draggable: "false" %>
+
+    <% else %>
+
+      <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
+        <%= form.govuk_error_summary %>
+
+        <%= form.govuk_collection_radio_buttons :incoming_trust_ceo_contact_id,
+              @project.contacts.incoming_trust,
+              :id,
+              :name,
+              :email_and_phone,
+              legend: {text: t("conversion.task.confirm_incoming_trust_ceo_contact.choose_a_contact.title"), size: "l"},
+              hint: {text: t("conversion.task.confirm_incoming_trust_ceo_contact.choose_a_contact.hint.html")},
+              form_group: {id: "who-is-the-incoming-trust-ceo"} %>
+
+        <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/app/views/transfers/tasks/confirm_incoming_trust_ceo_contact/edit.html.erb
+++ b/app/views/transfers/tasks/confirm_incoming_trust_ceo_contact/edit.html.erb
@@ -1,0 +1,53 @@
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.confirm_incoming_trust_ceo_contact.title")) %>
+<% end %>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-9">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @project.establishment.name %></span>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
+      <%= t("transfer.task.confirm_incoming_trust_ceo_contact.title") %>
+    </h1>
+
+    <div class="app-task-hint">
+      <%= t("transfer.task.confirm_incoming_trust_ceo_contact.hint.html", contacts_path: project_contacts_path(@project)) %>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <% if @project.contacts.incoming_trust.empty? %>
+
+      <h2 class="govuk-heading-l"><%= t("transfer.task.confirm_incoming_trust_ceo_contact.no_contacts.title") %></h2>
+      <%= govuk_inset_text(text: t("transfer.task.confirm_incoming_trust_ceo_contact.no_contacts.hint.html")) %>
+      <%= link_to "Add a contact", new_project_contact_path(@project), class: "govuk-button", data: {module: "govuk-button"}, draggable: "false" %>
+
+    <% else %>
+
+      <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
+        <%= form.govuk_error_summary %>
+
+        <%= form.govuk_collection_radio_buttons :incoming_trust_ceo_contact_id,
+              @project.contacts.incoming_trust,
+              :id,
+              :name,
+              :email_and_phone,
+              legend: {text: t("transfer.task.confirm_incoming_trust_ceo_contact.choose_a_contact.title"), size: "l"},
+              hint: {text: t("transfer.task.confirm_incoming_trust_ceo_contact.choose_a_contact.hint.html")},
+              form_group: {id: "who-is-the-incoming-trust-ceo"} %>
+
+        <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/config/locales/conversion/tasks/confirm_incoming_trust_ceo_contact.en.yml
+++ b/config/locales/conversion/tasks/confirm_incoming_trust_ceo_contact.en.yml
@@ -1,0 +1,20 @@
+en:
+  conversion:
+    task:
+      confirm_incoming_trust_ceo_contact:
+        title: Confirm the incoming trust CEO’s details
+        hint:
+          html:
+            <p>Check the contact details are correct, <a href="%{contacts_path}">edit incorrect contact
+            details and add missing contacts</a>. You may need to contact the person
+            who previously worked on the project to verify this.</p>
+        no_contacts:
+          title: Who is the incoming trust CEO?
+          hint:
+            html: <p>No contacts have been added to the project.</p>
+        choose_a_contact:
+          title: Who is the incoming trust CEO?
+          hint:
+            html:
+              <p>Choose the relevant person from the list of contacts. You may need to add a new contact if the person you are looking for is not in the list.</p>
+              <p>Their job title may be slightly different to the role described here. Choose the person whose role most closely matches the incoming trust CEO.</p>

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -53,6 +53,9 @@ en:
           incoming_trust_main_contact_name: Incoming trust main contact name
           incoming_trust_main_contact_email: Incoming trust main contact email
           incoming_trust_main_contact_role: Incoming trust main contact role
+          incoming_trust_ceo_contact_name: Incoming trust CEO name
+          incoming_trust_ceo_contact_role: Incoming trust CEO role
+          incoming_trust_ceo_contact_email: Incoming trust CEO email
           incoming_trust_sharepoint_link: Incoming trust sharepoint link
           incoming_trust_address_1: Incoming trust address 1
           incoming_trust_address_2: Incoming trust address 2

--- a/config/locales/transfer/tasks/confirm_incoming_trust_ceo_contact.en.yml
+++ b/config/locales/transfer/tasks/confirm_incoming_trust_ceo_contact.en.yml
@@ -1,0 +1,20 @@
+en:
+  transfer:
+    task:
+      confirm_incoming_trust_ceo_contact:
+        title: Confirm the incoming trust CEO’s details
+        hint:
+          html:
+            <p>Check the contact details are correct, <a href="%{contacts_path}">edit incorrect contact
+            details and add missing contacts</a>. You may need to contact the person
+            who previously worked on the project to verify this.</p>
+        no_contacts:
+          title: Who is the incoming trust CEO?
+          hint:
+            html: <p>No contacts have been added to the project.</p>
+        choose_a_contact:
+          title: Who is the incoming trust CEO?
+          hint:
+            html:
+              <p>Choose the relevant person from the list of contacts. You may need to add a new contact if the person you are looking for is not in the list.</p>
+              <p>Their job title may be slightly different to the role described here. Choose the person whose role most closely matches the incoming trust CEO.</p>

--- a/db/migrate/20240815105444_add_incoming_trust_ceo_to_key_contacts.rb
+++ b/db/migrate/20240815105444_add_incoming_trust_ceo_to_key_contacts.rb
@@ -1,0 +1,6 @@
+class AddIncomingTrustCeoToKeyContacts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :key_contacts, :incoming_trust_ceo_id, :uuid
+    add_index :key_contacts, :incoming_trust_ceo_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_14_100046) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_15_105444) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -249,8 +249,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_14_100046) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "chair_of_governors_id"
+    t.uuid "incoming_trust_ceo_id"
     t.index ["chair_of_governors_id"], name: "index_key_contacts_on_chair_of_governors_id"
     t.index ["headteacher_id"], name: "index_key_contacts_on_headteacher_id"
+    t.index ["incoming_trust_ceo_id"], name: "index_key_contacts_on_incoming_trust_ceo_id"
     t.index ["project_id"], name: "index_key_contacts_on_project_id"
   end
 

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature "Users can complete conversion tasks" do
     conditions_met
     confirm_headteacher_contact
     confirm_chair_of_governors_contact
+    confirm_incoming_trust
     main_contact
     proposed_capacity_of_the_academy
     receive_grant_payment_certificate

--- a/spec/features/conversions/users_can_confirm_the_incoming_trust_ceo_contact_spec.rb
+++ b/spec/features/conversions/users_can_confirm_the_incoming_trust_ceo_contact_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.feature "Users can confirm the incoming trust CEO contact" do
+  let(:user) { create(:user, :caseworker) }
+  let(:project) { create(:conversion_project, assigned_to: user) }
+
+  before do
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  context "when there are no contacts for the project" do
+    scenario "they see a helpful message and a link to the contacts tab" do
+      visit project_path(project)
+      click_link "Confirm the incoming trust CEO’s details"
+
+      expect(page).to have_content "No contacts have been added to the project."
+      expect(page).to have_link href: project_contacts_path(project), text: "edit incorrect contact details and add missing contacts"
+    end
+  end
+
+  context "when there are contacts but they are not in the correct category" do
+    let!(:contact) { create(:project_contact, category: :school_or_academy, project: project) }
+
+    scenario "they see a helpful message and a link to the contacts tab" do
+      visit project_path(project)
+      click_link "Confirm the incoming trust CEO’s details"
+
+      expect(page).to have_content "No contacts have been added to the project."
+      expect(page).to have_link href: project_contacts_path(project), text: "edit incorrect contact details and add missing contacts"
+    end
+  end
+
+  context "when there are contacts and they are in the correct category" do
+    let!(:contact) { create(:project_contact, category: :incoming_trust, project: project) }
+
+    scenario "they can choose the contact" do
+      visit project_path(project)
+      click_link "Confirm the incoming trust CEO’s details"
+
+      expect(page).to have_content contact.name
+      expect(page).to have_content contact.email
+      expect(page).to have_content contact.phone
+
+      choose contact.name
+
+      click_button "Save and return"
+
+      within ".app-task-list li:nth-of-type(1) li:nth-of-type(10)" do
+        expect(page).to have_content "Completed"
+      end
+    end
+  end
+end

--- a/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
+++ b/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
@@ -37,6 +37,7 @@ RSpec.feature "Users can complete transfer tasks" do
     stakeholder_kick_off
     conditions_met
     confirm_headteacher_contact
+    confirm_incoming_trust_ceo_contact
     main_contact
     bank_details_changing
     check_and_confirm_financial_information

--- a/spec/features/transfers/users_can_confirm_the_incoming_trust_ceo_contact_spec.rb
+++ b/spec/features/transfers/users_can_confirm_the_incoming_trust_ceo_contact_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.feature "Users can confirm the incoming trust CEO contact" do
+  let(:user) { create(:user, :caseworker) }
+  let(:project) { create(:transfer_project, assigned_to: user) }
+
+  before do
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  context "when there are no contacts for the project" do
+    scenario "they see a helpful message and a link to the contacts tab" do
+      visit project_path(project)
+      click_link "Confirm the incoming trust CEO’s details"
+
+      expect(page).to have_content "No contacts have been added to the project."
+      expect(page).to have_link href: project_contacts_path(project), text: "edit incorrect contact details and add missing contacts"
+    end
+  end
+
+  context "when there are contacts but they are not in the correct category" do
+    let!(:contact) { create(:project_contact, category: :school_or_academy, project: project) }
+
+    scenario "they see a helpful message and a link to the contacts tab" do
+      visit project_path(project)
+      click_link "Confirm the incoming trust CEO’s details"
+
+      expect(page).to have_content "No contacts have been added to the project."
+      expect(page).to have_link href: project_contacts_path(project), text: "edit incorrect contact details and add missing contacts"
+    end
+  end
+
+  context "when there are contacts and they are in the correct category" do
+    let!(:contact) { create(:project_contact, category: :incoming_trust, project: project) }
+
+    scenario "they can choose the contact" do
+      visit project_path(project)
+      click_link "Confirm the incoming trust CEO’s details"
+
+      expect(page).to have_content contact.name
+      expect(page).to have_content contact.email
+      expect(page).to have_content contact.phone
+
+      choose contact.name
+
+      click_button "Save and return"
+
+      within ".app-task-list li:nth-of-type(1) li:nth-of-type(4)" do
+        expect(page).to have_content "Completed"
+      end
+    end
+  end
+end

--- a/spec/models/conversion/task_list_spec.rb
+++ b/spec/models/conversion/task_list_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Conversion::TaskList do
         :academy_details,
         :confirm_headteacher_contact,
         :confirm_chair_of_governors_contact,
+        :confirm_incoming_trust_ceo_contact,
         :main_contact,
         :proposed_capacity_of_the_academy,
         :land_questionnaire,
@@ -60,6 +61,7 @@ RSpec.describe Conversion::TaskList do
               Conversion::Task::AcademyDetailsTaskForm,
               Conversion::Task::ConfirmHeadteacherContactTaskForm,
               Conversion::Task::ConfirmChairOfGovernorsContactTaskForm,
+              Conversion::Task::ConfirmIncomingTrustCeoContactTaskForm,
               Conversion::Task::MainContactTaskForm,
               Conversion::Task::ProposedCapacityOfTheAcademyTaskForm
             ]
@@ -122,7 +124,7 @@ RSpec.describe Conversion::TaskList do
       project = create(:conversion_project)
       task_list = described_class.new(project, user)
 
-      expect(task_list.tasks.count).to eql 32
+      expect(task_list.tasks.count).to eql 33
       expect(task_list.tasks.first).to be_a Conversion::Task::HandoverTaskForm
       expect(task_list.tasks.last).to be_a Conversion::Task::ReceiveGrantPaymentCertificateTaskForm
     end

--- a/spec/models/key_contacts_spec.rb
+++ b/spec/models/key_contacts_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe KeyContacts do
     it { is_expected.to belong_to(:project).required(true) }
     it { is_expected.to belong_to(:headteacher).optional(true) }
     it { is_expected.to belong_to(:chair_of_governors).optional(true) }
+    it { is_expected.to belong_to(:incoming_trust_ceo).optional(true) }
   end
 
   describe "headteacher" do
@@ -48,6 +49,26 @@ RSpec.describe KeyContacts do
       key_contacts = described_class.create!(project: project, chair_of_governors: contact)
 
       expect(key_contacts.chair_of_governors).to be contact
+    end
+  end
+
+  describe "incoming trust ceo" do
+    it "can be a project contact" do
+      contact = create(:project_contact)
+
+      project = create(:conversion_project)
+      key_contacts = described_class.create!(project: project, incoming_trust_ceo: contact)
+
+      expect(key_contacts.incoming_trust_ceo).to be contact
+    end
+
+    it "can be an establishment contact" do
+      contact = create(:establishment_contact)
+
+      project = create(:conversion_project)
+      key_contacts = described_class.create!(project: project, incoming_trust_ceo: contact)
+
+      expect(key_contacts.incoming_trust_ceo).to be contact
     end
   end
 end

--- a/spec/models/transfer/task_list_spec.rb
+++ b/spec/models/transfer/task_list_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Transfer::TaskList do
         :handover,
         :stakeholder_kick_off,
         :confirm_headteacher_contact,
+        :confirm_incoming_trust_ceo_contact,
         :main_contact,
         :request_new_urn_and_record,
         :sponsored_support_grant,
@@ -54,7 +55,7 @@ RSpec.describe Transfer::TaskList do
       project = create(:transfer_project)
       task_list = described_class.new(project, user)
 
-      expect(task_list.tasks.count).to eql 26
+      expect(task_list.tasks.count).to eql 27
       expect(task_list.tasks.first).to be_a Transfer::Task::HandoverTaskForm
       expect(task_list.tasks.last).to be_a Transfer::Task::DeclarationOfExpenditureCertificateTaskForm
     end

--- a/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
@@ -83,6 +83,27 @@ RSpec.describe Export::Csv::IncomingTrustPresenterModule do
     expect(subject.incoming_trust_sharepoint_link).to eql "https://educationgovuk-my.sharepoint.com/incoming-trust-folder"
   end
 
+  describe "incoming trust ceo contact" do
+    context "when there is a confirmed contact" do
+      let(:contact) { create(:project_contact) }
+
+      it "shows the correct details" do
+        KeyContacts.new(project: project, incoming_trust_ceo: contact)
+
+        expect(subject.incoming_trust_ceo_contact_name).to eql contact.name
+        expect(subject.incoming_trust_ceo_contact_role).to eql contact.title
+        expect(subject.incoming_trust_ceo_contact_email).to eql contact.email
+      end
+    end
+    context "when there is no confirmed contact" do
+      it "shows nothing" do
+        expect(subject.incoming_trust_ceo_contact_name).to be_nil
+        expect(subject.incoming_trust_ceo_contact_role).to be_nil
+        expect(subject.incoming_trust_ceo_contact_email).to be_nil
+      end
+    end
+  end
+
   def known_trust
     double(
       Api::AcademiesApi::Trust,


### PR DESCRIPTION
Just like the new headteacher and chair of governors, the incoming trust CEO is required data for downstream data users.

Our users are tasked with collecting the latest contact details and confirming them in a task on both conversions and transfers.

The data is exported as appropriate.

This is a repeat of the existng headteacher and chair of governors work.

There is no data to migrate and the existing 'main contact for incoming trust' will remain for now.

