### PR TITLE
Do not allow an outgoing trust contact to be created for Conversion projects

### DIFF
--- a/app/forms/contact/create_project_contact_form.rb
+++ b/app/forms/contact/create_project_contact_form.rb
@@ -26,6 +26,7 @@ class Contact::CreateProjectContactForm
     :phone
 
   validate :category_with_primary_contact
+  validate :outgoing_trust_for_transfer_only
 
   def initialize(contact:, project:, args: {})
     @project = project
@@ -89,6 +90,12 @@ class Contact::CreateProjectContactForm
     return unless primary_contact_for_category
 
     errors.add(:primary_contact_for_category, :category) unless CATEGORIES_WITH_PRIMARY_CONTACT.include?(category)
+  end
+
+  private def outgoing_trust_for_transfer_only
+    return if @project.is_a?(Transfer::Project)
+
+    errors.add(:category, :outgoing_trust_for_transfer_only) if category.eql?("outgoing_trust")
   end
 
   private def is_primary_contact_for_category?

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -105,6 +105,7 @@ en:
     attributes:
       category:
         blank: Choose a category
+        outgoing_trust_for_transfer_only: The Outgoing trust category is only for Transfer projects
       primary_contact_for_category:
         category: Only the incoming trust, outgoing trust and school or academy categories can have a primary contact
       base:

--- a/spec/forms/contact/create_project_contact_form_spec.rb
+++ b/spec/forms/contact/create_project_contact_form_spec.rb
@@ -105,6 +105,18 @@ RSpec.describe Contact::CreateProjectContactForm do
       expect(contact.category).to eq("other")
       expect(contact.organisation_name).to be_nil
     end
+
+    it "does not allow an outgoing trust contact to be created for a Conversion project" do
+      contact = Contact::Project.new
+      contact_form = Contact::CreateProjectContactForm.new(contact: contact, project: project)
+      contact_form.name = "Adifferent Name"
+      contact_form.email = "a.name@domain.com"
+      contact_form.title = "Role"
+      contact_form.category = "outgoing_trust"
+
+      expect(contact_form.valid?).to be false
+      expect(contact_form.errors[:category]).to include("The Outgoing trust category is only for Transfer projects")
+    end
   end
 
   describe "existing contact" do
@@ -171,7 +183,9 @@ RSpec.describe Contact::CreateProjectContactForm do
           end
         end
 
-        context "and the category is outgoing trust" do
+        context "and the category is outgoing trust (and the project is a transfer project)" do
+          let(:project) { create(:transfer_project) }
+
           it "is valid" do
             contact_form.category = "outgoing_trust"
 
@@ -335,8 +349,9 @@ RSpec.describe Contact::CreateProjectContactForm do
           end
         end
 
-        context "and the contact is for the outgoing trust category" do
+        context "and the contact is for the outgoing trust category (and the project is a transfer project)" do
           let(:contact) { create(:project_contact, project: project, category: "outgoing_trust") }
+          let(:project) { create(:transfer_project) }
 
           it "can be unset" do
             project.update!(outgoing_trust_main_contact_id: contact.id)


### PR DESCRIPTION

Conversion projects don't have the concept of an outgoing trust, so creating an outgoing trust contact for them doesn't make sense. Show a validation error if the user tries to create one.

