### PR TITLE
Add handover form object

### DIFF
--- a/app/forms/new_handover_stepped_form.rb
+++ b/app/forms/new_handover_stepped_form.rb
@@ -1,0 +1,69 @@
+class NewHandoverSteppedForm
+  include Teamable
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :assigned_to_regional_caseworker_team, :boolean
+  attribute :handover_note_body, :string
+  attribute :establishment_sharepoint_link, :string
+  attribute :incoming_trust_sharepoint_link, :string
+  attribute :outgoing_trust_sharepoint_link, :string
+  attribute :two_requires_improvement, :boolean
+  attribute :team, :string
+  attribute :email, :string
+
+  validates :assigned_to_regional_caseworker_team, inclusion: {in: [true, false]}
+
+  validates :handover_note_body, presence: true
+
+  validates :establishment_sharepoint_link, presence: true, sharepoint_url: true
+  validates :incoming_trust_sharepoint_link, presence: true, sharepoint_url: true
+
+  validates :outgoing_trust_sharepoint_link, presence: true, sharepoint_url: true, if: -> { @project.is_a?(Transfer::Project) }
+
+  validates :two_requires_improvement, inclusion: {in: [true, false]}, if: -> { @project.is_a?(Conversion::Project) }
+
+  validates :team, presence: true, inclusion: {in: regional_teams}, on: :assign
+
+  validates :email, presence: true, on: :assign
+  validates :email, format: {with: /\A\S+@education.gov.uk\z/i}, if: -> { email.present? }
+  validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}, if: -> { email.present? }
+
+  def self.list_of_teams
+    regional_teams.sort.map do |team|
+      OpenStruct.new(id: team, name: I18n.t("teams.#{team}"))
+    end
+  end
+
+  def initialize(project, user, args = {})
+    @user = user
+    @project = project
+    super(args)
+  end
+
+  def save
+    @project.assign_attributes({
+      team: team || :regional_casework_services,
+      assigned_to_id: assigned_user_id,
+      assigned_at: DateTime.now,
+      establishment_sharepoint_link: establishment_sharepoint_link,
+      incoming_trust_sharepoint_link: incoming_trust_sharepoint_link,
+      outgoing_trust_sharepoint_link: outgoing_trust_sharepoint_link,
+      two_requires_improvement: two_requires_improvement,
+      state: :active
+    })
+    @project.save!
+
+    create_handover_note!
+  end
+
+  private def assigned_user_id
+    return unless email
+
+    User.find_by_email(email).id
+  end
+
+  private def create_handover_note!
+    Note.create!(body: handover_note_body, project: @project, user: @user, task_identifier: :handover)
+  end
+end

