### PR TITLE
API can create transfer projects

### DIFF
--- a/app/api/v1/api.rb
+++ b/app/api/v1/api.rb
@@ -4,5 +4,6 @@ module V1
 
     mount Healthcheck
     mount Conversions
+    mount Transfers
   end
 end

--- a/app/api/v1/conversions.rb
+++ b/app/api/v1/conversions.rb
@@ -29,7 +29,9 @@ class V1::Conversions < Grape::API
         project = service.call
 
         {conversion_project_id: project.id}
-      rescue Api::Conversions::CreateProjectService::ProjectCreationError => e
+      rescue Api::Conversions::CreateProjectService::ValidationError => e
+        error!(e.message)
+      rescue Api::Conversions::CreateProjectService::CreationError => e
         error!(e.message)
       end
 
@@ -47,7 +49,9 @@ class V1::Conversions < Grape::API
           project = service.call
 
           {conversion_project_id: project.id}
-        rescue Api::Conversions::CreateProjectService::ProjectCreationError => e
+        rescue Api::Conversions::CreateProjectService::ValidationError => e
+          error!(e.message)
+        rescue Api::Conversions::CreateProjectService::CreationError => e
           error!(e.message)
         end
       end

--- a/app/api/v1/conversions.rb
+++ b/app/api/v1/conversions.rb
@@ -21,7 +21,9 @@ class V1::Conversions < Grape::API
         requires :incoming_trust_ukprn, type: Integer
       end
 
-      desc "Create a conversion project"
+      desc "Create a conversion project" do
+        failure [{code: 400, message: "Bad request"}]
+      end
       post "/" do
         project_params = declared(params)
 
@@ -30,7 +32,7 @@ class V1::Conversions < Grape::API
 
         {conversion_project_id: project.id}
       rescue Api::Conversions::CreateProjectService::ValidationError => e
-        error!(e.message)
+        error!(e.message, 400)
       rescue Api::Conversions::CreateProjectService::CreationError => e
         error!(e.message)
       end
@@ -41,7 +43,9 @@ class V1::Conversions < Grape::API
           requires :new_trust_name, type: String
         end
 
-        desc "Create a form a MAT conversion project"
+        desc "Create a form a MAT conversion project" do
+          failure [{code: 400, message: "Bad request"}]
+        end
         post "/" do
           project_params = declared(params)
 
@@ -50,7 +54,7 @@ class V1::Conversions < Grape::API
 
           {conversion_project_id: project.id}
         rescue Api::Conversions::CreateProjectService::ValidationError => e
-          error!(e.message)
+          error!(e.message, 400)
         rescue Api::Conversions::CreateProjectService::CreationError => e
           error!(e.message)
         end

--- a/app/api/v1/transfers.rb
+++ b/app/api/v1/transfers.rb
@@ -31,7 +31,9 @@ class V1::Transfers < Grape::API
         project = service.call
 
         {transfer_project_id: project.id}
-      rescue Api::Transfers::CreateProjectService::ProjectCreationError => e
+      rescue Api::Transfers::CreateProjectService::ValidationError => e
+        error!(e.message)
+      rescue Api::Transfers::CreateProjectService::CreationError => e
         error!(e.message)
       end
 
@@ -49,7 +51,9 @@ class V1::Transfers < Grape::API
           project = service.call
 
           {transfer_project_id: project.id}
-        rescue Api::Transfers::CreateProjectService::ProjectCreationError => e
+        rescue Api::Transfers::CreateProjectService::ValidationError => e
+          error!(e.message)
+        rescue Api::Transfers::CreateProjectService::CreationError => e
           error!(e.message)
         end
       end

--- a/app/api/v1/transfers.rb
+++ b/app/api/v1/transfers.rb
@@ -23,7 +23,9 @@ class V1::Transfers < Grape::API
         requires :incoming_trust_ukprn, type: Integer
       end
 
-      desc "Create a transfer project"
+      desc "Create a transfer project" do
+        failure [{code: 400, message: "Bad request"}]
+      end
       post "/" do
         project_params = declared(params)
 
@@ -32,7 +34,7 @@ class V1::Transfers < Grape::API
 
         {transfer_project_id: project.id}
       rescue Api::Transfers::CreateProjectService::ValidationError => e
-        error!(e.message)
+        error!(e.message, 400)
       rescue Api::Transfers::CreateProjectService::CreationError => e
         error!(e.message)
       end
@@ -43,7 +45,9 @@ class V1::Transfers < Grape::API
           requires :new_trust_name, type: String
         end
 
