### PR TITLE
CVE-2021-31799: A command injection vulnerability in RDoc

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,7 +337,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.1.0)
-    rdoc (2.5.11)
+    rdoc (6.3.1)
     redcarpet (3.5.1)
     redis (4.8.1)
     regexp_parser (2.9.0)


### PR DESCRIPTION
There is an open CVE for the RDoc Gem. Whilst the app doesn't use it directly, `irb` has it as a dependency. This PR simply bumps the version constrained in the `Gemfile.lock` so that the patched version is installed.

[1] https://www.ruby-lang.org/en/news/2021/05/02/os-command-injection-in-rdoc/