### PR TITLE
Better API validation errors

### DIFF
--- a/app/api/v1/conversions.rb
+++ b/app/api/v1/conversions.rb
@@ -35,7 +35,7 @@ class V1::Conversions < Grape::API
 
         {conversion_project_id: project.id}
       rescue Api::Conversions::CreateProjectService::ValidationError => e
-        error!(e.message, 400)
+        error!({validation_errors: e.validation_errors}, 400)
       rescue Api::Conversions::CreateProjectService::CreationError => e
         error!(e.message)
       end
@@ -59,7 +59,7 @@ class V1::Conversions < Grape::API
 
           {conversion_project_id: project.id}
         rescue Api::Conversions::CreateProjectService::ValidationError => e
-          error!(e.message, 400)
+          error!({validation_errors: e.validation_errors}, 400)
         rescue Api::Conversions::CreateProjectService::CreationError => e
           error!(e.message)
         end

--- a/app/api/v1/transfers.rb
+++ b/app/api/v1/transfers.rb
@@ -38,7 +38,7 @@ class V1::Transfers < Grape::API
 
         {transfer_project_id: project.id}
       rescue Api::Transfers::CreateProjectService::ValidationError => e
-        error!(e.message, 400)
+        error!({validation_errors: e.validation_errors}, 400)
       rescue Api::Transfers::CreateProjectService::CreationError => e
         error!(e.message)
       end
@@ -62,7 +62,7 @@ class V1::Transfers < Grape::API
 
           {transfer_project_id: project.id}
         rescue Api::Transfers::CreateProjectService::ValidationError => e
-          error!(e.message, 400)
+          error!({validation_errors: e.validation_errors}, 400)
         rescue Api::Transfers::CreateProjectService::CreationError => e
           error!(e.message)
         end

--- a/app/services/api/base_create_project_service.rb
+++ b/app/services/api/base_create_project_service.rb
@@ -5,7 +5,14 @@ class Api::BaseCreateProjectService
 
   class CreationError < StandardError; end
 
-  class ValidationError < StandardError; end
+  class ValidationError < StandardError
+    attr_reader :validation_errors
+
+    def initialize(message, validation_errors)
+      super(message)
+      @validation_errors = validation_errors.messages
+    end
+  end
 
   attribute :urn, :integer
   attribute :incoming_trust_ukprn, :integer

--- a/app/services/api/base_create_project_service.rb
+++ b/app/services/api/base_create_project_service.rb
@@ -96,7 +96,7 @@ class Api::BaseCreateProjectService
     if result.object.present?
       @establishment = result.object
     elsif result.error.is_a?(Api::AcademiesApi::Client::NotFoundError)
-      raise ValidationError.new("An establishment with URN: #{urn} could not be found on the Academies API")
+      nil
     else
       raise CreationError.new("Failed to fetch establishment with URN: #{urn} on Academies API")
     end
@@ -108,7 +108,7 @@ class Api::BaseCreateProjectService
     if result.object.present?
       result.object
     elsif result.error.is_a?(Api::AcademiesApi::Client::NotFoundError)
-      raise ValidationError.new("A trust with UKPRN: #{ukprn} could not be found on the Academies API")
+      nil
     else
       raise CreationError.new("Failed to fetch trust with UKPRN: #{ukprn} on Academies API")
     end

--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -33,7 +33,7 @@ class Api::Conversions::CreateProjectService < Api::BaseCreateProjectService
         raise CreationError.new("Conversion project could not be created via API, urn: #{urn}")
       end
     else
-      raise ValidationError.new(errors.full_messages.join(" "))
+      raise ValidationError.new("Validation error", errors)
     end
   end
 end

--- a/app/services/api/transfers/create_project_service.rb
+++ b/app/services/api/transfers/create_project_service.rb
@@ -50,7 +50,7 @@ class Api::Transfers::CreateProjectService < Api::BaseCreateProjectService
         raise CreationError.new("Transfer project could not be created via API, urn: #{urn}")
       end
     else
-      raise ValidationError.new(errors.full_messages.join(" "))
+      raise ValidationError.new("Validation error", errors)
     end
   end
 

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -108,7 +108,9 @@ RSpec.describe V1::Conversions do
           as: :json,
           headers: {Apikey: "testkey"}
 
-        expect(response.body).to eq({error: "Created by email is invalid"}.to_json)
+        expect(response.body).to include("validation_errors")
+        expect(response.body).to include("created_by_email")
+        expect(response.body).to include("is invalid")
         expect(response.status).to eq(400)
       end
     end
@@ -184,7 +186,9 @@ RSpec.describe V1::Conversions do
           as: :json,
           headers: {Apikey: "testkey"}
 
