### PR TITLE
Revert exports changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- The headteacher contact selected in the 'Confirm the headteacher’s details'
-  task is now included in the RPA, SUG and FA letters export. The contacts role
-  will always be exported as 'Headteacher'.
 - The incoming trust CEO contact selected in the 'Confirm the incoming trust
   CEO’s details' task is now included in the RPA, SUG and FA letters export. The
   contacts role will always be exported as 'CEO'.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- The incoming trust CEO contact selected in the 'Confirm the incoming trust
-  CEO’s details' task is now included in the RPA, SUG and FA letters export. The
-  contacts role will always be exported as 'CEO'.
 - Team lead users can now use the all projects and by month exports.
 
 ## [Release-88][release-88]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Requests to the Academies API now includes a User-Agent HTTP Header
 - AOPU becomes SOPU
-- The primary contact for school in the export no longer uses the first contact
-  if one is not set.
-- The primary contact for the school is now labelled in the export.
 - The content on the main contact task has been updated for accuracy on both
   conversions and transfers.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   CEO’s details' task is now included in the RPA, SUG and FA letters export. The
   contacts role will always be exported as 'CEO'.
 - Team lead users can now use the all projects and by month exports.
-- The primary contact for the incoming trust in the export no longer uses the
-  first contact if one is not set.
-- The primary contact for the incoming trust is now labelled in the export.
 - The primary contact for the outgoing trust in the export no longer uses the
   first contact if one is not set.
 - The primary contact for the outgoing trust is now labelled in the export.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   CEO’s details' task is now included in the RPA, SUG and FA letters export. The
   contacts role will always be exported as 'CEO'.
 - Team lead users can now use the all projects and by month exports.
-- The primary contact for the outgoing trust in the export no longer uses the
-  first contact if one is not set.
-- The primary contact for the outgoing trust is now labelled in the export.
 
 ## [Release-88][release-88]
 

--- a/app/presenters/export/csv/incoming_trust_presenter_module.rb
+++ b/app/presenters/export/csv/incoming_trust_presenter_module.rb
@@ -78,10 +78,9 @@ module Export::Csv::IncomingTrustPresenterModule
   end
 
   def incoming_trust_ceo_contact_role
-    # when exported this is ALWAYS 'CEO'
     return unless @project.key_contacts&.incoming_trust_ceo.present?
 
-    "CEO"
+    @project.key_contacts.incoming_trust_ceo.title
   end
 
   def incoming_trust_ceo_contact_email

--- a/app/presenters/export/csv/incoming_trust_presenter_module.rb
+++ b/app/presenters/export/csv/incoming_trust_presenter_module.rb
@@ -60,15 +60,15 @@ module Export::Csv::IncomingTrustPresenterModule
   end
 
   def incoming_trust_main_contact_name
-    @project.incoming_trust_main_contact&.name
+    incoming_trust_contact&.name
   end
 
   def incoming_trust_main_contact_role
-    @project.incoming_trust_main_contact&.title
+    incoming_trust_contact&.title
   end
 
   def incoming_trust_main_contact_email
-    @project.incoming_trust_main_contact&.email
+    incoming_trust_contact&.email
   end
 
   def incoming_trust_ceo_contact_name
@@ -94,5 +94,9 @@ module Export::Csv::IncomingTrustPresenterModule
     return unless @project.incoming_trust_sharepoint_link.present?
 
     @project.incoming_trust_sharepoint_link
+  end
+
+  private def incoming_trust_contact
+    @contacts_fetcher.incoming_trust_contact
   end
 end

--- a/app/presenters/export/csv/outgoing_trust_presenter_module.rb
+++ b/app/presenters/export/csv/outgoing_trust_presenter_module.rb
@@ -18,15 +18,15 @@ module Export::Csv::OutgoingTrustPresenterModule
   end
 
   def outgoing_trust_main_contact_name
-    @project.outgoing_trust_main_contact&.name
+    outgoing_trust_contact&.name
   end
 
   def outgoing_trust_main_contact_role
-    @project.outgoing_trust_main_contact&.title
+    outgoing_trust_contact&.title
   end
 
   def outgoing_trust_main_contact_email
-    @project.outgoing_trust_main_contact&.email
+    outgoing_trust_contact&.email
   end
 
   def outgoing_trust_identifier
@@ -91,5 +91,9 @@ module Export::Csv::OutgoingTrustPresenterModule
     return unless @project.key_contacts&.outgoing_trust_ceo.present?
 
     @project.key_contacts.outgoing_trust_ceo.email
