### PR TITLE
API can create grouped projects

### DIFF
--- a/app/api/v1/conversions.rb
+++ b/app/api/v1/conversions.rb
@@ -14,6 +14,7 @@ class V1::Conversions < Grape::API
       requires :created_by_first_name, type: String
       requires :created_by_last_name, type: String
       requires :prepare_id, type: Integer
+      optional :group_id, type: String
     end
 
     resource :conversions do

--- a/app/api/v1/transfers.rb
+++ b/app/api/v1/transfers.rb
@@ -16,6 +16,7 @@ class V1::Transfers < Grape::API
       requires :financial_safeguarding_governance_issues, type: Boolean
       requires :outgoing_trust_to_close, type: Boolean
       requires :prepare_id, type: Integer
+      optional :group_id, type: String
     end
 
     resource :transfers do

--- a/app/services/api/base_create_project_service.rb
+++ b/app/services/api/base_create_project_service.rb
@@ -17,6 +17,7 @@ class Api::BaseCreateProjectService
   attribute :created_by_last_name
   attribute :new_trust_reference_number
   attribute :new_trust_name
+  attribute :group_id
   attribute :prepare_id
 
   validates :urn, presence: true, urn: true
@@ -25,8 +26,19 @@ class Api::BaseCreateProjectService
   validates :new_trust_name, presence: true, if: -> { new_trust_reference_number.present? }
   validates :prepare_id, presence: true
 
+  validates_with GroupIdValidator
+
   def initialize(project_params)
     super
+  end
+
+  private def group
+    return nil unless group_id.present?
+
+    ProjectGroup.find_or_create_by(
+      group_identifier: group_id,
+      trust_ukprn: incoming_trust_ukprn
+    )
   end
 
   private def find_or_create_user

--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -20,6 +20,7 @@ class Api::Conversions::CreateProjectService < Api::BaseCreateProjectService
         tasks_data: tasks_data,
         region: establishment.region_code,
         prepare_id: prepare_id,
+        group: group,
         state: :inactive
       )
 

--- a/app/services/api/transfers/create_project_service.rb
+++ b/app/services/api/transfers/create_project_service.rb
@@ -7,6 +7,7 @@ class Api::Transfers::CreateProjectService < Api::BaseCreateProjectService
   attribute :outgoing_trust_to_close, :boolean
   attribute :new_trust_reference_number, :string
   attribute :new_trust_name, :string
+  attribute :group_id, :string
 
   def call
     if valid?
@@ -32,7 +33,8 @@ class Api::Transfers::CreateProjectService < Api::BaseCreateProjectService
         new_trust_reference_number: new_trust_reference_number,
         new_trust_name: new_trust_name,
         prepare_id: prepare_id,