-        expect(response.body).to eq({error: "Created by email is invalid"}.to_json)
+        expect(response.body).to include("validation_errors")
+        expect(response.body).to include("created_by_email")
+        expect(response.body).to include("is invalid")
         expect(response.status).to eq(400)
       end
     end

--- a/spec/api/v1/transfers_spec.rb
+++ b/spec/api/v1/transfers_spec.rb
@@ -108,7 +108,9 @@ RSpec.describe V1::Transfers do
           as: :json,
           headers: {Apikey: "testkey"}
 
-        expect(response.body).to eq({error: "Created by email is invalid"}.to_json)
+        expect(response.body).to include("validation_errors")
+        expect(response.body).to include("created_by_email")
+        expect(response.body).to include("is invalid")
         expect(response.status).to eq(400)
       end
     end
@@ -184,7 +186,9 @@ RSpec.describe V1::Transfers do
           as: :json,
           headers: {Apikey: "testkey"}
 
-        expect(response.body).to eq({error: "Created by email is invalid"}.to_json)
+        expect(response.body).to include("validation_errors")
+        expect(response.body).to include("created_by_email")
+        expect(response.body).to include("is invalid")
         expect(response.status).to eq(400)
       end
     end

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe Api::Conversions::CreateProjectService do
         expect { described_class.new(valid_parameters).call }
           .to raise_error(
             Api::Conversions::CreateProjectService::ValidationError,
-            "An establishment with URN: 123456 could not be found on the Academies API"
+            "Urn There's no school or academy with that URN. Check the number you entered is correct."
           )
       end
     end
@@ -207,7 +207,7 @@ RSpec.describe Api::Conversions::CreateProjectService do
         expect { described_class.new(valid_parameters).call }
           .to raise_error(
             Api::Conversions::CreateProjectService::ValidationError,
-            "A trust with UKPRN: 10066123 could not be found on the Academies API"
+            "Incoming trust ukprn There's no trust with that UKPRN. Check the number you entered is correct."
           )
       end
     end

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -167,11 +167,12 @@ RSpec.describe Api::Conversions::CreateProjectService do
         params = valid_parameters
         params[:urn] = 123
 
