### PR TITLE
(Fix) Correct link to edit Academy sharepoint link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   first contact if one is not set.
 - The primary contact for the outgoing trust is now labelled in the export.
 
+### Fixed
+
+- Corrected the Edit link for Sharepoint links on Conversions, it was pointing
+  to the Transfers edit page
+
 ## [Release-88][release-88]
 
 ### Changed

--- a/app/views/conversions/project_information/_academy_details.html.erb
+++ b/app/views/conversions/project_information/_academy_details.html.erb
@@ -35,7 +35,7 @@
               summary_list.with_row do |row|
                 row.with_key { t("project_information.show.academy_details.rows.sharepoint_folder") }
                 row.with_value { safe_link_to(t("project_information.show.academy_details.values.sharepoint_folder"), project.establishment_sharepoint_link) }
-                row.with_action(text: "Change", href: transfers_edit_path(@project, anchor: "sharepoint-folder-links"), visually_hidden_text: "edit sharepoint folder link")
+                row.with_action(text: "Change", href: conversions_edit_path(@project, anchor: "sharepoint-folder-links"), visually_hidden_text: "edit sharepoint folder link")
               end
             end %>
 


### PR DESCRIPTION
The link to edit the Sharepoint links for Conversion projects was pointing to the *transfers* edit page.