-        desc "Create a form a MAT conversion project"
+        desc "Create a form a MAT transfer project" do
+          failure [{code: 400, message: "Bad request"}]
+        end
         post "/" do
           project_params = declared(params)
 
@@ -52,7 +56,7 @@ class V1::Transfers < Grape::API
 
           {transfer_project_id: project.id}
         rescue Api::Transfers::CreateProjectService::ValidationError => e
-          error!(e.message)
+          error!(e.message, 400)
         rescue Api::Transfers::CreateProjectService::CreationError => e
           error!(e.message)
         end

--- a/app/api/v1/transfers.rb
+++ b/app/api/v1/transfers.rb
@@ -1,0 +1,58 @@
+class V1::Transfers < Grape::API
+  before do
+    authenticate!
+  end
+
+  resource :projects do
+    params do
+      requires :urn, type: Integer
+      requires :advisory_board_date, type: Date
+      requires :advisory_board_conditions, type: String
+      requires :provisional_transfer_date, type: Date
+      requires :created_by_email, type: String
+      requires :created_by_first_name, type: String
+      requires :created_by_last_name, type: String
+      requires :inadequate_ofsted, type: Boolean
+      requires :financial_safeguarding_governance_issues, type: Boolean
+      requires :outgoing_trust_to_close, type: Boolean
+      requires :prepare_id, type: Integer
+    end
+
+    resource :transfers do
+      params do
+        requires :incoming_trust_ukprn, type: Integer
+      end
+
+      desc "Create a transfer project"
+      post "/" do
+        project_params = declared(params)
+
+        service = Api::Transfers::CreateProjectService.new(project_params)
+        project = service.call
+
+        {transfer_project_id: project.id}
+      rescue Api::Transfers::CreateProjectService::ProjectCreationError => e
+        error!(e.message)
+      end
+
+      resource "form-a-mat" do
+        params do
+          requires :new_trust_reference_number, type: String
+          requires :new_trust_name, type: String
+        end
+
+        desc "Create a form a MAT conversion project"
+        post "/" do
+          project_params = declared(params)
+
+          service = Api::Transfers::CreateProjectService.new(project_params)
+          project = service.call
+
+          {transfer_project_id: project.id}
+        rescue Api::Transfers::CreateProjectService::ProjectCreationError => e
+          error!(e.message)
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/base_create_project_service.rb
+++ b/app/services/api/base_create_project_service.rb
@@ -3,7 +3,9 @@ class Api::BaseCreateProjectService
   include ActiveModel::Attributes
   include ActiveRecord::AttributeAssignment
 
-  class ProjectCreationError < StandardError; end
+  class CreationError < StandardError; end
+
+  class ValidationError < StandardError; end
 
   attribute :urn
   attribute :incoming_trust_ukprn
@@ -35,12 +37,12 @@ class Api::BaseCreateProjectService
     end
     user
   rescue ActiveRecord::RecordInvalid
-    raise ProjectCreationError.new("Failed to save user during API project creation, urn: #{urn}")
+    raise CreationError.new("Failed to save user during API project creation, urn: #{urn}")
   end
 
   private def establishment
     result = Api::AcademiesApi::Client.new.get_establishment(urn)
-    raise ProjectCreationError.new("Failed to fetch establishment from Academies API during project creation, urn: #{urn}") if result.error.present?
+    raise CreationError.new("Failed to fetch establishment from Academies API during project creation, urn: #{urn}") if result.error.present?
 
     result.object
   end

--- a/app/services/api/base_create_project_service.rb
+++ b/app/services/api/base_create_project_service.rb
@@ -1,0 +1,47 @@
+class Api::BaseCreateProjectService
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
+  class ProjectCreationError < StandardError; end
+
+  attribute :urn
+  attribute :incoming_trust_ukprn
+  attribute :advisory_board_date
+  attribute :advisory_board_conditions
+  attribute :directive_academy_order
+  attribute :created_by_email
+  attribute :created_by_first_name
+  attribute :created_by_last_name
+  attribute :new_trust_reference_number
+  attribute :new_trust_name
+  attribute :prepare_id
+
+  validates :urn, presence: true, urn: true
+  validates :incoming_trust_ukprn, ukprn: true, if: -> { incoming_trust_ukprn.present? }
+  validates :new_trust_reference_number, trust_reference_number: true, if: -> { new_trust_reference_number.present? }
+  validates :new_trust_name, presence: true, if: -> { new_trust_reference_number.present? }
+  validates :prepare_id, presence: true
+
+  def initialize(project_params)
+    super
+  end
+
+  private def find_or_create_user
+    user = User.find_or_create_by(email: created_by_email)
+    establishment_region = Project.regions.key(establishment.region_code)
+    unless user.persisted?
+      user.update!(first_name: created_by_first_name, last_name: created_by_last_name, team: establishment_region)
+    end
+    user
+  rescue ActiveRecord::RecordInvalid
+    raise ProjectCreationError.new("Failed to save user during API project creation, urn: #{urn}")
+  end
+
+  private def establishment
+    result = Api::AcademiesApi::Client.new.get_establishment(urn)
+    raise ProjectCreationError.new("Failed to fetch establishment from Academies API during project creation, urn: #{urn}") if result.error.present?
+
+    result.object
+  end
+end

