### PR TITLE
Refactor API specs

### DIFF
--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -1,49 +1,9 @@
 require "rails_helper"
 
 RSpec.describe V1::Conversions do
-  describe "get /" do
-    context "when there is no api key in the header" do
-      it "returns an Unauthorized error" do
-        get "/api/v1/projects/conversions"
-        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
-        expect(response.status).to eq(401)
-      end
-    end
+  before { mock_successful_api_response_to_create_any_project }
 
-    context "when there is an invalid api key in the header" do
-      it "returns an Unauthorized error" do
-        get "/api/v1/projects/conversions", headers: {ApiKey: "unknownkey"}
-        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
-        expect(response.status).to eq(401)
-      end
-    end
-
-    context "when there is an expired api key in the header" do
-      before do
-        ApiKey.create(api_key: "testkey", expires_at: Date.yesterday)
-      end
-
-      it "returns an Unauthorized error" do
-        get "/api/v1/projects/conversions", headers: {ApiKey: "testkey"}
-        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
-        expect(response.status).to eq(401)
-      end
-    end
-
-    context "when there is a valid api key in the header" do
-      before do
-        ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow)
-      end
-
-      it "returns Not Allowed" do
-        get "/api/v1/projects/conversions", headers: {Apikey: "testkey"}
-        expect(response.body).to eq({error: "405 Not Allowed"}.to_json)
-        expect(response.status).to eq(405)
-      end
-    end
-  end
-
-  describe "post /" do
+  describe "authorisation" do
     context "when there is no api key in the header" do
       it "returns an error" do
         post "/api/v1/projects/conversions"
@@ -70,268 +30,208 @@ RSpec.describe V1::Conversions do
         expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
       end
     end
+  end
 
-    context "when there is a valid api key in the header" do
+  describe "get requests are not allowed" do
+    context "when there is a valid api key" do
       before do
         ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow)
-        mock_successful_api_response_to_create_any_project
       end
 