+  end
+
+  private def outgoing_trust_contact
+    @contacts_fetcher.outgoing_trust_contact
   end
 end

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -97,15 +97,15 @@ module Export::Csv::SchoolPresenterModule
   alias_method :school_sharepoint_link_with_academy_label, :school_sharepoint_folder
 
   def school_main_contact_name
-    @project.establishment_main_contact&.name
+    school_or_academy_contact&.name
   end
 
   def school_main_contact_email
-    @project.establishment_main_contact&.email
+    school_or_academy_contact&.email
   end
 
   def school_main_contact_role
-    @project.establishment_main_contact&.title
+    school_or_academy_contact&.title
   end
 
   def headteacher_contact_name
@@ -125,5 +125,9 @@ module Export::Csv::SchoolPresenterModule
     return unless @project.key_contacts&.headteacher.present?
 
     @project.key_contacts.headteacher.email
+  end
+
+  private def school_or_academy_contact
+    @contacts_fetcher.school_or_academy_contact
   end
 end

--- a/app/presenters/export/csv/school_presenter_module.rb
+++ b/app/presenters/export/csv/school_presenter_module.rb
@@ -115,10 +115,9 @@ module Export::Csv::SchoolPresenterModule
   end
 
   def headteacher_contact_role
-    # when exported this is ALWAYS 'headteacher'
     return unless @project.key_contacts&.headteacher.present?
 
-    "Headteacher"
+    @project.key_contacts.headteacher.title
   end
 
   def headteacher_contact_email

--- a/app/services/contacts_fetcher_service.rb
+++ b/app/services/contacts_fetcher_service.rb
@@ -23,6 +23,16 @@ class ContactsFetcherService
     all_project_contacts.sort_by(&:name).group_by(&:category)
   end
 
+  def school_or_academy_contact
+    return if @all_contacts["school_or_academy"].nil?
+
+    if @project.establishment_main_contact_id.present?
+      @all_contacts["school_or_academy"].find { |c| c.id == @project.establishment_main_contact_id }
+    else
+      @all_contacts["school_or_academy"].first
+    end
+  end
+
   def local_authority_contact
     return if @all_contacts["local_authority"].nil?
 

--- a/app/services/contacts_fetcher_service.rb
+++ b/app/services/contacts_fetcher_service.rb
@@ -53,7 +53,6 @@ class ContactsFetcherService
     end
   end
 
-
   def local_authority_contact
     return if @all_contacts["local_authority"].nil?
 

--- a/app/services/contacts_fetcher_service.rb
+++ b/app/services/contacts_fetcher_service.rb
@@ -33,6 +33,17 @@ class ContactsFetcherService
     end
   end
 
+  def incoming_trust_contact
+    return if @all_contacts["incoming_trust"].nil?
+
+    if @project.incoming_trust_main_contact_id.present?
+      @all_contacts["incoming_trust"].find { |c| c.id == @project.incoming_trust_main_contact_id }
+    else
+      @all_contacts["incoming_trust"].first
+    end
+  end
+
+
   def local_authority_contact
     return if @all_contacts["local_authority"].nil?
 

--- a/app/services/contacts_fetcher_service.rb
+++ b/app/services/contacts_fetcher_service.rb
@@ -23,6 +23,16 @@ class ContactsFetcherService
     all_project_contacts.sort_by(&:name).group_by(&:category)
   end
 
+  def outgoing_trust_contact
+    return if @all_contacts["outgoing_trust"].nil?
+
+    if @project.outgoing_trust_main_contact_id.present?
+      @all_contacts["outgoing_trust"].find { |c| c.id == @project.outgoing_trust_main_contact_id }
+    else
+      @all_contacts["outgoing_trust"].first
+    end
+  end
+
   def school_or_academy_contact
     return if @all_contacts["school_or_academy"].nil?
 

--- a/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
+++ b/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
@@ -14,9 +14,6 @@ class Export::Conversions::RpaSugAndFaLettersCsvExportService < Export::CsvExpor
     school_main_contact_name
     school_main_contact_role
     school_main_contact_email
-    headteacher_contact_name
-    headteacher_contact_role
-    headteacher_contact_email
     chair_of_governors_name
     chair_of_governors_role
     chair_of_governors_email

--- a/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
+++ b/app/services/export/conversions/rpa_sug_and_fa_letters_csv_export_service.rb
@@ -40,9 +40,6 @@ class Export::Conversions::RpaSugAndFaLettersCsvExportService < Export::CsvExpor
     incoming_trust_address_town
     incoming_trust_address_county
     incoming_trust_address_postcode
