### PR TITLE
(176165 and 176166) Outgoing trust CEO contact task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - a new 'confirm the outgoing trust CEO contact' task has been added to transfer
   projects, users need to choose the appropriate contact from those available to
   the project, they may also have to add it
+- the confirmed outgoing trust CEO contact details are now included in the
+  export where appropriate.
 
 ## [Release-82][release-82]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the project, they may also have to add it
 - the confirmed incoming trust CEO contacts now appear in export where
   appropriate.
+- a new 'confirm the outgoing trust CEO contact' task has been added to transfer
+  projects, users need to choose the appropriate contact from those available to
+  the project, they may also have to add it
 
 ## [Release-82][release-82]
 

--- a/app/forms/transfer/task/confirm_outgoing_trust_ceo_contact_task_form.rb
+++ b/app/forms/transfer/task/confirm_outgoing_trust_ceo_contact_task_form.rb
@@ -1,0 +1,21 @@
+class Transfer::Task::ConfirmOutgoingTrustCeoContactTaskForm < BaseTaskForm
+  attribute :outgoing_trust_ceo_contact_id, :string
+
+  def initialize(tasks_data, user)
+    @tasks_data = tasks_data
+    @user = user
+    @project = @tasks_data.project
+    @key_contacts = KeyContacts.find_or_create_by(project: @project)
+
+    super(@tasks_data, @user)
+    self.outgoing_trust_ceo_contact_id = @key_contacts.outgoing_trust_ceo_id
+  end
+
+  def save
+    @key_contacts.update!(outgoing_trust_ceo_id: outgoing_trust_ceo_contact_id)
+  end
+
+  private def completed?
+    @key_contacts.outgoing_trust_ceo.present?
+  end
+end

--- a/app/models/key_contacts.rb
+++ b/app/models/key_contacts.rb
@@ -3,4 +3,5 @@ class KeyContacts < ApplicationRecord
   belongs_to :headteacher, class_name: "Contact", optional: true
   belongs_to :chair_of_governors, class_name: "Contact", optional: true
   belongs_to :incoming_trust_ceo, class_name: "Contact", optional: true
+  belongs_to :outgoing_trust_ceo, class_name: "Contact", optional: true
 end

--- a/app/models/transfer/task_list.rb
+++ b/app/models/transfer/task_list.rb
@@ -8,6 +8,7 @@ class Transfer::TaskList < ::BaseTaskList
           Transfer::Task::StakeholderKickOffTaskForm,
           Transfer::Task::ConfirmHeadteacherContactTaskForm,
           Transfer::Task::ConfirmIncomingTrustCeoContactTaskForm,
+          Transfer::Task::ConfirmOutgoingTrustCeoContactTaskForm,
           Transfer::Task::MainContactTaskForm,
           Transfer::Task::RequestNewUrnAndRecordTaskForm,
           Transfer::Task::SponsoredSupportGrantTaskForm,

--- a/app/presenters/export/csv/outgoing_trust_presenter_module.rb
+++ b/app/presenters/export/csv/outgoing_trust_presenter_module.rb
@@ -71,6 +71,24 @@ module Export::Csv::OutgoingTrustPresenterModule
     @project.outgoing_trust_sharepoint_link
   end
 
+  def outgoing_trust_ceo_contact_name
+    return unless @project.key_contacts&.outgoing_trust_ceo.present?
+
+    @project.key_contacts.outgoing_trust_ceo.name
+  end
+
+  def outgoing_trust_ceo_contact_role
+    return unless @project.key_contacts&.outgoing_trust_ceo.present?
+
+    @project.key_contacts.outgoing_trust_ceo.title
+  end
+
+  def outgoing_trust_ceo_contact_email
+    return unless @project.key_contacts&.outgoing_trust_ceo.present?
+
+    @project.key_contacts.outgoing_trust_ceo.email
+  end
+
   private def outgoing_trust_contact
     @contacts_fetcher.outgoing_trust_contact
   end

