### PR TITLE
Refine the Headteacher data migration

### DIFF
--- a/app/services/headteacher_data_migration_service.rb
+++ b/app/services/headteacher_data_migration_service.rb
@@ -21,13 +21,16 @@ class HeadteacherDataMigrationService
 
       if contacts_to_copy.present?
         contacts_to_copy.each do |contact|
+          next if Contact::Project.find_by(email: contact.email)
+
           puts "Copying contact #{contact.id}"
+          organisation_name = contact.establishment&.name
           new_contact = Contact::Project.create(
             name: contact.name,
             title: contact.title,
             email: contact.email,
             phone: contact.phone,
-            organisation_name: project.establishment.name,
+            organisation_name: organisation_name,
             category: :school_or_academy,
             project: project
           )


### PR DESCRIPTION
When running the Headteacher migration on test, we found two issues:

1) The Academies API timed out. Get around this be getting the contact establishment name (school name) from our local GIAS:Establishment tables.

2) There is a risk that we will try to create a new contact with the same email address as an existing contact. Skip the contact if this is the case.