-    incoming_trust_ceo_contact_name
-    incoming_trust_ceo_contact_role
-    incoming_trust_ceo_contact_email
     incoming_trust_main_contact_name
     incoming_trust_main_contact_role
     incoming_trust_main_contact_email

--- a/app/services/export/transfers/all_data_csv_export_service.rb
+++ b/app/services/export/transfers/all_data_csv_export_service.rb
@@ -60,7 +60,6 @@ class Export::Transfers::AllDataCsvExportService < Export::CsvExportService
     incoming_trust_main_contact_name
     incoming_trust_main_contact_email
     outgoing_trust_main_contact_name
-    outgoing_trust_main_contact_role
     outgoing_trust_main_contact_email
     incoming_trust_ceo_contact_name
     incoming_trust_ceo_contact_role

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -142,9 +142,9 @@ en:
           conversion_type: Conversion type
           transfer_type: Transfer type
           esfa_notes: ESFA notes
-          school_main_contact_email: Primary contact for school email
-          school_main_contact_name: Primary contact for school name
-          school_main_contact_role: Primary contact for school role
+          school_main_contact_email: School contact email
+          school_main_contact_name: School contact name
+          school_main_contact_role: School contact role
           headteacher_contact_name: Headteacher name
           headteacher_contact_role: Headteacher role
           headteacher_contact_email: Headteacher email

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -50,9 +50,9 @@ en:
           incoming_trust_identifier: Incoming trust group identifier
           incoming_trust_companies_house_number: Incoming trust companies house number
           incoming_trust_name: Incoming trust name
-          incoming_trust_main_contact_name: Primary contact for incoming trust name
-          incoming_trust_main_contact_email: Primary contact for incoming trust email
-          incoming_trust_main_contact_role: Primary contact for incoming trust role
+          incoming_trust_main_contact_name: Incoming trust main contact name
+          incoming_trust_main_contact_email: Incoming trust main contact email
+          incoming_trust_main_contact_role: Incoming trust main contact role
           incoming_trust_ceo_contact_name: Incoming trust CEO name
           incoming_trust_ceo_contact_role: Incoming trust CEO role
           incoming_trust_ceo_contact_email: Incoming trust CEO email

--- a/config/locales/export/csv/project.en.yml
+++ b/config/locales/export/csv/project.en.yml
@@ -99,9 +99,8 @@ en:
           outgoing_trust_address_town: Outgoing trust address town
           outgoing_trust_address_county: Outgoing trust address county
           outgoing_trust_address_postcode: Outgoing trust address postcode
-          outgoing_trust_main_contact_name: Primary contact for outgoing trust name
-          outgoing_trust_main_contact_role: Primary contact for outgoing trust title
-          outgoing_trust_main_contact_email: Primary contact for outgoing trust email
+          outgoing_trust_main_contact_name: Outgoing trust main contact name
+          outgoing_trust_main_contact_email: Outgoing trust main contact email
           outgoing_trust_ceo_contact_name: Outgoing trust CEO name
           outgoing_trust_ceo_contact_role: Outgoing trust CEO role
           outgoing_trust_ceo_contact_email: Outgoing trust CEO email

--- a/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Export::Csv::IncomingTrustPresenterModule do
 
   before do
     mock_successful_api_response_to_create_any_project
-    project.incoming_trust_main_contact = incoming_trust_main_contact
+    allow(project).to receive(:incoming_trust_main_contact_id).and_return(incoming_trust_main_contact.id)
   end
 
   it "presents the identifier" do

--- a/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/incoming_trust_presenter_module_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Export::Csv::IncomingTrustPresenterModule do
         KeyContacts.new(project: project, incoming_trust_ceo: contact)
 
         expect(subject.incoming_trust_ceo_contact_name).to eql contact.name
-        expect(subject.incoming_trust_ceo_contact_role).to eql "CEO"
+        expect(subject.incoming_trust_ceo_contact_role).to eql "CEO of Learning"
         expect(subject.incoming_trust_ceo_contact_email).to eql contact.email
       end
     end

--- a/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/outgoing_trust_presenter_module_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Export::Csv::OutgoingTrustPresenterModule do
 
   before do
     mock_successful_api_response_to_create_any_project
-    project.outgoing_trust_main_contact = outgoing_trust_main_contact
+    allow(project).to receive(:outgoing_trust_main_contact_id).and_return(outgoing_trust_main_contact.id)
     allow(project).to receive(:outgoing_trust).and_return(known_trust)
   end
 

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
         KeyContacts.new(project: project, headteacher: contact)
 
         expect(subject.headteacher_contact_name).to eql "Jo Example"
