### PR TITLE
Update Academies API timeout error

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,8 +107,8 @@ en:
       transfer: Transfer date history
   pages:
     academies_api_client_timeout:
-      title: Sorry, there was a problem
-      body_text: The service timed out when getting the details of the school or trust. Refresh the page to try again.
+      title: Sorry, the Academies API timed out
+      body_text: The API timed out when getting the details of the school or trust. Refresh the page to try again.
       email_help: Email the support team at %{email} if this error continues.
     academies_api_client_unauthorised:
       title: Sorry, there was a problem

--- a/spec/features/users_can_view_static_pages_spec.rb
+++ b/spec/features/users_can_view_static_pages_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Users can view static pages" do
     visit page_path(id: "academies_api_client_timeout")
 
     expect(page).to have_current_path("/academies_api_client_timeout")
-    expect(page).to have_content("Sorry, there was a problem")
+    expect(page).to have_content("Sorry, the Academies API timed out")
   end
 
   scenario "can see the `API unauthorised` error page" do


### PR DESCRIPTION
It would be helpful to the team to see this specific error in the
analytics.
