### PR TITLE
Update your team page titles

### DIFF
--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -49,15 +49,15 @@ en:
           empty: There are no in-progress projects for this user
     team:
       in_progress:
-        title: In progress
+        title: Your team projects in progress
       new:
-        title: New
+        title: Your team new projects
       completed:
-        title: Completed
+        title: Your team completed projects
       unassigned:
-        title: Unassigned
+        title: Your team unassigned projects
       users:
-        title: By user
+        title: Your team projects by user
       handed_over:
         title: Handed over
     regional:

--- a/spec/features/projects/users_can_view_a_list_of_regional_casework_services_projects_spec.rb
+++ b/spec/features/projects/users_can_view_a_list_of_regional_casework_services_projects_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Viewing regional casework services projects" do
 
         click_on "Your team projects"
 
-        expect(page.find("h1")).to have_content("Unassigned")
+        expect(page.find("h1")).to have_content("Your team unassigned projects")
       end
     end
 
@@ -59,7 +59,7 @@ RSpec.feature "Viewing regional casework services projects" do
 
         click_on "Your team projects"
 
-        expect(page.find("h1")).to have_content("In progress")
+        expect(page.find("h1")).to have_content("Your team projects in progress")
       end
     end
 
@@ -77,7 +77,7 @@ RSpec.feature "Viewing regional casework services projects" do
 
         click_on "Your team projects"
 
-        expect(page.find("h1")).to have_content("In progress")
+        expect(page.find("h1")).to have_content("Your team projects in progress")
       end
     end
   end


### PR DESCRIPTION
Make these page titles more explicit, mainly so that they show up in
analytics clearly.