-        expect(subject.headteacher_contact_role).to eql "Headteacher"
+        expect(subject.headteacher_contact_role).to eql "CEO of Learning"
         expect(subject.headteacher_contact_email).to eql "jo@example.com"
       end
     end

--- a/spec/presenters/export/csv/school_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/school_presenter_module_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Export::Csv::SchoolPresenterModule do
 
   before do
     mock_successful_api_response_to_create_any_project
-    project.establishment_main_contact = contact
+    allow(project).to receive(:establishment_main_contact_id).and_return(contact.id)
     allow(project).to receive(:director_of_child_services).and_return(director_of_child_services)
   end
 

--- a/spec/services/contacts_fetcher_service_spec.rb
+++ b/spec/services/contacts_fetcher_service_spec.rb
@@ -85,6 +85,26 @@ RSpec.describe ContactsFetcherService do
     end
   end
 
+  describe "#school_or_academy_contact" do
+    let!(:contact) { create(:project_contact, project: project, category: "school_or_academy") }
+
+    context "when there is an establishment_main_contact_id" do
+      before { allow(project).to receive(:establishment_main_contact_id).and_return(contact.id) }
+
+      it "returns the contact with that id" do
+        expect(described_class.new(project).school_or_academy_contact).to eq(contact)
+      end
+    end
+
+    context "when there is NOT an establishment_main_contact_id" do
+      before { allow(project).to receive(:establishment_main_contact_id).and_return(nil) }
+
+      it "returns the next matching contact" do
+        expect(described_class.new(project).school_or_academy_contact).to eq(contact)
+      end
+    end
+  end
+
   describe "#local_authority_contact" do
     let!(:contact) { create(:project_contact, project: project, category: "local_authority") }
 

--- a/spec/services/contacts_fetcher_service_spec.rb
+++ b/spec/services/contacts_fetcher_service_spec.rb
@@ -105,6 +105,26 @@ RSpec.describe ContactsFetcherService do
     end
   end
 
+  describe "#incoming_trust_contact" do
+    let!(:contact) { create(:project_contact, project: project, category: "incoming_trust") }
+
+    context "when there is an incoming_trust_main_contact_id" do
+      before { allow(project).to receive(:incoming_trust_main_contact_id).and_return(contact.id) }
+
+      it "returns the contact with that id" do
+        expect(described_class.new(project).incoming_trust_contact).to eq(contact)
+      end
+    end
+
+    context "when there is NOT an incoming_trust_main_contact_id" do
+      before { allow(project).to receive(:incoming_trust_main_contact_id).and_return(nil) }
+
+      it "returns the next matching contact" do
+        expect(described_class.new(project).incoming_trust_contact).to eq(contact)
+      end
+    end
+  end
+
   describe "#local_authority_contact" do
     let!(:contact) { create(:project_contact, project: project, category: "local_authority") }
 

--- a/spec/services/contacts_fetcher_service_spec.rb
+++ b/spec/services/contacts_fetcher_service_spec.rb
@@ -85,6 +85,26 @@ RSpec.describe ContactsFetcherService do
     end
   end
 
+  describe "#outgoing_trust_contact" do
+    let!(:contact) { create(:project_contact, project: project, category: "outgoing_trust") }
+
+    context "when there is an outgoing_trust_main_contact_id" do
+      before { allow(project).to receive(:outgoing_trust_main_contact_id).and_return(contact.id) }
+
+      it "returns the contact with that id" do
+        expect(described_class.new(project).outgoing_trust_contact).to eq(contact)
+      end
+    end
+
+    context "when there is NOT an outgoing_trust_main_contact_id" do
+      before { allow(project).to receive(:outgoing_trust_main_contact_id).and_return(nil) }
+
+      it "returns the next matching contact" do
+        expect(described_class.new(project).outgoing_trust_contact).to eq(contact)
+      end
+    end
+  end
+
   describe "#school_or_academy_contact" do
     let!(:contact) { create(:project_contact, project: project, category: "school_or_academy") }
 


### PR DESCRIPTION
Revert PRs #1881, #1882, #1883, #1869 and #1870

We do want to use these changes in the future, but not until October 2024 when the SOPU team will be ready for them and have updated their own processes accordingly.

Instead of reverting each PR in its own PR, we have reverted them all as commits in one PR. This will hopefully 🤞 make it easier to un-revert them in October.
