### PR TITLE
Identify ourselves when sending requests to Academies API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Requests to the Academies API now includes a User-Agent HTTP Header
+
 ## [Release-88][release-88]
 
 ### Changed

--- a/app/models/api/academies_api/client.rb
+++ b/app/models/api/academies_api/client.rb
@@ -110,7 +110,8 @@ class Api::AcademiesApi::Client
       },
       headers: {
         "Content-Type": "application/json",
-        ApiKey: ENV["ACADEMIES_API_KEY"]
+        ApiKey: ENV["ACADEMIES_API_KEY"],
+        "User-Agent": "Complete/1.0"
       }
     )
   end


### PR DESCRIPTION
## Changes

Adds the `User-Agent` HTTP Header to the faraday http client when interacting with the Academies API.

This will help with segmenting traffic reports for Academies API

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
