### PR TITLE
Add validaton to new projects on API

### DIFF
--- a/app/services/api/base_create_project_service.rb
+++ b/app/services/api/base_create_project_service.rb
@@ -7,18 +7,18 @@ class Api::BaseCreateProjectService
 
   class ValidationError < StandardError; end
 
-  attribute :urn
-  attribute :incoming_trust_ukprn
+  attribute :urn, :integer
+  attribute :incoming_trust_ukprn, :integer
   attribute :advisory_board_date, :date
-  attribute :advisory_board_conditions
-  attribute :directive_academy_order
-  attribute :created_by_email
-  attribute :created_by_first_name
-  attribute :created_by_last_name
-  attribute :new_trust_reference_number
-  attribute :new_trust_name
-  attribute :group_id
-  attribute :prepare_id
+  attribute :advisory_board_conditions, :string
+  attribute :directive_academy_order, :boolean
+  attribute :created_by_email, :string
+  attribute :created_by_first_name, :string
+  attribute :created_by_last_name, :string
+  attribute :new_trust_reference_number, :string
+  attribute :new_trust_name, :string
+  attribute :group_id, :string
+  attribute :prepare_id, :integer
 
   validates :urn, presence: true, urn: true
   validate :establishment_exists, if: -> { urn.present? }

--- a/app/services/api/base_create_project_service.rb
+++ b/app/services/api/base_create_project_service.rb
@@ -21,6 +21,8 @@ class Api::BaseCreateProjectService
   attribute :prepare_id
 
   validates :urn, presence: true, urn: true
+  validates_with UrnUniqueForApiValidator
+
   validates :incoming_trust_ukprn, ukprn: true, if: -> { incoming_trust_ukprn.present? }
   validates :new_trust_reference_number, trust_reference_number: true, if: -> { new_trust_reference_number.present? }
   validates :new_trust_name, presence: true, if: -> { new_trust_reference_number.present? }

--- a/app/services/api/base_create_project_service.rb
+++ b/app/services/api/base_create_project_service.rb
@@ -9,7 +9,7 @@ class Api::BaseCreateProjectService
 
   attribute :urn
   attribute :incoming_trust_ukprn
-  attribute :advisory_board_date
+  attribute :advisory_board_date, :date
   attribute :advisory_board_conditions
   attribute :directive_academy_order
   attribute :created_by_email
@@ -26,6 +26,9 @@ class Api::BaseCreateProjectService
 
   validates :incoming_trust_ukprn, ukprn: true, if: -> { incoming_trust_ukprn.present? }
   validate :trust_exists, if: -> { incoming_trust_ukprn.present? }
+
+  validates :advisory_board_date, presence: true
+  validates :advisory_board_date, date_in_the_past: true
 
   validates :new_trust_reference_number, trust_reference_number: true, if: -> { new_trust_reference_number.present? }
   validates :new_trust_name, presence: true, if: -> { new_trust_reference_number.present? }

--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -1,5 +1,5 @@
 class Api::Conversions::CreateProjectService < Api::BaseCreateProjectService
-  attribute :provisional_conversion_date
+  attribute :provisional_conversion_date, :date
 
   def call
     if valid?

--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -1,6 +1,8 @@
 class Api::Conversions::CreateProjectService < Api::BaseCreateProjectService
   attribute :provisional_conversion_date, :date
 
+  validates :provisional_conversion_date, first_day_of_month: true
+
   def call
     if valid?
       user = find_or_create_user

--- a/app/services/api/transfers/create_project_service.rb
+++ b/app/services/api/transfers/create_project_service.rb
@@ -6,6 +6,8 @@ class Api::Transfers::CreateProjectService < Api::BaseCreateProjectService
   attribute :financial_safeguarding_governance_issues, :boolean
   attribute :outgoing_trust_to_close, :boolean
 
+  validates :provisional_transfer_date, first_day_of_month: true
+
   validates :outgoing_trust_ukprn, ukprn: true, if: -> { outgoing_trust_ukprn.present? }
   validate :outgoing_trust_exists, if: -> { outgoing_trust_ukprn.present? }
 

--- a/app/services/api/transfers/create_project_service.rb
+++ b/app/services/api/transfers/create_project_service.rb
@@ -5,9 +5,6 @@ class Api::Transfers::CreateProjectService < Api::BaseCreateProjectService
   attribute :inadequate_ofsted, :boolean
   attribute :financial_safeguarding_governance_issues, :boolean
   attribute :outgoing_trust_to_close, :boolean
-  attribute :new_trust_reference_number, :string
-  attribute :new_trust_name, :string
-  attribute :group_id, :string
 
   def call
     if valid?

--- a/app/validators/urn_unique_for_api_validator.rb
+++ b/app/validators/urn_unique_for_api_validator.rb
@@ -1,0 +1,13 @@
+class UrnUniqueForApiValidator < ActiveModel::Validator
+  def validate(record)
+    return unless record.urn.present?
+
+    if record.is_a?(Api::Conversions::CreateProjectService)
+      record.errors.add(:urn, :duplicate) if Conversion::Project.where(urn: record.urn, state: [:active, :inactive]).any?
+    end
+
+    if record.is_a?(Api::Transfers::CreateProjectService)
+      record.errors.add(:urn, :duplicate) if Transfer::Project.where(urn: record.urn, state: [:active, :inactive]).any?
+    end
+  end
+end

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -132,5 +132,6 @@ en:
         blank: Enter a month and year for the provisional conversion date, like 9 2023
         invalid: Enter a month and year for the provisional conversion date, like 9 2023
         must_be_in_the_future: Provisional conversion date must be in the future
