### PR TITLE
(177164) Change the index view for external contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Users are now steered to create contacts with specific job titles, e.g.
   Headteacher or CEO
+- Change the display of contacts on the external contacts index page
 
 ## [Release-82][release-82]
 

--- a/app/helpers/contacts_helper.rb
+++ b/app/helpers/contacts_helper.rb
@@ -18,6 +18,23 @@ module ContactsHelper
     end
   end
 
+  def primary_contact_at_organisation(contact, category)
+    return unless contact.is_a?(Contact::Project)
+
+    case category
+    when "school_or_academy"
+      contact.establishment_main_contact ? I18n.t("yes") : I18n.t("no")
+    when "local_authority"
+      contact.local_authority_main_contact ? I18n.t("yes") : I18n.t("no")
+    when "incoming_trust"
+      contact.incoming_trust_main_contact ? I18n.t("yes") : I18n.t("no")
+    when "outgoing_trust"
+      contact.outgoing_trust_main_contact ? I18n.t("yes") : I18n.t("no")
+    else
+      I18n.t("no")
+    end
+  end
+
   def has_primary_contact?(category)
     return true if %w[school_or_academy incoming_trust outgoing_trust local_authority].include?(category)
     false

--- a/app/helpers/contacts_helper.rb
+++ b/app/helpers/contacts_helper.rb
@@ -17,4 +17,9 @@ module ContactsHelper
       I18n.t("contact.index.category_heading", category_name: category.humanize)
     end
   end
+
+  def has_primary_contact?(category)
+    return true if %w[school_or_academy incoming_trust outgoing_trust local_authority].include?(category)
+    false
+  end
 end

--- a/app/helpers/contacts_helper.rb
+++ b/app/helpers/contacts_helper.rb
@@ -2,4 +2,19 @@ module ContactsHelper
   def has_contacts?(contacts)
     contacts.present? && contacts.any?
   end
+
+  def category_header(category, project)
+    case category
+    when "school_or_academy"
+      I18n.t("contact.index.category_heading", category_name: project.establishment.name)
+    when "incoming_trust"
+      I18n.t("contact.index.category_heading", category_name: project.incoming_trust.name)
+    when "outgoing_trust"
+      I18n.t("contact.index.category_heading", category_name: project.outgoing_trust&.name)
+    when "local_authority"
+      I18n.t("contact.index.category_heading", category_name: project.local_authority&.name)
+    else
+      I18n.t("contact.index.category_heading", category_name: category.humanize)
+    end
+  end
 end

--- a/app/views/external_contacts/_contact_group.html.erb
+++ b/app/views/external_contacts/_contact_group.html.erb
@@ -1,4 +1,4 @@
-<h3 class="govuk-heading-m"><%= t("contact.index.category_heading", category_name: category.humanize) %></h3>
+<h3 class="govuk-heading-m"><%= category_header(category, @project) %></h3>
 
 <% contacts.each do |contact| %>
 

--- a/app/views/external_contacts/_contact_group.html.erb
+++ b/app/views/external_contacts/_contact_group.html.erb
@@ -5,7 +5,7 @@
   <div id="academyDetails" class="govuk-summary-card">
     <div class="govuk-summary-card__title-wrapper">
       <h3 class="govuk-summary-card__title">
-        <%= contact.name %>
+        <%= contact.title %>
       </h3>
       <% if contact.editable? %>
         <ul class="govuk-summary-card__actions">
@@ -19,16 +19,14 @@
     <div class="govuk-summary-card__content">
       <%= govuk_summary_list do |summary_list|
             summary_list.with_row do |row|
-              row.with_key { t("contact.details.title") }
-              row.with_value { contact.title }
-            end
-            summary_list.with_row do |row|
               row.with_key { t("contact.details.name") }
               row.with_value { contact.name }
             end
