### PR TITLE
Remote Docker compose version attribute

### DIFF
--- a/docker-compose.checks.yml
+++ b/docker-compose.checks.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   test:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 name: dfe-complete
 services:
   db:


### PR DESCRIPTION
The `version` attribute is no longer required and shows a deprecation
warning.