--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -26,10 +26,10 @@ class Api::Conversions::CreateProjectService < Api::BaseCreateProjectService
       if project.save(validate: false)
         project
       else
-        raise ProjectCreationError.new("Conversion project could not be created via API, urn: #{urn}")
+        raise CreationError.new("Conversion project could not be created via API, urn: #{urn}")
       end
     else
-      raise ProjectCreationError.new(errors.full_messages.join(" "))
+      raise ValidationError.new(errors.full_messages.join(" "))
     end
   end
 end

--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -1,32 +1,5 @@
-class Api::Conversions::CreateProjectService
-  include ActiveModel::Model
-  include ActiveModel::Attributes
-  include ActiveRecord::AttributeAssignment
-
-  class ProjectCreationError < StandardError; end
-
-  attribute :urn
-  attribute :incoming_trust_ukprn
-  attribute :advisory_board_date
-  attribute :advisory_board_conditions
+class Api::Conversions::CreateProjectService < Api::BaseCreateProjectService
   attribute :provisional_conversion_date
-  attribute :directive_academy_order
-  attribute :created_by_email
-  attribute :created_by_first_name
-  attribute :created_by_last_name
-  attribute :new_trust_reference_number
-  attribute :new_trust_name
-  attribute :prepare_id
-
-  validates :urn, presence: true, urn: true
-  validates :incoming_trust_ukprn, ukprn: true, if: -> { incoming_trust_ukprn.present? }
-  validates :new_trust_reference_number, trust_reference_number: true, if: -> { new_trust_reference_number.present? }
-  validates :new_trust_name, presence: true, if: -> { new_trust_reference_number.present? }
-  validates :prepare_id, presence: true
-
-  def initialize(project_params)
-    super
-  end
 
   def call
     user = find_or_create_user
@@ -53,28 +26,10 @@ class Api::Conversions::CreateProjectService
       if project.save(validate: false)
         project
       else
-        raise ProjectCreationError.new("Project could not be created via API, urn: #{urn}")
+        raise ProjectCreationError.new("Conversion project could not be created via API, urn: #{urn}")
       end
     else
       raise ProjectCreationError.new(errors.full_messages.join(" "))
     end
-  end
-
-  private def find_or_create_user
-    user = User.find_or_create_by(email: created_by_email)
-    establishment_region = Project.regions.key(establishment.region_code)
-    unless user.persisted?
-      user.update!(first_name: created_by_first_name, last_name: created_by_last_name, team: establishment_region)
-    end
-    user
-  rescue ActiveRecord::RecordInvalid
-    raise ProjectCreationError.new("Failed to save user during API project creation, urn: #{urn}")
-  end
-
-  private def establishment
-    result = Api::AcademiesApi::Client.new.get_establishment(urn)
-    raise ProjectCreationError.new("Failed to fetch establishment from Academies API during project creation, urn: #{urn}") if result.error.present?
-
-    result.object
   end
 end

--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -2,9 +2,9 @@ class Api::Conversions::CreateProjectService < Api::BaseCreateProjectService
   attribute :provisional_conversion_date
 
   def call
-    user = find_or_create_user
-
     if valid?