-            summary_list.with_row do |row|
-              row.with_key { t("contact.details.organisation_name") }
-              row.with_value { contact.organisation_name }
+            if contact.category.eql?("other") && contact.organisation_name
+              summary_list.with_row do |row|
+                row.with_key { t("contact.details.organisation_name") }
+                row.with_value { contact.organisation_name }
+              end
             end
             if contact.email.present?
               summary_list.with_row do |row|
@@ -48,30 +46,10 @@
                 row.with_value { t("yes") }
               end
             end
-            if contact.is_a?(Contact::Project)
-              if contact.establishment_main_contact
-                summary_list.with_row do |row|
-                  row.with_key { t("contact.details.establishment_main_contact") }
-                  row.with_value { t("yes") }
-                end
-              end
-              if contact.incoming_trust_main_contact
-                summary_list.with_row do |row|
-                  row.with_key { t("contact.details.incoming_trust_main_contact") }
-                  row.with_value { t("yes") }
-                end
-              end
-              if contact.outgoing_trust_main_contact
-                summary_list.with_row do |row|
-                  row.with_key { t("contact.details.outgoing_trust_main_contact") }
-                  row.with_value { t("yes") }
-                end
-              end
-              if contact.local_authority_main_contact
-                summary_list.with_row do |row|
-                  row.with_key { t("contact.details.local_authority_main_contact") }
-                  row.with_value { t("yes") }
-                end
+            if contact.is_a?(Contact::Project) && has_primary_contact?(category)
+              summary_list.with_row do |row|
+                row.with_key { t("contact.details.primary_contact") }
+                row.with_value { primary_contact_at_organisation(contact, category) }
               end
             end
           end %>

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -18,10 +18,7 @@ en:
       edit_link: Change
       funding_agreement_letters: This person will receive the funding agreement letters.
       main_contact: Project main contact
-      establishment_main_contact: Primary contact for school or academy?
-      incoming_trust_main_contact: Primary contact for incoming trust?
-      outgoing_trust_main_contact: Primary contact for outgoing trust?
-      local_authority_main_contact: Primary contact for local authority?
+      primary_contact: Primary contact at organisation?
     new:
       title: Add contact
       save_contact_button: Add contact

--- a/spec/features/users_can_manage_contacts_spec.rb
+++ b/spec/features/users_can_manage_contacts_spec.rb
@@ -28,7 +28,6 @@ RSpec.feature "Users can manage contacts" do
     create(:project_contact, category: :other, project: project)
     create(:project_contact, category: :school_or_academy, project: project)
     create(:project_contact, category: :incoming_trust, project: project)
-    create(:project_contact, category: :outgoing_trust, project: project)
     create(:project_contact, category: :solicitor, project: project)
     create(:project_contact, category: :diocese, project: project)
     create(:project_contact, category: :local_authority, project: project)
@@ -37,18 +36,12 @@ RSpec.feature "Users can manage contacts" do
 
     order_categories = page.find_all("h3.govuk-heading-m")
 
-    %i[
-      school_or_academy
-      incoming_trust
-      outgoing_trust
-      local_authority
-      solicitor
-      diocese
-      other
-    ].each_with_index do |category, index|
-      expect(order_categories[index].text)
-        .to eql I18n.t("contact.index.category_heading", category_name: category.to_s.humanize)
-    end
+    expect(order_categories[0].text).to eql(I18n.t("contact.index.category_heading", category_name: project.establishment.name))
+    expect(order_categories[1].text).to eql(I18n.t("contact.index.category_heading", category_name: project.incoming_trust.name))
+    expect(order_categories[2].text).to eql(I18n.t("contact.index.category_heading", category_name: project.local_authority.name))
+    expect(order_categories[3].text).to eql("Solicitor contacts")
+    expect(order_categories[4].text).to eql("Diocese contacts")
+    expect(order_categories[5].text).to eql("Other contacts")
   end
 
   context "adding a new headteacher" do
@@ -66,12 +59,11 @@ RSpec.feature "Users can manage contacts" do
 
       click_on "Save and continue"
 
