### PR TITLE
Update commercial transfer agreement tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - the actions for the 'Commercial transfer agreement' task for conversion
   projects, any completed actions will be migrated over, users may be required
   to confirm additional actions after this change.
+- the actions for the 'Commercial transfer agreement' task for transfer
+  projects.
 
 ## [Release-84][release-84]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- the actions for the 'Commercial transfer agreement' task for conversion
+  projects, any completed actions will be migrated over, users may be required
+  to confirm additional actions after this change.
+
 ## [Release-84][release-84]
 
 ### Changed

--- a/app/forms/conversion/task/commercial_transfer_agreement_task_form.rb
+++ b/app/forms/conversion/task/commercial_transfer_agreement_task_form.rb
@@ -1,5 +1,7 @@
 class Conversion::Task::CommercialTransferAgreementTaskForm < BaseTaskForm
-  attribute :email_signed, :boolean
-  attribute :receive_signed, :boolean
-  attribute :save_signed, :boolean
+  attribute :agreed, :boolean
+  attribute :signed, :boolean
+  attribute :questions_received, :boolean
+  attribute :questions_checked, :boolean
+  attribute :saved, :boolean
 end

--- a/app/forms/transfer/task/commercial_transfer_agreement_task_form.rb
+++ b/app/forms/transfer/task/commercial_transfer_agreement_task_form.rb
@@ -1,5 +1,7 @@
 class Transfer::Task::CommercialTransferAgreementTaskForm < BaseTaskForm
   attribute :confirm_agreed, :boolean
   attribute :confirm_signed, :boolean
+  attribute :questions_received, :boolean
+  attribute :questions_checked, :boolean
   attribute :save_confirmation_emails, :boolean
 end

--- a/app/views/conversions/tasks/commercial_transfer_agreement/edit.html.erb
+++ b/app/views/conversions/tasks/commercial_transfer_agreement/edit.html.erb
@@ -14,9 +14,11 @@
       <%= form.govuk_error_summary %>
 
       <div class="govuk-form-group">
-        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :email_signed)) %>
-        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :receive_signed)) %>
-        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :save_signed)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :agreed)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :signed)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :questions_received)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :questions_checked)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :saved)) %>
       </div>
 
       <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>

--- a/app/views/transfers/tasks/commercial_transfer_agreement/edit.html.erb
+++ b/app/views/transfers/tasks/commercial_transfer_agreement/edit.html.erb
@@ -16,6 +16,8 @@
       <div class="govuk-form-group">
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :confirm_agreed)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :confirm_signed)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :questions_received)) %>
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :questions_checked)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :save_confirmation_emails)) %>
       </div>
 

--- a/config/locales/conversion/tasks/commercial_transfer_agreement.en.yml
+++ b/config/locales/conversion/tasks/commercial_transfer_agreement.en.yml
@@ -5,10 +5,18 @@ en:
         title: Commercial transfer agreement
         hint:
           html: <p>The commercial transfer agreement is essential for all conversion projects.</p>
+        guidance_link: How to check and assure the commercial transfer agreeement
+        guidance:
+          html:
+            <p>You can <a href="https://educationgovuk.sharepoint.com/sites/lvewp00030/SitePages/3-Conversion%20Process/Commercial%20Transfer%20Agreement%20(CTA)/Commercial%20Transfer%20Agreement.aspx" target="_blank">read guidance about how use check and assure the agreement (opens in new tab)</a> on SharePoint.</p>
 
-        email_signed:
-          title: Email the solicitors to ask if all relevant parties have agreed and signed the commercial transfer agreement
-        receive_signed:
-          title: Receive email from the solicitors confirming all relevant parties have agreed and signed the commercial transfer agreement
-        save_signed:
+        agreed:
+          title: Confirm commercial transfer agreement is agreed
+        signed:
+          title: Confirm commercial transfer agreement is signed
+        questions_received:
+          title: Receive solicitor responses to assurance questions
+        questions_checked:
+          title: Check solicitor responses to assurance questions
+        saved:
           title: Save a copy of the confirmation email in the school's SharePoint folder

--- a/config/locales/transfer/tasks/commercial_transfer_agreement.en.yml
+++ b/config/locales/transfer/tasks/commercial_transfer_agreement.en.yml
@@ -7,10 +7,18 @@ en:
           html:
             <p>The commercial transfer agreement is essential for all transfer projects.</p>
             <p>It might not be agreed and signed until the final month before the academy is transferred.</p>
+        guidance_link: How to check and assure the commercial transfer agreeement
+        guidance:
+          html:
+            <p>You can <a href="https://educationgovuk.sharepoint.com/sites/lvewp00030/SitePages/3-Conversion%20Process/Commercial%20Transfer%20Agreement%20(CTA)/Commercial%20Transfer%20Agreement.aspx" target="_blank">read guidance about how use check and assure the agreement (opens in new tab)</a> on SharePoint.</p>
 
         confirm_agreed:
           title: Confirm commercial transfer agreement is agreed
         confirm_signed:
           title: Confirm commercial transfer agreement is signed
+        questions_received:
+          title: Receive solicitor responses to assurance questions
+        questions_checked:
+          title: Check solicitor responses to assurance questions
         save_confirmation_emails:
           title: Save a copy of the confirmation emails in the academy SharePoint folder

