### PR TITLE
Fix: deleted projects not shown in search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - the confirmed outgoing trust CEO contact details are now included in the
   export where appropriate.
 
+### Fixed
+
+- the search results no longer include 'deleted' projects.
+
 ## [Release-82][release-82]
 
 ### Added

--- a/app/services/project_search_service.rb
+++ b/app/services/project_search_service.rb
@@ -12,12 +12,12 @@ class ProjectSearchService
   end
 
   def search_by_urns(urns)
-    Project.where(urn: urns).includes(:assigned_to)
+    Project.not_deleted.where(urn: urns).includes(:assigned_to)
   end
 
   def search_by_ukprn(ukprn)
-    Project.where("incoming_trust_ukprn = ?", ukprn)
-      .or(Project.where("outgoing_trust_ukprn = ?", ukprn)).includes(:assigned_to)
+    Project.not_deleted.where("incoming_trust_ukprn = ?", ukprn)
+      .or(Project.not_deleted.where("outgoing_trust_ukprn = ?", ukprn)).includes(:assigned_to)
   end
 
   def search_by_words(query)


### PR DESCRIPTION
When removed the default scope that excluded deleted project (don't use
default scopes for filtering!) we missed the search results.

Right now deleted project should not show up anywhere except on the console.