-      let(:regional_delivery_officer) { create(:regional_delivery_officer_user) }
-
-      context "when all required params are present" do
-        context "and the required params are valid" do
-          it "creates a new project" do
-            post "/api/v1/projects/conversions",
-              params: {
-                urn: 121813,
-                incoming_trust_ukprn: 10066123,
-                advisory_board_date: "2024-1-1",
-                advisory_board_conditions: "Some conditions",
-                provisional_conversion_date: "2025-1-1",
-                directive_academy_order: true,
-                created_by_email: regional_delivery_officer.email,
-                created_by_first_name: regional_delivery_officer.first_name,
-                created_by_last_name: regional_delivery_officer.last_name,
-                prepare_id: 12345
-              },
-              as: :json,
-              headers: {Apikey: "testkey"}
-
-            project = Project.last
-            expect(response.body).to eq({conversion_project_id: project.id}.to_json)
-            expect(response.status).to eq(201)
-          end
-        end
-
-        context "but project creation fails" do
-          before do
-            allow_any_instance_of(Conversion::Project).to receive(:save).and_return(nil)
-          end
-
-          it "returns an error" do
-            post "/api/v1/projects/conversions",
-              params: {
-                urn: 123456,
-                incoming_trust_ukprn: 10066123,
-                advisory_board_date: "2024-1-1",
-                advisory_board_conditions: "Some conditions",
-                provisional_conversion_date: "2025-1-1",
-                directive_academy_order: true,
-                created_by_email: regional_delivery_officer.email,
-                created_by_first_name: regional_delivery_officer.first_name,
-                created_by_last_name: regional_delivery_officer.last_name,
-                prepare_id: 12345
-              },
-              as: :json,
-              headers: {Apikey: "testkey"}
-
-            expect(response.body).to eq({error: "Conversion project could not be created via API, urn: 123456"}.to_json)
-            expect(response.status).to eq(500)
-          end
-        end
-
-        context "but the created_by email is not valid" do
-          it "returns an error" do
-            post "/api/v1/projects/conversions",
-              params: {
-                urn: 121813,
-                incoming_trust_ukprn: 10066123,
-                advisory_board_date: "2024-1-1",
-                advisory_board_conditions: "Some conditions",
-                provisional_conversion_date: "2025-1-1",
-                directive_academy_order: true,
-                created_by_email: "nobody@school.gov.uk",
-                created_by_first_name: "Jane",
-                created_by_last_name: "Unknown",
-                prepare_id: 12345
-              },
-              as: :json,
-              headers: {Apikey: "testkey"}
-
-            expect(response.body).to eq({error: "Created by email is invalid"}.to_json)
-            expect(response.status).to eq(400)
-          end
-        end
-
-        context "but the URN or UKPRN parameters are not valid" do
-          it "creates a new project" do
-            post "/api/v1/projects/conversions",
-              params: {
-                urn: 123,
-                incoming_trust_ukprn: 123,
-                advisory_board_date: "2024-1-1",
-                advisory_board_conditions: "Some conditions",
-                provisional_conversion_date: "2025-1-1",
-                directive_academy_order: true,
-                created_by_email: regional_delivery_officer.email,
-                created_by_first_name: regional_delivery_officer.first_name,
-                created_by_last_name: regional_delivery_officer.last_name,
-                prepare_id: 12345
-              },
-              as: :json,
-              headers: {Apikey: "testkey"}
-
-            expect(response.body).to eq({error: "Urn URN must be 6 digits long. For example, 123456. Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678."}.to_json)
-            expect(response.status).to eq(400)
-          end
-        end
-
-        context "but the Academies API is not responding" do
-          before do
-            mock_academies_api_establishment_error(urn: 121813)
-          end
-
-          it "returns an error" do
-            post "/api/v1/projects/conversions",
-              params: {
-                urn: 121813,
-                incoming_trust_ukprn: 10066123,
-                advisory_board_date: "2024-1-1",
-                advisory_board_conditions: "Some conditions",
-                provisional_conversion_date: "2025-1-1",
-                directive_academy_order: true,
-                created_by_email: regional_delivery_officer.email,
-                created_by_first_name: regional_delivery_officer.first_name,
-                created_by_last_name: regional_delivery_officer.last_name,
-                prepare_id: 12345
-              },
-              as: :json,
-              headers: {Apikey: "testkey"}
-
-            expect(response.body).to eq({error: "Failed to fetch establishment with URN: 121813 on Academies API"}.to_json)
-            expect(response.status).to eq(500)
-          end
-        end
+      it "returns Not Allowed for conversions" do
+        get "/api/v1/projects/conversions", headers: {Apikey: "testkey"}
+        expect(response.body).to eq({error: "405 Not Allowed"}.to_json)
+        expect(response.status).to eq(405)
       end
 
-      context "when any required params are missing" do
-        it "returns an error" do
-          post "/api/v1/projects/conversions", headers: {Apikey: "testkey"}
-          expect(response.body).to include("urn is missing, advisory_board_date is missing, advisory_board_conditions is missing")
-          expect(response.status).to eq(400)
-        end
+      it "returns Not Allowed for fotm a MAT transfers" do
+        get "/api/v1/projects/conversions/form-a-mat", headers: {Apikey: "testkey"}
+        expect(response.body).to eq({error: "405 Not Allowed"}.to_json)
+        expect(response.status).to eq(405)
       end
     end
   end
 
-  describe "post form-a-mat/" do
-    context "when there is a valid api key in the header" do
-      before do
-        ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow)
-        mock_successful_api_response_to_create_any_project
-      end
+  describe "post to conversions" do
+    before { ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow) }
 
-      let(:regional_delivery_officer) { create(:regional_delivery_officer_user) }
+    context "when the request is successful" do
+      it "returns the project id with the status code 201" do
+        post "/api/v1/projects/conversions",
+          params: valid_conversion_parameters,
+          as: :json,
+          headers: {Apikey: "testkey"}
 