--- a/db/migrate/20240822104104_update_conversion_commercial_transfer_agreement_task.rb
+++ b/db/migrate/20240822104104_update_conversion_commercial_transfer_agreement_task.rb
@@ -1,0 +1,64 @@
+class UpdateConversionCommercialTransferAgreementTask < ActiveRecord::Migration[7.0]
+  def up
+    # Add new columns
+    add_column :conversion_tasks_data, :commercial_transfer_agreement_agreed, :boolean, default: false
+    add_column :conversion_tasks_data, :commercial_transfer_agreement_signed, :boolean, default: false
+    add_column :conversion_tasks_data, :commercial_transfer_agreement_questions_received, :boolean, default: false
+    add_column :conversion_tasks_data, :commercial_transfer_agreement_questions_checked, :boolean, default: false
+    add_column :conversion_tasks_data, :commercial_transfer_agreement_saved, :boolean, default: false
+
+    # migrate data
+    Conversion::TasksData.all.each do |t|
+      if t.commercial_transfer_agreement_email_signed
+        t.commercial_transfer_agreement_agreed = true
+        t.commercial_transfer_agreement_signed = true
+      end
+
+      if t.commercial_transfer_agreement_receive_signed
+        t.commercial_transfer_agreement_questions_received = true
+      end
+
+      if t.commercial_transfer_agreement_save_signed
+        t.commercial_transfer_agreement_saved = true
+      end
+
+      t.save(validate: false)
+    end
+
+    # remove columns
+    remove_column :conversion_tasks_data, :commercial_transfer_agreement_email_signed, :boolean
+    remove_column :conversion_tasks_data, :commercial_transfer_agreement_receive_signed, :boolean
+    remove_column :conversion_tasks_data, :commercial_transfer_agreement_save_signed, :boolean
+  end
+
+  def down
+    # restore old columns
+    add_column :conversion_tasks_data, :commercial_transfer_agreement_email_signed, :boolean, default: false
+    add_column :conversion_tasks_data, :commercial_transfer_agreement_receive_signed, :boolean, default: false
+    add_column :conversion_tasks_data, :commercial_transfer_agreement_save_signed, :boolean, default: false
+
+    # migrate data
+    Conversion::TasksData.all.each do |t|
+      if t.commercial_transfer_agreement_agreed && t.commercial_transfer_agreement_signed
+        t.commercial_transfer_agreement_email_signed = true
+      end
+
+      if t.commercial_transfer_agreement_questions_received
+        t.commercial_transfer_agreement_receive_signed = true
+      end
+
+      if t.commercial_transfer_agreement_saved
+        t.commercial_transfer_agreement_save_signed = true
+      end
+
+      t.save(validate: false)
+    end
+
+    # remove new columns
+    remove_column :conversion_tasks_data, :commercial_transfer_agreement_agreed, :boolean
+    remove_column :conversion_tasks_data, :commercial_transfer_agreement_signed, :boolean
+    remove_column :conversion_tasks_data, :commercial_transfer_agreement_questions_received, :boolean
+    remove_column :conversion_tasks_data, :commercial_transfer_agreement_questions_checked, :boolean
+    remove_column :conversion_tasks_data, :commercial_transfer_agreement_saved, :boolean
+  end
+end

--- a/db/migrate/20240827092019_update_transfer_commercial_transfer_agreement_task.rb
+++ b/db/migrate/20240827092019_update_transfer_commercial_transfer_agreement_task.rb
@@ -1,0 +1,6 @@
+class UpdateTransferCommercialTransferAgreementTask < ActiveRecord::Migration[7.0]
+  def change
+    add_column :transfer_tasks_data, :commercial_transfer_agreement_questions_received, :boolean, default: false
+    add_column :transfer_tasks_data, :commercial_transfer_agreement_questions_checked, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_22_104104) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_27_092019) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -472,6 +472,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_22_104104) do
     t.boolean "conditions_met_baseline_sheet_approved"
     t.boolean "form_m_not_applicable"
     t.boolean "articles_of_association_sent"
+    t.boolean "commercial_transfer_agreement_questions_received", default: false
+    t.boolean "commercial_transfer_agreement_questions_checked", default: false
   end
 
   create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_22_074901) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_22_104104) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -118,9 +118,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_22_074901) do
     t.boolean "tenancy_at_will_email_signed"
     t.boolean "tenancy_at_will_receive_signed"
     t.boolean "tenancy_at_will_save_signed"
-    t.boolean "commercial_transfer_agreement_email_signed"
-    t.boolean "commercial_transfer_agreement_receive_signed"
-    t.boolean "commercial_transfer_agreement_save_signed"
     t.boolean "share_information_email"
     t.boolean "redact_and_send_send_solicitors"
     t.boolean "articles_of_association_not_applicable"
@@ -158,6 +155,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_22_074901) do
     t.date "confirm_date_academy_opened_date_opened"
     t.string "risk_protection_arrangement_reason"
     t.boolean "articles_of_association_sent"
+    t.boolean "commercial_transfer_agreement_agreed", default: false
+    t.boolean "commercial_transfer_agreement_signed", default: false
+    t.boolean "commercial_transfer_agreement_questions_received", default: false
+    t.boolean "commercial_transfer_agreement_questions_checked", default: false
+    t.boolean "commercial_transfer_agreement_saved", default: false
   end
 
   create_table "dao_revocation_reasons", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|


### PR DESCRIPTION
We received feedback on the commercial transfer agreement task for both conversion and transfer projects.

This works implements the changes the design team came to from this feedback.

For conversion projects, we include a reversible schema and data migration as the actions have changed, these were validated with @SteveMilnes.

For transfers two actions have been added.