### PR TITLE
Not applicable tasks clear their values

### DIFF
--- a/app/forms/base_optional_task_form.rb
+++ b/app/forms/base_optional_task_form.rb
@@ -1,4 +1,6 @@
 class BaseOptionalTaskForm < BaseTaskForm
+  before_save :unset_attributes_when_not_applicable
+
   attribute :not_applicable, :boolean
 
   private def not_applicable?
@@ -11,5 +13,13 @@ class BaseOptionalTaskForm < BaseTaskForm
 
   private def actions_when_applicable
     attributes.except("not_applicable")
+  end
+
+  private def unset_attributes_when_not_applicable
+    if not_applicable?
+      assign_attributes(
+        actions_when_applicable.transform_values { nil }
+      )
+    end
   end
 end

--- a/app/forms/base_task_form.rb
+++ b/app/forms/base_task_form.rb
@@ -1,6 +1,9 @@
 class BaseTaskForm
   include ActiveModel::Model
   include ActiveModel::Attributes
+  extend ActiveModel::Callbacks
+
+  define_model_callbacks :save
 
   def self.identifier
     name.split("::").last.underscore.delete_suffix("_task_form")
@@ -13,8 +16,10 @@ class BaseTaskForm
   end
 
   def save
-    @tasks_data.assign_attributes prefixed_attributes
-    @tasks_data.save!
+    run_callbacks :save do
+      @tasks_data.assign_attributes prefixed_attributes
+      @tasks_data.save!
+    end
   end
 
   def identifier

--- a/app/forms/conversion/task/sponsored_support_grant_task_form.rb
+++ b/app/forms/conversion/task/sponsored_support_grant_task_form.rb
@@ -8,14 +8,4 @@ class Conversion::Task::SponsoredSupportGrantTaskForm < BaseOptionalTaskForm
   def type_options
     Conversion::TasksData.sponsored_support_grant_types.values
   end
-
-  def save
-    if not_applicable
-      @tasks_data.sponsored_support_grant_type = nil
-      @tasks_data.assign_attributes prefixed_attributes.except("sponsored_support_grant_type")
-    else
-      @tasks_data.assign_attributes prefixed_attributes
-    end
-    @tasks_data.save!
-  end
 end

--- a/app/forms/transfer/task/declaration_of_expenditure_certificate_task_form.rb
+++ b/app/forms/transfer/task/declaration_of_expenditure_certificate_task_form.rb
@@ -35,16 +35,4 @@ class Transfer::Task::DeclarationOfExpenditureCertificateTaskForm < BaseOptional
     errors.merge!(@date_param_errors)
     errors.empty?
   end
-
-  def save
-    if valid?
-      @tasks_data.assign_attributes(
-        declaration_of_expenditure_certificate_date_received: date_received,
-        declaration_of_expenditure_certificate_not_applicable: not_applicable,
-        declaration_of_expenditure_certificate_correct: correct,
-        declaration_of_expenditure_certificate_saved: saved
-      )
-      @tasks_data.save!
-    end
-  end
 end

--- a/app/forms/transfer/task/sponsored_support_grant_task_form.rb
+++ b/app/forms/transfer/task/sponsored_support_grant_task_form.rb
@@ -4,14 +4,4 @@ class Transfer::Task::SponsoredSupportGrantTaskForm < BaseOptionalTaskForm
   def type_options
     Transfer::TasksData.sponsored_support_grant_types.values
   end
-
-  def save
-    if not_applicable
-      @tasks_data.sponsored_support_grant_type = nil
-      @tasks_data.assign_attributes prefixed_attributes.except("sponsored_support_grant_type")
-    else
-      @tasks_data.assign_attributes prefixed_attributes
-    end
-    @tasks_data.save!
-  end
 end

--- a/spec/forms/conversion/tasks/articles_of_association_task_form_spec.rb
+++ b/spec/forms/conversion/tasks/articles_of_association_task_form_spec.rb
@@ -75,6 +75,23 @@ RSpec.describe Conversion::Task::ArticlesOfAssociationTaskForm do
 
         expect(task_form.status).to eql :not_applicable
       end
+
+      it "resets all other attributes" do
+        task_data = Conversion::TasksData.new
+        task_form = described_class.new(task_data, user)
+
+        task_form.received = true
+
+        task_form.save
+
+        expect(task_data.articles_of_association_received).to be true
+
+        task_form.not_applicable = true
+
+        task_form.save
+
+        expect(task_data.articles_of_association_received).to be nil
+      end
     end
 
     context "when the task has all completed actions" do


### PR DESCRIPTION
When marked as not applicable, some tasks clear their other values. We want this
to be the default behaviour for all optional tasks.

This work does that using callbacks on the `BaseTaskForm` which all tasks
inherit from.
