### PR TITLE
Add an "inactive" state to projects

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -92,7 +92,8 @@ class Project < ApplicationRecord
     active: 0,
     completed: 1,
     deleted: 2,
-    dao_revoked: 3
+    dao_revoked: 3,
+    inactive: 4
   }
 
   def establishment

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -469,12 +469,14 @@ RSpec.describe Project, type: :model do
         completed_project_1 = create(:conversion_project, completed_at: Date.today - 1.year, state: 1)
         completed_project_2 = create(:conversion_project, completed_at: Date.today - 6.months, state: 1)
         in_progress_project = create(:conversion_project, completed_at: nil, state: 0)
+        inactive_project = create(:conversion_project, state: 4)
 
         projects = Project.completed
 
         expect(projects).to include(completed_project_1, completed_project_2)
 
         expect(projects).to_not include(in_progress_project)
+        expect(projects).to_not include(inactive_project)
       end
     end
 
@@ -502,11 +504,13 @@ RSpec.describe Project, type: :model do
         completed_project = create(:conversion_project, completed_at: Date.today - 1.year, state: 1)
         in_progress_project_1 = create(:conversion_project, completed_at: nil, state: 0)
         in_progress_project_2 = create(:conversion_project, completed_at: nil, state: 0)
+        inactive_project = create(:conversion_project, state: 4)
 
         projects = Project.active
 
         expect(projects).to include(in_progress_project_1, in_progress_project_2)
         expect(projects).to_not include(completed_project)
+        expect(projects).to_not include(inactive_project)
       end
     end
 
@@ -530,11 +534,13 @@ RSpec.describe Project, type: :model do
         completed_project = create(:conversion_project, completed_at: Date.today - 1.year, state: 1)
         open_project_1 = create(:conversion_project, completed_at: nil, state: 0)
         open_project_2 = create(:conversion_project, completed_at: nil, state: 0)
+        inactive_project = create(:conversion_project, state: 4)
 
         projects = Project.in_progress
 
         expect(projects).to include(open_project_1, open_project_2)
         expect(projects).to_not include(completed_project)
+        expect(projects).to_not include(inactive_project)
       end
 
       it "does not include unassigned projects" do


### PR DESCRIPTION
Projects will soon be able to be added to Complete via an API call. These projects will be automatically created by the Prepare application.

Because the Prepare application does not hold all the mandatory information we need to create projects in Complete, these projects will be invalid. We need a way to indicate they are not ready to be worked on yet - they need to be triaged by DOs and put into a valid state.

To this end, add an "inactive" state to indicate these projects are not valid yet, and therefore cannot be worked on ("active" state).

