### PR TITLE
Add the Chair of governors role to exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the project, they may also have to add it
 - the confirmed outgoing trust CEO contact details are now included in the
   export where appropriate.
+- the confirmed chair of governors contact role is included in appropriate
+  exports.
 
 ### Fixed
 

--- a/app/presenters/export/csv/chair_of_governors_presenter_module.rb
+++ b/app/presenters/export/csv/chair_of_governors_presenter_module.rb
@@ -5,6 +5,12 @@ module Export::Csv::ChairOfGovernorsPresenterModule
     @project.key_contacts.chair_of_governors.name
   end
 
+  def chair_of_governors_role
+    return unless @project.key_contacts&.chair_of_governors.present?
+
+    @project.key_contacts.chair_of_governors.title
+  end
+
   def chair_of_governors_email
     return unless @project.key_contacts&.chair_of_governors.present?
 

--- a/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
+++ b/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
@@ -18,6 +18,7 @@ class Export::Conversions::RpaSugAndFaLettersCsvExportService < Export::CsvExpor
     headteacher_contact_role
     headteacher_contact_email
     chair_of_governors_name
+    chair_of_governors_role
     chair_of_governors_email
     academy_urn
     academy_ukprn

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -64,6 +64,7 @@ en:
           incoming_trust_address_county: Incoming trust address county
           incoming_trust_address_postcode: Incoming trust address postcode
           chair_of_governors_name: Chair of governors name
+          chair_of_governors_role: Chair of governors role
           chair_of_governors_email: Chair of governors email
           local_authority_code: Local authority code
           local_authority_name: Local authority

--- a/spec/presenters/export/csv/chair_of_governors_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/chair_of_governors_presenter_module_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Export::Csv::ChairOfGovernorsPresenterModule do
       presenter = Export::Csv::ProjectPresenter.new(project)
 
       expect(presenter.chair_of_governors_name).to eq contact.name
+      expect(presenter.chair_of_governors_role).to eq contact.title
       expect(presenter.chair_of_governors_email).to eq contact.email
     end
   end
@@ -25,6 +26,7 @@ RSpec.describe Export::Csv::ChairOfGovernorsPresenterModule do
       presenter = Export::Csv::ProjectPresenter.new(project)
 
       expect(presenter.chair_of_governors_name).to be_nil
+      expect(presenter.chair_of_governors_role).to be_nil
       expect(presenter.chair_of_governors_name).to be_nil
     end
   end
@@ -37,6 +39,7 @@ RSpec.describe Export::Csv::ChairOfGovernorsPresenterModule do
       presenter = Export::Csv::ProjectPresenter.new(project)
 
       expect(presenter.chair_of_governors_name).to be_nil
+      expect(presenter.chair_of_governors_role).to be_nil
       expect(presenter.chair_of_governors_name).to be_nil
     end
   end


### PR DESCRIPTION
When exported the confirmed chair of governors contact should include
their role.