+        must_be_first_of_the_month: must be on the first of the month
       academy_urn:
         matching_school_urn: Academy URN cannot be the same as the school URN

--- a/config/locales/transfer_project.en.yml
+++ b/config/locales/transfer_project.en.yml
@@ -123,6 +123,7 @@ en:
         blank: Enter a month and year for the provisional transfer date, like 9 2023
         must_be_in_the_future: Provisional transfer date must be in the future
         invalid: Enter a month and year for the provisional transfer date, like 9 2023
+        must_be_first_of_the_month: must be on the first of the month
       confirmed_transfer_date:
         invalid: Enter a valid month and year for the confirmed transfer date, like 9 2023
       outgoing_trust_sharepoint_link:

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe V1::Conversions do
 
         context "but the Academies API is not responding" do
           before do
-            mock_academies_api_establishment_not_found(urn: 121813)
+            mock_academies_api_establishment_error(urn: 121813)
           end
 
           it "returns an error" do
@@ -199,7 +199,7 @@ RSpec.describe V1::Conversions do
               as: :json,
               headers: {Apikey: "testkey"}
 
-            expect(response.body).to eq({error: "Failed to fetch establishment from Academies API during project creation, urn: 121813"}.to_json)
+            expect(response.body).to eq({error: "Failed to fetch establishment with URN: 121813 on Academies API"}.to_json)
             expect(response.status).to eq(500)
           end
         end

--- a/spec/api/v1/transfers_spec.rb
+++ b/spec/api/v1/transfers_spec.rb
@@ -189,8 +189,8 @@ RSpec.describe V1::Transfers do
               as: :json,
               headers: {Apikey: "testkey"}
 
-            expect(response.body).to eq({error: "Failed to fetch establishment from Academies API during project creation, urn: 123456"}.to_json)
-            expect(response.status).to eq(500)
+            expect(response.body).to eq({error: "An establishment with URN: 123456 could not be found on the Academies API"}.to_json)
+            expect(response.status).to eq(400)
           end
         end
       end

--- a/spec/api/v1/transfers_spec.rb
+++ b/spec/api/v1/transfers_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe V1::Transfers do
       created_by_last_name: regional_delivery_officer.last_name,
       inadequate_ofsted: true,
       financial_safeguarding_governance_issues: true,
-      outgoing_trust_ukprn: 567890,
+      outgoing_trust_ukprn: 12348765,
       outgoing_trust_to_close: true,
       prepare_id: 12345
     }
@@ -31,7 +31,7 @@ RSpec.describe V1::Transfers do
       created_by_last_name: regional_delivery_officer.last_name,
       inadequate_ofsted: true,
       financial_safeguarding_governance_issues: true,
-      outgoing_trust_ukprn: 567890,
+      outgoing_trust_ukprn: 12348765,
       outgoing_trust_to_close: true,
       prepare_id: 12345,
       new_trust_reference_number: "TR12345",

--- a/spec/models/project_group_spec.rb
+++ b/spec/models/project_group_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ProjectGroup, type: :model do
 
       mock_academies_api_trust_not_found(ukprn: subject.trust_ukprn)
 
-      expect(subject.trust.original_name).to eql "Could not find trust for UKPRN 1234567"
+      expect(subject.trust.original_name).to eql "Test Academies API not found error"
     end
 
     it "only calls the API once" do

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -5,207 +5,86 @@ RSpec.describe Api::Conversions::CreateProjectService do
     mock_successful_api_response_to_create_any_project
   end
 
-  def valid_parameters
-    {
-      urn: 123456,
-      incoming_trust_ukprn: 10066123,
-      new_trust_reference_number: "TR12345",
-      new_trust_name: "The New Trust",
-      advisory_board_date: "2024-1-1",
-      advisory_board_conditions: "Some conditions",
-      provisional_conversion_date: "2025-1-1",
-      directive_academy_order: true,
-      created_by_email: "test.user@education.gov.uk",
-      created_by_first_name: "Test",
-      created_by_last_name: "User",
-      prepare_id: 123456
-    }
+  subject { described_class.new(valid_parameters).call }
+
+  it "creates a new project" do
+    expect(subject).to be_a Conversion::Project
+    expect(subject.persisted?).to be true
+
+    expect(subject.urn).to eql 123456
+    expect(subject.conversion_date).to eql Date.new(2025, 1, 1)
   end
 
-  context "a 'regular' Conversion project" do
-    context "when the params contain details for an existing user" do
-      let(:user) { create(:regional_casework_services_user) }
+  it "creates the tasks data for the project" do
+    tasks_data = subject.tasks_data
 
-      it "creates the project using the existing user" do
-        result = described_class.new(valid_parameters).call
+    expect(tasks_data).to be_a Conversion::TasksData
+    expect(tasks_data.persisted?).to be true
+  end
 
