### PR TITLE
(Chore) Split the "manage contacts" feature spec up

### DIFF
--- a/spec/features/external_contacts/users_can_add_new_external_contacts_spec.rb
+++ b/spec/features/external_contacts/users_can_add_new_external_contacts_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Users can manage contacts" do
+RSpec.feature "Users can add new external contacts" do
   before do
     mock_successful_api_response_to_create_any_project
     sign_in_with_user(user)
@@ -9,40 +9,6 @@ RSpec.feature "Users can manage contacts" do
   let(:user) { create(:user, :caseworker) }
   let!(:project) { create(:conversion_project) }
   let!(:contact) { create(:project_contact, project: project) }
-
-  scenario "they can view a projects contacts" do
-    visit project_contacts_path(project)
-
-    expect(page).to have_content("Other contacts")
-
-    expect_page_to_have_contact(
-      name: "Jo Example",
-      organisation_name: "Some Organisation",
-      title: "CEO of Learning",
-      email: "jo@example.com",
-      phone: "01632 960123"
-    )
-  end
-
-  scenario "the contact groups are in the order users might expect to use them" do
-    create(:project_contact, category: :other, project: project)
-    create(:project_contact, category: :school_or_academy, project: project)
-    create(:project_contact, category: :incoming_trust, project: project)
-    create(:project_contact, category: :solicitor, project: project)
-    create(:project_contact, category: :diocese, project: project)
-    create(:project_contact, category: :local_authority, project: project)
-
-    visit project_contacts_path(project)
-
-    order_categories = page.find_all("h3.govuk-heading-m")
-
-    expect(order_categories[0].text).to eql(I18n.t("contact.index.category_heading", category_name: project.establishment.name))
-    expect(order_categories[1].text).to eql(I18n.t("contact.index.category_heading", category_name: project.incoming_trust.name))
-    expect(order_categories[2].text).to eql(I18n.t("contact.index.category_heading", category_name: project.local_authority.name))
-    expect(order_categories[3].text).to eql("Solicitor contacts")
-    expect(order_categories[4].text).to eql("Diocese contacts")
-    expect(order_categories[5].text).to eql("Other contacts")
-  end
 
   context "adding a new headteacher" do
     scenario "a headteacher is added with the required defaults" do
@@ -220,48 +186,6 @@ RSpec.feature "Users can manage contacts" do
         phone: "01632 960456"
       )
     end
-  end
-
-  scenario "they can delete a contact" do
-    visit project_contacts_path(project)
-    expect(page).to have_content("Other contacts")
-
-    expect_page_to_have_contact(
-      name: "Jo Example",
-      title: "CEO of Learning",
-      email: "jo@example.com",
-      phone: "01632 960123"
-    )
-
-    click_link "Edit"
-
-    click_link("Delete")
-
-    expect(page).to have_content("Are you sure you want to delete Jo Example?")
-    expect(page).to have_content("This will remove the contact for CEO of Learning called Jo Example from the contacts list.")
-
-    click_button("Delete")
-
-    expect(page).to have_content("There are not any contacts for this project yet.")
-  end
-
-  scenario "if a contact is the main contact, it is indicated on the contact" do
-    project.update!(main_contact_id: contact.id)
-
-    visit project_contacts_path(project)
-    expect(page).to have_content(I18n.t("contact.details.main_contact"))
-  end
-
-  scenario "if a project has a member of parliament, the MP is shown" do
-    member_details = Api::Persons::MemberDetails.new(first_name: "Robert", last_name: "Minister", email: "ministerr@parliament.gov.uk")
-
-    allow_any_instance_of(Project).to receive(:member_of_parliament).and_return(member_details)
-
-    visit project_contacts_path(project)
-
-    expect(page).to have_content("Parliamentary contacts")
-    expect(page).to have_content(member_details.name)
-    expect(page).to have_content(member_details.email)
   end
 
   private def expect_page_to_have_contact(name:, title:, organisation_name: nil, email: nil, phone: nil)

