### PR TITLE
AOPU becomes SOPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Requests to the Academies API now includes a User-Agent HTTP Header
+- AOPU becomes SOPU
 
 ## [Release-88][release-88]
 

--- a/config/locales/conversion/tasks/academy_details.en.yml
+++ b/config/locales/conversion/tasks/academy_details.en.yml
@@ -12,6 +12,6 @@ en:
           html:
             <p>Make sure the school and trust agree on the academy name.</p>
             <p>It must be confirmed at least 40 days before the academy opens.</p>
-            <p>If the name needs to change after that point, you must email AOPU (Academies Operational Practice Unit) as they will use this information to create the academy's URN (Unique Reference Number) and funding letters.</p>
+            <p>If the name needs to change after that point, you must email SOPU (Schools Operational Practice Unit) as they will use this information to create the academy's URN (Unique Reference Number) and funding letters.</p>
         name:
           title: Enter the academy name

--- a/config/locales/conversion/tasks/conditions_met.en.yml
+++ b/config/locales/conversion/tasks/conditions_met.en.yml
@@ -5,7 +5,7 @@ en:
         title: Confirm all conditions have been met
         hint:
           html:
-            "The deadline for meeting all conditions is in the email you got from the AOPU (Academies Operational Practice Unit) team. All conditions must be met before the deadline or the school will not be able to convert on %{date}."
+            "The deadline for meeting all conditions is in the email you got from the SOPU (Schools Operational Practice Unit) team. All conditions must be met before the deadline or the school will not be able to convert on %{date}."
         guidance_link: How to check all conditions have been met
         guidance:
           html:
@@ -20,7 +20,7 @@ en:
           title: Confirm all conditions are met
           hint:
             html:
-              <p>This will change the conversion's status on the "By month" project list. AOPU use that list to prepare funding agreement letters.</p>
+              <p>This will change the conversion's status on the "By month" project list. SOPU use that list to prepare funding agreement letters.</p>
           guidance_link: What to do if conditions are not met
           guidance:
             html:

--- a/config/locales/conversion/tasks/direction_to_transfer.en.yml
+++ b/config/locales/conversion/tasks/direction_to_transfer.en.yml
@@ -13,7 +13,7 @@ en:
           hint:
             html: 
               <p>Make sure information in the direction to transfer is correct and compare it against the model document.</p>
-              <p>Once checked and cleared, you must send the direction to transfer to AOPU (Academy Operational Practice Unit) at <a href="mailto:academiesdelivery.operations@education.gov.uk">academiesdelivery.operations@education.gov.uk</a> for signing.</p>
+              <p>Once checked and cleared, you must send the direction to transfer to SOPU (Schools Operational Practice Unit) at <a href="mailto:academiesdelivery.operations@education.gov.uk">academiesdelivery.operations@education.gov.uk</a> for signing.</p>
               <p>This must be sent to them by the deadline they set in their monthly email. This is at the same time as you send the single worksheet.</p>
           guidance_link: Help checking for changes
           guidance:

--- a/config/locales/conversion/tasks/trust_modification_order.en.yml
+++ b/config/locales/conversion/tasks/trust_modification_order.en.yml
@@ -12,8 +12,8 @@ en:
           title: Clear and sign the trust modification order
           hint:
             html:
-              <p>If one is needed, send the draft trust modification order and a copy of the original deed to AOPU (Academies Operational Practice Unit) at <a href="mailto:academiesdelivery.operations@education.gov.uk" class="govuk-link" target="_blank">academiesdelivery.operations@education.gov.uk</a>. If necessary, they will send it to the Legal Adviser's Office for clearing.</p>
-              <p>It can take several weeks to hear back from AOPU.</p>
+              <p>If one is needed, send the draft trust modification order and a copy of the original deed to SOPU (Schools Operational Practice Unit) at <a href="mailto:academiesdelivery.operations@education.gov.uk" class="govuk-link" target="_blank">academiesdelivery.operations@education.gov.uk</a>. If necessary, they will send it to the Legal Adviser's Office for clearing.</p>
+              <p>It can take several weeks to hear back from SOPU.</p>
               <p>You only need to send the cleared trust modification order to Academy Operations for signing.</p> 
               <p>This must be sent to them by the deadline they set in their monthly email. This is at the same time as you send the single worksheet.</p>
           guidance_link: When to use a trust modification order

--- a/config/locales/transfer/tasks/conditions_met.en.yml
+++ b/config/locales/transfer/tasks/conditions_met.en.yml
@@ -5,7 +5,7 @@ en:
         title: Confirm this transfer has authority to proceed
         hint:
           html:
-            The deadline for getting authority to proceed is in the email you got from AOPU (Academy Operational Practice Unit). The project must have authority to proceed by the deadline or the academy will not transfer on %{transfer_date}.
+            The deadline for getting authority to proceed is in the email you got from SOPU (Schools Operational Practice Unit). The project must have authority to proceed by the deadline or the academy will not transfer on %{transfer_date}.
         guidance_link: How to check the transfer has authority to proceed
         guidance:
           html:
@@ -30,7 +30,7 @@ en:
           hint:
             html:
               <p>This will change the transfer's status on the By Month project list.</p>
-              <p>AOPU and ESFA (Education and Skills Funding Agency) use it to prepare and send the GAG (general annual grant) funding.</p>
+              <p>SOPU and ESFA (Education and Skills Funding Agency) use it to prepare and send the GAG (general annual grant) funding.</p>
           guidance_link: What to do if the transfer does not have authority to proceed
           guidance:
             html:


### PR DESCRIPTION
## Changes

The new government have change the name of the Academies Operational Practice Unit to the Schools Operational Practice Unit.

This work makes those changes in content in Complete.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