-        state: :inactive
+        state: :inactive,
+        group: group
       )
 
       if project.save(validate: false)

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Api::Conversions::CreateProjectService do
     {
       urn: 123456,
       incoming_trust_ukprn: 10066123,
+      new_trust_reference_number: "TR12345",
+      new_trust_name: "The New Trust",
       advisory_board_date: "2024-1-1",
       advisory_board_conditions: "Some conditions",
       provisional_conversion_date: "2025-1-1",
@@ -23,30 +25,16 @@ RSpec.describe Api::Conversions::CreateProjectService do
   context "a 'regular' Conversion project" do
     context "when the params contain details for an existing user" do
       let(:user) { create(:regional_casework_services_user) }
-      let(:params) {
-        {
-          urn: 123456,
-          incoming_trust_ukprn: 10066123,
-          advisory_board_date: "2024-1-1",
-          advisory_board_conditions: "Some conditions",
-          provisional_conversion_date: "2025-1-1",
-          directive_academy_order: true,
-          created_by_email: user.email,
-          created_by_first_name: user.first_name,
-          created_by_last_name: user.last_name,
-          prepare_id: 123456
-        }
-      }
 
       it "creates the project using the existing user" do
-        result = described_class.new(params).call
+        result = described_class.new(valid_parameters).call
 
         expect(result).to be_a(Conversion::Project)
         expect(result.id).to eq(Conversion::Project.last.id)
       end
 
       it "creates a TasksData and assigns it to the project" do
-        result = described_class.new(params).call
+        result = described_class.new(valid_parameters).call
         tasks_data = Conversion::TasksData.last
 
         expect(result).to be_a(Conversion::Project)
@@ -54,43 +42,30 @@ RSpec.describe Api::Conversions::CreateProjectService do
       end
 
       it "sets the project region to be the same as the establishment region" do
-        result = described_class.new(params).call
+        result = described_class.new(valid_parameters).call
 
         expect(result.region).to eq("west_midlands")
       end
 
       it "saves the Prepare ID on the project" do
-        result = described_class.new(params).call
+        result = described_class.new(valid_parameters).call
 
         expect(result.prepare_id).to eq(123456)
       end
 
       it "sets the initial state to be 'inactive'" do
-        result = described_class.new(params).call
+        result = described_class.new(valid_parameters).call
 
         expect(result.state).to eq("inactive")
       end
     end
 
     context "when the params contain details for an unknown user" do
-      let(:params) {
-        {
-          urn: 123456,
-          incoming_trust_ukprn: 10066123,
-          advisory_board_date: "2024-1-1",
-          advisory_board_conditions: "Some conditions",
-          provisional_conversion_date: "2025-1-1",
-          directive_academy_order: true,
-          created_by_email: "bob@education.gov.uk",
-          created_by_first_name: "Bob",
-          created_by_last_name: "Governor",
-          prepare_id: 123456
-        }
-      }
-
       it "creates the project and a new user" do
+        params = valid_parameters
+
         result = described_class.new(params).call
-        new_user = User.find_by(email: "bob@education.gov.uk")
+        new_user = User.find_by(email: "test.user@education.gov.uk")
 
         expect(result).to be_a(Conversion::Project)
         expect(result.id).to eq(Conversion::Project.last.id)
@@ -98,30 +73,18 @@ RSpec.describe Api::Conversions::CreateProjectService do
       end
 
       it "puts the new user in the same regional team as the establishment" do
-        project = described_class.new(params).call
-        new_user = User.find_by(email: "bob@education.gov.uk")
+        project = described_class.new(valid_parameters).call
+        new_user = User.find_by(email: "test.user@education.gov.uk")
 
         expect(new_user.team).to eq(project.region)
       end
     end
 
     context "when the user's email is not valid" do
-      let(:params) {
-        {
-          urn: 123456,
-          incoming_trust_ukprn: 10066123,
-          advisory_board_date: "2024-1-1",
-          advisory_board_conditions: "Some conditions",
-          provisional_conversion_date: "2025-1-1",
-          directive_academy_order: true,
-          created_by_email: "bob@school.gov.uk",
-          created_by_first_name: "Bob",
-          created_by_last_name: "Teacher",
-          prepare_id: 123456
-        }
-      }
-
       it "returns an error" do
+        params = valid_parameters
+        params[:created_by_email] = "test@school.uk"
+
         expect { described_class.new(params).call }
           .to raise_error(Api::Conversions::CreateProjectService::CreationError,
             "Failed to save user during API project creation, urn: 123456")
@@ -129,22 +92,11 @@ RSpec.describe Api::Conversions::CreateProjectService do
     end
 
     context "when the URN or UKPRN are not valid" do
-      let(:params) {
-        {
-          urn: 123,
-          incoming_trust_ukprn: 100,
-          advisory_board_date: "2024-1-1",
-          advisory_board_conditions: "Some conditions",
-          provisional_conversion_date: "2025-1-1",
-          directive_academy_order: true,
-          created_by_email: "bob@education.gov.uk",
-          created_by_first_name: "Bob",
-          created_by_last_name: "Teacher",
-          prepare_id: 123456
-        }
-      }
-
       it "returns validation errors" do
+        params = valid_parameters
+        params[:urn] = 100
+        params[:incoming_trust_ukprn] = 123
+
         expect { described_class.new(params).call }
           .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
             "Urn URN must be 6 digits long. For example, 123456. Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678.")
