### PR TITLE
Show the Member of Parliament (if one exists) on external contacts page

### DIFF
--- a/app/views/conversions/external_contacts/index.html.erb
+++ b/app/views/conversions/external_contacts/index.html.erb
@@ -28,6 +28,9 @@
           <%= render partial: "contact_group", locals: {category: category, contacts: @grouped_contacts[category]} %>
         <% end %>
       <% end %>
+
     <% end %>
+
+    <%= render partial: "external_contacts/member_of_parliament", locals: { member_of_parliament: @project.member_of_parliament } %>
   </div>
 </div>

--- a/app/views/external_contacts/_member_of_parliament.html.erb
+++ b/app/views/external_contacts/_member_of_parliament.html.erb
@@ -1,0 +1,26 @@
+<% if member_of_parliament %>
+  <h3 class="govuk-heading-m"><%= t("contact.index.parliamentary_contacts_heading") %></h3>
+
+  <div id="memberOfParliamentDetails" class="govuk-summary-card">
+    <div class="govuk-summary-card__title-wrapper">
+      <h3 class="govuk-summary-card__title">
+        <%= t("helpers.contact_types.member_of_parliament") %>
+      </h3>
+    </div>
+
+    <div class="govuk-summary-card__content">
+      <%= govuk_summary_list do |summary_list|
+        summary_list.with_row do |row|
+          row.with_key { t("contact.details.name") }
+          row.with_value { member_of_parliament.name }
+        end
+        if member_of_parliament.email.present?
+          summary_list.with_row do |row|
+            row.with_key { t("contact.details.email") }
+            row.with_value { member_of_parliament.email }
+          end
+        end
+      end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/transfers/external_contacts/index.html.erb
+++ b/app/views/transfers/external_contacts/index.html.erb
@@ -20,5 +20,7 @@
       <% end %>
     <% end %>
 
+    <%= render partial: "external_contacts/member_of_parliament", locals: { member_of_parliament: @project.member_of_parliament } %>
+
   </div>
 </div>

--- a/config/locales/contact.en.yml
+++ b/config/locales/contact.en.yml
@@ -4,6 +4,7 @@ en:
       external_contacts: External contacts
       internal_contacts: Internal contacts
       category_heading: "%{category_name} contacts"
+      parliamentary_contacts_heading: Parliamentary contacts
       add_contact_button: Add contact
       no_contacts_yet: There are not any contacts for this project yet.
       external_contacts_hint:
@@ -101,6 +102,7 @@ en:
       incoming_trust_ceo: Incoming trust CEO (Chief executive officer)
       outgoing_trust_ceo: Outgoing trust CEO (Chief executive officer)
       chair_of_governors: Chair of governors
+      member_of_parliament: Member of Parliament
   errors:
     attributes:
       category:

--- a/spec/features/users_can_manage_contacts_spec.rb
+++ b/spec/features/users_can_manage_contacts_spec.rb
@@ -252,6 +252,18 @@ RSpec.feature "Users can manage contacts" do
     expect(page).to have_content(I18n.t("contact.details.main_contact"))
   end
 
+  scenario "if a project has a member of parliament, the MP is shown" do
+    member_details = Api::Persons::MemberDetails.new(first_name: "Robert", last_name: "Minister", email: "ministerr@parliament.gov.uk")
+
+    allow_any_instance_of(Project).to receive(:member_of_parliament).and_return(member_details)
+
+    visit project_contacts_path(project)
+
+    expect(page).to have_content("Parliamentary contacts")
+    expect(page).to have_content(member_details.name)
+    expect(page).to have_content(member_details.email)
+  end
+
   private def expect_page_to_have_contact(name:, title:, organisation_name: nil, email: nil, phone: nil)
     expect(page).to have_content(name)
     expect(page).to have_content(organisation_name) if organisation_name


### PR DESCRIPTION
We want to show the MP for a project on the external contacts page, if one exists. This contact is not part of the "other" project contacts (it is a different type, and retrieved from an API) so will not appear in the Grouped contacts list.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