+      user = find_or_create_user
+
       tasks_data = Conversion::TasksData.new
 
       project = Conversion::Project.new(

--- a/app/services/api/transfers/create_project_service.rb
+++ b/app/services/api/transfers/create_project_service.rb
@@ -1,0 +1,46 @@
+class Api::Transfers::CreateProjectService < Api::BaseCreateProjectService
+  attribute :provisional_transfer_date, :date
+  attribute :outgoing_trust_ukprn, :integer
+  attribute :two_requires_improvement, :boolean
+  attribute :inadequate_ofsted, :boolean
+  attribute :financial_safeguarding_governance_issues, :boolean
+  attribute :outgoing_trust_to_close, :boolean
+  attribute :new_trust_reference_number, :string
+  attribute :new_trust_name, :string
+
+  def call
+    user = find_or_create_user
+
+    if valid?
+      tasks_data = Transfer::TasksData.new(
+        inadequate_ofsted: inadequate_ofsted,
+        financial_safeguarding_governance_issues: financial_safeguarding_governance_issues,
+        outgoing_trust_to_close: outgoing_trust_to_close
+      )
+
+      project = Transfer::Project.new(
+        urn: urn,
+        incoming_trust_ukprn: incoming_trust_ukprn,
+        outgoing_trust_ukprn: outgoing_trust_ukprn,
+        advisory_board_date: advisory_board_date,
+        advisory_board_conditions: advisory_board_conditions,
+        transfer_date: provisional_transfer_date,
+        two_requires_improvement: two_requires_improvement,
+        regional_delivery_officer_id: user.id,
+        tasks_data: tasks_data,
+        region: establishment.region_code,
+        new_trust_reference_number: new_trust_reference_number,
+        new_trust_name: new_trust_name,
+        prepare_id: prepare_id
+      )
+
+      if project.save(validate: false)
+        project
+      else
+        raise ProjectCreationError.new("Transfer project could not be created via API, urn: #{urn}")
+      end
+    else
+      raise ProjectCreationError.new(errors.full_messages.join(" "))
+    end
+  end
+end

--- a/app/services/api/transfers/create_project_service.rb
+++ b/app/services/api/transfers/create_project_service.rb
@@ -9,9 +9,9 @@ class Api::Transfers::CreateProjectService < Api::BaseCreateProjectService
   attribute :new_trust_name, :string
 
   def call
-    user = find_or_create_user
-
     if valid?
+      user = find_or_create_user
+
       tasks_data = Transfer::TasksData.new(
         inadequate_ofsted: inadequate_ofsted,
         financial_safeguarding_governance_issues: financial_safeguarding_governance_issues,

--- a/app/services/api/transfers/create_project_service.rb
+++ b/app/services/api/transfers/create_project_service.rb
@@ -31,7 +31,8 @@ class Api::Transfers::CreateProjectService < Api::BaseCreateProjectService
         region: establishment.region_code,
         new_trust_reference_number: new_trust_reference_number,
         new_trust_name: new_trust_name,
-        prepare_id: prepare_id
+        prepare_id: prepare_id,
+        state: :inactive
       )
 
       if project.save(validate: false)

--- a/app/services/api/transfers/create_project_service.rb
+++ b/app/services/api/transfers/create_project_service.rb
@@ -37,10 +37,10 @@ class Api::Transfers::CreateProjectService < Api::BaseCreateProjectService
       if project.save(validate: false)
         project
       else
-        raise ProjectCreationError.new("Transfer project could not be created via API, urn: #{urn}")
+        raise CreationError.new("Transfer project could not be created via API, urn: #{urn}")
       end
     else
-      raise ProjectCreationError.new(errors.full_messages.join(" "))
+      raise ValidationError.new(errors.full_messages.join(" "))
     end
   end
 end

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe V1::Conversions do
               headers: {Apikey: "testkey"}
 
             expect(response.body).to eq({error: "Urn URN must be 6 digits long. For example, 123456. Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678."}.to_json)
-            expect(response.status).to eq(500)
+            expect(response.status).to eq(400)
           end
         end
 
@@ -270,7 +270,7 @@ RSpec.describe V1::Conversions do
               headers: {Apikey: "testkey"}
 
             expect(response.body).to eq({error: "New trust reference number The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234"}.to_json)
-            expect(response.status).to eq(500)
+            expect(response.status).to eq(400)
           end
         end
       end

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe V1::Conversions do
               as: :json,
               headers: {Apikey: "testkey"}
 
-            expect(response.body).to eq({error: "Project could not be created via API, urn: 123456"}.to_json)
+            expect(response.body).to eq({error: "Conversion project could not be created via API, urn: 123456"}.to_json)
             expect(response.status).to eq(500)
           end
         end

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -282,6 +282,34 @@ RSpec.describe V1::Conversions do
         end
       end
 
+      context "but project creation fails" do
+        before do
+          allow_any_instance_of(Conversion::Project).to receive(:save).and_return(nil)
+        end
+
+        it "returns an error" do
+          post "/api/v1/projects/conversions/form-a-mat",
+            params: {
+              urn: 123456,
+              new_trust_reference_number: "TR12345",
+              new_trust_name: "A new trust",
+              advisory_board_date: "2024-1-1",
+              advisory_board_conditions: "Some conditions",
+              provisional_conversion_date: "2025-1-1",
+              directive_academy_order: true,
+              created_by_email: regional_delivery_officer.email,
+              created_by_first_name: regional_delivery_officer.first_name,
+              created_by_last_name: regional_delivery_officer.last_name,
+              prepare_id: 12345
+            },
+            as: :json,
+            headers: {Apikey: "testkey"}
+
+          expect(response.body).to eq({error: "Conversion project could not be created via API, urn: 123456"}.to_json)
+          expect(response.status).to eq(500)
+        end
+      end
+
       context "when the 'regular' conversion parameters are posted to the Form a MAT endpoint" do
         it "returns an error" do
           post "/api/v1/projects/conversions/form-a-mat",

--- a/spec/api/v1/transfers_spec.rb
+++ b/spec/api/v1/transfers_spec.rb
@@ -1,0 +1,265 @@
+require "rails_helper"
+
+RSpec.describe V1::Transfers do
+  def valid_transfer_parameters
+    {
+      urn: 123456,
+      incoming_trust_ukprn: 12345678,
+      advisory_board_date: "2024-1-1",
+      advisory_board_conditions: "Some conditions",
+      provisional_transfer_date: "2025-1-1",
+      created_by_email: regional_delivery_officer.email,
+      created_by_first_name: regional_delivery_officer.first_name,
+      created_by_last_name: regional_delivery_officer.last_name,
+      inadequate_ofsted: true,
+      financial_safeguarding_governance_issues: true,
+      outgoing_trust_to_close: true,
+      prepare_id: 12345
+    }
+  end
+
+  def valid_form_a_mat_transfer_parameters
+    {
+      urn: 123456,
+      incoming_trust_ukprn: 12345678,
+      advisory_board_date: "2024-1-1",
+      advisory_board_conditions: "Some conditions",
+      provisional_transfer_date: "2025-1-1",
+      created_by_email: regional_delivery_officer.email,
+      created_by_first_name: regional_delivery_officer.first_name,
+      created_by_last_name: regional_delivery_officer.last_name,
+      inadequate_ofsted: true,
+      financial_safeguarding_governance_issues: true,
+      outgoing_trust_to_close: true,
+      prepare_id: 12345,
+      new_trust_reference_number: "TR12345",
+      new_trust_name: "A new trust"
+    }
+  end
+
+  describe "get /" do
+    context "when there is no api key in the header" do
+      it "returns an Unauthorized error" do
+        get "/api/v1/projects/transfers"
+        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when there is an invalid api key in the header" do
+      it "returns an Unauthorized error" do
+        get "/api/v1/projects/transfers", headers: {ApiKey: "unknownkey"}
+        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when there is an expired api key in the header" do
+      before do
+        ApiKey.create(api_key: "testkey", expires_at: Date.yesterday)
+      end
+
+      it "returns an Unauthorized error" do
+        get "/api/v1/projects/transfers", headers: {ApiKey: "testkey"}
+        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when there is a valid api key in the header" do
+      before do
+        ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow)
+      end
+
+      it "returns Not Allowed" do
+        get "/api/v1/projects/transfers", headers: {Apikey: "testkey"}
+        expect(response.body).to eq({error: "405 Not Allowed"}.to_json)
+        expect(response.status).to eq(405)
+      end
+    end
+  end
+
+  describe "post /" do
+    context "when there is no api key in the header" do
+      it "returns an error" do
+        post "/api/v1/projects/transfers"
+        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when there is an invalid api key in the header" do
+      it "returns an Unauthorized error" do
+        post "/api/v1/projects/transfers", headers: {ApiKey: "unknownkey"}
+        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context "when there is an expired api key in the header" do
+      before do
+        ApiKey.create(api_key: "testkey", expires_at: Date.yesterday)
+      end
+
+      it "returns an Unauthorized error" do
+        post "/api/v1/projects/transfers", headers: {ApiKey: "testkey"}
+        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
+      end
+    end
+
+    context "when there is a valid api key in the header" do
+      before do
+        ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow)
+        mock_successful_api_response_to_create_any_project
+      end
+
+      let(:regional_delivery_officer) { create(:regional_delivery_officer_user) }
+
+      context "when all required params are present" do
+        context "and the required params are valid" do
+          it "creates a new project" do
+            post "/api/v1/projects/transfers",
+              params: valid_transfer_parameters,
+              as: :json,
+              headers: {Apikey: "testkey"}
+
+            project = Project.last
+            expect(response.body).to eq({transfer_project_id: project.id}.to_json)
+            expect(response.status).to eq(201)
+          end
+        end
+
+        context "but project creation fails" do
+          before do
+            allow_any_instance_of(Transfer::Project).to receive(:save).and_return(nil)
+          end
+
+          it "returns an error" do
+            post "/api/v1/projects/transfers",
+              params: valid_transfer_parameters,
+              as: :json,
+              headers: {Apikey: "testkey"}
+
+            expect(response.body).to eq({error: "Transfer project could not be created via API, urn: 123456"}.to_json)
+            expect(response.status).to eq(500)
+          end
+        end
+
+        context "but the created_by email is not valid" do
+          it "returns an error" do
+            params = valid_transfer_parameters
+            params[:created_by_email] = "invalid@invalid.com"
+
+            post "/api/v1/projects/transfers",
+              params: params,
+              as: :json,
+              headers: {Apikey: "testkey"}
+
+            expect(response.body).to eq({error: "Failed to save user during API project creation, urn: 123456"}.to_json)
+            expect(response.status).to eq(500)
+          end
+        end
+
+        context "but the URN or UKPRN parameters are not valid" do
+          it "creates a new project" do
+            params = valid_transfer_parameters
+            params[:urn] = 123
+            params[:incoming_trust_ukprn] = 123
+
+            post "/api/v1/projects/transfers",
+              params: params,
+              as: :json,
+              headers: {Apikey: "testkey"}
+
+            expect(response.body).to eq({error: "Urn URN must be 6 digits long. For example, 123456. Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678."}.to_json)
+            expect(response.status).to eq(500)
+          end
+        end
+
+        context "but the urn cannot be found on the Acadanies API" do
+          before do
+            mock_establishment_not_found(urn: 123456)
+          end
+
+          it "returns an error" do
+            post "/api/v1/projects/transfers",
+              params: valid_transfer_parameters,
+              as: :json,
+              headers: {Apikey: "testkey"}
+
+            expect(response.body).to eq({error: "Failed to fetch establishment from Academies API during project creation, urn: 123456"}.to_json)
+            expect(response.status).to eq(500)
+          end
+        end
+      end
+
+      context "when any required params are missing" do
+        it "returns an error" do
+          post "/api/v1/projects/transfers", headers: {Apikey: "testkey"}
+          expect(response.body).to include("urn is missing, advisory_board_date is missing, advisory_board_conditions is missing")
+          expect(response.status).to eq(400)
+        end
+      end
+    end
+  end
+
+  describe "post form-a-mat/" do
+    context "when there is a valid api key in the header" do
+      before do
+        ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow)
+        mock_successful_api_response_to_create_any_project
+      end
+
+      let(:regional_delivery_officer) { create(:regional_delivery_officer_user) }
+
+      context "when all required params are present" do
+        context "and the required params are valid" do
+          it "creates a new Form a MAT project" do
+            post "/api/v1/projects/transfers/form-a-mat",
+              params: valid_form_a_mat_transfer_parameters,
+              as: :json,
+              headers: {Apikey: "testkey"}
+
+            project = Project.last
+            expect(response.body).to eq({transfer_project_id: project.id}.to_json)
+            expect(response.status).to eq(201)
+          end
+        end
+
+        context "but the new Trust Reference Number is not valid" do
+          it "returns an error" do
+            params = valid_form_a_mat_transfer_parameters
+            params[:new_trust_reference_number] = "12345"
+
+            post "/api/v1/projects/transfers/form-a-mat",
+              params: params,
+              as: :json,
+              headers: {Apikey: "testkey"}
+
+            expect(response.body).to eq({error: "New trust reference number The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234"}.to_json)
+            expect(response.status).to eq(500)
+          end
+        end
+      end
+
+      context "when any required params are missing" do
+        it "returns an error" do
+          post "/api/v1/projects/transfers/form-a-mat", headers: {Apikey: "testkey"}
+          expect(response.body).to include("urn is missing, advisory_board_date is missing, advisory_board_conditions is missing")
+        end
+      end
+
+      context "when the transfer parameters are posted to the Form a MAT endpoint" do
+        it "returns an error" do
+          post "/api/v1/projects/transfers/form-a-mat",
+            params: valid_transfer_parameters,
+            as: :json,
+            headers: {Apikey: "testkey"}
+
+          expect(response.body).to eq({error: "new_trust_reference_number is missing, new_trust_name is missing"}.to_json)
+          expect(response.status).to eq(400)
+        end
+      end
+    end
+  end
+end