-      context "when all required params are present" do
-        context "and the required params are valid" do
-          it "creates a new Form a MAT project" do
-            post "/api/v1/projects/conversions/form-a-mat",
-              params: {
-                urn: 121813,
-                new_trust_reference_number: "TR12345",
-                new_trust_name: "The New Trust",
-                advisory_board_date: "2024-1-1",
-                advisory_board_conditions: "Some conditions",
-                provisional_conversion_date: "2025-1-1",
-                directive_academy_order: true,
-                created_by_email: regional_delivery_officer.email,
-                created_by_first_name: regional_delivery_officer.first_name,
-                created_by_last_name: regional_delivery_officer.last_name,
-                prepare_id: 12345
-              },
-              as: :json,
-              headers: {Apikey: "testkey"}
-
-            project = Project.last
-            expect(response.body).to eq({conversion_project_id: project.id}.to_json)
-            expect(response.status).to eq(201)
-          end
-        end
-
-        context "but the new Trust Reference Number is not valid" do
-          it "returns an error" do
-            post "/api/v1/projects/conversions/form-a-mat",
-              params: {
-                urn: 121813,
-                new_trust_reference_number: "12345",
-                new_trust_name: "The New Trust",
-                advisory_board_date: "2024-1-1",
-                advisory_board_conditions: "Some conditions",
-                provisional_conversion_date: "2025-1-1",
-                directive_academy_order: true,
-                created_by_email: regional_delivery_officer.email,
-                created_by_first_name: regional_delivery_officer.first_name,
-                created_by_last_name: regional_delivery_officer.last_name,
-                prepare_id: 12345
-              },
-              as: :json,
-              headers: {Apikey: "testkey"}
-
-            expect(response.body).to eq({error: "New trust reference number The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234"}.to_json)
-            expect(response.status).to eq(400)
-          end
-        end
-      end
-
-      context "when any required params are missing" do
-        it "returns an error" do
-          post "/api/v1/projects/conversions/form-a-mat", headers: {Apikey: "testkey"}
-          expect(response.body).to include("urn is missing, advisory_board_date is missing, advisory_board_conditions is missing")
-        end
-      end
-
-      context "but project creation fails" do
-        before do
-          allow_any_instance_of(Conversion::Project).to receive(:save).and_return(nil)
-        end
-
-        it "returns an error" do
-          post "/api/v1/projects/conversions/form-a-mat",
-            params: {
-              urn: 123456,
-              new_trust_reference_number: "TR12345",
-              new_trust_name: "A new trust",
-              advisory_board_date: "2024-1-1",
-              advisory_board_conditions: "Some conditions",
-              provisional_conversion_date: "2025-1-1",
-              directive_academy_order: true,
-              created_by_email: regional_delivery_officer.email,
-              created_by_first_name: regional_delivery_officer.first_name,
-              created_by_last_name: regional_delivery_officer.last_name,
-              prepare_id: 12345
-            },
-            as: :json,
-            headers: {Apikey: "testkey"}
-
-          expect(response.body).to eq({error: "Conversion project could not be created via API, urn: 123456"}.to_json)
-          expect(response.status).to eq(500)
-        end
-      end
-
-      context "when the 'regular' conversion parameters are posted to the Form a MAT endpoint" do
-        it "returns an error" do
-          post "/api/v1/projects/conversions/form-a-mat",
-            params: {
-              urn: 121813,
-              incoming_trust_ukprn: 10066123,
-              advisory_board_date: "2024-1-1",
-              advisory_board_conditions: "Some conditions",
-              provisional_conversion_date: "2025-1-1",
-              directive_academy_order: true,
-              created_by_email: regional_delivery_officer.email,
-              created_by_first_name: regional_delivery_officer.first_name,
-              created_by_last_name: regional_delivery_officer.last_name,
-              prepare_id: 12345
-            },
-            as: :json,
-            headers: {Apikey: "testkey"}
-
-          expect(response.body).to eq({error: "new_trust_reference_number is missing, new_trust_name is missing"}.to_json)
-          expect(response.status).to eq(400)
-        end
+        project = Project.last
+        expect(response.body).to eq({conversion_project_id: project.id}.to_json)
+        expect(response.status).to eq(201)
       end
     end