-        expect { described_class.new(params).call }
-          .to raise_error(
-            Api::Conversions::CreateProjectService::ValidationError,
-            "Urn URN must be 6 digits long. For example, 123456."
-          )
+        subject = described_class.new(params)
+
+        expect { subject.call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("urn")
+        expect(subject.errors.to_json).to include("6 digits long")
       end
     end
 
@@ -179,11 +180,12 @@ RSpec.describe Api::Conversions::CreateProjectService do
       before { mock_academies_api_establishment_not_found(urn: 123456) }
 
       it "raises an error" do
-        expect { described_class.new(valid_parameters).call }
-          .to raise_error(
-            Api::Conversions::CreateProjectService::ValidationError,
-            "Urn There's no school or academy with that URN. Check the number you entered is correct."
-          )
+        subject = described_class.new(valid_parameters)
+
+        expect { subject.call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("urn")
+        expect(subject.errors.to_json).to include("no school or academy with that URN")
       end
     end
 
@@ -192,11 +194,12 @@ RSpec.describe Api::Conversions::CreateProjectService do
         params = valid_parameters
         params[:incoming_trust_ukprn] = 87654321
 
-        expect { described_class.new(params).call }
-          .to raise_error(
-            Api::Conversions::CreateProjectService::ValidationError,
-            "Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678."
-          )
+        subject = described_class.new(params)
+
+        expect { subject.call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("incoming_trust_ukprn")
+        expect(subject.errors.to_json).to include("8 digits long")
       end
     end
 
@@ -204,11 +207,12 @@ RSpec.describe Api::Conversions::CreateProjectService do
       before { mock_academies_api_trust_not_found(ukprn: 10066123) }
 
       it "raises an error" do
-        expect { described_class.new(valid_parameters).call }
-          .to raise_error(
-            Api::Conversions::CreateProjectService::ValidationError,
-            "Incoming trust ukprn There's no trust with that UKPRN. Check the number you entered is correct."
-          )
+        subject = described_class.new(valid_parameters)
+
+        expect { subject.call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("incoming_trust_ukprn")
+        expect(subject.errors.to_json).to include("no trust with that UKPRN")
       end
     end
 
@@ -217,23 +221,25 @@ RSpec.describe Api::Conversions::CreateProjectService do
         params = valid_parameters
         params[:prepare_id] = nil
 
-        expect { described_class.new(params).call }
-          .to raise_error(
-            Api::Conversions::CreateProjectService::ValidationError,
-            "Prepare You must supply a Prepare ID when creating a project via the API"
-          )
+        subject = described_class.new(params)
+
+        expect { subject.call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("prepare_id")
+        expect(subject.errors.to_json).to include("You must supply a Prepare ID")
       end
     end
 
-    context "when there is a in progress transfer project with the same URN" do
+    context "when there is a in progress conversion project with the same URN" do
       it "raises an error" do
         create(:conversion_project, urn: 123456)
 
-        expect { described_class.new(valid_parameters).call }
-          .to raise_error(
-            Api::Transfers::CreateProjectService::ValidationError,
-            "Urn There is already an in-progress project with this URN"
-          )
+        subject = described_class.new(valid_parameters)
+
+        expect { subject.call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("urn")
+        expect(subject.errors.to_json).to include("already an in-progress project")
       end
     end
 
@@ -256,9 +262,12 @@ RSpec.describe Api::Conversions::CreateProjectService do
         params[:incoming_trust_ukprn] = nil
         params[:new_trust_reference_number] = "12345"
 
-        expect { described_class.new(params).call }
-          .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
-            "New trust reference number The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234")
+        subject = described_class.new(params)
+
+        expect { subject.call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("new_trust_reference_number")
+        expect(subject.errors.to_json).to include("followed by 5 numbers")
       end
     end
 
@@ -267,9 +276,12 @@ RSpec.describe Api::Conversions::CreateProjectService do
         params = valid_parameters
         params[:advisory_board_date] = Date.today + 2.years
 
-        expect { described_class.new(params).call }
-          .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
-            "Advisory board date The advisory board date must be in the past")
+        result = described_class.new(params)
+
+        expect { result.call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError)
+        expect(result.errors.to_json).to include("advisory_board_date")
+        expect(result.errors.to_json).to include("must be in the past")
       end
     end
 
@@ -278,9 +290,12 @@ RSpec.describe Api::Conversions::CreateProjectService do
         params = valid_parameters
         params[:provisional_conversion_date] = "2024-1-2"
 
-        expect { described_class.new(params).call }
-          .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
-            "Provisional conversion date must be on the first of the month")
+        subject = described_class.new(params)
+
+        expect { subject.call }
+          .to raise_error(Api::Conversions::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("provisional_conversion_date")
+        expect(subject.errors.to_json).to include("the first of the month")
       end
     end
   end

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -178,11 +178,12 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
         params = valid_parameters
         params[:urn] = 123
 
-        expect { described_class.new(params).call }
-          .to raise_error(
-            Api::Transfers::CreateProjectService::ValidationError,
-            "Urn URN must be 6 digits long. For example, 123456."
-          )
+        subject = described_class.new(params)
+
+        expect { subject.call }
+          .to raise_error(Api::Transfers::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("urn")
+        expect(subject.errors.to_json).to include("6 digits")
       end
     end
 
@@ -190,11 +191,12 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
       before { mock_academies_api_establishment_not_found(urn: 123456) }
 
       it "raises an error" do
-        expect { described_class.new(valid_parameters).call }
-          .to raise_error(
-            Api::Transfers::CreateProjectService::ValidationError,
-            "Urn There's no school or academy with that URN. Check the number you entered is correct."
-          )
+        subject = described_class.new(valid_parameters)
+
+        expect { subject.call }
+          .to raise_error(Api::Transfers::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("urn")
+        expect(subject.errors.to_json).to include("no school or academy")
       end
     end
 
@@ -203,11 +205,12 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
         params = valid_parameters
         params[:incoming_trust_ukprn] = 87654321
 
-        expect { described_class.new(params).call }
-          .to raise_error(
-            Api::Transfers::CreateProjectService::ValidationError,
-            "Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678."
-          )
+        subject = described_class.new(params)
+
+        expect { subject.call }
+          .to raise_error(Api::Transfers::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("incoming_trust_ukprn")
+        expect(subject.errors.to_json).to include("8 digits")
       end
     end
 
@@ -215,11 +218,12 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
       before { mock_academies_api_trust_not_found(ukprn: 10066123) }
 
       it "raises an error" do
-        expect { described_class.new(valid_parameters).call }
-          .to raise_error(
-            Api::Transfers::CreateProjectService::ValidationError,
-            "Incoming trust ukprn There's no trust with that UKPRN. Check the number you entered is correct."
-          )
+        subject = described_class.new(valid_parameters)
+
+        expect { subject.call }
+          .to raise_error(Api::Transfers::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("incoming_trust_ukprn")
+        expect(subject.errors.to_json).to include("no trust with that UKPRN")
       end
     end
 
@@ -228,26 +232,25 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
         params = valid_parameters
         params[:outgoing_trust_ukprn] = 87654321
 
-        expect { described_class.new(params).call }
-          .to raise_error(
-            Api::Transfers::CreateProjectService::ValidationError,
-            "Outgoing trust ukprn UKPRN must be 8 digits long and start with a 1. For example, 12345678."
-          )
+        subject = described_class.new(params)
+
+        expect { subject.call }
+          .to raise_error(Api::Transfers::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("outgoing_trust_ukprn")
+        expect(subject.errors.to_json).to include("8 digits")
       end
     end
 
     context "when the trust for the outgoing trust UKPRN cannot be found" do
-      before { mock_academies_api_trust_not_found(ukprn: 12345678) }
+      before { mock_academies_api_trust_not_found(ukprn: 10010324) }
 
       it "raises an error" do
-        params = valid_parameters
-        params[:outgoing_trust_ukprn] = 12345678
+        subject = described_class.new(valid_parameters)
 
-        expect { described_class.new(params).call }
-          .to raise_error(
-            Api::Transfers::CreateProjectService::ValidationError,
-            "Outgoing trust ukprn There's no trust with that UKPRN. Check the number you entered is correct."
-          )
+        expect { subject.call }
+          .to raise_error(Api::Transfers::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("outgoing_trust_ukprn")
+        expect(subject.errors.to_json).to include("no trust with that UKPRN")
       end
     end
 
@@ -256,11 +259,12 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
         params = valid_parameters
         params[:prepare_id] = nil
 
-        expect { described_class.new(params).call }
-          .to raise_error(
-            Api::Transfers::CreateProjectService::ValidationError,
-            "Prepare You must supply a Prepare ID when creating a project via the API"
-          )
+        subject = described_class.new(params)
+
+        expect { subject.call }
+          .to raise_error(Api::Transfers::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("prepare_id")
+        expect(subject.errors.to_json).to include("You must supply a Prepare ID")
       end
     end
 
@@ -268,11 +272,12 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
       it "raises an error" do
         create(:transfer_project, urn: 123456)
 
-        expect { described_class.new(valid_parameters).call }
-          .to raise_error(
-            Api::Transfers::CreateProjectService::ValidationError,
-            "Urn There is already an in-progress project with this URN"
-          )
+        subject = described_class.new(valid_parameters)
+
+        expect { subject.call }
+          .to raise_error(Api::Transfers::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("urn")
+        expect(subject.errors.to_json).to include("already an in-progress project")
       end
     end
 
@@ -295,9 +300,12 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
         params[:incoming_trust_ukprn] = nil
         params[:new_trust_reference_number] = "12345"
 
-        expect { described_class.new(params).call }
-          .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
-            "New trust reference number The Trust reference number must be 'TR' followed by 5 numbers, e.g. TR01234")
+        subject = described_class.new(params)
+
+        expect { subject.call }
+          .to raise_error(Api::Transfers::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("new_trust_reference_number")
+        expect(subject.errors.to_json).to include("followed by 5 numbers")
       end
     end
 
@@ -306,9 +314,12 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
         params = valid_parameters
         params[:advisory_board_date] = Date.today + 2.years
 
-        expect { described_class.new(params).call }
-          .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
-            "Advisory board date The advisory board date must be in the past")
+        result = described_class.new(params)
+
+        expect { result.call }
+          .to raise_error(Api::Transfers::CreateProjectService::ValidationError)
+        expect(result.errors.to_json).to include("advisory_board_date")
+        expect(result.errors.to_json).to include("must be in the past")
       end
     end
 
@@ -317,9 +328,12 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
         params = valid_parameters
         params[:provisional_transfer_date] = "2024-1-2"
 
-        expect { described_class.new(params).call }
-          .to raise_error(Api::Conversions::CreateProjectService::ValidationError,
-            "Provisional transfer date must be on the first of the month")
+        subject = described_class.new(params)
+
+        expect { subject.call }
+          .to raise_error(Api::Transfers::CreateProjectService::ValidationError)
+        expect(subject.errors.to_json).to include("provisional_transfer_date")
+        expect(subject.errors.to_json).to include("the first of the month")
       end
     end
   end

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
         expect { described_class.new(valid_parameters).call }
           .to raise_error(
             Api::Transfers::CreateProjectService::ValidationError,
-            "An establishment with URN: 123456 could not be found on the Academies API"
+            "Urn There's no school or academy with that URN. Check the number you entered is correct."
           )
       end
     end
@@ -218,7 +218,7 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
         expect { described_class.new(valid_parameters).call }
           .to raise_error(
             Api::Transfers::CreateProjectService::ValidationError,
-            "A trust with UKPRN: 10066123 could not be found on the Academies API"
+            "Incoming trust ukprn There's no trust with that UKPRN. Check the number you entered is correct."
           )
       end
     end
@@ -246,7 +246,7 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
         expect { described_class.new(params).call }
           .to raise_error(
             Api::Transfers::CreateProjectService::ValidationError,
-            "A trust with UKPRN: 12345678 could not be found on the Academies API"
+            "Outgoing trust ukprn There's no trust with that UKPRN. Check the number you entered is correct."
           )
       end
     end


### PR DESCRIPTION
This work makes the validation errors returned by the API structured instead of
one big string.

Based on #1920 
