### PR TITLE
Allow operators to override the default minimum number of app Containers

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -165,6 +165,7 @@ No resources.
 | <a name="input_container_apps_allow_ips_inbound"></a> [container\_apps\_allow\_ips\_inbound](#input\_container\_apps\_allow\_ips\_inbound) | Restricts access to the Container Apps by creating a network security group rule that only allow inbound traffic from the provided list of IPs | `list(string)` | `[]` | no |
 | <a name="input_container_command"></a> [container\_command](#input\_container\_command) | Container command | `list(any)` | n/a | yes |
 | <a name="input_container_health_probe_protocol"></a> [container\_health\_probe\_protocol](#input\_container\_health\_probe\_protocol) | Use HTTPS or a TCP connection for the Container liveness probe | `string` | n/a | yes |
+| <a name="input_container_min_replicas"></a> [container\_min\_replicas](#input\_container\_min\_replicas) | Container min replicas | `number` | `1` | no |
 | <a name="input_container_port"></a> [container\_port](#input\_container\_port) | Container port | `number` | `3000` | no |
 | <a name="input_container_scale_http_concurrency"></a> [container\_scale\_http\_concurrency](#input\_container\_scale\_http\_concurrency) | When the number of concurrent HTTP requests exceeds this value, then another replica is added. Replicas continue to add to the pool up to the max-replicas amount. | `number` | `10` | no |
 | <a name="input_container_secret_environment_variables"></a> [container\_secret\_environment\_variables](#input\_container\_secret\_environment\_variables) | Container secret environment variables | `map(string)` | n/a | yes |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -20,6 +20,7 @@ module "azure_container_apps_hosting" {
   container_command                      = local.container_command
   container_secret_environment_variables = local.container_secret_environment_variables
   container_scale_http_concurrency       = local.container_scale_http_concurrency
+  container_min_replicas                 = local.container_min_replicas
 
   enable_worker_container       = local.enable_worker_container
   worker_container_command      = local.worker_container_command

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -57,6 +57,7 @@ locals {
   monitor_email_receivers                         = var.monitor_email_receivers
   enable_container_health_probe                   = var.enable_container_health_probe
   container_health_probe_protocol                 = var.container_health_probe_protocol
+  container_min_replicas                          = var.container_min_replicas
   monitor_endpoint_healthcheck                    = var.monitor_endpoint_healthcheck
   existing_logic_app_workflow                     = var.existing_logic_app_workflow
   existing_network_watcher_name                   = var.existing_network_watcher_name

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -239,6 +239,12 @@ variable "worker_container_max_replicas" {
   default     = 1
 }
 
+variable "container_min_replicas" {
+  description = "Container min replicas"
+  type        = number
+  default     = 1
+}
+
 variable "enable_cdn_frontdoor" {
   description = "Enable Azure CDN FrontDoor. This will use the Container Apps endpoint as the origin."
   type        = bool


### PR DESCRIPTION
The default number of containers is `1` but in Production we occasionally run into issues with Container App host migrations. Having `2` minimum in Production should cover us for any interruptions