--- a/app/services/export/transfers/all_data_csv_export_service.rb
+++ b/app/services/export/transfers/all_data_csv_export_service.rb
@@ -64,6 +64,9 @@ class Export::Transfers::AllDataCsvExportService < Export::CsvExportService
     incoming_trust_ceo_contact_name
     incoming_trust_ceo_contact_role
     incoming_trust_ceo_contact_email
+    outgoing_trust_ceo_contact_name
+    outgoing_trust_ceo_contact_role
+    outgoing_trust_ceo_contact_email
     solicitor_contact_name
     solicitor_contact_email
     diocese_contact_name

--- a/app/views/transfers/tasks/confirm_outgoing_trust_ceo_contact/edit.html.erb
+++ b/app/views/transfers/tasks/confirm_outgoing_trust_ceo_contact/edit.html.erb
@@ -1,0 +1,53 @@
+<% content_for :pre_content_nav do %>
+  <% render partial: "shared/back_link", locals: {href: project_tasks_path(@project)} %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("transfer.task.confirm_outgoing_trust_ceo_contact.title")) %>
+<% end %>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-9">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @project.establishment.name %></span>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
+      <%= t("transfer.task.confirm_outgoing_trust_ceo_contact.title") %>
+    </h1>
+
+    <div class="app-task-hint">
+      <%= t("transfer.task.confirm_outgoing_trust_ceo_contact.hint.html", contacts_path: project_contacts_path(@project)) %>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <% if @project.contacts.outgoing_trust.empty? %>
+
+      <h2 class="govuk-heading-l"><%= t("transfer.task.confirm_outgoing_trust_ceo_contact.no_contacts.title") %></h2>
+      <%= govuk_inset_text(text: t("transfer.task.confirm_outgoing_trust_ceo_contact.no_contacts.hint.html")) %>
+      <%= link_to "Add a contact", new_project_contact_path(@project), class: "govuk-button", data: {module: "govuk-button"}, draggable: "false" %>
+
+    <% else %>
+
+      <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
+        <%= form.govuk_error_summary %>
+
+        <%= form.govuk_collection_radio_buttons :outgoing_trust_ceo_contact_id,
+              @project.contacts.outgoing_trust,
+              :id,
+              :name,
+              :email_and_phone,
+              legend: {text: t("transfer.task.confirm_outgoing_trust_ceo_contact.choose_a_contact.title"), size: "l"},
+              hint: {text: t("transfer.task.confirm_outgoing_trust_ceo_contact.choose_a_contact.hint.html")},
+              form_group: {id: "who-is-the-outgoing-trust-ceo"} %>
+
+        <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: "shared/tasks/task_notes" %>
+  </div>
+</div>

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -100,6 +100,9 @@ en:
           outgoing_trust_address_postcode: Outgoing trust address postcode
           outgoing_trust_main_contact_name: Outgoing trust main contact name
           outgoing_trust_main_contact_email: Outgoing trust main contact email
+          outgoing_trust_ceo_contact_name: Outgoing trust CEO name
+          outgoing_trust_ceo_contact_role: Outgoing trust CEO role
+          outgoing_trust_ceo_contact_email: Outgoing trust CEO email
           incoming_trust_ukprn: Incoming trust UKPRN
           inadequate_ofsted: Transfer due to inadequate
           financial_safeguarding_governance_issues: Transfer due to financial, safeguarding or governance