--- a/spec/api/v1/transfers_spec.rb
+++ b/spec/api/v1/transfers_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe V1::Transfers do
               headers: {Apikey: "testkey"}
 
             expect(response.body).to eq({error: "Urn URN must be 6 digits long. For example, 123456. Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678."}.to_json)
-            expect(response.status).to eq(500)
+            expect(response.status).to eq(400)
           end
         end
 
@@ -237,7 +237,7 @@ RSpec.describe V1::Transfers do
               headers: {Apikey: "testkey"}
 
             expect(response.body).to eq({error: "New trust reference number The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234"}.to_json)
-            expect(response.status).to eq(500)
+            expect(response.status).to eq(400)
           end
         end
       end

--- a/spec/api/v1/transfers_spec.rb
+++ b/spec/api/v1/transfers_spec.rb
@@ -260,6 +260,22 @@ RSpec.describe V1::Transfers do
           expect(response.status).to eq(400)
         end
       end
+
+      context "but project creation fails" do
+        before do
+          allow_any_instance_of(Transfer::Project).to receive(:save).and_return(nil)
+        end
+
+        it "returns an error" do
+          post "/api/v1/projects/transfers/form-a-mat",
+            params: valid_form_a_mat_transfer_parameters,
+            as: :json,
+            headers: {Apikey: "testkey"}
+
+          expect(response.body).to eq({error: "Transfer project could not be created via API, urn: 123456"}.to_json)
+          expect(response.status).to eq(500)
+        end
+      end
     end
   end
 end

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe Api::Conversions::CreateProjectService do
       it "returns an error" do
         expect { described_class.new(params).call }
           .to raise_error(Api::Conversions::CreateProjectService::ProjectCreationError,
-            "Project could not be created via API, urn: 123456")
+            "Conversion project could not be created via API, urn: 123456")
       end
     end
   end

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -272,4 +272,29 @@ RSpec.describe Api::Conversions::CreateProjectService do
       end
     end
   end