+
+    context "when a required parameter is missing" do
+      it "returns an error with the status code 400" do
+        params = valid_conversion_parameters
+        params.delete(:urn)
+
+        post "/api/v1/projects/conversions",
+          params: params,
+          headers: {Apikey: "testkey"}
+
+        expect(response.body).to include("urn is missing")
+        expect(response.status).to eq(400)
+      end
+    end
+
+    context "when an optional parameter is included" do
+      it "is successful" do
+        params = valid_conversion_parameters
+        params[:group_id] = "GRP_12345678"
+
+        post "/api/v1/projects/conversions",
+          params: params,
+          as: :json,
+          headers: {Apikey: "testkey"}
+
+        project = Project.last
+        expect(response.body).to eq({conversion_project_id: project.id}.to_json)
+        expect(response.status).to eq(201)
+      end
+    end
+
+    context "when there is a validation error" do
+      it "returns the error with the status code 400" do
+        params = valid_conversion_parameters
+        params[:created_by_email] = "invalid@invalid.com"
+
+        post "/api/v1/projects/conversions",
+          params: params,
+          as: :json,
+          headers: {Apikey: "testkey"}
+
+        expect(response.body).to eq({error: "Created by email is invalid"}.to_json)
+        expect(response.status).to eq(400)
+      end
+    end
+
+    context "when there is an error" do
+      before { allow_any_instance_of(Conversion::Project).to receive(:save).and_return(nil) }
+
+      it "returns the error with the status code 500" do
+        post "/api/v1/projects/conversions",
+          params: valid_conversion_parameters,
+          as: :json,
+          headers: {Apikey: "testkey"}
+
+        expect(response.body).to eq({error: "Conversion project could not be created via API, urn: 123456"}.to_json)
+        expect(response.status).to eq(500)
+      end
+    end
+  end
+
+  describe "post transfers/form-a-mat/" do
+    before { ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow) }
+
+    context "when the request is successful" do
+      it "returns the project id with the status code 201" do
+        post "/api/v1/projects/conversions/form-a-mat",
+          params: valid_form_a_mat_conversion_parameters,
+          as: :json,
+          headers: {Apikey: "testkey"}
+
+        project = Project.last
+        expect(response.body).to eq({conversion_project_id: project.id}.to_json)
+        expect(response.status).to eq(201)
+      end
+    end
+
+    context "when a required parameter is missing" do
+      it "returns an error with the status code 400" do
+        params = valid_form_a_mat_conversion_parameters
+        params.delete(:new_trust_reference_number)
+
+        post "/api/v1/projects/conversions/form-a-mat",
+          params: params,
+          headers: {Apikey: "testkey"}
+
+        expect(response.body).to include("new_trust_reference_number is missing")
+        expect(response.status).to eq(400)
+      end
+    end
+
+    context "when an optional parameter is included" do
+      it "is successful" do
+        params = valid_form_a_mat_conversion_parameters
+        params[:group_id] = "GRP_12345678"
+
+        post "/api/v1/projects/conversions/form-a-mat",
+          params: params,
+          as: :json,
+          headers: {Apikey: "testkey"}
+
+        project = Project.last
+        expect(response.body).to eq({conversion_project_id: project.id}.to_json)
+        expect(response.status).to eq(201)
+      end
+    end
+
+    context "when there is a validation error" do
+      it "returns the error with the status code 400" do
+        params = valid_form_a_mat_conversion_parameters
+        params[:created_by_email] = "invalid@invalid.com"
+
+        post "/api/v1/projects/conversions/form-a-mat",
+          params: params,
+          as: :json,
+          headers: {Apikey: "testkey"}
+
+        expect(response.body).to eq({error: "Created by email is invalid"}.to_json)
+        expect(response.status).to eq(400)
+      end
+    end
+
+    context "when there is an error" do
+      before { allow_any_instance_of(Conversion::Project).to receive(:save).and_return(nil) }
+
+      it "returns the error with the status code 500" do
+        post "/api/v1/projects/conversions/form-a-mat",
+          params: valid_form_a_mat_conversion_parameters,
+          as: :json,
+          headers: {Apikey: "testkey"}
+
+        expect(response.body).to eq({error: "Conversion project could not be created via API, urn: 123456"}.to_json)
+        expect(response.status).to eq(500)
+      end
+    end
+  end
+
+  def valid_conversion_parameters
+    {
+      urn: 123456,
+      incoming_trust_ukprn: 12345678,
+      advisory_board_date: "2024-1-1",
+      advisory_board_conditions: "Some conditions",
+      provisional_conversion_date: "2025-1-1",
+      directive_academy_order: true,
+      created_by_email: "test.user@education.gov.uk",
+      created_by_first_name: "Test",
+      created_by_last_name: "User",
+      prepare_id: 12345
+    }
+  end
+
+  def valid_form_a_mat_conversion_parameters
+    {
+      urn: 123456,
+      advisory_board_date: "2024-1-1",
+      advisory_board_conditions: "Some conditions",
+      provisional_conversion_date: "2025-1-1",
+      directive_academy_order: true,
+      created_by_email: "test.user@education.gov.uk",
+      created_by_first_name: "Test",
+      created_by_last_name: "User",
+      prepare_id: 12345,
+      new_trust_reference_number: "TR12345",
+      new_trust_name: "A new trust"
+    }
   end
 end

