### PR TITLE
Remove directive academy orders from API Transfers

### DIFF
--- a/app/services/api/base_create_project_service.rb
+++ b/app/services/api/base_create_project_service.rb
@@ -11,7 +11,6 @@ class Api::BaseCreateProjectService
   attribute :incoming_trust_ukprn, :integer
   attribute :advisory_board_date, :date
   attribute :advisory_board_conditions, :string
-  attribute :directive_academy_order, :boolean
   attribute :created_by_email, :string
   attribute :created_by_first_name, :string
   attribute :created_by_last_name, :string

--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -1,5 +1,6 @@
 class Api::Conversions::CreateProjectService < Api::BaseCreateProjectService
   attribute :provisional_conversion_date, :date
+  attribute :directive_academy_order, :boolean
 
   validates :provisional_conversion_date, first_day_of_month: true
 

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -397,7 +397,6 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
       advisory_board_date: "2024-1-1",
       advisory_board_conditions: "Some conditions",
       provisional_transfer_date: "2025-1-1",
-      directive_academy_order: true,
       created_by_email: "test.user@education.gov.uk",
       created_by_first_name: "Test",
       created_by_last_name: "User",


### PR DESCRIPTION
This attribute is only for conversions so we move it to the subclass and
remove it from the transfer spec where it never got used.

Based on #1918