-      expect(page).to have_content("School or academy contacts")
+      expect(page).to have_content("#{project.establishment.name} contacts")
 
       expect_page_to_have_contact(
         name: "Jane Headteacher",
         title: "Headteacher",
-        organisation_name: project.establishment.name.to_s,
         email: "some@example.com",
         phone: "01632 960456"
       )
@@ -93,8 +85,8 @@ RSpec.feature "Users can manage contacts" do
 
       click_on "Save and continue"
 
-      expect(page).to have_content("School or academy contacts")
-      expect(page).to have_content(I18n.t("contact.details.establishment_main_contact"))
+      expect(page).to have_content("#{project.establishment.name} contacts")
+      expect(page).to have_content(I18n.t("contact.details.primary_contact"))
     end
   end
 
@@ -113,12 +105,11 @@ RSpec.feature "Users can manage contacts" do
 
       click_on "Save and continue"
 
-      expect(page).to have_content("Incoming trust contacts")
+      expect(page).to have_content("#{project.incoming_trust.name} contacts")
 
       expect_page_to_have_contact(
         name: "Jane Finance",
         title: "CEO",
-        organisation_name: project.incoming_trust.name.to_s,
         email: "some@example.com",
         phone: "01632 960456"
       )
@@ -142,12 +133,11 @@ RSpec.feature "Users can manage contacts" do
 
       click_on "Save and continue"
 
-      expect(page).to have_content("Outgoing trust contacts")
+      expect(page).to have_content("#{project.outgoing_trust.name} contacts")
 
       expect_page_to_have_contact(
         name: "Bob Finance",
         title: "CEO",
-        organisation_name: project.outgoing_trust.name.to_s,
         email: "some@example.com",
         phone: "01632 960456"
       )
@@ -169,8 +159,8 @@ RSpec.feature "Users can manage contacts" do
 
       click_on "Save and continue"
 
-      expect(page).to have_content("Outgoing trust contacts")
-      expect(page).to have_content(I18n.t("contact.details.outgoing_trust_main_contact"))
+      expect(page).to have_content("#{project.outgoing_trust.name} contacts")
+      expect(page).to have_content(I18n.t("contact.details.primary_contact"))
     end
   end
 
@@ -189,7 +179,7 @@ RSpec.feature "Users can manage contacts" do
 
       click_on "Save and continue"
 