--- a/spec/api/v1/transfers_spec.rb
+++ b/spec/api/v1/transfers_spec.rb
@@ -1,87 +1,9 @@
 require "rails_helper"
 
 RSpec.describe V1::Transfers do
-  def valid_transfer_parameters
-    {
-      urn: 123456,
-      incoming_trust_ukprn: 12345678,
-      advisory_board_date: "2024-1-1",
-      advisory_board_conditions: "Some conditions",
-      provisional_transfer_date: "2025-1-1",
-      created_by_email: regional_delivery_officer.email,
-      created_by_first_name: regional_delivery_officer.first_name,
-      created_by_last_name: regional_delivery_officer.last_name,
-      inadequate_ofsted: true,
-      financial_safeguarding_governance_issues: true,
-      outgoing_trust_ukprn: 12348765,
-      outgoing_trust_to_close: true,
-      prepare_id: 12345
-    }
-  end
+  before { mock_successful_api_response_to_create_any_project }
 
-  def valid_form_a_mat_transfer_parameters
-    {
-      urn: 123456,
-      incoming_trust_ukprn: 12345678,
-      advisory_board_date: "2024-1-1",
-      advisory_board_conditions: "Some conditions",
-      provisional_transfer_date: "2025-1-1",
-      created_by_email: regional_delivery_officer.email,
-      created_by_first_name: regional_delivery_officer.first_name,
-      created_by_last_name: regional_delivery_officer.last_name,
-      inadequate_ofsted: true,
-      financial_safeguarding_governance_issues: true,
-      outgoing_trust_ukprn: 12348765,
-      outgoing_trust_to_close: true,
-      prepare_id: 12345,
-      new_trust_reference_number: "TR12345",
-      new_trust_name: "A new trust"
-    }
-  end
-
-  describe "get /" do
-    context "when there is no api key in the header" do
-      it "returns an Unauthorized error" do
-        get "/api/v1/projects/transfers"
-        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
-        expect(response.status).to eq(401)
-      end
-    end
-
-    context "when there is an invalid api key in the header" do
-      it "returns an Unauthorized error" do
-        get "/api/v1/projects/transfers", headers: {ApiKey: "unknownkey"}
-        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
-        expect(response.status).to eq(401)
-      end
-    end
-
-    context "when there is an expired api key in the header" do
-      before do
-        ApiKey.create(api_key: "testkey", expires_at: Date.yesterday)
-      end
-
-      it "returns an Unauthorized error" do
-        get "/api/v1/projects/transfers", headers: {ApiKey: "testkey"}
-        expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
-        expect(response.status).to eq(401)
-      end
-    end
-
-    context "when there is a valid api key in the header" do
-      before do
-        ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow)
-      end
-
-      it "returns Not Allowed" do
-        get "/api/v1/projects/transfers", headers: {Apikey: "testkey"}
-        expect(response.body).to eq({error: "405 Not Allowed"}.to_json)
-        expect(response.status).to eq(405)
-      end
-    end
-  end
-
-  describe "post /" do
+  describe "authorisation" do
     context "when there is no api key in the header" do
       it "returns an error" do
         post "/api/v1/projects/transfers"
@@ -108,176 +30,215 @@ RSpec.describe V1::Transfers do
         expect(response.body).to eq({error: "Unauthorized. Invalid or expired token."}.to_json)
       end
     end
+  end
 