-        expect(result).to be_a(Conversion::Project)
-        expect(result.id).to eq(Conversion::Project.last.id)
-      end
+  it "creates the user to attribute the project to i.e the 'Regional Delivery Officer'" do
+    user = subject.regional_delivery_officer
 
-      it "creates a TasksData and assigns it to the project" do
-        result = described_class.new(valid_parameters).call
-        tasks_data = Conversion::TasksData.last
+    expect(user.persisted?).to be true
+    expect(user.email).to eql "test.user@education.gov.uk"
+  end
 
-        expect(result).to be_a(Conversion::Project)
-        expect(result.tasks_data).to eq(tasks_data)
-      end
+  it "sets the project region to be the same as the establishment region" do
+    expect(subject.region).to eql "west_midlands"
+  end
 
-      it "sets the project region to be the same as the establishment region" do
-        result = described_class.new(valid_parameters).call
+  it "creates the user in the same regional team as the project establishment" do
+    user = subject.regional_delivery_officer
 
-        expect(result.region).to eq("west_midlands")
-      end
+    expect(user.team).to eql "west_midlands"
+  end
 
-      it "saves the Prepare ID on the project" do
-        result = described_class.new(valid_parameters).call
+  it "saves the Prepare ID on the project" do
+    expect(subject.prepare_id).to eq(123456)
+  end
 
-        expect(result.prepare_id).to eq(123456)
-      end
+  it "sets the initial state to be 'inactive'" do
+    expect(subject.state).to eq("inactive")
+  end
 
-      it "sets the initial state to be 'inactive'" do
-        result = described_class.new(valid_parameters).call
+  context "when a user exists with the same email address" do
+    it "assigns that user to the project and does not create another" do
+      existing_user = create(
+        :user,
+        email: "test.user@education.gov.uk",
+        first_name: "Test",
+        last_name: "Last",
+        team: :london
+      )
+      user = subject.regional_delivery_officer
 
-        expect(result.state).to eq("inactive")
-      end
-    end
-
-    context "when the params contain details for an unknown user" do
-      it "creates the project and a new user" do
-        params = valid_parameters
-
-        result = described_class.new(params).call
-        new_user = User.find_by(email: "test.user@education.gov.uk")
-
-        expect(result).to be_a(Conversion::Project)
-        expect(result.id).to eq(Conversion::Project.last.id)
-        expect(result.regional_delivery_officer_id).to eq(new_user.id)
-      end
-
-      it "puts the new user in the same regional team as the establishment" do
-        project = described_class.new(valid_parameters).call
-        new_user = User.find_by(email: "test.user@education.gov.uk")
-
-        expect(new_user.team).to eq(project.region)
-      end
-    end
-
-    context "when the user's email is not valid" do
-      it "returns an error" do
-        params = valid_parameters
-        params[:created_by_email] = "test@school.uk"
-
-        expect { described_class.new(params).call }
-          .to raise_error(Api::Conversions::CreateProjectService::CreationError,
-            "Failed to save user during API project creation, urn: 123456")
-      end
-    end
-
-    context "when the URN or UKPRN are not valid" do
-      it "returns validation errors" do
-        params = valid_parameters
-        params[:urn] = 100
-        params[:incoming_trust_ukprn] = 123
-
-        expect { described_class.new(params).call }
-          .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
-            "Urn URN must be 6 digits long. For example, 123456. Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678.")
-      end
-    end
-
-    context "when the Prepare ID is missing" do
-      it "returns validation errors" do
-        params = valid_parameters
-        params[:prepare_id] = nil
-
-        expect { described_class.new(params).call }
-          .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
-            "Prepare You must supply a Prepare ID when creating a project via the API")
-      end
-    end
-
-    context "when the Academies API returns an error on fetching the establishment" do
-      let(:user) { create(:regional_casework_services_user) }
-
-      before do
-        mock_academies_api_establishment_not_found(urn: 123456)
-      end
-
-      it "returns an error" do
-        expect { described_class.new(valid_parameters).call }
-          .to raise_error(Api::Conversions::CreateProjectService::CreationError,
-            "Failed to fetch establishment from Academies API during project creation, urn: 123456")
-      end
-    end
-
-    context "when the project save fails for an unknown reason" do
-      before do
-        allow_any_instance_of(Conversion::Project).to receive(:save).and_return(nil)
-      end
-
-      let(:user) { create(:regional_casework_services_user) }
-
-      it "returns an error" do
-        expect { described_class.new(valid_parameters).call }
-          .to raise_error(Api::Conversions::CreateProjectService::CreationError,
-            "Conversion project could not be created via API, urn: 123456")
-      end
+      expect(user).to eql existing_user
+      expect(User.count).to be 1
     end
   end
 