@@ -152,21 +104,10 @@ RSpec.describe Api::Conversions::CreateProjectService do
     end
 
     context "when the Prepare ID is missing" do
-      let(:params) {
-        {
-          urn: 123456,
-          incoming_trust_ukprn: 10000001,
-          advisory_board_date: "2024-1-1",
-          advisory_board_conditions: "Some conditions",
-          provisional_conversion_date: "2025-1-1",
-          directive_academy_order: true,
-          created_by_email: "bob@education.gov.uk",
-          created_by_first_name: "Bob",
-          created_by_last_name: "Teacher"
-        }
-      }
-
       it "returns validation errors" do
+        params = valid_parameters
+        params[:prepare_id] = nil
+
         expect { described_class.new(params).call }
           .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
             "Prepare You must supply a Prepare ID when creating a project via the API")
@@ -175,27 +116,13 @@ RSpec.describe Api::Conversions::CreateProjectService do
 
     context "when the Academies API returns an error on fetching the establishment" do
       let(:user) { create(:regional_casework_services_user) }
-      let(:params) {
-        {
-          urn: 123456,
-          incoming_trust_ukprn: 10066123,
-          advisory_board_date: "2024-1-1",
-          advisory_board_conditions: "Some conditions",
-          provisional_conversion_date: "2025-1-1",
-          directive_academy_order: true,
-          created_by_email: user.email,
-          created_by_first_name: user.first_name,
-          created_by_last_name: user.last_name,
-          prepare_id: 123456
-        }
-      }
 
       before do
         mock_establishment_not_found(urn: 123456)
       end
 
       it "returns an error" do
-        expect { described_class.new(params).call }
+        expect { described_class.new(valid_parameters).call }
           .to raise_error(Api::Conversions::CreateProjectService::CreationError,
             "Failed to fetch establishment from Academies API during project creation, urn: 123456")
       end
@@ -207,23 +134,9 @@ RSpec.describe Api::Conversions::CreateProjectService do
       end
 
       let(:user) { create(:regional_casework_services_user) }
-      let(:params) {
-        {
-          urn: 123456,
-          incoming_trust_ukprn: 10066123,
-          advisory_board_date: "2024-1-1",
-          advisory_board_conditions: "Some conditions",
-          provisional_conversion_date: "2025-1-1",
-          directive_academy_order: true,
-          created_by_email: user.email,
-          created_by_first_name: user.first_name,
-          created_by_last_name: user.last_name,
-          prepare_id: 123456
-        }
-      }
 
       it "returns an error" do
-        expect { described_class.new(params).call }
+        expect { described_class.new(valid_parameters).call }
           .to raise_error(Api::Conversions::CreateProjectService::CreationError,
             "Conversion project could not be created via API, urn: 123456")
       end
@@ -233,23 +146,11 @@ RSpec.describe Api::Conversions::CreateProjectService do
   context "a Form a MAT Conversion project" do
     context "when the params contain details for an existing user" do
       let(:user) { create(:regional_casework_services_user) }
-      let(:params) {
-        {
-          urn: 123456,
-          new_trust_reference_number: "TR12345",
-          new_trust_name: "The New Trust",
-          advisory_board_date: "2024-1-1",
-          advisory_board_conditions: "Some conditions",
-          provisional_conversion_date: "2025-1-1",
-          directive_academy_order: true,
-          created_by_email: user.email,
-          created_by_first_name: user.first_name,
-          created_by_last_name: user.last_name,
-          prepare_id: 123456
-        }
-      }
 
       it "creates the project using the existing user" do
+        params = valid_parameters
+        params[:incoming_trust_ukprn] = nil
+
         result = described_class.new(params).call
 
         expect(result).to be_a(Conversion::Project)
@@ -257,6 +158,8 @@ RSpec.describe Api::Conversions::CreateProjectService do
       end
 
       it "the project is a Form a MAT project" do
+        params = valid_parameters
+        params[:incoming_trust_ukprn] = nil
         result = described_class.new(params).call
 
         expect(result.form_a_mat?).to be true
