### PR TITLE
Set project state to "inactive" when created via the API

### DIFF
--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -46,7 +46,8 @@ class Api::Conversions::CreateProjectService
         regional_delivery_officer_id: user.id,
         tasks_data: tasks_data,
         region: establishment.region_code,
-        prepare_id: prepare_id
+        prepare_id: prepare_id,
+        state: :inactive
       )
 
       if project.save(validate: false)

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe Api::Conversions::CreateProjectService do
 
         expect(result.prepare_id).to eq(123456)
       end
+
+      it "sets the initial state to be 'inactive'" do
+        result = described_class.new(params).call
+
+        expect(result.state).to eq("inactive")
+      end
     end
 
     context "when the params contain details for an unknown user" do


### PR DESCRIPTION
When a project is created via the API, set its state to "inactive" to indicate it is not ready to be worked on yet.

