### PR TITLE
Remove headteacher column from export

### DIFF
--- a/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
+++ b/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
@@ -14,9 +14,6 @@ class Export::Conversions::RpaSugAndFaLettersCsvExportService < Export::CsvExpor
     school_main_contact_name
     school_main_contact_role
     school_main_contact_email
-    headteacher_contact_name
-    headteacher_contact_role
-    headteacher_contact_email
     chair_of_governors_name
     chair_of_governors_role
     chair_of_governors_email


### PR DESCRIPTION
Our new 'contact tasks' are about to be deployed but we realised that we
are about to enter the largest openers month of the year, September and
doing so will introduce gaps in the data that downstream users rely on.

On reflection, we decided that it would be better to leave this export
as is until after September.
