### PR TITLE
Remove the MP details from the Conversion "by month" exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- MP details are no longer included in the Conversions "By month" exports
+
 ## [Release-87][release-87]
 
 ### Changed

--- a/app/services/export/conversions/all_data_csv_export_service.rb
+++ b/app/services/export/conversions/all_data_csv_export_service.rb
@@ -65,13 +65,6 @@ class Export::Conversions::AllDataCsvExportService < Export::CsvExportService
     solicitor_contact_email
     diocese_contact_name
     diocese_contact_email
-    mp_name
-    mp_constituency
-    mp_email
-    mp_address_1
-    mp_address_2
-    mp_address_3
-    mp_address_postcode
     director_of_child_services_name
     director_of_child_services_email
     director_of_child_services_role


### PR DESCRIPTION
Adding the MP details to exports affects the performance. Users don't need the MP details in this export anyway, so remove them.