@@ -264,23 +167,11 @@ RSpec.describe Api::Conversions::CreateProjectService do
     end
 
     context "when the new Trust Reference Number is not valid" do
-      let(:params) {
-        {
-          urn: 123456,
-          new_trust_reference_number: "12345",
-          new_trust_name: "The New Trust",
-          advisory_board_date: "2024-1-1",
-          advisory_board_conditions: "Some conditions",
-          provisional_conversion_date: "2025-1-1",
-          directive_academy_order: true,
-          created_by_email: "bob@education.gov.uk",
-          created_by_first_name: "Bob",
-          created_by_last_name: "Teacher",
-          prepare_id: 123456
-        }
-      }
-
       it "returns validation errors" do
+        params = valid_parameters
+        params[:incoming_trust_ukprn] = nil
+        params[:new_trust_reference_number] = "12345"
+
         expect { described_class.new(params).call }
           .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
             "New trust reference number The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234")
@@ -293,23 +184,11 @@ RSpec.describe Api::Conversions::CreateProjectService do
       end
 
       let(:user) { create(:regional_casework_services_user) }
-      let(:params) {
-        {
-          urn: 123456,
-          new_trust_reference_number: "TR12345",
-          new_trust_name: "The New Trust",
-          advisory_board_date: "2024-1-1",
-          advisory_board_conditions: "Some conditions",
-          provisional_conversion_date: "2025-1-1",
-          directive_academy_order: true,
-          created_by_email: "bob@education.gov.uk",
-          created_by_first_name: "Bob",
-          created_by_last_name: "Teacher",
-          prepare_id: 123456
-        }
-      }
 
       it "raises an error" do
+        params = valid_parameters
+        params[:incoming_trust_ukprn] = nil
+
         expect { described_class.new(params).call }
           .to raise_error(Api::Conversions::CreateProjectService::CreationError,
             "Conversion project could not be created via API, urn: 123456")
@@ -318,26 +197,14 @@ RSpec.describe Api::Conversions::CreateProjectService do
   end
 
   context "when the parameters are invalid" do
-    let(:params) {
-      {
-        urn: 1234567890,
-        new_trust_reference_number: "12345",
-        new_trust_name: "The New Trust",
-        advisory_board_date: "2024-1-1",
-        advisory_board_conditions: "Some conditions",
-        provisional_conversion_date: "2025-1-1",
-        directive_academy_order: true,
-        created_by_email: "bob@education.gov.uk",
-        created_by_first_name: "Bob",
-        created_by_last_name: "Teacher",
-        prepare_id: 123456
-      }
-    }
-
     it "does not attempt to find or create a user" do
       allow(User).to receive(:find_or_create_by).and_call_original
+      params = valid_parameters
+      params[:incoming_trust_ukprn] = nil
+      params[:urn] = 1234
 
-      expect { described_class.new(params).call }.to raise_error(Api::Conversions::CreateProjectService::ValidationError)
+      expect { described_class.new(params).call }
+        .to raise_error(Api::Conversions::CreateProjectService::ValidationError)
       expect(User).not_to have_received(:find_or_create_by)
     end
   end

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -207,6 +207,21 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
     end
   end
 
+  describe "form a MAT projects" do
+    it "creates a new form a MAT project" do
+      params = valid_transfer_parameters
+      params[:incoming_trust_ukprn] = nil
+
+      subject = described_class.new(params).call
+      expect(subject).to be_a Transfer::Project
+      expect(subject.persisted?).to be true
+
+      expect(subject.urn).to eql 123456
+      expect(subject.transfer_date).to eql Date.new(2025, 1, 1)
+      expect(subject.form_a_mat?).to be true
+    end
+  end
+
   describe "groups" do
     context "when there is a group id" do
       context "when the group does not exist" do


### PR DESCRIPTION
This work allows the API to create grouped projects by accepting the group
identifier from Prepare.

Along the way we update and refactor some specs.

[Task 180539](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/180539?McasTsid=26110&McasCtx=4): Update existing API calls to find or create project groups

