### PR TITLE
(Fix) Remove strict numericality validation on pupil capacity

### DIFF
--- a/app/forms/conversion/task/proposed_capacity_of_the_academy_task_form.rb
+++ b/app/forms/conversion/task/proposed_capacity_of_the_academy_task_form.rb
@@ -3,7 +3,7 @@ class Conversion::Task::ProposedCapacityOfTheAcademyTaskForm < BaseOptionalTaskF
   attribute :seven_to_eleven_years, :string
   attribute :twelve_or_above_years, :string
 
-  validates :reception_to_six_years, presence: true, numericality: {only_numeric: true}, unless: :not_applicable?
-  validates :seven_to_eleven_years, presence: true, numericality: {only_numeric: true}, unless: :not_applicable?
-  validates :twelve_or_above_years, presence: true, numericality: {only_numeric: true}, unless: :not_applicable?
+  validates :reception_to_six_years, presence: true, numericality: true, unless: :not_applicable?
+  validates :seven_to_eleven_years, presence: true, numericality: true, unless: :not_applicable?
+  validates :twelve_or_above_years, presence: true, numericality: true, unless: :not_applicable?
 end

--- a/spec/forms/conversion/tasks/proposed_capacity_of_the_academy_task_form_spec.rb
+++ b/spec/forms/conversion/tasks/proposed_capacity_of_the_academy_task_form_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Conversion::Task::ProposedCapacityOfTheAcademyTaskForm do
+  describe "validations" do
+    describe "pupil capacities" do
+      it "must be numbers" do
+        user = build(:user)
+        task_form = described_class.new(Conversion::TasksData.new, user)
+        task_form.assign_attributes(
+          reception_to_six_years: "100",
+          seven_to_eleven_years: "200",
+          twelve_or_above_years: "300"
+        )
+
+        expect(task_form).to be_valid
+      end
+
+      it "cannot be numbers in words" do
+        user = build(:user)
+        task_form = described_class.new(Conversion::TasksData.new, user)
+        task_form.assign_attributes(
+          reception_to_six_years: "one hundred",
+          seven_to_eleven_years: "two hundred",
+          twelve_or_above_years: "three hundred"
+        )
+
+        expect(task_form).to be_invalid
+      end
+
+      it "cannot be blank" do
+        user = build(:user)
+        task_form = described_class.new(Conversion::TasksData.new, user)
+        task_form.assign_attributes(
+          reception_to_six_years: "",
+          seven_to_eleven_years: "",
+          twelve_or_above_years: ""
+        )
+
+        expect(task_form).to be_invalid
+      end
+    end
+  end
+end


### PR DESCRIPTION
A user noticed they were no longer able to add pupil capacity to their task. After investigation, it seemes that we had `string` db columns for these values, which should be numbers. Previously, it seems the `only_numeric` validator would parse strings into numbers for validation, but possibly after upgrading to Rails 7.1 this no longer works (?)

We are faced with a choice of changing the db columns to integer, or changing the validation to only use `numericality`, and not `only_numeric`. For now this is the choice we're making.

