### PR TITLE
(181801) Show the MP's display name with title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- The MP's name is now their full name with title (e.g. The Right Honourable)
+
 ## [Release-89][release-89]
 
 ### Changed

--- a/app/models/api/persons/member_details.rb
+++ b/app/models/api/persons/member_details.rb
@@ -5,10 +5,11 @@ class Api::Persons::MemberDetails
     @first_name = args["firstName"]
     @last_name = args["lastName"]
     @email = args["email"]
+    @name_with_title = args["displayNameWithTitle"]
   end
 
   def name
-    "#{@first_name} #{@last_name}"
+    @name_with_title
   end
 
   # In the application context, all MPs have this address

--- a/spec/features/external_contacts/users_can_view_external_contacts_spec.rb
+++ b/spec/features/external_contacts/users_can_view_external_contacts_spec.rb
@@ -51,14 +51,14 @@ RSpec.feature "Users can view external contacts" do
   end
 
   scenario "if a project has a member of parliament, the MP is shown" do
-    member_details = Api::Persons::MemberDetails.new({firstName: "Robert", lastName: "Minister", email: "ministerr@parliament.gov.uk"}.with_indifferent_access)
+    member_details = Api::Persons::MemberDetails.new({firstName: "Robert", lastName: "Minister", displayNameWithTitle: "The Right Honourable Firstname Lastname", email: "ministerr@parliament.gov.uk"}.with_indifferent_access)
 
     allow_any_instance_of(Project).to receive(:member_of_parliament).and_return(member_details)
 
     visit project_contacts_path(project)
 
     expect(page).to have_content("Parliamentary contacts")
-    expect(page).to have_content("Robert Minister")
+    expect(page).to have_content("The Right Honourable Firstname Lastname")
     expect(page).to have_content("ministerr@parliament.gov.uk")
   end
 end

--- a/spec/models/api/persons/client_spec.rb
+++ b/spec/models/api/persons/client_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Api::Persons::Client do
 
           member = result.object
 
-          expect(member.name).to eql "First Last"
+          expect(member.name).to eql "The Right Honourable Firstname Lastname"
           expect(member.email).to eql "lastf@parliament.gov.uk"
         end
       end
@@ -87,7 +87,7 @@ RSpec.describe Api::Persons::Client do
 
         expect(Rails.cache).to have_received(:write).once
 
-        expect(member.name).to eql "First Last"
+        expect(member.name).to eql "The Right Honourable Firstname Lastname"
         expect(member.email).to eql "lastf@parliament.gov.uk"
       end
     end

--- a/spec/models/api/persons/member_details_spec.rb
+++ b/spec/models/api/persons/member_details_spec.rb
@@ -5,13 +5,14 @@ RSpec.describe Api::Persons::MemberDetails do
     described_class.new({
       firstName: "First",
       lastName: "Last",
-      email: "lastf@parliament.gov.uk"
+      email: "lastf@parliament.gov.uk",
+      displayNameWithTitle: "The Right Honourable Firstname Lastname"
     }.with_indifferent_access)
   end
 
   describe "#name" do
     it "returns the full name of the member of parliament" do
-      expect(member.name).to eql "First Last"
+      expect(member.name).to eql "The Right Honourable Firstname Lastname"
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe Project, type: :model do
       mock_successful_persons_api_client
 
       expect(project.member_of_parliament).to be_a Api::Persons::MemberDetails
-      expect(project.member_of_parliament.name).to eql "First Last"
+      expect(project.member_of_parliament.name).to eql "The Right Honourable Firstname Lastname"
     end
 
     it "only goes to the API once per instance of Project" do

--- a/spec/presenters/export/csv/mp_presenter_module_spec.rb
+++ b/spec/presenters/export/csv/mp_presenter_module_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Export::Csv::MpPresenterModule do
     before { mock_successful_persons_api_client }
 
     it "presents the name" do
-      expect(subject.mp_name).to eql "First Last"
+      expect(subject.mp_name).to eql "The Right Honourable Firstname Lastname"
     end
 
     it "presents the email" do

--- a/spec/requests/member_of_parliament_controller_spec.rb
+++ b/spec/requests/member_of_parliament_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe MemberOfParliamentController, type: :request do
       it "includes the members details" do
         get project_mp_path(project)
 
-        expect(response.body).to include("First Last")
+        expect(response.body).to include("The Right Honourable Firstname Lastname")
         expect(response.body).to include("lastf@parliament.gov.uk")
       end
     end
@@ -43,6 +43,7 @@ def test_successful_persons_api_call
   member = Api::Persons::MemberDetails.new({
     firstName: "First",
     lastName: "Last",
+    displayNameWithTitle: "The Right Honourable Firstname Lastname",
     email: "lastf@parliament.gov.uk"
   }.with_indifferent_access)
 

--- a/spec/support/persons_api_helpers.rb
+++ b/spec/support/persons_api_helpers.rb
@@ -18,6 +18,7 @@ module PersonsApiHelpers
           [200, nil, {
             firstName: "First",
             lastName: "Last",
+            displayNameWithTitle: "The Right Honourable Firstname Lastname",
             email: "lastf@parliament.gov.uk"
           }.to_json]
         end
@@ -47,7 +48,7 @@ module PersonsApiHelpers
 
   def mock_successful_persons_api_client
     member = Api::Persons::MemberDetails.new(
-      {firstName: "First", lastName: "Last", email: "lastf@parliament.gov.uk"}.with_indifferent_access
+      {firstName: "First", lastName: "Last", displayNameWithTitle: "The Right Honourable Firstname Lastname", email: "lastf@parliament.gov.uk"}.with_indifferent_access
     )
     result = Api::Persons::Client::Result.new(member, nil)
     client = Api::Persons::Client.new


### PR DESCRIPTION
The consumers of the exports want to address their letters to MPs using the MP's full name & title (e.g. the Right Honourable). We can get this from the Persons API as `displayNameWithTitle`

Keep the first & last name for now in case we still need to use these elsewhere.