--- a/spec/features/external_contacts/users_can_edit_external_contacts_spec.rb
+++ b/spec/features/external_contacts/users_can_edit_external_contacts_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.feature "Users can edit external contacts" do
+  before do
+    mock_successful_api_response_to_create_any_project
+    sign_in_with_user(user)
+  end
+
+  let(:user) { create(:user, :caseworker) }
+  let!(:project) { create(:conversion_project) }
+  let!(:contact) { create(:project_contact, project: project) }
+
+  scenario "they can delete a contact" do
+    visit project_contacts_path(project)
+    expect(page).to have_content("Other contacts")
+
+    expect(page).to have_content("Jo Example")
+    expect(page).to have_content("Some Organisation")
+    expect(page).to have_content("CEO of Learning")
+    expect(page).to have_content("jo@example.com")
+    expect(page).to have_content("01632 960123")
+
+    click_link "Edit"
+
+    click_link("Delete")
+
+    expect(page).to have_content("Are you sure you want to delete Jo Example?")
+    expect(page).to have_content("This will remove the contact for CEO of Learning called Jo Example from the contacts list.")
+
+    click_button("Delete")
+
+    expect(page).to have_content("There are not any contacts for this project yet.")
+  end
+
+  scenario "they can edit a contact" do
+    visit project_contacts_path(project)
+    expect(page).to have_content("Other contacts")
+
+    expect(page).to have_content("Jo Example")
+
+    click_link "Edit"
+
+    fill_in "Full name", with: "Josephine Example"
+    click_on "Save contact"
+    expect(page).to have_content("Josephine Example")
+  end
+
+  context "when the contact can be set as a primary contact" do
+    let!(:contact) { create(:project_contact, project: project, category: "school_or_academy") }
+
+    scenario "they can set an existing contact as a primary contact for the organisation" do
+      visit project_contacts_path(project)
+      expect(page).to have_content("#{project.establishment.name} contacts")
+
+      click_link "Edit"
+
+      within "#primary-contact-for-category" do
+        choose "Yes"
+      end
+
+      click_on "Save contact"
+      expect(page).to have_content("Primary contact at organisation?")
+      expect(page).to have_content("Yes")
+    end
+  end
+end

--- a/spec/features/external_contacts/users_can_view_external_contacts_spec.rb
+++ b/spec/features/external_contacts/users_can_view_external_contacts_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.feature "Users can view external contacts" do
+  before do
+    mock_successful_api_response_to_create_any_project
+    sign_in_with_user(user)
+  end
+
+  let(:user) { create(:user, :caseworker) }
+  let!(:project) { create(:conversion_project) }
+  let!(:contact) { create(:project_contact, project: project) }
+
+  scenario "they can view a projects contacts" do
+    visit project_contacts_path(project)
+
+    expect(page).to have_content("Other contacts")
+
+    expect(page).to have_content("Jo Example")
+    expect(page).to have_content("Some Organisation")
+    expect(page).to have_content("CEO of Learning")
+    expect(page).to have_content("jo@example.com")
+    expect(page).to have_content("01632 960123")
+  end
+
+  scenario "if a contact is the main contact, it is indicated on the contact" do
+    project.update!(main_contact_id: contact.id)
+
+    visit project_contacts_path(project)
+    expect(page).to have_content(I18n.t("contact.details.main_contact"))
+  end
+
+  scenario "the contact groups are in the order users might expect to use them" do
+    create(:project_contact, category: :other, project: project)
+    create(:project_contact, category: :school_or_academy, project: project)
+    create(:project_contact, category: :incoming_trust, project: project)
+    create(:project_contact, category: :solicitor, project: project)
+    create(:project_contact, category: :diocese, project: project)
+    create(:project_contact, category: :local_authority, project: project)
+
+    visit project_contacts_path(project)
+
+    order_categories = page.find_all("h3.govuk-heading-m")
+
+    expect(order_categories[0].text).to eql(I18n.t("contact.index.category_heading", category_name: project.establishment.name))
+    expect(order_categories[1].text).to eql(I18n.t("contact.index.category_heading", category_name: project.incoming_trust.name))
+    expect(order_categories[2].text).to eql(I18n.t("contact.index.category_heading", category_name: project.local_authority.name))
+    expect(order_categories[3].text).to eql("Solicitor contacts")
+    expect(order_categories[4].text).to eql("Diocese contacts")
+    expect(order_categories[5].text).to eql("Other contacts")
+  end
+
+  scenario "if a project has a member of parliament, the MP is shown" do
+    member_details = Api::Persons::MemberDetails.new({firstName: "Robert", lastName: "Minister", email: "ministerr@parliament.gov.uk"}.with_indifferent_access)
+
+    allow_any_instance_of(Project).to receive(:member_of_parliament).and_return(member_details)
+
+    visit project_contacts_path(project)
+
+    expect(page).to have_content("Parliamentary contacts")
+    expect(page).to have_content("Robert Minister")
+    expect(page).to have_content("ministerr@parliament.gov.uk")
+  end
+end


### PR DESCRIPTION
This spec had become too big and unwieldy; split it up into 3 smaller feature specs.

