### PR TITLE
Remove logic from primary incoming trust contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   CEO’s details' task is now included in the RPA, SUG and FA letters export. The
   contacts role will always be exported as 'CEO'.
 - Team lead users can now use the all projects and by month exports.
+- The primary contact for the incoming trust in the export no longer uses the
+  first contact if one is not set.
+- The primary contact for the incoming trust is now labelled in the export.
 
 ## [Release-88][release-88]
 

--- a/app/presenters/export/csv/incoming_trust_presenter_module.rb
+++ b/app/presenters/export/csv/incoming_trust_presenter_module.rb
@@ -60,15 +60,15 @@ module Export::Csv::IncomingTrustPresenterModule
   end
 
   def incoming_trust_main_contact_name
-    incoming_trust_contact&.name
+    @project.incoming_trust_main_contact&.name
   end
 
   def incoming_trust_main_contact_role
-    incoming_trust_contact&.title
+    @project.incoming_trust_main_contact&.title
   end
 
   def incoming_trust_main_contact_email
-    incoming_trust_contact&.email
+    @project.incoming_trust_main_contact&.email
   end
 
   def incoming_trust_ceo_contact_name
@@ -94,9 +94,5 @@ module Export::Csv::IncomingTrustPresenterModule
     return unless @project.incoming_trust_sharepoint_link.present?
 
     @project.incoming_trust_sharepoint_link
-  end
-
-  private def incoming_trust_contact
-    @contacts_fetcher.incoming_trust_contact
   end
 end

--- a/app/services/contacts_fetcher_service.rb
+++ b/app/services/contacts_fetcher_service.rb
@@ -33,16 +33,6 @@ class ContactsFetcherService
     end
   end
 
-  def incoming_trust_contact
-    return if @all_contacts["incoming_trust"].nil?
-
-    if @project.incoming_trust_main_contact_id.present?
-      @all_contacts["incoming_trust"].find { |c| c.id == @project.incoming_trust_main_contact_id }
-    else
-      @all_contacts["incoming_trust"].first
-    end
-  end
-
   def local_authority_contact
     return if @all_contacts["local_authority"].nil?
 

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -50,9 +50,9 @@ en:
           incoming_trust_identifier: Incoming trust group identifier
           incoming_trust_companies_house_number: Incoming trust companies house number
           incoming_trust_name: Incoming trust name
-          incoming_trust_main_contact_name: Incoming trust main contact name
-          incoming_trust_main_contact_email: Incoming trust main contact email
-          incoming_trust_main_contact_role: Incoming trust main contact role
+          incoming_trust_main_contact_name: Primary contact for incoming trust name
+          incoming_trust_main_contact_email: Primary contact for incoming trust email
+          incoming_trust_main_contact_role: Primary contact for incoming trust role
           incoming_trust_ceo_contact_name: Incoming trust CEO name
           incoming_trust_ceo_contact_role: Incoming trust CEO role
           incoming_trust_ceo_contact_email: Incoming trust CEO email

--- a/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Export::Csv::IncomingTrustPresenterModule do
 
   before do
     mock_successful_api_response_to_create_any_project
-    allow(project).to receive(:incoming_trust_main_contact_id).and_return(incoming_trust_main_contact.id)
+    project.incoming_trust_main_contact = incoming_trust_main_contact
   end
 
   it "presents the identifier" do

--- a/spec/services/contacts_fetcher_service_spec.rb
+++ b/spec/services/contacts_fetcher_service_spec.rb
@@ -105,26 +105,6 @@ RSpec.describe ContactsFetcherService do
     end
   end
 
-  describe "#incoming_trust_contact" do
-    let!(:contact) { create(:project_contact, project: project, category: "incoming_trust") }
-
-    context "when there is an incoming_trust_main_contact_id" do
-      before { allow(project).to receive(:incoming_trust_main_contact_id).and_return(contact.id) }
-
-      it "returns the contact with that id" do
-        expect(described_class.new(project).incoming_trust_contact).to eq(contact)
-      end
-    end
-
-    context "when there is NOT an incoming_trust_main_contact_id" do
-      before { allow(project).to receive(:incoming_trust_main_contact_id).and_return(nil) }
-
-      it "returns the next matching contact" do
-        expect(described_class.new(project).incoming_trust_contact).to eq(contact)
-      end
-    end
-  end
-
   describe "#local_authority_contact" do
     let!(:contact) { create(:project_contact, project: project, category: "local_authority") }
 


### PR DESCRIPTION
Having this logic is confusing users, if the primary incoming trust
contact is not set, showing nothing is a better outcome.

The column header is also causing confusion, we are going to use the
phrase 'Primary contact for incoming trust' for this export as it
matches up with the application UI.
