### PR TITLE
Making conversion support grant references consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## Changed
+
+- changing 'convesion grant' references to 'conversion support grant' to match
+  Apply and Prepare
+
 ## [Release-83][release-83]
 
 ### Added

--- a/config/locales/conversion/tasks/conversion_grant.en.yml
+++ b/config/locales/conversion/tasks/conversion_grant.en.yml
@@ -2,8 +2,8 @@ en:
   conversion:
     task:
       conversion_grant:
-        title:  Process conversion grant
-        guidance_link: How to process a conversion grant
+        title:  Process conversion support grant
+        guidance_link: How to process a conversion support grant
         guidance:
           html:
             <p>Check the grant claim form is ready, the school or trust has a vendor account and send the correct information to the Grant Payments team.</p>
@@ -17,7 +17,7 @@ en:
           guidance_link: How to set up a vendor account
           guidance:
             html:
-              <p>The school or trust receiving the conversion grant must have a vendor account.</p>
+              <p>The school or trust receiving the conversion support grant must have a vendor account.</p>
               <p>Schools and trusts can <a href="https://www.gov.uk/guidance/provide-information-about-your-banking-and-payments-to-dfe" class="govuk-link" target="_blank">set up a vendor account (opens in new tab)</a> when they provide information about their banking and payments to Department for Education.</p>
               <p>Share the link with them so they can register if needed.</p>
               <p>It can take 15 to 20 days for an account to be created.</p>
@@ -45,7 +45,7 @@ en:
               <p>The subject line of the email must include the:</p>
               <ul>
                 <li>region the school is in</li>
-                <li>grant type (converter grant)</li>
+                <li>grant type</li>
                 <li>school's name</li>
               </ul>
               <p>The content of the email must include the:</p>

--- a/config/locales/conversion/tasks/sponsored_support_grant.en.yml
+++ b/config/locales/conversion/tasks/sponsored_support_grant.en.yml
@@ -39,7 +39,7 @@ en:
             <li>£110,000 for primary and special schools</li>
             <li>£150,000 secondary and all-through schools</li>
             </ul>
-            <p>All grants include the £25,000 conversion grant. This is used to fund
+            <p>All grants include the £25,000 conversion support grant. This is used to fund
             conversion costs, such as legal expenses. Any amount left after
             conversion costs have been paid for should be used for school
             improvements.</p>


### PR DESCRIPTION
## Changes

This work changes uses of 'conversion grant' to 'conversion support grant'

This makes small content changes to 2 tasks.

- Process the conversion grant (now Process the conversion support grant)
- Confirm and process the sponsored support grant

This follows discussion with funding teams to understand what the names of the pre-opening support grants are and is part of wider work to make this naming convention consistent across Apply, Prepare and Complete.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
