### PR TITLE
Add confirm headteacher contact details to export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Requests to the Academies API now includes a User-Agent HTTP Header
 - AOPU becomes SOPU
 
+### Added
+
+- The headteacher contact selected in the 'Confirm the headteacher’s details'
+  task is now included in the RPA, SUG and FA letters export. The contacts role
+  will always be exported as 'Headteacher'.
+
 ## [Release-88][release-88]
 
 ### Changed

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -115,9 +115,10 @@ module Export::Csv::SchoolPresenterModule
   end
 
   def headteacher_contact_role
+    # when exported this is ALWAYS 'headteacher'
     return unless @project.key_contacts&.headteacher.present?
 
-    @project.key_contacts.headteacher.title
+    "Headteacher"
   end
 
   def headteacher_contact_email

--- a/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
+++ b/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
@@ -14,6 +14,9 @@ class Export::Conversions::RpaSugAndFaLettersCsvExportService < Export::CsvExpor
     school_main_contact_name
     school_main_contact_role
     school_main_contact_email
+    headteacher_contact_name
+    headteacher_contact_role
+    headteacher_contact_email
     chair_of_governors_name
     chair_of_governors_role
     chair_of_governors_email

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
         KeyContacts.new(project: project, headteacher: contact)
 
         expect(subject.headteacher_contact_name).to eql "Jo Example"
-        expect(subject.headteacher_contact_role).to eql "CEO of Learning"
+        expect(subject.headteacher_contact_role).to eql "Headteacher"
         expect(subject.headteacher_contact_email).to eql "jo@example.com"
       end
     end


### PR DESCRIPTION
The headteacher needs to be included in the RPA, SUG and FA letters
export.

The role must always be 'Headteacher' so we update the presenter to make
sure this is the case (we have taken steps to ensure that newly added
contacts have the correct role, but this covers legacy contacts as
well).

