### PR TITLE
Fix fixture_path deprecation warning

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,7 +43,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
Rails 7.1 switches this to `fixture_paths` which is an array now, see:

https://rubyonrails.org/2023/3/18/this-week-in-rails-testfixtures-fixture_path-deprecation-findermethods-find-support-for-composite-primary-key-values-87e6e69a
