### PR TITLE
Fix the proposed capacity task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - unknown task identifier paths now show a 'page not found' error.
+- the conversion project 'Confirm the proposed capacity of the academy' is now
+  fixed and accepting values.
 
 ## [Release-85][release-85]
 

--- a/app/forms/conversion/task/proposed_capacity_of_the_academy_task_form.rb
+++ b/app/forms/conversion/task/proposed_capacity_of_the_academy_task_form.rb
@@ -3,7 +3,7 @@ class Conversion::Task::ProposedCapacityOfTheAcademyTaskForm < BaseOptionalTaskF
   attribute :seven_to_eleven_years, :string
   attribute :twelve_or_above_years, :string
 
-  validates :reception_to_six_years, presence: true, numericality: {only_numeric: true}, unless: :not_applicable?
-  validates :seven_to_eleven_years, presence: true, numericality: {only_numeric: true}, unless: :not_applicable?
-  validates :twelve_or_above_years, presence: true, numericality: {only_numeric: true}, unless: :not_applicable?
+  validates :reception_to_six_years, presence: true, numericality: {only_integer: true}, unless: :not_applicable?
+  validates :seven_to_eleven_years, presence: true, numericality: {only_integer: true}, unless: :not_applicable?
+  validates :twelve_or_above_years, presence: true, numericality: {only_integer: true}, unless: :not_applicable?
 end

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -312,6 +312,23 @@ RSpec.feature "Users can complete conversion tasks" do
     end
   end
 
+  describe "the proposed academy capacity task" do
+    let(:project) { create(:conversion_project, assigned_to: user) }
+
+    scenario "they provide the figures" do
+      visit project_tasks_path(project)
+      click_on "Confirm the proposed capacity of the academy"
+      fill_in "What is the proposed capacity for pupils in reception to year 6?", with: "100"
+      fill_in "What is the proposed capacity for pupils in years 7 to 11?", with: "200"
+      fill_in "What is the proposed capacity for students in year 12 or above?", with: "300"
+      click_on I18n.t("task_list.continue_button.text")
+
+      expect(project.reload.tasks_data.proposed_capacity_of_the_academy_reception_to_six_years).to eql "100"
+      expect(project.reload.tasks_data.proposed_capacity_of_the_academy_seven_to_eleven_years).to eql "200"
+      expect(project.reload.tasks_data.proposed_capacity_of_the_academy_twelve_or_above_years).to eql "300"
+    end
+  end
+
   mandatory_tasks.each do |task|
     scenario "a user can complete the actions on the mandatory #{I18n.t("conversion.task.#{task}.title")} task" do
       click_on I18n.t("conversion.task.#{task}.title")

--- a/spec/forms/conversion/tasks/proposed_capacity_of_the_academy_task_form_spec.rb
+++ b/spec/forms/conversion/tasks/proposed_capacity_of_the_academy_task_form_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe Conversion::Task::ProposedCapacityOfTheAcademyTaskForm do
+  before { mock_all_academies_api_responses }
+
+  let(:user) { create(:user) }
+  let(:project) { create(:conversion_project) }
+  let(:form) { described_class.new(project.tasks_data, user) }
+
+  describe "validation" do
+    context "when the values are numbers" do
+      it "is valid" do
+        attributes = {}
+        attributes["reception_to_six_years"] = "10"
+        attributes["seven_to_eleven_years"] = "20"
+        attributes["twelve_or_above_years"] = "30"
+
+        form.assign_attributes(attributes)
+
+        expect(form).to be_valid
+      end
+    end
+
+    context "when the values are not whole numbers" do
+      it "invalid" do
+        attributes = {}
+        attributes["reception_to_six_years"] = "1.5"
+        attributes["seven_to_eleven_years"] = "2.5"
+        attributes["twelve_or_above_years"] = "3.5"
+
+        form.assign_attributes(attributes)
+
+        expect(form).to be_invalid
+      end
+    end
+
+    context "when the values are not numbers" do
+      it "invalid" do
+        attributes = {}
+        attributes["reception_to_six_years"] = "ten"
+        attributes["seven_to_eleven_years"] = "twenty"
+        attributes["twelve_or_above_years"] = "thirty"
+
+        form.assign_attributes(attributes)
+
+        expect(form).to be_invalid
+      end
+    end
+
+    context "when the values are empty" do
+      it "invalid" do
+        attributes = {}
+        attributes["reception_to_six_years"] = ""
+        attributes["seven_to_eleven_years"] = ""
+        attributes["twelve_or_above_years"] = ""
+
+        form.assign_attributes(attributes)
+
+        expect(form).to be_invalid
+      end
+    end
+  end
+end


### PR DESCRIPTION
Whilst the implementation of this task is not ideal, we know it was
working at some point as we have data in production. Around the time of
the upgrade to Rails 7.1 we had a report of not being able to submit
valid values.

When we investigated we noticed that the columns in the database are
stored as strings, there wasn't any test coverage for the custom data in
the task and the validation was not working as expected.

This work fixes the validation and adds test coverage, however we
decided not to change the database column at this time because we want
to unblock users quickly.
