### PR TITLE
Add email validation to the API services

### DIFF
--- a/app/services/api/base_create_project_service.rb
+++ b/app/services/api/base_create_project_service.rb
@@ -34,6 +34,9 @@ class Api::BaseCreateProjectService
   validates :new_trust_name, presence: true, if: -> { new_trust_reference_number.present? }
   validates :prepare_id, presence: true
 
+  validates :created_by_email, format: {with: /\A\S+@education.gov.uk\z/i}
+  validates :created_by_email, format: {with: URI::MailTo::EMAIL_REGEXP}
+
   validates_with GroupIdValidator
 
   def initialize(project_params)

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -149,8 +149,8 @@ RSpec.describe V1::Conversions do
               as: :json,
               headers: {Apikey: "testkey"}
 
-            expect(response.body).to eq({error: "Failed to save user during API project creation, urn: 121813"}.to_json)
-            expect(response.status).to eq(500)
+            expect(response.body).to eq({error: "Created by email is invalid"}.to_json)
+            expect(response.status).to eq(400)
           end
         end
 

--- a/spec/api/v1/transfers_spec.rb
+++ b/spec/api/v1/transfers_spec.rb
@@ -157,8 +157,8 @@ RSpec.describe V1::Transfers do
               as: :json,
               headers: {Apikey: "testkey"}
 
-            expect(response.body).to eq({error: "Failed to save user during API project creation, urn: 123456"}.to_json)
-            expect(response.status).to eq(500)
+            expect(response.body).to eq({error: "Created by email is invalid"}.to_json)
+            expect(response.status).to eq(400)
           end
         end
 

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Api::Conversions::CreateProjectService do
       params[:created_by_email] = "invalid@example.com"
 
       expect { described_class.new(params).call }
-        .to raise_error(Api::Conversions::CreateProjectService::CreationError)
+        .to raise_error(Api::Conversions::CreateProjectService::ValidationError)
     end
   end
 
@@ -315,6 +315,21 @@ RSpec.describe Api::Conversions::CreateProjectService do
         expect { described_class.new(params).call }
           .to raise_error(Api::Conversions::CreateProjectService::CreationError,
             "Conversion project could not be created via API, urn: 123456")
+      end
+    end
+
+    context "when the user cannot be saved" do
+      before do
+        allow(User).to receive(:find_or_create_by).and_raise(ActiveRecord::RecordInvalid)
+      end
+
+      it "raises an error" do
+        params = valid_parameters
+        params[:incoming_trust_ukprn] = nil
+
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Conversions::CreateProjectService::CreationError,
+            "Failed to save user during API project creation, urn: 123456")
       end
     end
   end

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
       params[:created_by_email] = "invalid@example.com"
 
       expect { described_class.new(params).call }
-        .to raise_error(Api::Transfers::CreateProjectService::CreationError)
+        .to raise_error(Api::Transfers::CreateProjectService::ValidationError)
     end
   end
 
@@ -357,6 +357,21 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
             Api::Transfers::CreateProjectService::CreationError,
             "Transfer project could not be created via API, urn: 123456"
           )
+      end
+    end
+
+    context "when the user cannot be saved" do
+      before do
+        allow(User).to receive(:find_or_create_by).and_raise(ActiveRecord::RecordInvalid)
+      end
+
+      it "raises an error" do
+        params = valid_parameters
+        params[:incoming_trust_ukprn] = nil
+
+        expect { described_class.new(params).call }
+          .to raise_error(Api::Transfers::CreateProjectService::CreationError,
+            "Failed to save user during API project creation, urn: 123456")
       end
     end
   end


### PR DESCRIPTION
When creating projects on the API we need an email address that must be
valid and at @education.gov.uk domain.

Previously the model validation would be applied but validating before
we try and create the user is far more preferable, returning 400 with a
validation error instead of 500.

