### PR TITLE
Remove logic from primary establishment contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Requests to the Academies API now includes a User-Agent HTTP Header
 - AOPU becomes SOPU
+- The primary contact for school in the export no longer uses the first contact
+  if one is not set.
+- The primary contact for the school is now labelled in the export.
 
 ## [Release-88][release-88]
 

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -97,15 +97,15 @@ module Export::Csv::SchoolPresenterModule
   alias_method :school_sharepoint_link_with_academy_label, :school_sharepoint_folder
 
   def school_main_contact_name
-    school_or_academy_contact&.name
+    @project.establishment_main_contact&.name
   end
 
   def school_main_contact_email
-    school_or_academy_contact&.email
+    @project.establishment_main_contact&.email
   end
 
   def school_main_contact_role
-    school_or_academy_contact&.title
+    @project.establishment_main_contact&.title
   end
 
   def headteacher_contact_name
@@ -124,9 +124,5 @@ module Export::Csv::SchoolPresenterModule
     return unless @project.key_contacts&.headteacher.present?
 
     @project.key_contacts.headteacher.email
-  end
-
-  private def school_or_academy_contact
-    @contacts_fetcher.school_or_academy_contact
   end
 end

--- a/app/services/contacts_fetcher_service.rb
+++ b/app/services/contacts_fetcher_service.rb
@@ -23,16 +23,6 @@ class ContactsFetcherService
     all_project_contacts.sort_by(&:name).group_by(&:category)
   end
 
-  def school_or_academy_contact
-    return if @all_contacts["school_or_academy"].nil?
-
-    if @project.establishment_main_contact_id.present?
-      @all_contacts["school_or_academy"].find { |c| c.id == @project.establishment_main_contact_id }
-    else
-      @all_contacts["school_or_academy"].first
-    end
-  end
-
   def outgoing_trust_contact
     return if @all_contacts["outgoing_trust"].nil?
 

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -141,9 +141,9 @@ en:
           conversion_type: Conversion type
           transfer_type: Transfer type
           esfa_notes: ESFA notes
-          school_main_contact_email: School contact email
-          school_main_contact_name: School contact name
-          school_main_contact_role: School contact role
+          school_main_contact_email: Primary contact for school email
+          school_main_contact_name: Primary contact for school name
+          school_main_contact_role: Primary contact for school role
           headteacher_contact_name: Headteacher name
           headteacher_contact_role: Headteacher role
           headteacher_contact_email: Headteacher email

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
 
   before do
     mock_successful_api_response_to_create_any_project
-    allow(project).to receive(:establishment_main_contact_id).and_return(contact.id)
+    project.establishment_main_contact = contact
     allow(project).to receive(:director_of_child_services).and_return(director_of_child_services)
   end
 

--- a/spec/services/contacts_fetcher_service_spec.rb
+++ b/spec/services/contacts_fetcher_service_spec.rb
@@ -85,26 +85,6 @@ RSpec.describe ContactsFetcherService do
     end
   end
 
-  describe "#school_or_academy_contact" do
-    let!(:contact) { create(:project_contact, project: project, category: "school_or_academy") }
-
-    context "when there is an establishment_main_contact_id" do
-      before { allow(project).to receive(:establishment_main_contact_id).and_return(contact.id) }
-
-      it "returns the contact with that id" do
-        expect(described_class.new(project).school_or_academy_contact).to eq(contact)
-      end
-    end
-
-    context "when there is NOT an establishment_main_contact_id" do
-      before { allow(project).to receive(:establishment_main_contact_id).and_return(nil) }
-
-      it "returns the next matching contact" do
-        expect(described_class.new(project).school_or_academy_contact).to eq(contact)
-      end
-    end
-  end
-
   describe "#outgoing_trust_contact" do
     let!(:contact) { create(:project_contact, project: project, category: "outgoing_trust") }
 


### PR DESCRIPTION
Remove logic from primary establishment contact
    
Having this logic is confusing users, if the primary establishment
contact is not set, showing nothing is a better outcome.
    
The column header is also causing confusion, we are going to use the
phrase 'Primary school contact' for this export as it matches up with
the application UI.