+
+  context "when the parameters are invalid" do
+    let(:params) {
+      {
+        urn: 1234567890,
+        new_trust_reference_number: "12345",
+        new_trust_name: "The New Trust",
+        advisory_board_date: "2024-1-1",
+        advisory_board_conditions: "Some conditions",
+        provisional_conversion_date: "2025-1-1",
+        directive_academy_order: true,
+        created_by_email: "bob@education.gov.uk",
+        created_by_first_name: "Bob",
+        created_by_last_name: "Teacher",
+        prepare_id: 123456
+      }
+    }
+
+    it "does not attempt to find or create a user" do
+      allow(User).to receive(:find_or_create_by).and_call_original
+
+      expect { described_class.new(params).call }.to raise_error(Api::Conversions::CreateProjectService::ProjectCreationError)
+      expect(User).not_to have_received(:find_or_create_by)
+    end
+  end
 end

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -1,0 +1,177 @@
+require "rails_helper"
+
+RSpec.describe Api::Transfers::CreateProjectService, type: :model do
+  def valid_transfer_parameters
+    {
+      urn: 123456,
+      incoming_trust_ukprn: 10066123,
+      outgoing_trust_ukprn: 10010324,
+      advisory_board_date: "2024-1-1",
+      advisory_board_conditions: "Some conditions",
+      provisional_transfer_date: "2025-1-1",
+      directive_academy_order: true,
+      created_by_email: "test.user@education.gov.uk",
+      created_by_first_name: "Test",
+      created_by_last_name: "User",
+      two_requires_improvement: true,
+      prepare_id: 123456,
+      inadequate_ofsted: true,
+      financial_safeguarding_governance_issues: true,
+      outgoing_trust_to_close: true,
+      new_trust_reference_number: "TR12345",
+      new_trust_name: "A new trust"
+    }
+  end
+
+  before do
+    mock_successful_api_response_to_create_any_project
+  end
+
+  subject { described_class.new(valid_transfer_parameters).call }
+
+  it "creates a new project" do
+    expect(subject).to be_a Transfer::Project
+    expect(subject.persisted?).to be true
+
+    expect(subject.urn).to eql 123456
+    expect(subject.transfer_date).to eql Date.new(2025, 1, 1)
+  end
+
+  it "creates the tasks data for the project" do
+    tasks_data = subject.tasks_data
+
+    expect(tasks_data).to be_a Transfer::TasksData
+    expect(tasks_data.persisted?).to be true
+
+    expect(tasks_data.inadequate_ofsted).to be true
+    expect(tasks_data.financial_safeguarding_governance_issues).to be true
+    expect(tasks_data.outgoing_trust_to_close).to be true
+  end
+
+  it "creates the user to attribute the project to i.e the 'Regional Delivery Officer'" do
+    user = subject.regional_delivery_officer
+
+    expect(user.persisted?).to be true
+    expect(user.email).to eql "test.user@education.gov.uk"
+  end
+
+  it "sets the project region to be the same as the establishment region" do
+    expect(subject.region).to eql "west_midlands"
+  end
+
+  it "creates the user in the same regional team as the project establishment" do
+    user = subject.regional_delivery_officer
+
+    expect(user.team).to eql "west_midlands"
+  end
+
+  it "saves the Prepare ID on the project" do
+    expect(subject.prepare_id).to eq(123456)
+  end
+
+  context "when a user exists with the same email address" do
+    it "assigns that user to the project and does not create another" do
+      existing_user = create(
+        :user,
+        email: "test.user@education.gov.uk",
+        first_name: "Test",
+        last_name: "Last",
+        team: :london
+      )
+      user = subject.regional_delivery_officer
+
+      expect(user).to eql existing_user
+      expect(User.count).to be 1
+    end
+  end
+
+  context "when the user's email is not valid i.e. not @education.gov.uk" do
+    it "raises an error" do
+      params = valid_transfer_parameters
+      params[:created_by_email] = "invalid@example.com"
+
+      expect { described_class.new(params).call }
+        .to raise_error(Api::Transfers::CreateProjectService::ProjectCreationError)
+    end
+  end
+
+  context "when the URN is not invalid" do
+    it "raises an error" do
+      params = valid_transfer_parameters
+      params[:urn] = 123
+
+      expect { described_class.new(params).call }
+        .to raise_error(
+          Api::Transfers::CreateProjectService::ProjectCreationError,
+          "Urn URN must be 6 digits long. For example, 123456."
+        )
+    end
+  end
+
+  context "when the incoming trust UKPRN is invalid" do
+    it "raises an error" do
+      params = valid_transfer_parameters
+      params[:incoming_trust_ukprn] = 87654321
+
+      expect { described_class.new(params).call }
+        .to raise_error(
+          Api::Transfers::CreateProjectService::ProjectCreationError,
+          "Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678."
+        )
+    end
+  end
+
+  context "when the Prepare ID is missing" do
+    it "raises an error" do
+      params = valid_transfer_parameters
+      params[:prepare_id] = nil
+
+      expect { described_class.new(params).call }
+        .to raise_error(
+          Api::Transfers::CreateProjectService::ProjectCreationError,
+          "Prepare You must supply a Prepare ID when creating a project via the API"
+        )
+    end
+  end
+
+  context "when the Academies API returns an error on fetching the establishment" do
+    before do
+      mock_establishment_not_found(urn: 123456)
+    end
+
+    it "returns an error" do
+      params = valid_transfer_parameters
+      params[:urn] = 123456
+
+      expect { described_class.new(params).call }
+        .to raise_error(
+          Api::Transfers::CreateProjectService::ProjectCreationError,
+          "Failed to fetch establishment from Academies API during project creation, urn: 123456"
+        )
+    end
+  end
+
+  context "when the project save fails for an unknown reason" do
+    before do
+      allow_any_instance_of(Transfer::Project).to receive(:save).and_return(nil)
+    end
+
+    it "returns an error" do
+      params = valid_transfer_parameters
+      params[:urn] = 123456
+
+      expect { described_class.new(params).call }
+        .to raise_error(
+          Api::Transfers::CreateProjectService::ProjectCreationError,
+          "Transfer project could not be created via API, urn: 123456"
+        )
+    end
+  end
+
+  context "when creating a form a Multi Academy Trust (MAT) transfer" do
+    it "saves the new trust details" do
+      expect(subject.new_trust_reference_number).to eql "TR12345"
+      expect(subject.new_trust_name).to eql "A new trust"
+    end
+  end
+end

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -69,6 +69,10 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
     expect(subject.prepare_id).to eq(123456)
   end
 
+  it "sets the initial state to be 'inactive'" do
+    expect(subject.state).to eq("inactive")
+  end
+
   context "when a user exists with the same email address" do
     it "assigns that user to the project and does not create another" do
       existing_user = create(

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -174,4 +174,16 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
       expect(subject.new_trust_name).to eql "A new trust"
     end
   end
+
+  context "when the parameters are invalid" do
+    it "does not attempt to find or create a user" do
+      params = valid_transfer_parameters
+      params[:urn] = 1234567890
+
+      allow(User).to receive(:find_or_create_by).and_call_original
+
+      expect { described_class.new(params).call }.to raise_error(Api::Transfers::CreateProjectService::ProjectCreationError)
+      expect(User).not_to have_received(:find_or_create_by)
+    end
+  end
 end


### PR DESCRIPTION
The Complete API can already create a conversion project and a form a MAT
conversion project. This work adds transfer and form a MAT transfer projects
along with some improvements and fixes.

The API is not used in production yet so we have time to make improvements
beyond this work, but we wanted to keep this part as small as we could.


