### PR TITLE
Allow team leads to export data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The incoming trust CEO contact selected in the 'Confirm the incoming trust
   CEO’s details' task is now included in the RPA, SUG and FA letters export. The
   contacts role will always be exported as 'CEO'.
+- Team lead users can now use the all projects and by month exports.
 
 ## [Release-88][release-88]
 

--- a/app/policies/export_policy.rb
+++ b/app/policies/export_policy.rb
@@ -25,6 +25,7 @@ class ExportPolicy
     return true if @user.data_consumers_team?
     return true if @user.business_support_team?
     return true if @user.service_support_team?
+    return true if @user.manage_team?
 
     false
   end

--- a/spec/policies/export_policy_spec.rb
+++ b/spec/policies/export_policy_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ExportPolicy do
   let(:data_consumers_user) { build(:user, team: :data_consumers) }
   let(:rdo_user) { build(:regional_delivery_officer_user) }
   let(:rcs_user) { build(:regional_casework_services_user) }
+  let(:rcs_team_lead_user) { build(:regional_casework_services_user, :team_leader) }
   let(:service_support_user) { build(:service_support_user) }
   let(:business_support_user) { build(:user, team: :business_support) }
 
@@ -14,16 +15,7 @@ RSpec.describe ExportPolicy do
       expect(described_class).to permit(data_consumers_user)
       expect(described_class).not_to permit(rdo_user)
       expect(described_class).not_to permit(rcs_user)
-    end
-  end
-
-  permissions :service_support? do
-    it "grants access if the user is a service support user" do
-      expect(described_class).to permit(service_support_user)
-      expect(described_class).not_to permit(data_consumers_user)
-      expect(described_class).not_to permit(business_support_user)
-      expect(described_class).not_to permit(rdo_user)
-      expect(described_class).not_to permit(rcs_user)
+      expect(described_class).to permit(rcs_team_lead_user)
     end
   end
 end


### PR DESCRIPTION
We want team lead users, those with the `manage_team` attribute set to
use the exports.

Here we adjust the policy to allow this.
