### PR TITLE
Update for docker compose

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -15,7 +15,7 @@ Make sure you can run appropriate versions in you development environment.
 ## Setup Microsoft SQL Server environment
 
 As we run Microsoft SQL Server, we have to run it inside a container. To make
-this as simple as we can we use docker-compose to launch an appropriate
+this as simple as we can we use docker compose to launch an appropriate
 instance.
 
 1. Duplicate `.env.database.example` as `.env.database` and set:

--- a/script/start_backing_services
+++ b/script/start_backing_services
@@ -4,8 +4,8 @@
 # Make sure the backing services are running
 
 echo "==> Checking backing services"
-if ! docker-compose ps | grep -q "dfe-complete-sql-backing-service\|Up"; then
+if ! docker compose ps | grep -q "dfe-complete-sql-backing-service\|Up"; then
   echo "--> Starting backing services with docker-compose.yml"
-  docker-compose -f docker-compose.yml up -d
+  docker compose -f docker-compose.yml up -d
   sleep 3
 fi

--- a/script/stop_backing_services
+++ b/script/stop_backing_services
@@ -4,7 +4,7 @@
 # Make sure the backing services are running
 
 echo "==> Checking backing services"
-if docker-compose ps | grep -q "dfe-complete-sql-backing-service\|Up"; then
+if docker compose ps | grep -q "dfe-complete-sql-backing-service\|Up"; then
   echo "--> Stoping backing services with docker-compose.yml"
-  docker-compose -f docker-compose.yml down
+  docker compose -f docker-compose.yml down
 fi


### PR DESCRIPTION
The `docker-compose` command has been removed and included in the
`docker` command - this work adjust our scripts to reflect this change
and use `docker compose`.
