### PR TITLE
Remove logic from primary outgoing trust contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The primary contact for the incoming trust in the export no longer uses the
   first contact if one is not set.
 - The primary contact for the incoming trust is now labelled in the export.
+- The primary contact for the outgoing trust in the export no longer uses the
+  first contact if one is not set.
+- The primary contact for the outgoing trust is now labelled in the export.
 
 ## [Release-88][release-88]
 

--- a/app/presenters/export/csv/outgoing_trust_presenter_module.rb
+++ b/app/presenters/export/csv/outgoing_trust_presenter_module.rb
@@ -18,11 +18,15 @@ module Export::Csv::OutgoingTrustPresenterModule
   end
 
   def outgoing_trust_main_contact_name
-    outgoing_trust_contact&.name
+    @project.outgoing_trust_main_contact&.name
+  end
+
+  def outgoing_trust_main_contact_role
+    @project.outgoing_trust_main_contact&.title
   end
 
   def outgoing_trust_main_contact_email
-    outgoing_trust_contact&.email
+    @project.outgoing_trust_main_contact&.email
   end
 
   def outgoing_trust_identifier
@@ -87,9 +91,5 @@ module Export::Csv::OutgoingTrustPresenterModule
     return unless @project.key_contacts&.outgoing_trust_ceo.present?
 
     @project.key_contacts.outgoing_trust_ceo.email
-  end
-
-  private def outgoing_trust_contact
-    @contacts_fetcher.outgoing_trust_contact
   end
 end

--- a/app/services/contacts_fetcher_service.rb
+++ b/app/services/contacts_fetcher_service.rb
@@ -23,16 +23,6 @@ class ContactsFetcherService
     all_project_contacts.sort_by(&:name).group_by(&:category)
   end
 
-  def outgoing_trust_contact
-    return if @all_contacts["outgoing_trust"].nil?
-
-    if @project.outgoing_trust_main_contact_id.present?
-      @all_contacts["outgoing_trust"].find { |c| c.id == @project.outgoing_trust_main_contact_id }
-    else
-      @all_contacts["outgoing_trust"].first
-    end
-  end
-
   def local_authority_contact
     return if @all_contacts["local_authority"].nil?
 

--- a/app/services/export/transfers/all_data_csv_export_service.rb
+++ b/app/services/export/transfers/all_data_csv_export_service.rb
@@ -60,6 +60,7 @@ class Export::Transfers::AllDataCsvExportService < Export::CsvExportService
     incoming_trust_main_contact_name
     incoming_trust_main_contact_email
     outgoing_trust_main_contact_name
+    outgoing_trust_main_contact_role
     outgoing_trust_main_contact_email
     incoming_trust_ceo_contact_name
     incoming_trust_ceo_contact_role

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -99,8 +99,9 @@ en:
           outgoing_trust_address_town: Outgoing trust address town
           outgoing_trust_address_county: Outgoing trust address county
           outgoing_trust_address_postcode: Outgoing trust address postcode
-          outgoing_trust_main_contact_name: Outgoing trust main contact name
-          outgoing_trust_main_contact_email: Outgoing trust main contact email
+          outgoing_trust_main_contact_name: Primary contact for outgoing trust name
+          outgoing_trust_main_contact_role: Primary contact for outgoing trust title
+          outgoing_trust_main_contact_email: Primary contact for outgoing trust email
           outgoing_trust_ceo_contact_name: Outgoing trust CEO name
           outgoing_trust_ceo_contact_role: Outgoing trust CEO role
           outgoing_trust_ceo_contact_email: Outgoing trust CEO email

--- a/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Export::Csv::OutgoingTrustPresenterModule do
 
   before do
     mock_successful_api_response_to_create_any_project
-    allow(project).to receive(:outgoing_trust_main_contact_id).and_return(outgoing_trust_main_contact.id)
+    project.outgoing_trust_main_contact = outgoing_trust_main_contact
     allow(project).to receive(:outgoing_trust).and_return(known_trust)
   end
 
@@ -25,6 +25,10 @@ RSpec.describe Export::Csv::OutgoingTrustPresenterModule do
 
   it "presents the main contact name" do
     expect(subject.outgoing_trust_main_contact_name).to eql "Jo Example"
+  end
+
+  it "presents the main contact role" do
+    expect(subject.outgoing_trust_main_contact_role).to eql "CEO of Learning"
   end
 
   it "presents the main contact email" do

--- a/spec/services/contacts_fetcher_service_spec.rb
+++ b/spec/services/contacts_fetcher_service_spec.rb
@@ -85,26 +85,6 @@ RSpec.describe ContactsFetcherService do
     end
   end
 
-  describe "#outgoing_trust_contact" do
-    let!(:contact) { create(:project_contact, project: project, category: "outgoing_trust") }
-
-    context "when there is an outgoing_trust_main_contact_id" do
-      before { allow(project).to receive(:outgoing_trust_main_contact_id).and_return(contact.id) }
-
-      it "returns the contact with that id" do
-        expect(described_class.new(project).outgoing_trust_contact).to eq(contact)
-      end
-    end
-
-    context "when there is NOT an outgoing_trust_main_contact_id" do
-      before { allow(project).to receive(:outgoing_trust_main_contact_id).and_return(nil) }
-
-      it "returns the next matching contact" do
-        expect(described_class.new(project).outgoing_trust_contact).to eq(contact)
-      end
-    end
-  end
-
   describe "#local_authority_contact" do
     let!(:contact) { create(:project_contact, project: project, category: "local_authority") }
 


### PR DESCRIPTION
Having this logic is confusing users, if the primary outgoing trust
contact is not set, showing nothing is a better outcome. We also added
the primary outgoing trust contact role.

The column header is also causing confusion, we are going to use the
phrase 'Primary contact for outgoing trust' for this export as it
matches up with the application UI.