--- a/config/locales/transfer/tasks/confirm_outgoing_trust_ceo_contact.en.yml
+++ b/config/locales/transfer/tasks/confirm_outgoing_trust_ceo_contact.en.yml
@@ -1,0 +1,20 @@
+en:
+  transfer:
+    task:
+      confirm_outgoing_trust_ceo_contact:
+        title: Confirm the outgoing trust CEO’s details
+        hint:
+          html:
+            <p>Check the contact details are correct, <a href="%{contacts_path}">edit incorrect contact
+            details and add missing contacts</a>. You may need to contact the person
+            who previously worked on the project to verify this.</p>
+        no_contacts:
+          title: Who is the outgoing trust CEO?
+          hint:
+            html: <p>No contacts have been added to the project.</p>
+        choose_a_contact:
+          title: Who is the outgoing trust CEO?
+          hint:
+            html:
+              <p>Choose the relevant person from the list of contacts. You may need to add a new contact if the person you are looking for is not in the list.</p>
+              <p>Their job title may be slightly different to the role described here. Choose the person whose role most closely matches the outgoing trust CEO.</p>

--- a/db/migrate/20240815142453_add_outgoing_trust_ceo_to_key_contacts.rb
+++ b/db/migrate/20240815142453_add_outgoing_trust_ceo_to_key_contacts.rb
@@ -1,0 +1,6 @@
+class AddOutgoingTrustCeoToKeyContacts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :key_contacts, :outgoing_trust_ceo_id, :uuid
+    add_index :key_contacts, :outgoing_trust_ceo_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_15_105444) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_15_142453) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -250,9 +250,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_15_105444) do
     t.datetime "updated_at", null: false
     t.uuid "chair_of_governors_id"
     t.uuid "incoming_trust_ceo_id"
+    t.uuid "outgoing_trust_ceo_id"
     t.index ["chair_of_governors_id"], name: "index_key_contacts_on_chair_of_governors_id"
     t.index ["headteacher_id"], name: "index_key_contacts_on_headteacher_id"
     t.index ["incoming_trust_ceo_id"], name: "index_key_contacts_on_incoming_trust_ceo_id"
+    t.index ["outgoing_trust_ceo_id"], name: "index_key_contacts_on_outgoing_trust_ceo_id"
     t.index ["project_id"], name: "index_key_contacts_on_project_id"
   end
 

--- a/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
+++ b/spec/features/transfers/users_can_complete_transfer_tasks_spec.rb
@@ -38,6 +38,7 @@ RSpec.feature "Users can complete transfer tasks" do
     conditions_met
     confirm_headteacher_contact
     confirm_incoming_trust_ceo_contact
+    confirm_outgoing_trust_ceo_contact
     main_contact
     bank_details_changing
     check_and_confirm_financial_information

--- a/spec/features/transfers/users_can_confirm_the_outgoing_trust_ceo_contact_spec.rb
+++ b/spec/features/transfers/users_can_confirm_the_outgoing_trust_ceo_contact_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.feature "Users can confirm the outgoing trust CEO contact" do
+  let(:user) { create(:user, :caseworker) }
+  let(:project) { create(:transfer_project, assigned_to: user) }
+
+  before do
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  context "when there are no contacts for the project" do
+    scenario "they see a helpful message and a link to the contacts tab" do
+      visit project_path(project)
+      click_link "Confirm the outgoing trust CEO’s details"
+
+      expect(page).to have_content "No contacts have been added to the project."
+      expect(page).to have_link href: project_contacts_path(project), text: "edit incorrect contact details and add missing contacts"
+    end
+  end
+
+  context "when there are contacts but they are not in the correct category" do
+    let!(:contact) { create(:project_contact, category: :school_or_academy, project: project) }
+
+    scenario "they see a helpful message and a link to the contacts tab" do
+      visit project_path(project)
+      click_link "Confirm the outgoing trust CEO’s details"
+
+      expect(page).to have_content "No contacts have been added to the project."
+      expect(page).to have_link href: project_contacts_path(project), text: "edit incorrect contact details and add missing contacts"
+    end
+  end
+
+  context "when there are contacts and they are in the correct category" do
+    let!(:contact) { create(:project_contact, category: :outgoing_trust, project: project) }
+
+    scenario "they can choose the contact" do
+      visit project_path(project)
+      click_link "Confirm the outgoing trust CEO’s details"
+
+      expect(page).to have_content contact.name
+      expect(page).to have_content contact.email
+      expect(page).to have_content contact.phone
+
+      choose contact.name
+
+      click_button "Save and return"
+
+      within ".app-task-list li:nth-of-type(1) li:nth-of-type(5)" do
+        expect(page).to have_content "Completed"
+      end
+    end
+  end
+end