--- a/spec/forms/new_handover_stepped_form_spec.rb
+++ b/spec/forms/new_handover_stepped_form_spec.rb
@@ -1,0 +1,363 @@
+require "rails_helper"
+
+RSpec.describe NewHandoverSteppedForm, type: :model do
+  before do
+    mock_successful_api_response_to_create_any_project
+  end
+
+  describe "validations" do
+    context "in the default validation context" do
+      context "for a conversion project" do
+        let(:regional_delivery_officer) { create(:regional_delivery_officer_user) }
+        let(:project) { create(:conversion_project) }
+        let(:params) { valid_conversion_attributes }
+        subject { described_class.new(project, regional_delivery_officer, params) }
+
+        describe "with all valid attributes" do
+          it "is valid" do
+            params[:team] = nil
+            params[:email] = nil
+
+            expect(subject).to be_valid
+          end
+        end
+
+        describe "assigned to regional casework team" do
+          it "is required" do
+            params[:assigned_to_regional_caseworker_team] = nil
+
+            expect(subject).to be_invalid
+          end
+        end
+
+        describe "handover note" do
+          it "is required" do
+            params[:handover_note_body] = nil
+
+            expect(subject).to be_invalid
+          end
+        end
+
+        describe "sharepoint links" do
+          it "establishment is required" do
+            params[:establishment_sharepoint_link] = nil
+
+            expect(subject).to be_invalid
+          end
+
+          it "incoming trust is required" do
+            params[:incoming_trust_sharepoint_link] = nil
+
+            expect(subject).to be_invalid
+          end
+
+          it "must be a valid sharepoint link" do
+            params[:establishment_sharepoint_link] = "http://not.sharepoint.com"
+
+            expect(subject).to be_invalid
+          end
+        end
+
+        describe "requires two requires improvement" do
+          it "is required" do
+            params[:two_requires_improvement] = nil
+
+            expect(subject).to be_invalid
+          end
+        end
+      end
+
+      context "for a transfer project" do
+        let(:regional_delivery_officer) { create(:regional_delivery_officer_user) }
+        let(:project) { create(:transfer_project) }
+        let(:params) { valid_transfer_attributes }
+        subject { described_class.new(project, regional_delivery_officer, params) }
+
+        describe "with all valid attributes" do
+          it "is valid" do
+            params[:team] = nil
+            params[:email] = nil
+
+            expect(subject).to be_valid
+          end
+        end
+
+        describe "assigned to regional casework team" do
+          it "is required" do
+            params[:assigned_to_regional_caseworker_team] = nil
+
+            expect(subject).to be_invalid
+          end
+        end
+
+        describe "handover note" do
+          it "is required" do
+            params[:handover_note_body] = nil
+
+            expect(subject).to be_invalid
+          end
+        end
+
+        describe "sharepoint links" do
+          it "establishment is required" do
+            params[:establishment_sharepoint_link] = nil
+
+            expect(subject).to be_invalid
+          end
+
+          it "incoming trust is required" do
+            params[:incoming_trust_sharepoint_link] = nil
+
+            expect(subject).to be_invalid
+          end
+
+          it "outgoing trust is required" do
+            params[:outgoing_trust_sharepoint_link] = nil
+
+            expect(subject).to be_invalid
+          end
+
+          it "must be a valid sharepoint link" do
+            params[:establishment_sharepoint_link] = "http://not.sharepoint.com"
+
+            expect(subject).to be_invalid
+          end
+        end
+      end
+    end
+
+    context "in the assign validation context" do
+      context "for a conversion project" do
+        let(:regional_delivery_officer) { create(:regional_delivery_officer_user) }
+        let(:project) { create(:conversion_project) }
+        let(:params) { valid_conversion_attributes }
+        subject { described_class.new(project, regional_delivery_officer, params) }
+
+        describe "with all valid attributes" do
+          it "is valid" do
+            expect(subject).to be_valid(:assign)
+          end
+        end
+
+        it "requires the default attributes" do
+          params[:assigned_to_regional_caseworker_team] = nil
+          params[:handover_note_body] = nil
+          params[:establishment_sharepoint_link] = nil
+          params[:incoming_trust_sharepoint_link] = nil
+          params[:two_requires_improvement] = nil
+
+          expect(subject).to be_invalid(:assign)
+        end
+
+        describe "team" do
+          it "is required" do
+            params[:team] = nil
+
+            expect(subject).to be_invalid(:assign)
+          end
+
+          it "must be a valid team" do
+            params[:team] = "not_a_team"
+
+            expect(subject).to be_invalid(:assign)
+          end
+        end
+
+        describe "email" do
+          it "is required" do
+            params[:email] = nil
+
+            expect(subject).to be_invalid(:assign)
+          end
+
+          it "must be an @education.gov.uk address" do
+            params[:email] = "test.user@another.com"
+
+            expect(subject).to be_invalid(:assign)
+          end
+
+          it "must be a valid email address" do
+            params[:email] = "test.user.another.com"
+
+            expect(subject).to be_invalid(:assign)
+          end
+        end
+      end
+
+      context "for a transfer project" do
+        let(:regional_delivery_officer) { create(:regional_delivery_officer_user) }
+        let(:project) { create(:transfer_project) }
+        let(:params) { valid_transfer_attributes }
+        subject { described_class.new(project, regional_delivery_officer, params) }
+
+        describe "with all valid attributes" do
+          it "is valid" do
+            expect(subject).to be_valid(:assign)
+          end
+        end
+
+        it "requires the default attributes" do
+          params[:assigned_to_regional_caseworker_team] = nil
+          params[:handover_note_body] = nil
+          params[:establishment_sharepoint_link] = nil
+          params[:incoming_trust_sharepoint_link] = nil
+          params[:outgoing_trust_sharepoint_link] = nil
+
+          expect(subject).to be_invalid(:assign)
+        end
+
+        describe "team" do
+          it "is required" do
+            params[:team] = nil
+
+            expect(subject).to be_invalid(:assign)
+          end
+
+          it "must be a valid team" do
+            params[:team] = "not_a_team"
+
+            expect(subject).to be_invalid(:assign)
+          end
+        end
+
+        describe "email" do
+          it "is required" do
+            params[:email] = nil
+
+            expect(subject).to be_invalid(:assign)
+          end
+
+          it "must be an @education.gov.uk address" do
+            params[:email] = "test.user@another.com"
+
+            expect(subject).to be_invalid(:assign)
+          end
+
+          it "must be a valid email address" do
+            params[:email] = "test.user.another.com"
+
+            expect(subject).to be_invalid(:assign)
+          end
+        end
+      end
+    end
+  end
+
+  describe ".list_of_teams" do
+    it "returns an ordered  list of teams with id and name" do
+      team_list = described_class.list_of_teams
+
+      expect(team_list.first.id).to eql("east_midlands")
+      expect(team_list.first.name).to eql("East Midlands")
+
+      expect(team_list.last.id).to eql("yorkshire_and_the_humber")
+      expect(team_list.last.name).to eql("Yorkshire and the Humber")
+    end
+  end
+
+  describe "#save" do
+    it "updates the project, making it valid and sets the state to active" do
+      user = create(:regional_delivery_officer_user, email: "test.user@education.gov.uk")
+      project = build(
+        :conversion_project,
+        :inactive,
+        establishment_sharepoint_link: nil,
+        incoming_trust_sharepoint_link: nil,
+        two_requires_improvement: nil
+      )
+
+      expect(project).to be_invalid
+
+      subject = described_class.new(project, user, valid_conversion_attributes).save
+
+      expect(subject).to be_valid
+      expect(project.establishment_sharepoint_link).to eql "https://educationgovuk-my.sharepoint.com/establishment"
+      expect(project.incoming_trust_sharepoint_link).to eql "https://educationgovuk-my.sharepoint.com/incoming_trust"
+      expect(project.two_requires_improvement).to be true
+      expect(project).to be_active
+    end
+
+    it "creates the handover note" do
+      user = create(:regional_delivery_officer_user, email: "test.user@education.gov.uk")
+      project = build(
+        :conversion_project,
+        :inactive
+      )
+
+      expect(project.notes.count).to be_zero
+
+      described_class.new(project, user, valid_conversion_attributes).save
+      subject = project.handover_note
+
+      expect(subject.body).to eql "This is a test note.\n\nUsed in tests."
+      expect(subject.user).to eql user
+    end
+
+    context "when assigned to regional casework services team" do
+      it "assigns correctly" do
+        user = create(:regional_delivery_officer_user, email: "test.user@education.gov.uk")
+        project = build(
+          :conversion_project,
+          :inactive,
+          team: nil,
+          assigned_to: nil
+        )
+        params = valid_conversion_attributes
+        params[:assigned_to_regional_caseworker_team] = true
+        params[:team] = nil
+        params[:email] = nil
+
+        described_class.new(project, user, params).save
+
+        expect(project.team).to eql "regional_casework_services"
+        expect(project.assigned_to).to be_nil
+      end
+    end
+
+    context "when assigned to a regional team" do
+      it "assigns correctly" do
+        assigned_user = create(:regional_delivery_officer_user, email: "east.midlands@education.gov.uk")
+        user = create(:regional_delivery_officer_user, email: "test.user@education.gov.uk")
+        project = build(
+          :conversion_project,
+          :inactive,
+          team: nil,
+          assigned_to: nil
+        )
+        params = valid_conversion_attributes
+        params[:assigned_to_regional_caseworker_team] = false
+        params[:team] = "east_midlands"
+        params[:email] = "east.midlands@education.gov.uk"
+
+        described_class.new(project, user, params).save
+
+        expect(project.team).to eql "east_midlands"
+        expect(project.assigned_to).to eql assigned_user
+      end
+    end
+  end
+
+  def valid_conversion_attributes
+    {
+      assigned_to_regional_caseworker_team: true,
+      handover_note_body: "This is a test note.\n\nUsed in tests.",
+      establishment_sharepoint_link: "https://educationgovuk-my.sharepoint.com/establishment",
+      incoming_trust_sharepoint_link: "https://educationgovuk-my.sharepoint.com/incoming_trust",
+      two_requires_improvement: true,
+      team: "east_midlands",
+      email: "test.user@education.gov.uk"
+    }
+  end
+
+  def valid_transfer_attributes
+    {
+      assigned_to_regional_caseworker_team: true,
+      handover_note_body: "This is a test note.\n\nUsed in tests.",
+      establishment_sharepoint_link: "https://educationgovuk-my.sharepoint.com/establishment",
+      incoming_trust_sharepoint_link: "https://educationgovuk-my.sharepoint.com/incoming_trust",
+      outgoing_trust_sharepoint_link: "https://educationgovuk-my.sharepoint.com/incoming_trust",
+      team: "east_midlands",
+      email: "test.user@education.gov.uk"
+    }
+  end
+end


### PR DESCRIPTION
To 'handover' a project created on the API we need to add some
attributes that do not exist in the Prepare application and so cannot be
provided, projects added via the API are invalid until this is done.

The attributes differ for conversions and transfers and the actual
assignment to a user is different depending on the team the project is
assigned to.

As the variation is so small, we kept to this single fancy form object
with two validation contexts. Project use single table inheritance, so
we can assign the project type attributes regardless.

The default context is used when the project is assigned to the Regional
casework services team.

The 'assign' context is used when the project is assigned to one of the
regional teams and so requires extra attributes to be set.

This essentially makes this a very small 'stepped' form with only two
steps, which we have done before, we'll send all the attributes to the
second step when we need to.

We ensure the unused attributes are set to nil so we can simply save
whichever Project is passed in.

This will likely need refinement once in use, but it's a lot to review already
so I would like to get this in first!
