### PR TITLE
Update the govuk_markdown gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem "govuk-components", "~> 4.1", ">= 4.1.1"
 gem "govuk_design_system_formbuilder", "~> 4.1", ">= 4.1.1"
 
 # Use govuk_markdown to transform Markdown into GOV.UK Frontend-compliant HTML
-gem "govuk_markdown"
+gem "govuk_markdown", "~>2"
 
 gem "faraday"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
       activemodel (>= 6.1)
       activesupport (>= 6.1)
       html-attributes-utils (~> 1)
-    govuk_markdown (1.0.0)
+    govuk_markdown (2.0.2)
       activesupport
       redcarpet
     grape (2.1.3)
@@ -234,7 +234,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
-    minitest (5.23.1)
+    minitest (5.25.1)
     msgpack (1.7.2)
     multi_xml (0.6.0)
     mustermann (3.0.0)
@@ -338,7 +338,7 @@ GEM
     rainbow (3.1.1)
     rake (13.1.0)
     rdoc (6.3.1)
-    redcarpet (3.5.1)
+    redcarpet (3.6.0)
     redis (4.8.1)
     regexp_parser (2.9.0)
     reline (0.4.3)
@@ -498,7 +498,7 @@ DEPENDENCIES
   faraday
   govuk-components (~> 4.1, >= 4.1.1)
   govuk_design_system_formbuilder (~> 4.1, >= 4.1.1)
-  govuk_markdown
+  govuk_markdown (~> 2)
   grape (~> 2.0)
   grape-swagger (~> 2.1)
   high_voltage

--- a/config/initializers/govuk_markdown.rb
+++ b/config/initializers/govuk_markdown.rb
@@ -1,6 +1,6 @@
 module GovukMarkdown
-  def self.render(markdown)
-    renderer = GovukMarkdown::Renderer.new(with_toc_data: true, link_attributes: {class: "govuk-link", target: "_blank"})
+  def self.render(markdown, govuk_options = {})
+    renderer = GovukMarkdown::Renderer.new(govuk_options, {with_toc_data: true, link_attributes: {class: "govuk-link", target: "_blank"}})
     Redcarpet::Markdown.new(renderer, tables: true, no_intra_emphasis: true).render(markdown).strip
   end
 end


### PR DESCRIPTION
Whilst testing a Rails update, we found the new version of this gem
requires a slight change to our custom renderer.

We are just passing the new `govuk_options` in.
