### PR TITLE
Update the main contact task content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The primary contact for school in the export no longer uses the first contact
   if one is not set.
 - The primary contact for the school is now labelled in the export.
+- The content on the main contact task has been updated for accuracy on both
+  conversions and transfers.
 
 ### Added
 

--- a/config/locales/conversion/tasks/main_contact.en.yml
+++ b/config/locales/conversion/tasks/main_contact.en.yml
@@ -6,8 +6,8 @@ en:
         no_contacts:
           hint:
             html:
-              <p>This is the person who will get the funding letters and other important documents during the conversion. They will most likely be from the school or trust.</p>
-              <p>It is not necessarily the person you contact most throughout the project.</p>
+              <p>This is your first point of contact if you have any questions about the project. You may know them as the external project lead.</p>
+              <p>They might be from the school, trust, local authority, diocese or they could be a consultant.</p>
           title: Add a contact
           add_contacts_guidance_html:
             <p>No contacts have been added to this project.</a>
@@ -16,6 +16,6 @@ en:
           title: Choose a contact
           hint:
             html:
-              <p>This is the person who will get the funding letters and other important documents during the conversion. They will most likely be from the school or trust.</p>
-              <p>It is not necessarily the person you contact most throughout the project.</p>
+              <p>This is your first point of contact if you have any questions about the project. You may know them as the external project lead.</p>
+              <p>They might be from the school, trust, local authority, diocese or they could be a consultant.</p>
               <p>You must <a href="%{add_contact_link}">add a new contact</a> first if they are not already in the list of contacts.</p>

--- a/config/locales/transfer/tasks/main_contact.en.yml
+++ b/config/locales/transfer/tasks/main_contact.en.yml
@@ -7,8 +7,8 @@ en:
           title: Add contacts
           hint:
             html:
-              <p>This is the person who will get important documents during the transfer. They will most likely be from the academy or incoming trust.<p>
-              <p>It is not necessarily the person you contact most throughout the project.</p>
+              <p>This is your first point of contact if you have any questions about the project. You may know them as the external project lead.</p>
+              <p>They might be from the school, trust, local authority, diocese or they could be a consultant.</p>
           add_contacts_guidance_html:
             <p>No contacts have been added to this project.</p>
             <p>You must <a href="%{add_contact_link}">add a contact</a> before you can confirm the main contact.</p>
@@ -16,6 +16,6 @@ en:
           title: Choose a contact
           hint:
             html:
-              <p>This is the person who will get important documents during the transfer. They will most likely be from the academy or incoming trust.<p>
-              <p>It is not necessarily the person you contact most throughout the project.</p>
+              <p>This is your first point of contact if you have any questions about the project. You may know them as the external project lead.</p>
+              <p>They might be from the school, trust, local authority, diocese or they could be a consultant.</p>
               <p>You must <a href="%{add_contact_link}">add a new contact</a> first if they are not already in the list of contacts.</p>


### PR DESCRIPTION
This content is misleading as the main contact is not used for the
funding letters.

