### PR TITLE
Return a Member of parliament from Project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- the Member of parliament for a school is now included in the RPA, SUG and FA
+  letters export when one can be found via the new Persons API.
+
 ## [Release-86][release-86]
 
 ### Fixed

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -111,10 +111,7 @@ class Project < ApplicationRecord
   end
 
   def member_of_parliament
-    # until the Persons API is available in production, we have to return nil
-    # call `fetch_member_of_parliament` when the API goes live.
-    nil
-    # @member_of_parliament ||= fetch_member_of_parliament
+    @member_of_parliament ||= fetch_member_of_parliament
   end
 
   def unassigned_to_user?

--- a/spec/accessibility/contacts_spec.rb
+++ b/spec/accessibility/contacts_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature "Test contacts accessibility", driver: :headless_firefox, accessib
   before do
     sign_in_with_user(user)
     mock_all_academies_api_responses
+    mock_successful_persons_api_client
   end
 
   scenario "show contacts page" do

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -137,6 +137,8 @@ RSpec.feature "Users can complete conversion tasks" do
 
     context "when the project has no contacts" do
       it "directs the user to add contacts" do
+        mock_successful_persons_api_client
+
         visit project_tasks_path(project)
         click_on "Confirm the main contact"
 

--- a/spec/features/conversions/users_can_select_a_main_contact_spec.rb
+++ b/spec/features/conversions/users_can_select_a_main_contact_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Users select a main contact for a conversion" do
 
   before do
     mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    mock_successful_persons_api_client
     sign_in_with_user(user)
   end
 

--- a/spec/features/external_contacts/users_can_add_new_external_contacts_spec.rb
+++ b/spec/features/external_contacts/users_can_add_new_external_contacts_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.feature "Users can add new external contacts" do
   before do
     mock_successful_api_response_to_create_any_project
+    mock_successful_persons_api_client
     sign_in_with_user(user)
   end
 

--- a/spec/features/external_contacts/users_can_edit_external_contacts_spec.rb
+++ b/spec/features/external_contacts/users_can_edit_external_contacts_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.feature "Users can edit external contacts" do
   before do
     mock_successful_api_response_to_create_any_project
+    mock_successful_persons_api_client
     sign_in_with_user(user)
   end
 

--- a/spec/features/external_contacts/users_can_view_external_contacts_spec.rb
+++ b/spec/features/external_contacts/users_can_view_external_contacts_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.feature "Users can view external contacts" do
   before do
     mock_successful_api_response_to_create_any_project
+    mock_successful_persons_api_client
     sign_in_with_user(user)
   end
 

--- a/spec/features/transfers/tasks/users_can_compelte_main_contact_spec.rb
+++ b/spec/features/transfers/tasks/users_can_compelte_main_contact_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "Users can complete the main contact task" do
 
   before do
     mock_all_academies_api_responses
+    mock_successful_persons_api_client
     sign_in_with_user(user)
     visit project_tasks_path(project)
   end

--- a/spec/features/transfers/users_can_view_a_transfer_spec.rb
+++ b/spec/features/transfers/users_can_view_a_transfer_spec.rb
@@ -56,6 +56,8 @@ RSpec.feature "Users can view a transfer" do
   end
 
   scenario "they can view the external contacts" do
+    mock_successful_persons_api_client
+
     visit project_contacts_path(transfer_project)
 
     expect(page).to have_content(transfer_project.urn)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe Project, type: :model do
     end
   end
 
-  describe "#member_of_parliament", skip: "Waiting for production Persons API" do
+  describe "#member_of_parliament" do
     it "returns the details of the MP for the projects establishment constituency" do
       mock_all_academies_api_responses
       project = build(:conversion_project)
@@ -374,7 +374,7 @@ RSpec.describe Project, type: :model do
     it "only goes to the API once per instance of Project" do
       mock_all_academies_api_responses
       project = build(:conversion_project)
-      client = mock_successful_persons_api
+      client = mock_successful_persons_api_client
 
       project.member_of_parliament
       project.member_of_parliament

--- a/spec/presenters/export/csv/mp_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/mp_presenter_module_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Export::Csv::MpPresenterModule, skip: "Waiting for Person API" do
+RSpec.describe Export::Csv::MpPresenterModule do
   before do
     mock_all_academies_api_responses
     allow(project.establishment).to receive(:parliamentary_constituency).and_return("Constituency Name")

--- a/spec/requests/external_contacts_controller_spec.rb
+++ b/spec/requests/external_contacts_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ExternalContactsController, type: :request do
   before do
     sign_in_with(user)
     mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_persons_api_client
   end
 
   describe "#index" do

--- a/spec/requests/member_of_parliament_controller_spec.rb
+++ b/spec/requests/member_of_parliament_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MemberOfParliamentController, type: :request do
   let(:project) { create(:conversion_project, assigned_to: user) }
 
   describe "#show" do
-    context "when the Member of Parliament is found", skip: "Waiting for Persons API" do
+    context "when the Member of Parliament is found" do
       before do
         test_successful_persons_api_call
       end


### PR DESCRIPTION
We had this disabled whilst the Persons API was deployed to all
environments, as this has now been done, we can enable the return of an
MP.