-  context "a Form a MAT Conversion project" do
-    context "when the params contain details for an existing user" do
-      let(:user) { create(:regional_casework_services_user) }
-
-      it "creates the project using the existing user" do
-        params = valid_parameters
-        params[:incoming_trust_ukprn] = nil
-
-        result = described_class.new(params).call
-
-        expect(result).to be_a(Conversion::Project)
-        expect(result.id).to eq(Conversion::Project.last.id)
-      end
-
-      it "the project is a Form a MAT project" do
-        params = valid_parameters
-        params[:incoming_trust_ukprn] = nil
-        result = described_class.new(params).call
-
-        expect(result.form_a_mat?).to be true
-      end
-    end
-
-    context "when the new Trust Reference Number is not valid" do
-      it "returns validation errors" do
-        params = valid_parameters
-        params[:incoming_trust_ukprn] = nil
-        params[:new_trust_reference_number] = "12345"
-
-        expect { described_class.new(params).call }
-          .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
-            "New trust reference number The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234")
-      end
-    end
-
-    context "when the project cannot be saved" do
-      before do
-        allow_any_instance_of(Conversion::Project).to receive(:save).and_return(nil)
-      end
-
-      let(:user) { create(:regional_casework_services_user) }
-
-      it "raises an error" do
-        params = valid_parameters
-        params[:incoming_trust_ukprn] = nil
-
-        expect { described_class.new(params).call }
-          .to raise_error(Api::Conversions::CreateProjectService::CreationError,
-            "Conversion project could not be created via API, urn: 123456")
-      end
-    end
-  end
-
-  context "when the parameters are invalid" do
-    it "does not attempt to find or create a user" do
-      allow(User).to receive(:find_or_create_by).and_call_original
+  context "when the user's email is not valid i.e. not @education.gov.uk" do
+    it "raises an error" do
       params = valid_parameters
-      params[:incoming_trust_ukprn] = nil
-      params[:urn] = 1234
+      params[:created_by_email] = "invalid@example.com"
 
       expect { described_class.new(params).call }
-        .to raise_error(Api::Conversions::CreateProjectService::ValidationError)
-      expect(User).not_to have_received(:find_or_create_by)
+        .to raise_error(Api::Conversions::CreateProjectService::CreationError)
+    end
+  end
+
+  describe "a Form a MAT Conversion project" do
+    it "saves the new trust details" do
+      expect(subject.new_trust_reference_number).to eql "TR12345"
+      expect(subject.new_trust_name).to eql "A new trust"
+    end
+
+    it "the project is a Form a MAT project" do
+      params = valid_parameters
+      params[:incoming_trust_ukprn] = nil
+      result = described_class.new(params).call
+
+      expect(result.form_a_mat?).to be true
     end
   end
 
@@ -270,7 +149,46 @@ RSpec.describe Api::Conversions::CreateProjectService do
   end
 
   describe "validations" do
-    context "when there is a in progress conversion project with the same URN" do
+    context "when the URN is not invalid" do
+      it "raises an error" do
+        params = valid_parameters
+        params[:urn] = 123
+
+        expect { described_class.new(params).call }
+          .to raise_error(
+            Api::Conversions::CreateProjectService::ValidationError,
+            "Urn URN must be 6 digits long. For example, 123456."
+          )
+      end
+    end
+
+    context "when the incoming trust UKPRN is invalid" do
+      it "raises an error" do
+        params = valid_parameters
+        params[:incoming_trust_ukprn] = 87654321
+
+        expect { described_class.new(params).call }
+          .to raise_error(
+            Api::Conversions::CreateProjectService::ValidationError,
+            "Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678."
+          )
+      end
+    end
+
+    context "when the Prepare ID is missing" do
+      it "raises an error" do
+        params = valid_parameters
+        params[:prepare_id] = nil
+
+        expect { described_class.new(params).call }
+          .to raise_error(
+            Api::Conversions::CreateProjectService::ValidationError,
+            "Prepare You must supply a Prepare ID when creating a project via the API"
+          )
+      end
+    end
+
+    context "when there is a in progress transfer project with the same URN" do
       it "raises an error" do
         create(:conversion_project, urn: 123456)
 
@@ -281,5 +199,80 @@ RSpec.describe Api::Conversions::CreateProjectService do
           )
       end
     end
+
+    context "when the parameters are invalid" do
+      it "does not attempt to find or create a user" do
+        allow(User).to receive(:find_or_create_by).and_call_original
+        params = valid_parameters
+        params[:incoming_trust_ukprn] = nil
+        params[:urn] = 1234
+
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError)
+        expect(User).not_to have_received(:find_or_create_by)
+      end
+    end
+
+    context "when the new Trust Reference Number is not valid" do
+      it "returns validation errors" do
+        params = valid_parameters
+        params[:incoming_trust_ukprn] = nil
+        params[:new_trust_reference_number] = "12345"
+
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
+            "New trust reference number The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234")
+      end
+    end
+  end
+
+  describe "errors" do
+    context "when the Academies API returns an error on fetching the establishment" do
+      let(:user) { create(:regional_casework_services_user) }
+
+      before do
+        mock_academies_api_establishment_not_found(urn: 123456)
+      end
+
+      it "returns an error" do
+        expect { described_class.new(valid_parameters).call }
+          .to raise_error(Api::Conversions::CreateProjectService::CreationError,
+            "Failed to fetch establishment from Academies API during project creation, urn: 123456")
+      end
+    end
+
+    context "when the project cannot be saved" do
+      before do
+        allow_any_instance_of(Conversion::Project).to receive(:save).and_return(nil)
+      end
+
+      let(:user) { create(:regional_casework_services_user) }
+
+      it "raises an error" do
+        params = valid_parameters
+        params[:incoming_trust_ukprn] = nil
+
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Conversions::CreateProjectService::CreationError,
+            "Conversion project could not be created via API, urn: 123456")
+      end
+    end
+  end
+
+  def valid_parameters
+    {
+      urn: 123456,
+      incoming_trust_ukprn: 10066123,
+      new_trust_reference_number: "TR12345",
+      new_trust_name: "A new trust",
+      advisory_board_date: "2024-1-1",
+      advisory_board_conditions: "Some conditions",
+      provisional_conversion_date: "2025-1-1",
+      directive_academy_order: true,
+      created_by_email: "test.user@education.gov.uk",
+      created_by_first_name: "Test",
+      created_by_last_name: "User",
+      prepare_id: 123456
+    }
   end
 end

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -187,6 +187,18 @@ RSpec.describe Api::Conversions::CreateProjectService do
       end
     end
 
