### PR TITLE
(Fix) Remove non-unique ID from Contact Summary Card

### DIFF
--- a/app/views/external_contacts/_contact_group.html.erb
+++ b/app/views/external_contacts/_contact_group.html.erb
@@ -2,7 +2,7 @@
 
 <% contacts.each do |contact| %>
 
-  <div id="academyDetails" class="govuk-summary-card">
+  <div class="govuk-summary-card">
     <div class="govuk-summary-card__title-wrapper">
       <h3 class="govuk-summary-card__title">
         <%= contact.title %>


### PR DESCRIPTION
The contact summary card's IDs were not unique. We were going to add unique ones but 1) the IDs are not used in any tests; and 2) an ID is not mandatory according to the design system. So instead we have removed them.
