### PR TITLE
Migrate users in the AOPU and ESFA teams into the "data consumers" team

### DIFF
--- a/app/services/data_consumers_migration_service.rb
+++ b/app/services/data_consumers_migration_service.rb
@@ -1,0 +1,31 @@
+# Data migration service
+#
+# This data migration is designed to be run in production and then deleted
+#
+# It moves any users in the `academies_operational_practice_unit` or
+# `education_and_skills_funding_agency` team into the `data_consumers`
+# team
+#
+# To run:
+#
+# bin/rails runner DataConsumersMigrationService.new.migrate!
+#
+class DataConsumersMigrationService
+  def migrate!
+    esfa_users = User.education_and_skills_funding_agency_team
+    puts "#{esfa_users.count} ESFA users to update"
+    esfa_users.each do |user|
+      user.team = :data_consumers
+      user.save!(validate: false)
+    end
+
+    aopu_users = User.academies_operational_practice_unit_team
+    puts "#{aopu_users.count} AOPU users to update"
+    aopu_users.each do |user|
+      user.team = :data_consumers
+      user.save!(validate: false)
+    end
+
+    puts "#{User.data_consumers_team.count} Data consumer users after migration"
+  end
+end

--- a/spec/services/data_consumers_migration_service_spec.rb
+++ b/spec/services/data_consumers_migration_service_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe DataConsumersMigrationService do
+  it "moves all ESFA and AOPU users to the new Data consumers team" do
+    create(:user, team: :education_and_skills_funding_agency, email: "user1@education.gov.uk")
+    create(:user, team: :academies_operational_practice_unit, email: "user2@education.gov.uk")
+    create(:regional_casework_services_user, email: "user3@education.gov.uk")
+
+    DataConsumersMigrationService.new.migrate!
+
+    expect(User.count).to eq(3)
+    expect(User.data_consumers_team.count).to eq(2)
+  end
+
+  it "handles any invalid users" do
+    user = build(:user, team: :education_and_skills_funding_agency, email: "user@education.co.uk")
+    user.save(validate: false)
+
+    DataConsumersMigrationService.new.migrate!
+
+    expect(User.count).to eq(1)
+    expect(User.data_consumers_team.count).to eq(1)
+  end
+end


### PR DESCRIPTION
We are consolidating all ESFA and AOPU users into a new "data consumers" team. This migration moves all ESFA and AOPU users innto the new team.