-    context "when there is a valid api key in the header" do
+  describe "get requests are not allowed" do
+    context "when there is a valid api key" do
       before do
         ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow)
-        mock_successful_api_response_to_create_any_project
       end
 
-      let(:regional_delivery_officer) { create(:regional_delivery_officer_user) }
-
-      context "when all required params are present" do
-        context "and the required params are valid" do
-          it "creates a new project" do
-            post "/api/v1/projects/transfers",
-              params: valid_transfer_parameters,
-              as: :json,
-              headers: {Apikey: "testkey"}
-
-            project = Project.last
-            expect(response.body).to eq({transfer_project_id: project.id}.to_json)
-            expect(response.status).to eq(201)
-          end
-        end
-
-        context "but project creation fails" do
-          before do
-            allow_any_instance_of(Transfer::Project).to receive(:save).and_return(nil)
-          end
-
-          it "returns an error" do
-            post "/api/v1/projects/transfers",
-              params: valid_transfer_parameters,
-              as: :json,
-              headers: {Apikey: "testkey"}
-
-            expect(response.body).to eq({error: "Transfer project could not be created via API, urn: 123456"}.to_json)
-            expect(response.status).to eq(500)
-          end
-        end
-
-        context "but the created_by email is not valid" do
-          it "returns an error" do
-            params = valid_transfer_parameters
-            params[:created_by_email] = "invalid@invalid.com"
-
-            post "/api/v1/projects/transfers",
-              params: params,
-              as: :json,
-              headers: {Apikey: "testkey"}
-
-            expect(response.body).to eq({error: "Created by email is invalid"}.to_json)
-            expect(response.status).to eq(400)
-          end
-        end
-
-        context "but the URN or UKPRN parameters are not valid" do
-          it "creates a new project" do
-            params = valid_transfer_parameters
-            params[:urn] = 123
-            params[:incoming_trust_ukprn] = 123
-
-            post "/api/v1/projects/transfers",
-              params: params,
-              as: :json,
-              headers: {Apikey: "testkey"}
-
-            expect(response.body).to eq({error: "Urn URN must be 6 digits long. For example, 123456. Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678."}.to_json)
-            expect(response.status).to eq(400)
-          end
-        end
-
-        context "but the urn cannot be found on the Acadanies API" do
-          before do
-            mock_academies_api_establishment_not_found(urn: 123456)
-          end
-
-          it "returns an error" do
-            post "/api/v1/projects/transfers",
-              params: valid_transfer_parameters,
-              as: :json,
-              headers: {Apikey: "testkey"}
-
-            expect(response.body).to eq({error: "An establishment with URN: 123456 could not be found on the Academies API"}.to_json)
-            expect(response.status).to eq(400)
-          end
-        end
+      it "returns Not Allowed for transfers" do
+        get "/api/v1/projects/transfers", headers: {Apikey: "testkey"}
+        expect(response.body).to eq({error: "405 Not Allowed"}.to_json)
+        expect(response.status).to eq(405)
       end
 
-      context "when any required params are missing" do
-        it "returns an error" do
-          post "/api/v1/projects/transfers", headers: {Apikey: "testkey"}
-          expect(response.body).to include("urn is missing, advisory_board_date is missing, advisory_board_conditions is missing")
-          expect(response.status).to eq(400)
-        end
+      it "returns Not Allowed for fotm a MAT transfers" do
+        get "/api/v1/projects/transfers/form-a-mat", headers: {Apikey: "testkey"}
+        expect(response.body).to eq({error: "405 Not Allowed"}.to_json)
+        expect(response.status).to eq(405)
       end
     end
   end
 
-  describe "post form-a-mat/" do
-    context "when there is a valid api key in the header" do
-      before do
-        ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow)
-        mock_successful_api_response_to_create_any_project
-      end
+  describe "post to transfers" do
+    before { ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow) }
 
-      let(:regional_delivery_officer) { create(:regional_delivery_officer_user) }
+    context "when the request is successful" do
+      it "returns the project id with the status code 201" do
+        post "/api/v1/projects/transfers",
+          params: valid_transfer_parameters,
+          as: :json,
+          headers: {Apikey: "testkey"}
 
