### PR TITLE
(178320) Add a new "Data consumers" team

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - the actions for the 'Commercial transfer agreement' task for transfer
   projects.
 
+### Added
+
+- Add a new "Data consumers" team which will eventually replace the ESFA and
+  AOPU teams
+
 ## [Release-84][release-84]
 
 ### Changed

--- a/app/models/concerns/teamable.rb
+++ b/app/models/concerns/teamable.rb
@@ -18,7 +18,8 @@ module Teamable
     service_support: "service_support",
     academies_operational_practice_unit: "academies_operational_practice_unit",
     education_and_skills_funding_agency: "education_and_skills_funding_agency",
-    business_support: "business_support"
+    business_support: "business_support",
+    data_consumers: "data_consumers"
   })
 
   PROJECT_TEAMS = REGIONAL_TEAMS.merge({regional_casework_services: "regional_casework_services"})

--- a/app/policies/export_policy.rb
+++ b/app/policies/export_policy.rb
@@ -24,6 +24,7 @@ class ExportPolicy
   def csv?
     return true if @user.education_and_skills_funding_agency_team?
     return true if @user.academies_operational_practice_unit_team?
+    return true if @user.data_consumers_team?
     return true if @user.business_support_team?
     return true if @user.service_support_team?
 

--- a/config/locales/teams.en.yml
+++ b/config/locales/teams.en.yml
@@ -14,3 +14,4 @@ en:
     academies_operational_practice_unit: Academies operational practice unit
     education_and_skills_funding_agency: Education and skills funding agency
     business_support: Business support
+    data_consumers: Data consumers

--- a/config/locales/user.en.yml
+++ b/config/locales/user.en.yml
@@ -64,6 +64,7 @@ en:
       academies_operational_practice_unit: AOPU (Academies Operational Practice Unit)
       education_and_skills_funding_agency: ESFA (Education and Skills Funding Agency)
       business_support: Business support
+      data_consumers: Data consumers - ESFA (Education and Skills Funding Agency) and AOPU (Academies Operational Practice Unit) users
   helpers:
     legend:
       user:

--- a/spec/features/all_projects/by_month/users_can_view_projects_by_month_spec.rb
+++ b/spec/features/all_projects/by_month/users_can_view_projects_by_month_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Users can view projects by month" do
   context "a data user (who can export)" do
-    let(:user) { create(:user, team: "education_and_skills_funding_agency") }
+    let(:user) { create(:user, team: "data_consumers") }
 
     scenario "the user sees the date range option in the By Month view" do
       sign_in_with_user(user)

--- a/spec/features/all_projects/export/export_users_can_see_an_export_landing_page_spec.rb
+++ b/spec/features/all_projects/export/export_users_can_see_an_export_landing_page_spec.rb
@@ -34,6 +34,18 @@ RSpec.feature "Export users can see the exports landing page" do
     expect(page).to have_content("pre-transfer grants for academies joining a different trust")
   end
 
+  scenario "a data consumers user can see the exports landing page" do
+    user = create(:user, team: :data_consumers)
+
+    sign_in_with_user(user)
+    click_on "Exports"
+
+    expect(page).to have_content("funding agreement letter contacts, RPA and start-up grants")
+    expect(page).to have_content("pre-opening grants for schools becoming academies")
+    expect(page).to have_content("academies due to transfer in a date range")
+    expect(page).to have_content("pre-transfer grants for academies joining a different trust")
+  end
+
   scenario "a business support user can see the exports landing page" do
     user = create(:user, team: :business_support)
 

--- a/spec/models/statistics/user_statistics_spec.rb
+++ b/spec/models/statistics/user_statistics_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Statistics::UserStatistics, type: :model do
       expect(subject.users_count_per_team).to eq({
         academies_operational_practice_unit: 0,
         business_support: 0,
+        data_consumers: 0,
         east_midlands: 0,
         east_of_england: 0,
         education_and_skills_funding_agency: 1,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -259,11 +259,11 @@ RSpec.describe User do
     it "returns the correct team options for a user" do
       options = described_class.new.team_options
 
-      expect(options.count).to eql 14
+      expect(options.count).to eql 15
       expect(options.first.id).to eql "london"
       expect(options.first.name).to eql "London"
-      expect(options.last.id).to eql "business_support"
-      expect(options.last.name).to eql "Business support"
+      expect(options.last.id).to eql "data_consumers"
+      expect(options.last.name).to include "Data consumers"
     end
   end
 
@@ -311,7 +311,7 @@ RSpec.describe User do
     end
 
     it "has the expected enum values" do
-      expect(User.teams.count).to eq(14)
+      expect(User.teams.count).to eq(15)
     end
   end
 

--- a/spec/policies/export_policy_spec.rb
+++ b/spec/policies/export_policy_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe ExportPolicy do
   let(:esfa_user) { build(:user, team: :education_and_skills_funding_agency) }
   let(:aopu_user) { build(:user, team: :academies_operational_practice_unit) }
+  let(:data_consumers_user) { build(:user, team: :data_consumers) }
   let(:rdo_user) { build(:regional_delivery_officer_user) }
   let(:rcs_user) { build(:regional_casework_services_user) }
   let(:service_support_user) { build(:service_support_user) }
@@ -14,6 +15,7 @@ RSpec.describe ExportPolicy do
       expect(described_class).to permit(aopu_user)
       expect(described_class).to permit(business_support_user)
       expect(described_class).to permit(service_support_user)
+      expect(described_class).to permit(data_consumers_user)
       expect(described_class).not_to permit(rdo_user)
       expect(described_class).not_to permit(rcs_user)
     end
@@ -24,6 +26,7 @@ RSpec.describe ExportPolicy do
       expect(described_class).to permit(service_support_user)
       expect(described_class).not_to permit(esfa_user)
       expect(described_class).not_to permit(aopu_user)
+      expect(described_class).not_to permit(data_consumers_user)
       expect(described_class).not_to permit(business_support_user)
       expect(described_class).not_to permit(rdo_user)
       expect(described_class).not_to permit(rcs_user)


### PR DESCRIPTION
We are going to consolidate the EFSA & APOU users into one "can export" team.

First of all, create a new team these users will eventually belong to and give the team the same permissions as existing ESFA & AOPU teams.


