### PR TITLE
Fix: Auth in API docs

### DIFF
--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -18,10 +18,15 @@ class Api < Grape::API
     security_definitions: {
       api_key: {
         type: "apiKey",
-        name: "Apikey",
+        name: "ApiKey",
         in: "header"
       }
     },
+    security: [
+      {
+        api_key: []
+      }
+    ],
     consumes: ["application/json"],
     produces: ["application/json"],
     tags: [


### PR DESCRIPTION
We need to make the security declaration and requirement for the API to
work in the Swagger docs:

https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#security-requirement-object