+    context "when the trust for the incoming trust UKPRN cannot be found" do
+      before { mock_academies_api_trust_not_found(ukprn: 10066123) }
+
+      it "raises an error" do
+        expect { described_class.new(valid_parameters).call }
+          .to raise_error(
+            Api::Conversions::CreateProjectService::ValidationError,
+            "A trust with UKPRN: 10066123 could not be found on the Academies API"
+          )
+      end
+    end
+
     context "when the Prepare ID is missing" do
       it "raises an error" do
         params = valid_parameters
@@ -250,6 +262,20 @@ RSpec.describe Api::Conversions::CreateProjectService do
         expect { described_class.new(valid_parameters).call }
           .to raise_error(Api::Conversions::CreateProjectService::CreationError,
             "Failed to fetch establishment with URN: 123456 on Academies API")
+      end
+    end
+
+    context "when the Academies API returns an error on fetching the incoming trust" do
+      before do
+        mock_academies_api_trust_error(ukprn: 10066123)
+      end
+
+      it "raises an error" do
+        expect { described_class.new(valid_parameters).call }
+          .to raise_error(
+            Api::Transfers::CreateProjectService::CreationError,
+            "Failed to fetch trust with UKPRN: 10066123 on Academies API"
+          )
       end
     end
 

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -268,4 +268,18 @@ RSpec.describe Api::Conversions::CreateProjectService do
       end
     end
   end
+
+  describe "validations" do
+    context "when there is a in progress conversion project with the same URN" do
+      it "raises an error" do
+        create(:conversion_project, urn: 123456)
+
+        expect { described_class.new(valid_parameters).call }
+          .to raise_error(
+            Api::Transfers::CreateProjectService::ValidationError,
+            "Urn There is already an in-progress project with this URN"
+          )
+      end
+    end
+  end
 end

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Api::Conversions::CreateProjectService do
   end
 
   describe "validations" do
-    context "when the URN is not invalid" do
+    context "when the URN is invalid" do
       it "raises an error" do
         params = valid_parameters
         params[:urn] = 123

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -259,6 +259,17 @@ RSpec.describe Api::Conversions::CreateProjectService do
             "Advisory board date The advisory board date must be in the past")
       end
     end
+
+    context "when the provisional conversion date is not on the 1st" do
+      it "raises a validation error" do
+        params = valid_parameters
+        params[:provisional_conversion_date] = "2024-1-2"
+
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
+            "Provisional conversion date must be on the first of the month")
+      end
+    end
   end
 
   describe "errors" do

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -162,6 +162,18 @@ RSpec.describe Api::Conversions::CreateProjectService do
       end
     end
 
+    context "when the establishment for the URN cannot be found" do
+      before { mock_academies_api_establishment_not_found(urn: 123456) }
+
+      it "raises an error" do
+        expect { described_class.new(valid_parameters).call }
+          .to raise_error(
+            Api::Conversions::CreateProjectService::ValidationError,
+            "An establishment with URN: 123456 could not be found on the Academies API"
+          )
+      end
+    end
+
     context "when the incoming trust UKPRN is invalid" do
       it "raises an error" do
         params = valid_parameters
@@ -231,13 +243,13 @@ RSpec.describe Api::Conversions::CreateProjectService do
       let(:user) { create(:regional_casework_services_user) }
 
       before do
-        mock_academies_api_establishment_not_found(urn: 123456)
+        mock_academies_api_establishment_error(urn: 123456)
       end
 
       it "returns an error" do
         expect { described_class.new(valid_parameters).call }
           .to raise_error(Api::Conversions::CreateProjectService::CreationError,
-            "Failed to fetch establishment from Academies API during project creation, urn: 123456")
+            "Failed to fetch establishment with URN: 123456 on Academies API")
       end
     end
 

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -248,6 +248,17 @@ RSpec.describe Api::Conversions::CreateProjectService do
             "New trust reference number The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234")
       end
     end
+
+    context "when the advisory board date is in the future" do
+      it "raises a validation error" do
+        params = valid_parameters
+        params[:advisory_board_date] = Date.today + 2.years
+
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
+            "Advisory board date The advisory board date must be in the past")
+      end
+    end
   end
 
   describe "errors" do

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -259,6 +259,17 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
             "New trust reference number The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234")
       end
     end
