### PR TITLE
Handover index and check views

### DIFF
--- a/app/controllers/all/handover/projects_controller.rb
+++ b/app/controllers/all/handover/projects_controller.rb
@@ -1,0 +1,11 @@
+class All::Handover::ProjectsController < ApplicationController
+  after_action :verify_authorized
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
+
+  def index
+    authorize Project, :handover?
+
+    @pager, @projects = pagy(Project.inactive.ordered_by_significant_date)
+    AcademiesApiPreFetcherService.new.call!(@projects)
+  end
+end

--- a/app/controllers/all/handover/projects_controller.rb
+++ b/app/controllers/all/handover/projects_controller.rb
@@ -8,4 +8,17 @@ class All::Handover::ProjectsController < ApplicationController
     @pager, @projects = pagy(Project.inactive.ordered_by_significant_date)
     AcademiesApiPreFetcherService.new.call!(@projects)
   end
+
+  def check
+    authorize Project, :handover?
+
+    @project = Project.find(params[:id])
+
+    case @project.type
+    when "Conversion::Project"
+      render "all/handover/projects/conversion/check"
+    when "Transfer::Project"
+      render "all/handover/projects/transfer/check"
+    end
+  end
 end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -10,6 +10,10 @@ class ProjectPolicy
     true
   end
 
+  def handover?
+    @user.is_regional_delivery_officer?
+  end
+
   def show?
     return false if @project.deleted?
 

--- a/app/views/all/handover/projects/_handover_table.html.erb
+++ b/app/views/all/handover/projects/_handover_table.html.erb
@@ -1,0 +1,30 @@
+<% if projects.empty? %>
+  <%= govuk_inset_text(text: t("project.table..empty")) %>
+<% else %>
+  <table class="govuk-table" name="projects_table" aria-label="Projects table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.incoming_trust") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.provisional_conversion_or_transfer_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.advisory_board_date") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% projects.each do |project| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+        <td class="govuk-table__cell"><%= project.urn %></td>
+        <td class="govuk-table__cell"><%= project.incoming_trust.name %></td>
+        <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
+        <td class="govuk-table__cell"><%= project.advisory_board_date.to_fs(:govuk) %></td>
+        <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<%= govuk_pagination(pagy: pager) %>

--- a/app/views/all/handover/projects/_handover_table.html.erb
+++ b/app/views/all/handover/projects/_handover_table.html.erb
@@ -10,6 +10,7 @@
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.provisional_conversion_or_transfer_date") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.table.headers.advisory_board_date") %></th>
         <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
+        <th class="govuk-table__header" scope="col"><%= t("project.table.headers.add_handover_details") %></th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -21,6 +22,9 @@
         <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
         <td class="govuk-table__cell"><%= project.advisory_board_date.to_fs(:govuk) %></td>
         <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
+        <td class="govuk-table__cell">
+          <%= link_to t("project.table.body.add_handover_details"), check_all_handover_projects_path(project) %>
+        </td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/all/handover/projects/_transfer_summary.html.erb
+++ b/app/views/all/handover/projects/_transfer_summary.html.erb
@@ -1,0 +1,42 @@
+    <%= govuk_summary_list(actions: false, html_attributes: {id: "project-summary", class: "dfe-summary-list--project-summary"}) do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.type") }
+            row.with_value { t("project.handover.check.summary.values.project_type.#{project.type_locale}") }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.academy_name") }
+            row.with_value { project.establishment.name }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.urn") }
+            row.with_value { project.urn.to_s }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.incoming_trust.name") }
+            row.with_value { project.incoming_trust.name }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.incoming_trust.ukprn") }
+            row.with_value { project.incoming_trust.ukprn }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.outgoing_trust.name") }
+            row.with_value { project.outgoing_trust.name }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.outgoing_trust.ukprn") }
+            row.with_value { project.outgoing_trust.ukprn }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.advisory_board_date") }
+            row.with_value { project.advisory_board_date.to_fs(:govuk) }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.provisional_transfer_date") }
+            row.with_value { project.transfer_date.to_fs(:govuk) }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.regional_delivery_officer") }
+            row.with_value { project.regional_delivery_officer.full_name }
+          end
+        end %>

--- a/app/views/all/handover/projects/conversion/check.html.erb
+++ b/app/views/all/handover/projects/conversion/check.html.erb
@@ -1,0 +1,66 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("project.handover.check.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      <%= t("project.handover.check.title") %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <%= govuk_summary_list(actions: false, html_attributes: {id: "project-summary", class: "dfe-summary-list--project-summary"}) do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.type") }
+            row.with_value { t("project.handover.check.summary.values.project_type.#{@project.type_locale}") }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.school_name") }
+            row.with_value { @project.establishment.name }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.urn") }
+            row.with_value { @project.urn.to_s }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.incoming_trust.name") }
+            row.with_value { @project.incoming_trust.name }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.incoming_trust.ukprn") }
+            row.with_value { @project.incoming_trust.ukprn }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.advisory_board_date") }
+            row.with_value { @project.advisory_board_date.to_fs(:govuk) }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.provisional_conversion_date") }
+            row.with_value { @project.conversion_date.to_fs(:govuk) }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.directive_academy_order") }
+            row.with_value { t("project.handover.check.summary.values.directive_academy_order.#{@project.directive_academy_order}") }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.regional_delivery_officer") }
+            row.with_value { @project.regional_delivery_officer.full_name }
+          end
+        end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-button-group">
+      <%= link_to t("project.handover.check.cancel"), all_handover_projects_path, class: "govuk-link" %>
+    </div>
+  </div>
+</div>