-      context "when all required params are present" do
-        context "and the required params are valid" do
-          it "creates a new Form a MAT project" do
-            post "/api/v1/projects/transfers/form-a-mat",
-              params: valid_form_a_mat_transfer_parameters,
-              as: :json,
-              headers: {Apikey: "testkey"}
-
-            project = Project.last
-            expect(response.body).to eq({transfer_project_id: project.id}.to_json)
-            expect(response.status).to eq(201)
-          end
-        end
-
-        context "but the new Trust Reference Number is not valid" do
-          it "returns an error" do
-            params = valid_form_a_mat_transfer_parameters
-            params[:new_trust_reference_number] = "12345"
-
-            post "/api/v1/projects/transfers/form-a-mat",
-              params: params,
-              as: :json,
-              headers: {Apikey: "testkey"}
-
-            expect(response.body).to eq({error: "New trust reference number The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234"}.to_json)
-            expect(response.status).to eq(400)
-          end
-        end
-      end
-
-      context "when any required params are missing" do
-        it "returns an error" do
-          post "/api/v1/projects/transfers/form-a-mat", headers: {Apikey: "testkey"}
-          expect(response.body).to include("urn is missing, advisory_board_date is missing, advisory_board_conditions is missing")
-        end
-      end
-
-      context "when the transfer parameters are posted to the Form a MAT endpoint" do
-        it "returns an error" do
-          post "/api/v1/projects/transfers/form-a-mat",
-            params: valid_transfer_parameters,
-            as: :json,
-            headers: {Apikey: "testkey"}
-
-          expect(response.body).to eq({error: "new_trust_reference_number is missing, new_trust_name is missing"}.to_json)
-          expect(response.status).to eq(400)
-        end
-      end
-
-      context "but project creation fails" do
-        before do
-          allow_any_instance_of(Transfer::Project).to receive(:save).and_return(nil)
-        end
-
-        it "returns an error" do
-          post "/api/v1/projects/transfers/form-a-mat",
-            params: valid_form_a_mat_transfer_parameters,
-            as: :json,
-            headers: {Apikey: "testkey"}
-
-          expect(response.body).to eq({error: "Transfer project could not be created via API, urn: 123456"}.to_json)
-          expect(response.status).to eq(500)
-        end
+        project = Project.last
+        expect(response.body).to eq({transfer_project_id: project.id}.to_json)
+        expect(response.status).to eq(201)
       end
     end
