### PR TITLE
Add confirm incoming trust contact details to export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The headteacher contact selected in the 'Confirm the headteacher’s details'
   task is now included in the RPA, SUG and FA letters export. The contacts role
   will always be exported as 'Headteacher'.
+- The incoming trust CEO contact selected in the 'Confirm the incoming trust
+  CEO’s details' task is now included in the RPA, SUG and FA letters export. The
+  contacts role will always be exported as 'CEO'.
 
 ## [Release-88][release-88]
 

--- a/app/presenters/export/csv/incoming_trust_presenter_module.rb
+++ b/app/presenters/export/csv/incoming_trust_presenter_module.rb
@@ -78,9 +78,10 @@ module Export::Csv::IncomingTrustPresenterModule
   end
 
   def incoming_trust_ceo_contact_role
+    # when exported this is ALWAYS 'CEO'
     return unless @project.key_contacts&.incoming_trust_ceo.present?
 
-    @project.key_contacts.incoming_trust_ceo.title
+    "CEO"
   end
 
   def incoming_trust_ceo_contact_email

--- a/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
+++ b/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
@@ -43,6 +43,9 @@ class Export::Conversions::RpaSugAndFaLettersCsvExportService < Export::CsvExpor
     incoming_trust_address_town
     incoming_trust_address_county
     incoming_trust_address_postcode
+    incoming_trust_ceo_contact_name
+    incoming_trust_ceo_contact_role
+    incoming_trust_ceo_contact_email
     incoming_trust_main_contact_name
     incoming_trust_main_contact_role
     incoming_trust_main_contact_email

--- a/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Export::Csv::IncomingTrustPresenterModule do
         KeyContacts.new(project: project, incoming_trust_ceo: contact)
 
         expect(subject.incoming_trust_ceo_contact_name).to eql contact.name
-        expect(subject.incoming_trust_ceo_contact_role).to eql contact.title
+        expect(subject.incoming_trust_ceo_contact_role).to eql "CEO"
         expect(subject.incoming_trust_ceo_contact_email).to eql contact.email
       end
     end


### PR DESCRIPTION
The incoming trust CEO needs to be included in the RPA, SUG and FA letters
export.

The role must always be 'CEO' so we update the presenter to make
sure this is the case (we have taken steps to ensure that newly added
contacts have the correct role, but this covers legacy contacts as
well).
