### PR TITLE
Allow users to select the GIAS-imported Headteachers in the Headteacher task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - changing 'convesion grant' references to 'conversion support grant' to match
   Apply and Prepare
+- The GIAS-imported Headteacher data is now selectable in the "Choose the
+  Headteacher" task
 
 ## [Release-83][release-83]
 

--- a/app/forms/conversion/task/confirm_headteacher_contact_task_form.rb
+++ b/app/forms/conversion/task/confirm_headteacher_contact_task_form.rb
@@ -15,6 +15,12 @@ class Conversion::Task::ConfirmHeadteacherContactTaskForm < BaseTaskForm
     @key_contacts.update!(headteacher_id: headteacher_contact_id)
   end
 
+  def selectable_contacts
+    project_contacts = @project.contacts.school_or_academy.to_a
+    project_contacts << Contact::Establishment.find_by(establishment_urn: @project.urn)
+    project_contacts.compact
+  end
+
   private def completed?
     @key_contacts.headteacher.present?
   end

--- a/app/forms/transfer/task/confirm_headteacher_contact_task_form.rb
+++ b/app/forms/transfer/task/confirm_headteacher_contact_task_form.rb
@@ -15,6 +15,12 @@ class Transfer::Task::ConfirmHeadteacherContactTaskForm < BaseTaskForm
     @key_contacts.update!(headteacher_id: headteacher_contact_id)
   end
 
+  def selectable_contacts
+    project_contacts = @project.contacts.school_or_academy.to_a
+    project_contacts << Contact::Establishment.find_by(establishment_urn: @project.urn)
+    project_contacts.compact
+  end
+
   private def completed?
     @key_contacts.headteacher.present?
   end

--- a/app/views/conversions/tasks/confirm_headteacher_contact/edit.html.erb
+++ b/app/views/conversions/tasks/confirm_headteacher_contact/edit.html.erb
@@ -22,7 +22,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <% if @project.contacts.school_or_academy.empty? %>
+    <% if @task.selectable_contacts.empty? %>
 
       <h2 class="govuk-heading-l"><%= t("conversion.task.confirm_headteacher_contact.no_contacts.title") %></h2>
       <%= govuk_inset_text(text: t("conversion.task.confirm_headteacher_contact.no_contacts.hint.html")) %>
@@ -34,7 +34,7 @@
         <%= form.govuk_error_summary %>
 
         <%= form.govuk_collection_radio_buttons :headteacher_contact_id,
-              @project.contacts.school_or_academy,
+              @task.selectable_contacts,
               :id,
               :name,
               :email_and_phone,

--- a/app/views/transfers/tasks/confirm_headteacher_contact/edit.html.erb
+++ b/app/views/transfers/tasks/confirm_headteacher_contact/edit.html.erb
@@ -22,7 +22,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <% if @project.contacts.school_or_academy.empty? %>
+    <% if @task.selectable_contacts.empty? %>
 
       <h2 class="govuk-heading-l"><%= t("transfer.task.confirm_headteacher_contact.no_contacts.title") %></h2>
       <%= govuk_inset_text(text: t("transfer.task.confirm_headteacher_contact.no_contacts.hint.html")) %>
@@ -34,7 +34,7 @@
         <%= form.govuk_error_summary %>
 
         <%= form.govuk_collection_radio_buttons :headteacher_contact_id,
-              @project.contacts.school_or_academy,
+              @task.selectable_contacts,
               :id,
               :name,
               :email_and_phone,

--- a/spec/features/conversions/users_can_confirm_the_headteacher_contact_spec.rb
+++ b/spec/features/conversions/users_can_confirm_the_headteacher_contact_spec.rb
@@ -51,4 +51,25 @@ RSpec.feature "Users can confirm the headteacher contact" do
       end
     end
   end
+
+  context "when there are contacts imported from GIAS" do
+    let!(:contact) { create(:establishment_contact, establishment_urn: project.urn) }
+
+    scenario "they can choose the contact" do
+      visit project_path(project)
+      click_link "Confirm the headteacher’s details"
+
+      expect(page).to have_content contact.name
+      expect(page).to have_content contact.email
+      expect(page).to have_content contact.phone
+
+      choose contact.name
+
+      click_button "Save and return"
+
+      within ".app-task-list li:nth-of-type(1) li:nth-of-type(8)" do
+        expect(page).to have_content "Completed"
+      end
+    end
+  end
 end

--- a/spec/features/transfers/users_can_confirm_the_headteacher_contact_spec.rb
+++ b/spec/features/transfers/users_can_confirm_the_headteacher_contact_spec.rb
@@ -51,4 +51,25 @@ RSpec.feature "Users can confirm the headteacher contact" do
       end
     end
   end
+
+  context "when there are contacts imported from GIAS" do
+    let!(:contact) { create(:establishment_contact, establishment_urn: project.urn) }
+
+    scenario "they can choose the contact" do
+      visit project_path(project)
+      click_link "Confirm the headteacher’s details"
+
+      expect(page).to have_content contact.name
+      expect(page).to have_content contact.email
+      expect(page).to have_content contact.phone
+
+      choose contact.name
+
+      click_button "Save and return"
+
+      within ".app-task-list li:nth-of-type(1) li:nth-of-type(3)" do
+        expect(page).to have_content "Completed"
+      end
+    end
+  end
 end


### PR DESCRIPTION


After deploying the latest changes, users were confused as to why they were unable to select the GIAS-imported Headteachers in the new Headteacher task. We had previously decided the data quality in these contacts was not good enough and hoped users would be able to enter their own Headteacher details. However some users still want to be able to use this data.

As a fix, we have decided to allow users to choose the GIAS-imported Headteachers, despite them being of dubious data quality.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