+
+    context "when the advisory board date is in the future" do
+      it "raises a validation error" do
+        params = valid_parameters
+        params[:advisory_board_date] = Date.today + 2.years
+
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
+            "Advisory board date The advisory board date must be in the past")
+      end
+    end
   end
 
   describe "errors" do

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -173,6 +173,18 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
       end
     end
 
+    context "when the establishment for the URN cannot be found" do
+      before { mock_academies_api_establishment_not_found(urn: 123456) }
+
+      it "raises an error" do
+        expect { described_class.new(valid_parameters).call }
+          .to raise_error(
+            Api::Transfers::CreateProjectService::ValidationError,
+            "An establishment with URN: 123456 could not be found on the Academies API"
+          )
+      end
+    end
+
     context "when the incoming trust UKPRN is invalid" do
       it "raises an error" do
         params = valid_parameters
@@ -240,7 +252,7 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
   describe "errors" do
     context "when the Academies API returns an error on fetching the establishment" do
       before do
-        mock_establishment_not_found(urn: 123456)
+        mock_academies_api_establishment_error(urn: 123456)
       end
 
       it "returns an error" do
@@ -250,7 +262,7 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
         expect { described_class.new(params).call }
           .to raise_error(
             Api::Transfers::CreateProjectService::CreationError,
-            "Failed to fetch establishment from Academies API during project creation, urn: 123456"
+            "Failed to fetch establishment with URN: 123456 on Academies API"
           )
       end
     end

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
   end
 
   describe "validations" do
-    context "when the URN is not invalid" do
+    context "when the URN is invalid" do
       it "raises an error" do
         params = valid_parameters
         params[:urn] = 123

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -298,6 +298,17 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
             "Advisory board date The advisory board date must be in the past")
       end
     end
+
+    context "when the provisional transfer date is not on the 1st" do
+      it "raises a validation error" do
+        params = valid_parameters
+        params[:provisional_transfer_date] = "2024-1-2"
+
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
+            "Provisional transfer date must be on the first of the month")
+      end
+    end
   end
 
   describe "errors" do

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -145,6 +145,18 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
           )
       end
     end
+
+    context "when there is a in progress transfer project with the same URN" do
+      it "raises an error" do
+        create(:transfer_project, urn: 123456)
+
+        expect { described_class.new(valid_transfer_parameters).call }
+          .to raise_error(
+            Api::Transfers::CreateProjectService::ValidationError,
+            "Urn There is already an in-progress project with this URN"
+          )
+      end
+    end
   end
 
   describe "errors" do

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -198,6 +198,18 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
       end
     end
 
+    context "when the trust for the incoming trust UKPRN cannot be found" do
+      before { mock_academies_api_trust_not_found(ukprn: 10066123) }
+
+      it "raises an error" do
+        expect { described_class.new(valid_parameters).call }
+          .to raise_error(
+            Api::Transfers::CreateProjectService::ValidationError,
+            "A trust with UKPRN: 10066123 could not be found on the Academies API"
+          )
+      end
+    end
+
     context "when the Prepare ID is missing" do
       it "raises an error" do
         params = valid_parameters
@@ -255,7 +267,7 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
         mock_academies_api_establishment_error(urn: 123456)
       end
 
-      it "returns an error" do
+      it "raises an error" do
         params = valid_parameters
         params[:urn] = 123456
 
@@ -263,6 +275,20 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
           .to raise_error(
             Api::Transfers::CreateProjectService::CreationError,
             "Failed to fetch establishment with URN: 123456 on Academies API"
+          )
+      end
+    end
+
+    context "when the Academies API returns an error on fetching the incoming trust" do
+      before do
+        mock_academies_api_trust_error(ukprn: 10066123)
+      end
+
+      it "raises an error" do
+        expect { described_class.new(valid_parameters).call }
+          .to raise_error(
+            Api::Transfers::CreateProjectService::CreationError,
+            "Failed to fetch trust with UKPRN: 10066123 on Academies API"
           )
       end
     end

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -1,33 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Api::Transfers::CreateProjectService, type: :model do
-  def valid_transfer_parameters
-    {
-      urn: 123456,
-      incoming_trust_ukprn: 10066123,
-      outgoing_trust_ukprn: 10010324,
-      advisory_board_date: "2024-1-1",
-      advisory_board_conditions: "Some conditions",
-      provisional_transfer_date: "2025-1-1",
-      directive_academy_order: true,
-      created_by_email: "test.user@education.gov.uk",
-      created_by_first_name: "Test",
-      created_by_last_name: "User",
-      two_requires_improvement: true,
-      prepare_id: 123456,
-      inadequate_ofsted: true,
-      financial_safeguarding_governance_issues: true,
-      outgoing_trust_to_close: true,
-      new_trust_reference_number: "TR12345",
-      new_trust_name: "A new trust"
-    }
-  end
-
   before do
     mock_successful_api_response_to_create_any_project
   end
 
-  subject { described_class.new(valid_transfer_parameters).call }
+  subject { described_class.new(valid_parameters).call }
 
   it "creates a new project" do
     expect(subject).to be_a Transfer::Project
@@ -91,11 +69,26 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
 
   context "when the user's email is not valid i.e. not @education.gov.uk" do
     it "raises an error" do