--- a/app/views/all/handover/projects/index.html.erb
+++ b/app/views/all/handover/projects/index.html.erb
@@ -1,0 +1,22 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("project.all.handover.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      <%= t("project.all.handover.title") %>
+    </h1>
+    <%= t("project.all.handover.body_html") %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render partial: "handover_table", locals: {projects: @projects, pager: @pager} %>
+  </div>
+</div>

--- a/app/views/all/handover/projects/transfer/check.html.erb
+++ b/app/views/all/handover/projects/transfer/check.html.erb
@@ -1,0 +1,70 @@
+<% content_for :primary_navigation do %>
+  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_title(t("project.handover.check.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      <%= t("project.handover.check.title") %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <%= govuk_summary_list(actions: false, html_attributes: {id: "project-summary", class: "dfe-summary-list--project-summary"}) do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.type") }
+            row.with_value { t("project.handover.check.summary.values.project_type.#{@project.type_locale}") }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.academy_name") }
+            row.with_value { @project.establishment.name }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.urn") }
+            row.with_value { @project.urn.to_s }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.incoming_trust.name") }
+            row.with_value { @project.incoming_trust.name }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.incoming_trust.ukprn") }
+            row.with_value { @project.incoming_trust.ukprn }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.outgoing_trust.name") }
+            row.with_value { @project.outgoing_trust.name }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.outgoing_trust.ukprn") }
+            row.with_value { @project.outgoing_trust.ukprn }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.advisory_board_date") }
+            row.with_value { @project.advisory_board_date.to_fs(:govuk) }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.provisional_transfer_date") }
+            row.with_value { @project.transfer_date.to_fs(:govuk) }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.regional_delivery_officer") }
+            row.with_value { @project.regional_delivery_officer.full_name }
+          end
+        end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-button-group">
+      <%= link_to t("project.handover.check.cancel"), all_handover_projects_path, class: "govuk-link" %>
+    </div>
+  </div>
+</div>

--- a/config/locales/handover.en.yml
+++ b/config/locales/handover.en.yml
@@ -1,0 +1,29 @@
+en:
+  project:
+    handover:
+      check:
+        title: Check you have the right project
+        cancel: Choose a different project
+        summary:
+          type: Type of project
+          school_name: School name
+          academy_name: Academy name
+          urn: URN
+          incoming_trust:
+            name: Incoming trust name
+            ukprn: Incoming trust UKPRN
+          outgoing_trust:
+            name: Outgoing trust name
+            ukprn: Outgoing trust UKPRN
+          advisory_board_date: Advisory board date
+          provisional_conversion_date: Provisional conversion date
+          provisional_transfer_date: Provisional transfer date
+          directive_academy_order: Type of academy order
+          regional_delivery_officer: Assigned to in Prepare
+          values:
+            project_type:
+              conversion_project: Conversion project
+              transfer_project: Transfer project
+            directive_academy_order:
+              "true": "DAO (Directive academy order)"
+              "false": "AO (Academy order)"

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -194,6 +194,7 @@ en:
         added_by: Added by
         conversion_date: Conversion date
         advisory_board_date: Advisory board date
+        add_handover_details: Add handover details
         provisional_conversion_or_transfer_date: Provisional conversion or transfer date
         conversion_or_transfer_date: Conversion or transfer date
         created_at: Created at date
@@ -252,6 +253,7 @@ en:
         export_link: Export
         export_link_title_conversions_html: Download the funding export for %{date} conversions
         conversion_project_count_html: "%{count} <span class='govuk-visually-hidden'>school(s) converting in %{date}</span>"
+        add_handover_details: Add handover details
       empty:
         projects: There are no projects
       in_progress:

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -17,6 +17,12 @@ en:
       completing_a_project_link: Completing a project
       dao_revocation_link: Revoke a Directive Academy Order
     all:
+      handover:
+        title: Projects to handover
+        body_html:
+          <p>These projects have been worked on in Prepare, approved, and automatically added to Complete.</p>
+          <p>However, you must add some missing details before the project can continue.</p>
+          <p>Confirm who will manage these projects next, then add handover notes and contact details.</p>
       in_progress:
         title: All projects in progress
         tab: All projects
@@ -187,6 +193,8 @@ en:
         assign: Assign project
         added_by: Added by
         conversion_date: Conversion date
+        advisory_board_date: Advisory board date
+        provisional_conversion_or_transfer_date: Provisional conversion or transfer date
         conversion_or_transfer_date: Conversion or transfer date
         created_at: Created at date
         revised_date: Revised date

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,7 @@ Rails.application.routes.draw do
       namespace :all do
         namespace :handover do
           get "/", to: "projects#index"
+          get "/:id/check", to: "projects#check", as: :check
         end
         namespace :in_progress, path: "in-progress" do
           get "all", to: "projects#all_index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,9 @@ Rails.application.routes.draw do
   resources :projects, only: %i[index] do
     collection do
       namespace :all do
+        namespace :handover do
+          get "/", to: "projects#index"
+        end
         namespace :in_progress, path: "in-progress" do
           get "all", to: "projects#all_index"
           get "conversions", to: "projects#conversions_index"

--- a/spec/features/all_projects/handover/user_can_handover_projects_spec.rb
+++ b/spec/features/all_projects/handover/user_can_handover_projects_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.feature "Users can handover projects" do
+  before do
+    user = create(:regional_delivery_officer_user)
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  context "when the project is a conversion" do
+    let!(:conversion_project) {
+      create(
+        :conversion_project,
+        state: :inactive, urn: 123456,
+        conversion_date: Date.new(2024, 2, 1)
+      )
+    }
+
+    scenario "they can check they have the right project and cancel if not" do
+      visit all_handover_projects_path
+      click_link "Add handover details"
+
+      expect(page).to have_content("Check you have the right project")
+      expect(page).to have_content("Conversion project")
+      expect(page).to have_content(conversion_project.urn)
+
+      click_link "Choose a different project"
+
+      expect(page).to have_content("Projects to handover")
+      expect(page).to have_content("These projects have been worked on in Prepare")
+    end
+  end
+
+  context "when the project is a transfer" do
+    let!(:transfer_project) {
+      create(
+        :transfer_project,
+        state: :inactive,
+        urn: 165432,
+        transfer_date: Date.new(2024, 1, 1)
+      )
+    }
+
+    scenario "they can check they have the right project and cancel if not" do
+      visit all_handover_projects_path
+      click_link "Add handover details"
+
+      expect(page).to have_content("Check you have the right project")
+      expect(page).to have_content("Transfer project")
+      expect(page).to have_content(transfer_project.urn)
+
+      click_link "Choose a different project"
+
+      expect(page).to have_content("Projects to handover")
+      expect(page).to have_content("These projects have been worked on in Prepare")
+    end
+  end
+end

--- a/spec/features/all_projects/handover/user_can_view_a_list_of_projects_spec.rb
+++ b/spec/features/all_projects/handover/user_can_view_a_list_of_projects_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.feature "Users can view a list of handover projects" do
+  before do
+    user = create(:regional_delivery_officer_user)
+    sign_in_with_user(user)
+    mock_all_academies_api_responses
+  end
+
+  scenario "as a table" do
+    conversion_project = create(:conversion_project, state: :inactive, urn: 123456, conversion_date: Date.new(2024, 2, 1))
+    transfer_project = create(:transfer_project, state: :inactive, urn: 165432, transfer_date: Date.new(2024, 1, 1))
+
+    visit all_handover_projects_path
+
+    expect(page).to have_content("Projects to handover")
+    expect(page).to have_content("These projects have been worked on in Prepare")
+
+    within("tbody tr:first-of-type") do
+      expect(page).to have_content(transfer_project.urn)
+    end
+
+    within("tbody tr:last-of-type") do
+      expect(page).to have_content(conversion_project.urn)
+    end
+  end
+end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -173,4 +173,16 @@ RSpec.describe ProjectPolicy do
       expect(subject).not_to permit(create(:user))
     end
   end
+
+  permissions :handover? do
+    it "grants access if the user is a regional delivery officer" do
+      expect(subject).to permit(build(:regional_delivery_officer_user))
+    end
+
+    it "denies access if the user is not a regional delivery officer" do
+      expect(subject).not_to permit(build(:regional_casework_services_user))
+      expect(subject).not_to permit(build(:service_support_user))
+      expect(subject).not_to permit(build(:inactive_user))
+    end
+  end
 end

--- a/spec/requests/all/handover/projects_controller_spec.rb
+++ b/spec/requests/all/handover/projects_controller_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe All::Handover::ProjectsController, type: :request do
+  before do
+    user = create(:regional_delivery_officer_user)
+    sign_in_with(user)
+    mock_all_academies_api_responses
+  end
+
+  describe "#check" do
+    context "when the project is a conversion" do
+      let!(:project) { create(:conversion_project) }
+
+      it "renders the correct template" do
+        get "/projects/all/handover/#{project.id}/check"
+
+        expect(response).to render_template("all/handover/projects/conversion/check")
+      end
+    end
+
+    context "when the project is a transfer" do
+      let!(:project) { create(:transfer_project) }
+
+      it "renders the correct template" do
+        get "/projects/all/handover/#{project.id}/check"
+
+        expect(response).to render_template("all/handover/projects/transfer/check")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This works start the handover journeys for Regional Delivery Officers to hand
projects that have been created on the API from the Prepare application to other
users.

We introduce the index view of projects in the `inactive` state and a 'check
you have the right project' view for both conversions and transfers.

Users can cancel from the check pages, returning to the index.

We have not added the index to the navigation yet or implemented the actual handover process.

The API is not in use right now so there is no risk of users attempting this journey even if they came across it without the navigation.