--- a/spec/models/key_contacts_spec.rb
+++ b/spec/models/key_contacts_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe KeyContacts do
     it { is_expected.to belong_to(:headteacher).optional(true) }
     it { is_expected.to belong_to(:chair_of_governors).optional(true) }
     it { is_expected.to belong_to(:incoming_trust_ceo).optional(true) }
+    it { is_expected.to belong_to(:outgoing_trust_ceo).optional(true) }
   end
 
   describe "headteacher" do
@@ -69,6 +70,26 @@ RSpec.describe KeyContacts do
       key_contacts = described_class.create!(project: project, incoming_trust_ceo: contact)
 
       expect(key_contacts.incoming_trust_ceo).to be contact
+    end
+  end
+
+  describe "outgoing trust ceo" do
+    it "can be a project contact" do
+      contact = create(:project_contact)
+
+      project = create(:transfer_project)
+      key_contacts = described_class.create!(project: project, outgoing_trust_ceo: contact)
+
+      expect(key_contacts.outgoing_trust_ceo).to be contact
+    end
+
+    it "can be an establishment contact" do
+      contact = create(:establishment_contact)
+
+      project = create(:transfer_project)
+      key_contacts = described_class.create!(project: project, outgoing_trust_ceo: contact)
+
+      expect(key_contacts.outgoing_trust_ceo).to be contact
     end
   end
 end

--- a/spec/models/transfer/task_list_spec.rb
+++ b/spec/models/transfer/task_list_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Transfer::TaskList do
         :stakeholder_kick_off,
         :confirm_headteacher_contact,
         :confirm_incoming_trust_ceo_contact,
+        :confirm_outgoing_trust_ceo_contact,
         :main_contact,
         :request_new_urn_and_record,
         :sponsored_support_grant,
@@ -55,7 +56,7 @@ RSpec.describe Transfer::TaskList do
       project = create(:transfer_project)
       task_list = described_class.new(project, user)
 
-      expect(task_list.tasks.count).to eql 27
+      expect(task_list.tasks.count).to eql 28
       expect(task_list.tasks.first).to be_a Transfer::Task::HandoverTaskForm
       expect(task_list.tasks.last).to be_a Transfer::Task::DeclarationOfExpenditureCertificateTaskForm
     end

--- a/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
@@ -48,6 +48,27 @@ RSpec.describe Export::Csv::OutgoingTrustPresenterModule do
     expect(subject.outgoing_trust_sharepoint_link).to eql "https://educationgovuk-my.sharepoint.com/outgoing-trust-folder"
   end
 
+  describe "outgoing trust CEO contact" do
+    context "when there is a contact" do
+      it "presents the contact details" do
+        contact = create(:project_contact)
+        KeyContacts.new(project: project, outgoing_trust_ceo: contact)
+
+        expect(subject.outgoing_trust_ceo_contact_name).to eql "Jo Example"
+        expect(subject.outgoing_trust_ceo_contact_role).to eql "CEO of Learning"
+        expect(subject.outgoing_trust_ceo_contact_email).to eql "jo@example.com"
+      end
+    end
+
+    context "when there is no contact" do
+      it "presents nothing" do
+        expect(subject.outgoing_trust_ceo_contact_name).to be_nil
+        expect(subject.outgoing_trust_ceo_contact_role).to be_nil
+        expect(subject.outgoing_trust_ceo_contact_email).to be_nil
+      end
+    end
+  end
+
   def known_trust
     double(
       Api::AcademiesApi::Trust,


### PR DESCRIPTION
The outgoing trust CEO contact details are required be some downstream data users.

This work adds a task to collect and confirm the contact details and include them in the export.

Based on #1807 