-      params = valid_transfer_parameters
+      params = valid_parameters
       params[:created_by_email] = "invalid@example.com"
 
       expect { described_class.new(params).call }
         .to raise_error(Api::Transfers::CreateProjectService::CreationError)
+    end
+  end
+
+  describe "a Form a MAT Conversion project" do
+    it "saves the new trust details" do
+      expect(subject.new_trust_reference_number).to eql "TR12345"
+      expect(subject.new_trust_name).to eql "A new trust"
+    end
+
+    it "the project is a Form a MAT project" do
+      params = valid_parameters
+      params[:incoming_trust_ukprn] = nil
+      result = described_class.new(params).call
+
+      expect(result.form_a_mat?).to be true
     end
   end
 
@@ -106,10 +99,70 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
     end
   end
 
+  describe "groups" do
+    context "when there is a group id" do
+      context "when the group does not exist" do
+        it "creates the group and adds the project" do
+          params = valid_parameters
+          params[:group_id] = "GRP_00000001"
+
+          subject = described_class.new(params).call
+
+          expect(subject.group).to be_present
+          expect(subject.group.group_identifier).to eql "GRP_00000001"
+          expect(ProjectGroup.count).to be 1
+        end
+      end
+
+      context "but the id is not valid" do
+        it "is invalid" do
+          params = valid_parameters
+          params[:group_id] = "G0001"
+
+          subject = described_class.new(params)
+
+          expect(subject).to be_invalid
+        end
+      end
+
+      context "when the group already exists" do
+        it "adds the project without creating a new group" do
+          ProjectGroup.create(
+            group_identifier: "GRP_00000002",
+            trust_ukprn: 10066123
+          )
+          params = valid_parameters
+          params[:group_id] = "GRP_00000002"
+
+          subject = described_class.new(params).call
+
+          expect(subject.group).to be_present
+          expect(subject.group.group_identifier).to eql "GRP_00000002"
+          expect(ProjectGroup.count).to be 1
+        end
+
+        context "but the incoming trust UKPRN does not match the others in the group" do
+          it "is invalid" do
+            ProjectGroup.create(
+              group_identifier: "GRP_00000002",
+              trust_ukprn: 10000000
+            )
+            params = valid_parameters
+            params[:group_id] = "GRP_00000002"
+
+            subject = described_class.new(params)
+
+            expect(subject).to be_invalid
+          end
+        end
+      end
+    end
+  end
+
   describe "validations" do
     context "when the URN is not invalid" do
       it "raises an error" do
-        params = valid_transfer_parameters
+        params = valid_parameters
         params[:urn] = 123
 
         expect { described_class.new(params).call }
@@ -122,7 +175,7 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
 
     context "when the incoming trust UKPRN is invalid" do
       it "raises an error" do
-        params = valid_transfer_parameters
+        params = valid_parameters
         params[:incoming_trust_ukprn] = 87654321
 
         expect { described_class.new(params).call }
@@ -135,7 +188,7 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
 
     context "when the Prepare ID is missing" do
       it "raises an error" do
-        params = valid_transfer_parameters
+        params = valid_parameters
         params[:prepare_id] = nil
 
         expect { described_class.new(params).call }
@@ -150,11 +203,36 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
       it "raises an error" do
         create(:transfer_project, urn: 123456)
 
-        expect { described_class.new(valid_transfer_parameters).call }
+        expect { described_class.new(valid_parameters).call }
           .to raise_error(
             Api::Transfers::CreateProjectService::ValidationError,
             "Urn There is already an in-progress project with this URN"
           )
+      end
+    end
+
+    context "when the parameters are invalid" do
+      it "does not attempt to find or create a user" do
+        allow(User).to receive(:find_or_create_by).and_call_original
+        params = valid_parameters
+        params[:incoming_trust_ukprn] = nil
+        params[:urn] = 1234
+
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError)
+        expect(User).not_to have_received(:find_or_create_by)
+      end
+    end
+
+    context "when the new Trust Reference Number is not valid" do
+      it "returns validation errors" do
+        params = valid_parameters
+        params[:incoming_trust_ukprn] = nil
+        params[:new_trust_reference_number] = "12345"
+
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
+            "New trust reference number The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234")
       end
     end
   end
@@ -166,7 +244,7 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
       end
 
       it "returns an error" do
-        params = valid_transfer_parameters
+        params = valid_parameters
         params[:urn] = 123456
 
         expect { described_class.new(params).call }
@@ -183,7 +261,7 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
       end
 
       it "raises an error" do
-        params = valid_transfer_parameters
+        params = valid_parameters
         params[:urn] = 123456
 
         expect { described_class.new(params).call }
@@ -195,63 +273,25 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
     end
   end
 
