### PR TITLE
Move the Risk Protection Policy task to the first tasklist section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - notes added during a change of significant date, including during the
   stakeholder kick off task now only appear under the date history tab of a
   project and not the project notes tab.
+- Move the Risk Protection Arrangement task to the first tasklist section
 
 ### Added
 

--- a/app/models/conversion/task_list.rb
+++ b/app/models/conversion/task_list.rb
@@ -6,6 +6,7 @@ class Conversion::TaskList < ::BaseTaskList
         tasks: [
           Conversion::Task::HandoverTaskForm,
           Conversion::Task::StakeholderKickOffTaskForm,
+          Conversion::Task::RiskProtectionArrangementTaskForm,
           Conversion::Task::CheckAccuracyOfHigherNeedsTaskForm,
           Conversion::Task::CompleteNotificationOfChangeTaskForm,
           Conversion::Task::ConversionGrantTaskForm,
@@ -39,7 +40,6 @@ class Conversion::TaskList < ::BaseTaskList
       {
         identifier: :get_ready_for_opening,
         tasks: [
-          Conversion::Task::RiskProtectionArrangementTaskForm,
           Conversion::Task::SingleWorksheetTaskForm,
           Conversion::Task::SchoolCompletedTaskForm,
           Conversion::Task::ConditionsMetTaskForm,

--- a/app/models/transfer/task_list.rb
+++ b/app/models/transfer/task_list.rb
@@ -6,6 +6,7 @@ class Transfer::TaskList < ::BaseTaskList
         tasks: [
           Transfer::Task::HandoverTaskForm,
           Transfer::Task::StakeholderKickOffTaskForm,
+          Transfer::Task::RpaPolicyTaskForm,
           Transfer::Task::ConfirmHeadteacherContactTaskForm,
           Transfer::Task::ConfirmIncomingTrustCeoContactTaskForm,
           Transfer::Task::ConfirmOutgoingTrustCeoContactTaskForm,
@@ -35,7 +36,6 @@ class Transfer::TaskList < ::BaseTaskList
       {
         identifier: :get_ready_for_opening,
         tasks: [
-          Transfer::Task::RpaPolicyTaskForm,
           Transfer::Task::BankDetailsChangingTaskForm,
           Transfer::Task::ConfirmIncomingTrustHasCompletedAllActionsTaskForm,
           Transfer::Task::ConditionsMetTaskForm

--- a/spec/features/conversions/users_can_confirm_the_chair_of_governors_contact_spec.rb
+++ b/spec/features/conversions/users_can_confirm_the_chair_of_governors_contact_spec.rb
@@ -46,7 +46,8 @@ RSpec.feature "Users can confirm the chair of governors contact" do
 
       click_button "Save and return"
 
-      within ".app-task-list li:nth-of-type(1) li:nth-of-type(10)" do
+      row = page.find(".app-task-list li:nth-of-type(1) li", text: "Confirm the chair of governors’ details")
+      within row do
         expect(page).to have_content "Completed"
       end
     end

--- a/spec/features/conversions/users_can_confirm_the_chair_of_governors_contact_spec.rb
+++ b/spec/features/conversions/users_can_confirm_the_chair_of_governors_contact_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Users can confirm the chair of governors contact" do
 
       click_button "Save and return"
 
-      within ".app-task-list li:nth-of-type(1) li:nth-of-type(9)" do
+      within ".app-task-list li:nth-of-type(1) li:nth-of-type(10)" do
         expect(page).to have_content "Completed"
       end
     end

--- a/spec/features/conversions/users_can_confirm_the_headteacher_contact_spec.rb
+++ b/spec/features/conversions/users_can_confirm_the_headteacher_contact_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Users can confirm the headteacher contact" do
 
       click_button "Save and return"
 
-      within ".app-task-list li:nth-of-type(1) li:nth-of-type(8)" do
+      within ".app-task-list li:nth-of-type(1) li:nth-of-type(9)" do
         expect(page).to have_content "Completed"
       end
     end

--- a/spec/features/conversions/users_can_confirm_the_headteacher_contact_spec.rb
+++ b/spec/features/conversions/users_can_confirm_the_headteacher_contact_spec.rb
@@ -46,7 +46,8 @@ RSpec.feature "Users can confirm the headteacher contact" do
 
       click_button "Save and return"
 
-      within ".app-task-list li:nth-of-type(1) li:nth-of-type(9)" do
+      row = page.find(".app-task-list li:nth-of-type(1) li", text: "Confirm the headteacher’s details")
+      within row do
         expect(page).to have_content "Completed"
       end
     end

--- a/spec/features/conversions/users_can_confirm_the_incoming_trust_ceo_contact_spec.rb
+++ b/spec/features/conversions/users_can_confirm_the_incoming_trust_ceo_contact_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Users can confirm the incoming trust CEO contact" do
 
       click_button "Save and return"
 
-      within ".app-task-list li:nth-of-type(1) li:nth-of-type(10)" do
+      within ".app-task-list li:nth-of-type(1) li:nth-of-type(11)" do
         expect(page).to have_content "Completed"
       end
     end

--- a/spec/features/conversions/users_can_confirm_the_incoming_trust_ceo_contact_spec.rb
+++ b/spec/features/conversions/users_can_confirm_the_incoming_trust_ceo_contact_spec.rb
@@ -46,7 +46,8 @@ RSpec.feature "Users can confirm the incoming trust CEO contact" do
 
       click_button "Save and return"
 
-      within ".app-task-list li:nth-of-type(1) li:nth-of-type(11)" do
+      row = page.find(".app-task-list li:nth-of-type(1) li", text: "Confirm the incoming trust CEO’s details")
+      within row do
         expect(page).to have_content "Completed"
       end
     end

--- a/spec/features/transfers/users_can_confirm_the_headteacher_contact_spec.rb
+++ b/spec/features/transfers/users_can_confirm_the_headteacher_contact_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Users can confirm the headteacher contact" do
 
       click_button "Save and return"
 
-      within ".app-task-list li:nth-of-type(1) li:nth-of-type(3)" do
+      within ".app-task-list li:nth-of-type(1) li:nth-of-type(4)" do
         expect(page).to have_content "Completed"
       end
     end

--- a/spec/features/transfers/users_can_confirm_the_headteacher_contact_spec.rb
+++ b/spec/features/transfers/users_can_confirm_the_headteacher_contact_spec.rb
@@ -46,7 +46,8 @@ RSpec.feature "Users can confirm the headteacher contact" do
 
       click_button "Save and return"
 
-      within ".app-task-list li:nth-of-type(1) li:nth-of-type(4)" do
+      row = page.find(".app-task-list li:nth-of-type(1) li", text: "Confirm the headteacher’s details")
+      within row do
         expect(page).to have_content "Completed"
       end
     end

--- a/spec/features/transfers/users_can_confirm_the_incoming_trust_ceo_contact_spec.rb
+++ b/spec/features/transfers/users_can_confirm_the_incoming_trust_ceo_contact_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Users can confirm the incoming trust CEO contact" do
 
       click_button "Save and return"
 
-      within ".app-task-list li:nth-of-type(1) li:nth-of-type(4)" do
+      within ".app-task-list li:nth-of-type(1) li:nth-of-type(5)" do
         expect(page).to have_content "Completed"
       end
     end

--- a/spec/features/transfers/users_can_confirm_the_incoming_trust_ceo_contact_spec.rb
+++ b/spec/features/transfers/users_can_confirm_the_incoming_trust_ceo_contact_spec.rb
@@ -46,7 +46,8 @@ RSpec.feature "Users can confirm the incoming trust CEO contact" do
 
       click_button "Save and return"
 
-      within ".app-task-list li:nth-of-type(1) li:nth-of-type(5)" do
+      row = page.find(".app-task-list li:nth-of-type(1) li", text: "Confirm the incoming trust CEO’s details")
+      within row do
         expect(page).to have_content "Completed"
       end
     end

--- a/spec/features/transfers/users_can_confirm_the_outgoing_trust_ceo_contact_spec.rb
+++ b/spec/features/transfers/users_can_confirm_the_outgoing_trust_ceo_contact_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Users can confirm the outgoing trust CEO contact" do
 
       click_button "Save and return"
 
-      within ".app-task-list li:nth-of-type(1) li:nth-of-type(5)" do
+      within ".app-task-list li:nth-of-type(1) li:nth-of-type(6)" do
         expect(page).to have_content "Completed"
       end
     end

--- a/spec/features/transfers/users_can_confirm_the_outgoing_trust_ceo_contact_spec.rb
+++ b/spec/features/transfers/users_can_confirm_the_outgoing_trust_ceo_contact_spec.rb
@@ -46,7 +46,8 @@ RSpec.feature "Users can confirm the outgoing trust CEO contact" do
 
       click_button "Save and return"
 
-      within ".app-task-list li:nth-of-type(1) li:nth-of-type(6)" do
+      row = page.find(".app-task-list li:nth-of-type(1) li", text: "Confirm the outgoing trust CEO’s details")
+      within row do
         expect(page).to have_content "Completed"
       end
     end

--- a/spec/models/conversion/task_list_spec.rb
+++ b/spec/models/conversion/task_list_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Conversion::TaskList do
       converison_task_list_identifiers = [
         :handover,
         :stakeholder_kick_off,
+        :risk_protection_arrangement,
         :check_accuracy_of_higher_needs,
         :complete_notification_of_change,
         :conversion_grant,
@@ -31,7 +32,6 @@ RSpec.describe Conversion::TaskList do
         :subleases,
         :tenancy_at_will,
         :commercial_transfer_agreement,
-        :risk_protection_arrangement,
         :single_worksheet,
         :school_completed,
         :conditions_met,
@@ -54,6 +54,7 @@ RSpec.describe Conversion::TaskList do
             tasks: [
               Conversion::Task::HandoverTaskForm,
               Conversion::Task::StakeholderKickOffTaskForm,
+              Conversion::Task::RiskProtectionArrangementTaskForm,
               Conversion::Task::CheckAccuracyOfHigherNeedsTaskForm,
               Conversion::Task::CompleteNotificationOfChangeTaskForm,
               Conversion::Task::ConversionGrantTaskForm,
@@ -88,7 +89,6 @@ RSpec.describe Conversion::TaskList do
           {
             identifier: :get_ready_for_opening,
             tasks: [
-              Conversion::Task::RiskProtectionArrangementTaskForm,
               Conversion::Task::SingleWorksheetTaskForm,
               Conversion::Task::SchoolCompletedTaskForm,
               Conversion::Task::ConditionsMetTaskForm,

--- a/spec/models/transfer/task_list_spec.rb
+++ b/spec/models/transfer/task_list_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Transfer::TaskList do
       transfer_task_list_identifiers = [
         :handover,
         :stakeholder_kick_off,
+        :rpa_policy,
         :confirm_headteacher_contact,
         :confirm_incoming_trust_ceo_contact,
         :confirm_outgoing_trust_ceo_contact,
@@ -27,7 +28,6 @@ RSpec.describe Transfer::TaskList do
         :deed_termination_church_agreement,
         :commercial_transfer_agreement,
         :closure_or_transfer_declaration,
-        :rpa_policy,
         :bank_details_changing,
         :confirm_incoming_trust_has_completed_all_actions,
         :conditions_met,


### PR DESCRIPTION
The RPA task is being missed by some caseworkers, move it higher up the task list to see if this makes it more obvious.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
