### PR TITLE
Update project level notes scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   to confirm additional actions after this change.
 - the actions for the 'Commercial transfer agreement' task for transfer
   projects.
+- notes added during a change of significant date, including during the
+  stakeholder kick off task now only appear under the date history tab of a
+  project and not the project notes tab.
 
 ## [Release-84][release-84]
 

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -8,7 +8,11 @@ class Note < ApplicationRecord
 
   default_scope { order(created_at: "desc") }
 
-  scope :project_level_notes, ->(project) { where(task_identifier: nil).and(where(project: project)) }
+  scope :project_level_notes, ->(project) {
+    where(project: project)
+      .where(notable_type: nil).where(task_identifier: nil)
+      .or(where.not(notable_type: "SignificantDateHistoryReason"))
+  }
 
   # When no value is provided, Rails will store an empty string. Instead, we want to ensure
   # these are stored as NULL, so that we aren't mixing blanks and NULLs.

--- a/spec/factories/note_factory.rb
+++ b/spec/factories/note_factory.rb
@@ -14,5 +14,10 @@ FactoryBot.define do
       notable { association :date_history_reason }
       body { "This is the reason the conversion date has changed" }
     end
+
+    trait :for_dao_revocation_reason do
+      notable { association :dao_revocation_reason }
+      body { "The DAO has been revoked" }
+    end
   end
 end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -35,14 +35,27 @@ RSpec.describe Note, type: :model do
     end
 
     describe "project_level_notes" do
-      let!(:project_level_note) { create(:note) }
-      let!(:task_level_note) { create(:note, task_identifier: "handover") }
+      let!(:project) { create(:conversion_project) }
+      let!(:project_level_note) { create(:note, project: project) }
+      let!(:task_level_note) { create(:note, task_identifier: "handover", project: project) }
+      let!(:significant_date_note) { create(:note, :for_significant_date_history_reason, project: project) }
+      let!(:dao_revocation_note) { create(:note, :for_dao_revocation_reason, project: project) }
 
-      subject { Note.project_level_notes(project_level_note.project) }
+      subject { Note.project_level_notes(project) }
 
-      it "returns only project level notes" do
+      it "does not include task level notes" do
         expect(subject).to include project_level_note
         expect(subject).not_to include task_level_note
+      end
+
+      it "does not include significant date history notes" do
+        expect(subject).to include project_level_note
+        expect(subject).not_to include significant_date_note
+      end
+
+      it "does include dao revocation notes" do
+        expect(subject).to include project_level_note
+        expect(subject).to include dao_revocation_note
       end
     end
   end


### PR DESCRIPTION
'Project level notes' are:

- not notes associated to a task
- not notes associated to a change of significant date

but they are:

- notes associated to a DAO revocation
- all other types of notes

This work adjusts the scope we use to define this and in summary,
removes the significant date change notes from the project notes tab,
they are still shown on their own tab.