-  describe "groups" do
-    context "when there is a group id" do
-      context "when the group does not exist" do
-        it "creates the group and adds the project" do
-          params = valid_transfer_parameters
-          params[:group_id] = "GRP_00000001"
-
-          subject = described_class.new(params).call
-
-          expect(subject.group).to be_present
-          expect(subject.group.group_identifier).to eql "GRP_00000001"
-          expect(ProjectGroup.count).to be 1
-        end
-      end
-
-      context "but the id is not valid" do
-        it "is invalid" do
-          params = valid_transfer_parameters
-          params[:group_id] = "G0001"
-
-          subject = described_class.new(params)
-
-          expect(subject).to be_invalid
-        end
-      end
-
-      context "when the group already exists" do
-        it "adds the project without creating a new group" do
-          ProjectGroup.create(
-            group_identifier: "GRP_00000002",
-            trust_ukprn: 10066123
-          )
-          params = valid_transfer_parameters
-          params[:group_id] = "GRP_00000002"
-
-          subject = described_class.new(params).call
-
-          expect(subject.group).to be_present
-          expect(subject.group.group_identifier).to eql "GRP_00000002"
-          expect(ProjectGroup.count).to be 1
-        end
-
-        context "but the incoming trust UKPRN does not match the others in the group" do
-          it "is invalid" do
-            ProjectGroup.create(
-              group_identifier: "GRP_00000002",
-              trust_ukprn: 10000000
-            )
-            params = valid_transfer_parameters
-            params[:group_id] = "GRP_00000002"
-
-            subject = described_class.new(params)
-
-            expect(subject).to be_invalid
-          end
-        end
-      end
-    end
+  def valid_parameters
+    {
+      urn: 123456,
+      incoming_trust_ukprn: 10066123,
+      outgoing_trust_ukprn: 10010324,
+      advisory_board_date: "2024-1-1",
+      advisory_board_conditions: "Some conditions",
+      provisional_transfer_date: "2025-1-1",
+      directive_academy_order: true,
+      created_by_email: "test.user@education.gov.uk",
+      created_by_first_name: "Test",
+      created_by_last_name: "User",
+      two_requires_improvement: true,
+      prepare_id: 123456,
+      inadequate_ofsted: true,
+      financial_safeguarding_governance_issues: true,
+      outgoing_trust_to_close: true,
+      new_trust_reference_number: "TR12345",
+      new_trust_name: "A new trust"
+    }
   end
 end

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -210,6 +210,34 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
       end
     end
 
+    context "when the outgoing trust UKPRN is invalid" do
+      it "raises an error" do
+        params = valid_parameters
+        params[:outgoing_trust_ukprn] = 87654321
+
+        expect { described_class.new(params).call }
+          .to raise_error(
+            Api::Transfers::CreateProjectService::ValidationError,
+            "Outgoing trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678."
+          )
+      end
+    end
+
+    context "when the trust for the outgoing trust UKPRN cannot be found" do
+      before { mock_academies_api_trust_not_found(ukprn: 12345678) }
+
+      it "raises an error" do
+        params = valid_parameters
+        params[:outgoing_trust_ukprn] = 12345678
+
+        expect { described_class.new(params).call }
+          .to raise_error(
+            Api::Transfers::CreateProjectService::ValidationError,
+            "A trust with UKPRN: 12345678 could not be found on the Academies API"
+          )
+      end
+    end
+
     context "when the Prepare ID is missing" do
       it "raises an error" do
         params = valid_parameters

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -136,7 +136,10 @@ module AcademiesApiHelpers
   # Not found
   def mock_academies_api_trust_not_found(ukprn:)
     mock_client = Api::AcademiesApi::Client.new
-    not_found_result = Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::NotFoundError.new(I18n.t("academies_api.get_trust.errors.not_found", ukprn: ukprn)))
+    not_found_result = Api::AcademiesApi::Client::Result.new(
+      nil,
+      Api::AcademiesApi::Client::NotFoundError.new("Test Academies API not found error")
+    )
     allow(mock_client).to receive(:get_trust).with(ukprn).and_return(not_found_result)
     allow(Api::AcademiesApi::Client).to receive(:new).and_return(mock_client)
   end
@@ -145,7 +148,8 @@ module AcademiesApiHelpers
   def mock_academies_api_trust_unauthorised(ukprn:)
     test_client = Api::AcademiesApi::Client.new
 
-    allow(test_client).to receive(:get_trust).with(ukprn).and_raise(Api::AcademiesApi::Client::UnauthorisedError)
+    allow(test_client).to receive(:get_trust).with(ukprn)
+      .and_raise(Api::AcademiesApi::Client::UnauthorisedError.new("Test Academies API unauthorised error"))
     allow(Api::AcademiesApi::Client).to receive(:new).and_return(test_client)
   end
 
@@ -153,7 +157,10 @@ module AcademiesApiHelpers
   def mock_academies_api_trust_error(ukprn:)
     test_client = Api::AcademiesApi::Client.new
 
-    allow(test_client).to receive(:get_trust).with(ukprn).and_return(Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::NotFoundError.new))
+    allow(test_client).to receive(:get_trust).with(ukprn).and_return(Api::AcademiesApi::Client::Result.new(
+      nil,
+      Api::AcademiesApi::Client::Error.new("Test Academies API error")
+    ))
     allow(Api::AcademiesApi::Client).to receive(:new).and_return(test_client)
   end
 end


### PR DESCRIPTION
This work sets out to update the validation applied when a new project is created via the API. Essentially the validation is the same as the manual process the form objects use, with slight variations.

There is a lot of duplication here which is to be expected as the objects work in similar ways with variations, the end goal is to get rid of the manual forms, so at that point a lot of the duplication goes away.

Along the way we tried to make the specs as clear and as similar as possible, but this is possibly subjective!
