### PR TITLE
Fix unknown task identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- unknown task identifier paths now show a 'page not found' error.
+
 ## [Release-85][release-85]
 
 ### Changed

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -33,10 +33,6 @@ class TasksController < ApplicationController
     end
   end
 
-  private def find_project
-    @project = Project.find(params[:project_id])
-  end
-
   private def find_tasks_data
     @tasks_data = @project.tasks_data
   end

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -71,6 +71,17 @@ RSpec.describe TasksController do
     end
   end
 
+  context "when the task identifier is not valid" do
+    it "renders a not found error" do
+      mock_successful_api_response_to_create_any_project
+      project = create(:conversion_project, assigned_to: user)
+
+      get project_edit_task_path(project, :not_a_task)
+
+      expect(response).to have_http_status :not_found
+    end
+  end
+
   describe "side navigation" do
     before do
       mock_all_academies_api_responses


### PR DESCRIPTION
When loading a task into the edit view it was previously possible to put
in any string as the path and raise an error as the controller tries to
load the class with the string.

This work adds an error when the path cannot be turned into a Task class
and `rescues_from` from the error with a 404 page.