-      expect(page).to have_content("School or academy contacts")
+      expect(page).to have_content("#{project.establishment.name} contacts")
 
       expect_page_to_have_contact(
         name: "Susan Chair",

--- a/spec/helpers/contacts_helper_spec.rb
+++ b/spec/helpers/contacts_helper_spec.rb
@@ -26,4 +26,44 @@ RSpec.describe ContactsHelper, type: :helper do
       end
     end
   end
+
+  describe "#category_header" do
+    before { mock_successful_api_response_to_create_any_project }
+    let(:project) { build(:transfer_project) }
+
+    it "includes the establishment name when the category is 'school_or_academy'" do
+      category = "school_or_academy"
+      expect(helper.category_header(category, project)).to eq("#{project.establishment.name} contacts")
+    end
+
+    it "includes the incoming trust name when the category is 'incoming_trust'" do
+      category = "incoming_trust"
+      expect(helper.category_header(category, project)).to eq("#{project.incoming_trust.name} contacts")
+    end
+
+    it "includes the outgoing trust name when the category is 'outgoing_trust'" do
+      category = "outgoing_trust"
+      expect(helper.category_header(category, project)).to eq("#{project.outgoing_trust.name} contacts")
+    end
+
+    it "includes the local authority name when the category is 'local_authority'" do
+      category = "local_authority"
+      expect(helper.category_header(category, project)).to eq("#{project.local_authority.name} contacts")
+    end
+
+    it "includes the category name when the category is 'other'" do
+      category = "other"
+      expect(helper.category_header(category, project)).to eq("Other contacts")
+    end
+
+    it "includes the category name when the category is 'solicitor'" do
+      category = "solicitor"
+      expect(helper.category_header(category, project)).to eq("Solicitor contacts")
+    end
+
+    it "includes the category name when the category is 'diocese'" do
+      category = "diocese"
+      expect(helper.category_header(category, project)).to eq("Diocese contacts")
+    end
+  end
 end

--- a/spec/helpers/contacts_helper_spec.rb
+++ b/spec/helpers/contacts_helper_spec.rb
@@ -66,4 +66,19 @@ RSpec.describe ContactsHelper, type: :helper do
       expect(helper.category_header(category, project)).to eq("Diocese contacts")
     end
   end
+
+  describe "#has_primary_contact?" do
+    it "returns true for the categories that have a primary contact" do
+      expect(helper.has_primary_contact?("school_or_academy")).to be true
+      expect(helper.has_primary_contact?("local_authority")).to be true
+      expect(helper.has_primary_contact?("incoming_trust")).to be true
+      expect(helper.has_primary_contact?("outgoing_trust")).to be true
+    end
+
+    it "returns false for other categories" do
+      expect(helper.has_primary_contact?("other")).to be false
+      expect(helper.has_primary_contact?("diocese")).to be false
+      expect(helper.has_primary_contact?("solicitor")).to be false
+    end
+  end
 end

--- a/spec/helpers/contacts_helper_spec.rb
+++ b/spec/helpers/contacts_helper_spec.rb
@@ -81,4 +81,41 @@ RSpec.describe ContactsHelper, type: :helper do
       expect(helper.has_primary_contact?("solicitor")).to be false
     end
   end
+
+  describe "#primary_contact_at_organisation" do
+    before { mock_successful_api_response_to_create_any_project }
+
+    it "returns nothing for contacts which are not Contact::Project type" do
+      expect(helper.primary_contact_at_organisation(build(:director_of_child_services), "local_authority")).to be_nil
+    end
+
+    it "returns 'no' for categories that do not have a primary contact type" do
+      expect(helper.primary_contact_at_organisation(build(:project_contact), "other")).to eq("No")
+    end
+
+    it "returns 'yes' when contact is the primary contact for that category" do
+      project = build(:conversion_project)
+      school_contact = create(:project_contact, project: project)
+      trust_contact = create(:project_contact, project: project)
+      local_authority_contact = create(:project_contact, project: project)
+      project.establishment_main_contact = school_contact
+      project.incoming_trust_main_contact = trust_contact
+      project.local_authority_main_contact = local_authority_contact
+
+      expect(helper.primary_contact_at_organisation(school_contact, "school_or_academy")).to eq("Yes")
+      expect(helper.primary_contact_at_organisation(trust_contact, "incoming_trust")).to eq("Yes")
+      expect(helper.primary_contact_at_organisation(local_authority_contact, "local_authority")).to eq("Yes")
+    end
+
+    it "returns 'no' when contact is not the primary contact for that category" do
+      project = build(:conversion_project)
+      school_contact = create(:project_contact, project: project)
+      trust_contact = create(:project_contact, project: project)
+      local_authority_contact = create(:project_contact, project: project)
+
+      expect(helper.primary_contact_at_organisation(school_contact, "school_or_academy")).to eq("No")
+      expect(helper.primary_contact_at_organisation(trust_contact, "incoming_trust")).to eq("No")
+      expect(helper.primary_contact_at_organisation(local_authority_contact, "local_authority")).to eq("No")
+    end
+  end
 end


### PR DESCRIPTION
## Changes

- The contact group headers now feature the school/trust/local authority name,
or group type (solicitor etc) if there is no named organisation

- The contact entries do not show the organisation name, except in the case of
"other" contacts, which could belong to any organisation.

- Change the display of the "Primary contact" indicator

<img width="461" alt="Screenshot 2024-08-20 at 11 36 15" src="https://github.com/user-attachments/assets/d71bceef-1e4d-4dee-ad03-639836beca35">


## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
