### PR TITLE
Ensure Inactive projects don't appear in listing pages

### DIFF
--- a/app/controllers/your/projects_controller.rb
+++ b/app/controllers/your/projects_controller.rb
@@ -11,7 +11,7 @@ class Your::ProjectsController < ApplicationController
 
   def added_by
     authorize Project, :index?
-    @pager, @projects = pagy(Project.added_by(current_user).not_completed.ordered_by_significant_date.includes(:assigned_to))
+    @pager, @projects = pagy(Project.added_by(current_user).not_completed.not_inactive.ordered_by_significant_date.includes(:assigned_to))
 
     AcademiesApiPreFetcherService.new.call!(@projects)
   end

--- a/spec/features/projects/added_by/user_can_view_the_projects_they_have_added_spec.rb
+++ b/spec/features/projects/added_by/user_can_view_the_projects_they_have_added_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature "Viewing all projects a user has added" do
     let!(:in_progress_project) { create(:conversion_project, urn: 115652, regional_delivery_officer: user) }
     let!(:sponsored_in_progress_project) { create(:conversion_project, urn: 112209, directive_academy_order: true, regional_delivery_officer: user) }
     let!(:voluntary_in_progress_project) { create(:conversion_project, urn: 103835, directive_academy_order: false, regional_delivery_officer: user) }
+    let!(:inactive_project) { create(:conversion_project, :inactive, urn: 187356, regional_delivery_officer: user) }
     let!(:other_project) { create(:conversion_project) }
 
     scenario "they can view all in progress projects that they added" do
@@ -43,6 +44,7 @@ RSpec.feature "Viewing all projects a user has added" do
         expect(page).to have_content(voluntary_in_progress_project.urn)
 
         expect(page).not_to have_content(completed_project.urn)
+        expect(page).not_to have_content(inactive_project.urn)
         expect(page).not_to have_content(other_project.urn)
       end
     end

--- a/spec/features/projects/view_unassigend_team_projects_spec.rb
+++ b/spec/features/projects/view_unassigend_team_projects_spec.rb
@@ -9,13 +9,15 @@ RSpec.feature "Viewing unassigned team projects" do
   context "as a regional casework services lead" do
     let(:user) { create(:user, :team_leader) }
 
-    scenario "they can view all unassigned projects in the team" do
+    scenario "they can view all unassigned projects in the team, except for inactive projects" do
       matching_project = create(:conversion_project, assigned_to: nil, team: "regional_casework_services")
+      inactive_project = create(:conversion_project, :inactive, urn: 156843, team: "regional_casework_services")
 
       visit unassigned_team_projects_path
 
       expect(page).to have_content(matching_project.urn)
       expect(page).to have_content(matching_project.establishment.region_name)
+      expect(page).not_to have_content(inactive_project.urn)
     end
   end
 end

--- a/spec/services/by_month_project_fetcher_service_spec.rb
+++ b/spec/services/by_month_project_fetcher_service_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe ByMonthProjectFetcherService do
 
         unconfirmed_project = create(:conversion_project, significant_date_provisional: true, significant_date: january)
         completed_project = create(:conversion_project, :completed, significant_date: january)
+        inactive_project = create(:conversion_project, :inactive, significant_date: january)
 
         create(:date_history, project: project_1, previous_date: january, revised_date: january)
         create(:date_history, project: project_2, previous_date: february, revised_date: march)
@@ -61,6 +62,7 @@ RSpec.describe ByMonthProjectFetcherService do
         expect(result).to eq([project_1, project_2, project_3])
         expect(result).not_to include(unconfirmed_project)
         expect(result).not_to include(completed_project)
+        expect(result).not_to include(inactive_project)
       end
     end
   end
@@ -111,11 +113,13 @@ RSpec.describe ByMonthProjectFetcherService do
 
         unconfirmed_project = create(:transfer_project, significant_date_provisional: true, significant_date: january)
         completed_project = create(:transfer_project, :completed, significant_date: january)
+        inactive_project = create(:transfer_project, :inactive, significant_date: january)
 
         result = described_class.new.transfer_projects_by_date_range(Date.parse("2023-1-1"), Date.parse("2023-3-1"))
         expect(result).to eq([project_1, project_2, project_3])
         expect(result).not_to include(unconfirmed_project)
         expect(result).not_to include(completed_project)
+        expect(result).not_to include(inactive_project)
       end
     end
   end

--- a/spec/services/by_region_project_fetcher_service_spec.rb
+++ b/spec/services/by_region_project_fetcher_service_spec.rb
@@ -55,11 +55,12 @@ RSpec.describe ByRegionProjectFetcherService do
       expect(described_class.new.regional_casework_services_projects(user.team)).to match_array []
     end
 
-    it "does not include completed, deleted or dao_revoked projects" do
+    it "does not include completed, deleted, inactive or dao_revoked projects" do
       user = create(:user, team: "london")
       _completed_project = create(:conversion_project, :completed, region: "london", team: "regional_casework_services")
       _deleted_project = create(:conversion_project, :deleted, region: "north_west", team: "regional_casework_services")
       _dao_revoked_project = create(:conversion_project, :dao_revoked, region: "north_west", team: "regional_casework_services")
+      _inactive_project = create(:conversion_project, :inactive, region: "north_west", team: "regional_casework_services")
 
       expect(described_class.new.regional_casework_services_projects(user.team)).to match_array []
     end


### PR DESCRIPTION
Inactive (state: 4) projects are not included in most listing pages but add some tests to make sure they dofinitely don't. Also exclude them from the "added_by" page and "not completed" by team pages.

