### PR TITLE
Release 83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release-83][release-83]
+
 ### Added
 
 - a new 'confirm the headteacher contact' task has been added, users need to
@@ -2152,7 +2154,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-82...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-83...HEAD
+[release-83]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-82...release-83
 [release-82]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-81...release-82
 [release-81]:


### PR DESCRIPTION
Added

- a new 'confirm the headteacher contact' task has been added, users need to choose the appropriate contact from those available to the project, they may also have to add it
- transfer project also have a new 'confirm the headteacher contact' task that works the same as for conversions.
- the confirmed headteacher contact details are now included in exports where needed.
- a new task 'confirm the chair of governors' task has been added to conversion projects, users must supply and indicate which contact fills this role.
- a new 'confirm the incoming trust CEO contact' task has been added to conversion projects, users need to choose the appropriate contact from those available to the project, they may also have to add it
- a new 'confirm the incoming trust CEO contact' task has been added to transfer projects, users need to choose the appropriate contact from those available to the project, they may also have to add it
- the confirmed incoming trust CEO contacts now appear in export where appropriate.
- a new 'confirm the outgoing trust CEO contact' task has been added to transfer projects, users need to choose the appropriate contact from those available to the project, they may also have to add it
- the confirmed outgoing trust CEO contact details are now included in the export where appropriate.
- the confirmed chair of governors contact role is included in appropriate exports.

Fixed

- the search results no longer include 'deleted' projects.

Changed

- Users are now steered to create contacts with specific job titles, e.g. Headteacher or CEO
- Change the display of contacts on the external contacts index page

## Changes

_Add a summary of the changes in this pull request_

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