+
+    context "when a required parameter is missing" do
+      it "returns an error with the status code 400" do
+        params = valid_transfer_parameters
+        params.delete(:urn)
+
+        post "/api/v1/projects/transfers",
+          params: params,
+          headers: {Apikey: "testkey"}
+
+        expect(response.body).to include("urn is missing")
+        expect(response.status).to eq(400)
+      end
+    end
+
+    context "when an optional parameter is included" do
+      it "is successful" do
+        params = valid_form_a_mat_transfer_parameters
+        params[:group_id] = "GRP_12345678"
+
+        post "/api/v1/projects/transfers",
+          params: params,
+          as: :json,
+          headers: {Apikey: "testkey"}
+
+        project = Project.last
+        expect(response.body).to eq({transfer_project_id: project.id}.to_json)
+        expect(response.status).to eq(201)
+      end
+    end
+
+    context "when there is a validation error" do
+      it "returns the error with the status code 400" do
+        params = valid_transfer_parameters
+        params[:created_by_email] = "invalid@invalid.com"
+
+        post "/api/v1/projects/transfers",
+          params: params,
+          as: :json,
+          headers: {Apikey: "testkey"}
+
+        expect(response.body).to eq({error: "Created by email is invalid"}.to_json)
+        expect(response.status).to eq(400)
+      end
+    end
+
+    context "when there is an error" do
+      before { allow_any_instance_of(Transfer::Project).to receive(:save).and_return(nil) }
+
+      it "returns the error with the status code 500" do
+        post "/api/v1/projects/transfers",
+          params: valid_transfer_parameters,
+          as: :json,
+          headers: {Apikey: "testkey"}
+
+        expect(response.body).to eq({error: "Transfer project could not be created via API, urn: 123456"}.to_json)
+        expect(response.status).to eq(500)
+      end
+    end
+  end
+
+  describe "post transfers/form-a-mat/" do
+    before { ApiKey.create(api_key: "testkey", expires_at: Date.tomorrow) }
+
+    context "when the request is successful" do
+      it "returns the project id with the status code 201" do
+        post "/api/v1/projects/transfers/form-a-mat",
+          params: valid_form_a_mat_transfer_parameters,
+          as: :json,
+          headers: {Apikey: "testkey"}
+
+        project = Project.last
+        expect(response.body).to eq({transfer_project_id: project.id}.to_json)
+        expect(response.status).to eq(201)
+      end
+    end
+
+    context "when a required parameter is missing" do
+      it "returns an error with the status code 400" do
+        params = valid_form_a_mat_transfer_parameters
+        params.delete(:new_trust_reference_number)
+
+        post "/api/v1/projects/transfers/form-a-mat",
+          params: params,
+          headers: {Apikey: "testkey"}
+
+        expect(response.body).to include("new_trust_reference_number is missing")
+        expect(response.status).to eq(400)
+      end
+    end
+
+    context "when an optional parameter is included" do
+      it "is successful" do
+        params = valid_form_a_mat_transfer_parameters
+        params[:group_id] = "GRP_12345678"
+
+        post "/api/v1/projects/transfers/form-a-mat",
+          params: params,
+          as: :json,
+          headers: {Apikey: "testkey"}
+
+        project = Project.last
+        expect(response.body).to eq({transfer_project_id: project.id}.to_json)
+        expect(response.status).to eq(201)
+      end
+    end
+
+    context "when there is a validation error" do
+      it "returns the error with the status code 400" do
+        params = valid_form_a_mat_transfer_parameters
+        params[:created_by_email] = "invalid@invalid.com"
+
+        post "/api/v1/projects/transfers/form-a-mat",
+          params: params,
+          as: :json,
+          headers: {Apikey: "testkey"}
+
+        expect(response.body).to eq({error: "Created by email is invalid"}.to_json)
+        expect(response.status).to eq(400)
+      end
+    end
+
+    context "when there is an error" do
+      before { allow_any_instance_of(Transfer::Project).to receive(:save).and_return(nil) }
+
+      it "returns the error with the status code 500" do
+        post "/api/v1/projects/transfers/form-a-mat",
+          params: valid_form_a_mat_transfer_parameters,
+          as: :json,
+          headers: {Apikey: "testkey"}
+
+        expect(response.body).to eq({error: "Transfer project could not be created via API, urn: 123456"}.to_json)
+        expect(response.status).to eq(500)
+      end
+    end
+  end
+
+  def valid_transfer_parameters
+    {
+      urn: 123456,
+      incoming_trust_ukprn: 12345678,
+      advisory_board_date: "2024-1-1",
+      advisory_board_conditions: "Some conditions",
+      provisional_transfer_date: "2025-1-1",
+      created_by_email: "test.user@education.gov.uk",
+      created_by_first_name: "Test",
+      created_by_last_name: "User",
+      inadequate_ofsted: true,
+      financial_safeguarding_governance_issues: true,
+      outgoing_trust_ukprn: 12348765,
+      outgoing_trust_to_close: true,
+      prepare_id: 12345
+    }
+  end
+
+  def valid_form_a_mat_transfer_parameters
+    {
+      urn: 123456,
+      incoming_trust_ukprn: 12345678,
+      advisory_board_date: "2024-1-1",
+      advisory_board_conditions: "Some conditions",
+      provisional_transfer_date: "2025-1-1",
+      created_by_email: "test.user@education.gov.uk",
+      created_by_first_name: "Test",
+      created_by_last_name: "User",
+      inadequate_ofsted: true,
+      financial_safeguarding_governance_issues: true,
+      outgoing_trust_ukprn: 12348765,
+      outgoing_trust_to_close: true,
+      prepare_id: 12345,
+      new_trust_reference_number: "TR12345",
+      new_trust_name: "A new trust"
+    }
   end
 end


### PR DESCRIPTION
These API specs are working a little too hard, covering behaviour that really
belongs in the services that back the API.

This work refactors the specs to focus on more generic behaviour:

- successful request
- validation errors
- other errors
- required fields
- optional fields
- authorisation
