### PR TITLE
User can handover inactive projects

### DIFF
--- a/app/controllers/all/handover/handovers_controller.rb
+++ b/app/controllers/all/handover/handovers_controller.rb
@@ -1,11 +1,12 @@
 class All::Handover::HandoversController < ApplicationController
-  after_action :verify_authorized
+  include Projectable
   rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
+
+  before_action :set_form, except: [:check, :new]
+  after_action :verify_authorized
 
   def check
     authorize Project, :handover?
-
-    @project = Project.find(params[:id])
 
     case @project.type
     when "Conversion::Project"
@@ -13,5 +14,66 @@ class All::Handover::HandoversController < ApplicationController
     when "Transfer::Project"
       render "all/handover/projects/transfer/check"
     end
+  end
+
+  def new
+    authorize Project, :handover?
+
+    @form = NewHandoverSteppedForm.new(@project, @current_user)
+
+    render new_template_path
+  end
+
+  def create
+    authorize Project, :handover?
+
+    if @form.valid?
+      case @form.assigned_to_regional_caseworker_team
+      when true
+        @form.save
+        render "all/handover/projects/assigned_regional_casework_services"
+      when false
+        render "all/handover/projects/assign"
+      end
+    else
+      render new_template_path
+    end
+  end
+
+  def assign
+    authorize Project, :handover?
+
+    if @form.valid?(:assign)
+      @form.save
+      render "all/handover/projects/assigned_region"
+    else
+      render "all/handover/projects/assign"
+    end
+  end
+
+  private def new_template_path
+    case @project.type
+    when "Conversion::Project"
+      "all/handover/projects/conversion/new"
+    when "Transfer::Project"
+      "all/handover/projects/transfer/new"
+    end
+  end
+
+  private def set_form
+    @form = NewHandoverSteppedForm.new(@project, @current_user, handover_params)
+  end
+
+  private def handover_params
+    params.require(:new_handover_stepped_form).permit(
+      :assigned_to_regional_caseworker_team,
+      :handover_note_body,
+      :establishment_sharepoint_link,
+      :incoming_trust_sharepoint_link,
+      :outgoing_trust_sharepoint_link,
+      :two_requires_improvement,
+      :email,
+      :team
+    )
   end
 end

--- a/app/controllers/all/handover/handovers_controller.rb
+++ b/app/controllers/all/handover/handovers_controller.rb
@@ -1,0 +1,17 @@
+class All::Handover::HandoversController < ApplicationController
+  after_action :verify_authorized
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
+
+  def check
+    authorize Project, :handover?
+
+    @project = Project.find(params[:id])
+
+    case @project.type
+    when "Conversion::Project"
+      render "all/handover/projects/conversion/check"
+    when "Transfer::Project"
+      render "all/handover/projects/transfer/check"
+    end
+  end
+end

--- a/app/controllers/all/handover/projects_controller.rb
+++ b/app/controllers/all/handover/projects_controller.rb
@@ -1,24 +1,10 @@
 class All::Handover::ProjectsController < ApplicationController
   after_action :verify_authorized
-  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
 
   def index
     authorize Project, :handover?
 
     @pager, @projects = pagy(Project.inactive.ordered_by_significant_date)
     AcademiesApiPreFetcherService.new.call!(@projects)
-  end
-
-  def check
-    authorize Project, :handover?
-
-    @project = Project.find(params[:id])
-
-    case @project.type
-    when "Conversion::Project"
-      render "all/handover/projects/conversion/check"
-    when "Transfer::Project"
-      render "all/handover/projects/transfer/check"
-    end
   end
 end

--- a/app/controllers/concerns/projectable.rb
+++ b/app/controllers/concerns/projectable.rb
@@ -6,6 +6,8 @@ module Projectable
   end
 
   private def find_project
+    raise ActiveRecord::RecordNotFound unless valid_uuid?
+
     @project = Project.find(params[:project_id])
   end
 
@@ -18,5 +20,9 @@ module Projectable
     when "Transfer::Project"
       append_view_path "app/views/transfers"
     end
+  end
+
+  private def valid_uuid?
+    /[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i.match(params[:project_id])
   end
 end

--- a/app/forms/new_handover_stepped_form.rb
+++ b/app/forms/new_handover_stepped_form.rb
@@ -28,6 +28,7 @@ class NewHandoverSteppedForm
   validates :email, presence: true, on: :assign
   validates :email, format: {with: /\A\S+@education.gov.uk\z/i}, if: -> { email.present? }
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}, if: -> { email.present? }
+  validate :email_exists, on: :assign, if: -> { email.present? }
 
   def self.list_of_teams
     regional_teams.sort.map do |team|
@@ -57,10 +58,14 @@ class NewHandoverSteppedForm
     create_handover_note!
   end
 
+  private def email_exists
+    errors.add(:email, :email_does_not_exist) unless assigned_user_id
+  end
+
   private def assigned_user_id
     return unless email
 
-    User.find_by_email(email).id
+    User.find_by_email(email)&.id
   end
 
   private def create_handover_note!

--- a/app/views/all/handover/projects/_handover_table.html.erb
+++ b/app/views/all/handover/projects/_handover_table.html.erb
@@ -1,5 +1,5 @@
 <% if projects.empty? %>
-  <%= govuk_inset_text(text: t("project.table..empty")) %>
+  <%= govuk_inset_text(text: t("project.table.empty.handover")) %>
 <% else %>
   <table class="govuk-table" name="projects_table" aria-label="Projects table">
     <thead class="govuk-table__head">

--- a/app/views/all/handover/projects/assign.html.erb
+++ b/app/views/all/handover/projects/assign.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: assign_all_handover_projects_path(@project) do |form| %>
+
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_collection_radio_buttons :team, @form.class.list_of_teams, :id, :name %>
+
+      <%= form.govuk_text_field :email, label: {size: "m"}, width: 20 %>
+
+      <%= form.hidden_field :assigned_to_regional_caseworker_team %>
+      <%= form.hidden_field :handover_note_body %>
+      <%= form.hidden_field :establishment_sharepoint_link %>
+      <%= form.hidden_field :incoming_trust_sharepoint_link %>
+      <%= form.hidden_field :outgoing_trust_sharepoint_link %>
+      <%= form.hidden_field :two_requires_improvement %>
+
+      <%= form.govuk_submit(t("confirm")) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/all/handover/projects/assigned_region.html.erb
+++ b/app/views/all/handover/projects/assigned_region.html.erb
@@ -1,0 +1,32 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_panel(
+          title_text: "Project assigned",
+          text: "#{@project.establishment.name}<br> <strong>URN #{@project.urn}</strong>".html_safe
+        ) %>
+
+    <h2 class="govuk-heading-m">What happens next?</h2>
+    <p>This project will appear in the relevant team and person's project lists and work on it can begin.</p>
+
+    <h2 class="govuk-heading-m">Add contact details</h2>
+    <p>You must
+    <%= link_to "add contact details", project_contacts_path(@project) %>
+    for the:</p>
+    <ul>
+      <li>school</li>
+      <li>trust</li>
+      <li>solicitors</li>
+      <li>local authority</li>
+      <li>diocese (if applicable)</li>
+    </ul>
+    <p>This will make sure that teams who process funding letters and other legal documents can contact the relevant people.</p>
+
+    <%= govuk_button_link_to "Add contacts", project_contacts_path(@project) %>
+
+    <h2 class="govuk-heading-m">Hand over a another project</h2>
+    <p>You can
+    <%= link_to "return to the list of projects to handover", all_handover_projects_path %>
+    if you need to add details to others.</p>
+
+  </div>
+</div>

--- a/app/views/all/handover/projects/assigned_regional_casework_services.html.erb
+++ b/app/views/all/handover/projects/assigned_regional_casework_services.html.erb
@@ -1,0 +1,34 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_panel(
+          title_text: "Project handed over to Regional Casework Services",
+          text: "#{@project.establishment.name}<br> <strong>URN #{@project.urn}</strong>".html_safe
+        ) %>
+
+      <h2 class="govuk-heading-m">What happens next?</h2>
+      <p>This project will appear in the Regional Casework Services' project list.</p>
+      <p>It will only be assigned to a caseworker when external contacts have been added.</p>
+
+    <h2 class="govuk-heading-m">Add contact details</h2>
+    <p>You must
+    <%= link_to "add contact details", project_contacts_path(@project) %>
+    for the:</p>
+    <ul>
+      <li>school</li>
+      <li>trust</li>
+      <li>solicitors</li>
+      <li>local authority</li>
+      <li>diocese (if applicable)</li>
+    </ul>
+    <p>This will help the person continuing this project to organise the kick-off meeting.</p>
+    <p>Do not add any internal contacts.</p>
+
+    <%= govuk_button_link_to "Add contacts", project_contacts_path(@project) %>
+
+    <h2 class="govuk-heading-m">Hand over a nother project</h2>
+    <p>You can
+    <%= link_to "return to the list of projects to handover", all_handover_projects_path %>
+    if you need to add details to others.</p>
+
+  </div>
+</div>

--- a/app/views/all/handover/projects/conversion/check.html.erb
+++ b/app/views/all/handover/projects/conversion/check.html.erb
@@ -16,11 +16,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <%= govuk_summary_list(actions: false, html_attributes: {id: "project-summary", class: "dfe-summary-list--project-summary"}) do |summary_list|
-          summary_list.with_row do |row|
-            row.with_key { t("project.handover.check.summary.type") }
-            row.with_value { t("project.handover.check.summary.values.project_type.#{@project.type_locale}") }
-          end
+    <%= govuk_summary_list(actions: false, html_attributes: {id: "project-summary"}) do |summary_list|
           summary_list.with_row do |row|
             row.with_key { t("project.handover.check.summary.school_name") }
             row.with_value { @project.establishment.name }
@@ -28,6 +24,14 @@
           summary_list.with_row do |row|
             row.with_key { t("project.handover.check.summary.urn") }
             row.with_value { @project.urn.to_s }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.type") }
+            row.with_value { t("project.handover.check.summary.values.project_type.#{@project.type_locale}") }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.form_a_mat") }
+            row.with_value { t(@project.form_a_mat?) }
           end
           summary_list.with_row do |row|
             row.with_key { t("project.handover.check.summary.incoming_trust.name") }
@@ -60,6 +64,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <div class="govuk-button-group">
+      <%= link_to t("project.handover.check.confirm"), new_all_handover_projects_path(@project), class: "govuk-button" %>
       <%= link_to t("project.handover.check.cancel"), all_handover_projects_path, class: "govuk-link" %>
     </div>
   </div>

--- a/app/views/all/handover/projects/conversion/new.html.erb
+++ b/app/views/all/handover/projects/conversion/new.html.erb
@@ -1,0 +1,38 @@
+<% content_for :page_title do %>
+  <%= page_title(t("project.handover.new.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: new_all_handover_projects_path(@project) do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, yes_no_responses, :id, :name, form_group: {id: "assigned-to-regional-caseworker-team"} %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_text_area :handover_note_body,
+              label: {text: t("project.new.handover_comments_label"), size: "m"},
+              hint: {text: t("project.new.handover_comments_hint").html_safe} %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m"} %>
+        <%= form.govuk_text_field :incoming_trust_sharepoint_link, label: {size: "m"} %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_collection_radio_buttons :two_requires_improvement,
+              yes_no_responses,
+              :id,
+              :name,
+              legend: {text: t("helpers.legend.conversion_project.two_requires_improvement")},
+              hint: {text: t("helpers.hint.conversion_project.two_requires_improvement")},
+              form_group: {id: "two-requires-improvement"} %>
+      </div>
+
+      <%= form.govuk_submit(t("confirm")) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/all/handover/projects/transfer/check.html.erb
+++ b/app/views/all/handover/projects/transfer/check.html.erb
@@ -16,11 +16,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <%= govuk_summary_list(actions: false, html_attributes: {id: "project-summary", class: "dfe-summary-list--project-summary"}) do |summary_list|
-          summary_list.with_row do |row|
-            row.with_key { t("project.handover.check.summary.type") }
-            row.with_value { t("project.handover.check.summary.values.project_type.#{@project.type_locale}") }
-          end
+    <%= govuk_summary_list(actions: false, html_attributes: {id: "project-summary"}) do |summary_list|
           summary_list.with_row do |row|
             row.with_key { t("project.handover.check.summary.academy_name") }
             row.with_value { @project.establishment.name }
@@ -28,6 +24,14 @@
           summary_list.with_row do |row|
             row.with_key { t("project.handover.check.summary.urn") }
             row.with_value { @project.urn.to_s }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.type") }
+            row.with_value { t("project.handover.check.summary.values.project_type.#{@project.type_locale}") }
+          end
+          summary_list.with_row do |row|
+            row.with_key { t("project.handover.check.summary.form_a_mat") }
+            row.with_value { t(@project.form_a_mat?) }
           end
           summary_list.with_row do |row|
             row.with_key { t("project.handover.check.summary.incoming_trust.name") }
@@ -64,6 +68,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <div class="govuk-button-group">
+      <%= link_to t("project.handover.check.confirm"), new_all_handover_projects_path(@project), class: "govuk-button" %>
       <%= link_to t("project.handover.check.cancel"), all_handover_projects_path, class: "govuk-link" %>
     </div>
   </div>

--- a/app/views/all/handover/projects/transfer/new.html.erb
+++ b/app/views/all/handover/projects/transfer/new.html.erb
@@ -1,0 +1,29 @@
+<% content_for :page_title do %>
+  <%= page_title(t("project.handover.new.title")) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: new_all_handover_projects_path(@project) do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_collection_radio_buttons :assigned_to_regional_caseworker_team, yes_no_responses, :id, :name, form_group: {id: "assigned-to-regional-caseworker-team"} %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_text_area :handover_note_body,
+              label: {text: t("project.new.handover_comments_label"), size: "m"},
+              hint: {text: t("project.new.handover_comments_hint").html_safe} %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.govuk_text_field :establishment_sharepoint_link, label: {size: "m"} %>
+        <%= form.govuk_text_field :incoming_trust_sharepoint_link, label: {size: "m"} %>
+        <%= form.govuk_text_field :outgoing_trust_sharepoint_link, label: {size: "m"} %>
+      </div>
+
+      <%= form.govuk_submit(t("confirm")) %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,8 @@ en:
   support_email_subject: "Complete conversions, transfers and changes: support query"
   "yes": "Yes"
   "no": "No"
+  "true": "Yes"
+  "false": "No"
   cancel: Cancel
   edit: Edit
   delete: Delete

--- a/config/locales/handover.en.yml
+++ b/config/locales/handover.en.yml
@@ -28,3 +28,31 @@ en:
             directive_academy_order:
               "true": "DAO (Directive academy order)"
               "false": "AO (Academy order)"
+      new:
+        title: Add handover details
+  helpers:
+    legend:
+      new_handover_stepped_form:
+        assigned_to_regional_caseworker_team: Will RCS (Regional Casework Services) manage this project next?
+        team: Which region will complete this project?
+    label:
+      new_handover_stepped_form:
+        establishment_sharepoint_link: School SharePoint link
+        incoming_trust_sharepoint_link: Incoming trust SharePoint link
+        outgoing_trust_sharepoint_link: Outgoing trust SharePoint link
+        email: Who will complete this project?
+    hint:
+      new_handover_stepped_form:
+        establishment_sharepoint_link_html:
+          <p>If the school applied to convert, you must save the application form in the Schools' SharePoint folder.</p>
+          <p>You must also save the academy order and advisory board template. Do this whether the school applied to convert or not.</p>
+        incoming_trust_sharepoint_link_html:
+          <p>Provide a link to the SharePoint folder for the incoming trust. This is where you save all the relevant trust documents.</p>
+        outgoing_trust_sharepoint_link_html:
+          <p>Provide a link to the SharePoint folder for the outgoing trust. This is where you save all the relevant trust documents.</p>
+        email: Enter the name or @education.gov.uk email address of the person who will work on this project next.
+  activemodel:
+    errors:
+      models:
+        new_handover_stepped_form:
+          email_does_not_exist: Email address could not be found

--- a/config/locales/handover.en.yml
+++ b/config/locales/handover.en.yml
@@ -5,9 +5,10 @@ en:
         title: Check you have the right project
         cancel: Choose a different project
         summary:
-          type: Type of project
+          type: Project type
           school_name: School name
           academy_name: Academy name
+          form_a_mat: Form a MAT?
           urn: URN
           incoming_trust:
             name: Incoming trust name
@@ -22,8 +23,8 @@ en:
           regional_delivery_officer: Assigned to in Prepare
           values:
             project_type:
-              conversion_project: Conversion project
-              transfer_project: Transfer project
+              conversion_project: Conversion
+              transfer_project: Transfer
             directive_academy_order:
               "true": "DAO (Directive academy order)"
               "false": "AO (Academy order)"

--- a/config/locales/project.en.yml
+++ b/config/locales/project.en.yml
@@ -256,6 +256,7 @@ en:
         add_handover_details: Add handover details
       empty:
         projects: There are no projects
+        handover: There are no projects to handover
       in_progress:
         empty: There are no projects in progress.
         conversions:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,7 +145,7 @@ Rails.application.routes.draw do
       namespace :all do
         namespace :handover do
           get "/", to: "projects#index"
-          get "/:id/check", to: "projects#check", as: :check
+          get "/:id/check", to: "handovers#check", as: :check
         end
         namespace :in_progress, path: "in-progress" do
           get "all", to: "projects#all_index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,7 +145,10 @@ Rails.application.routes.draw do
       namespace :all do
         namespace :handover do
           get "/", to: "projects#index"
-          get "/:id/check", to: "handovers#check", as: :check
+          get "/:project_id/check", to: "handovers#check", as: :check
+          get "/:project_id/new", to: "handovers#new", as: :new
+          post "/:project_id/new", to: "handovers#create"
+          post "/:project_id/assign", to: "handovers#assign", as: :assign
         end
         namespace :in_progress, path: "in-progress" do
           get "all", to: "projects#all_index"

--- a/spec/features/all_projects/handover/handover_conversion_project_spec.rb
+++ b/spec/features/all_projects/handover/handover_conversion_project_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.feature "Handover a conversion project" do
+  before do
+    application_user = create(:regional_delivery_officer_user)
+    sign_in_with_user(application_user)
+    mock_all_academies_api_responses
+  end
+
+  scenario "to the Regional team" do
+    prepare_user = create(:user, email: "prepare.user@education.gov.uk", first_name: "Prepare", last_name: "User", team: "east_midlands")
+    complete_user = create(:user, email: "complete.user@education.gov.uk", first_name: "Complete", last_name: "User", team: :north_west)
+    project = create(:conversion_project, :inactive, regional_delivery_officer: prepare_user)
+
+    visit all_handover_projects_path
+
+    expect(page).to have_content(project.urn)
+
+    click_link "Add handover details"
+
+    expect(page).to have_content("Check you have the right project")
+    expect(page).to have_content(project.urn)
+
+    click_link "Confirm"
+
+    expect(page).to have_content("Will RCS (Regional Casework Services) manage this project next?")
+
+    within "#assigned-to-regional-caseworker-team" do
+      choose "No"
+    end
+    fill_in "Handover comments", with: "Test handover comments.\n\nThese are the handover comments for tests."
+    fill_in "School SharePoint link", with: "https://educationgovuk.sharepoint.com/establishment"
+    fill_in "Incoming trust SharePoint link", with: "https://educationgovuk.sharepoint.com/incoming-trust"
+    within "#two-requires-improvement" do
+      choose "No"
+    end
+    click_button "Confirm"
+
+    expect(page).to have_content("Which region will complete this project?")
+
+    choose "North West"
+    fill_in "Who will complete this project?", with: complete_user.email
+    click_button "Confirm"
+
+    expect(page).to have_content("Project assigned")
+    expect(page).to have_link("add contact details")
+    expect(page).to have_link("return to the list of projects to handover")
+  end
+
+  scenario "to the Regional Casework Services team" do
+    prepare_user = create(:user, email: "prepare.user@education.gov.uk", first_name: "Prepare", last_name: "User", team: "east_midlands")
+    project = create(:conversion_project, :inactive, regional_delivery_officer: prepare_user)
+
+    visit all_handover_projects_path
+
+    expect(page).to have_content(project.urn)
+
+    click_link "Add handover details"
+
+    expect(page).to have_content("Check you have the right project")
+    expect(page).to have_content(project.urn)
+
+    click_link "Confirm"
+
+    expect(page).to have_content("Will RCS (Regional Casework Services) manage this project next?")
+
+    within "#assigned-to-regional-caseworker-team" do
+      choose "Yes"
+    end
+    fill_in "Handover comments", with: "Test handover comments.\n\nThese are the handover comments for tests."
+    fill_in "School SharePoint link", with: "https://educationgovuk.sharepoint.com/establishment"
+    fill_in "Incoming trust SharePoint link", with: "https://educationgovuk.sharepoint.com/incoming-trust"
+    within "#two-requires-improvement" do
+      choose "No"
+    end
+    click_button "Confirm"
+
+    expect(page).to have_content("Project handed over to Regional Casework Services")
+    expect(page).to have_link("add contact details")
+    expect(page).to have_link("return to the list of projects to handover")
+  end
+end

--- a/spec/features/all_projects/handover/handover_transfer_project_spec.rb
+++ b/spec/features/all_projects/handover/handover_transfer_project_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.feature "Handover a transfer project" do
+  before do
+    application_user = create(:regional_delivery_officer_user)
+    sign_in_with_user(application_user)
+    mock_all_academies_api_responses
+  end
+
+  scenario "to the Regional team" do
+    prepare_user = create(:user, email: "prepare.user@education.gov.uk", first_name: "Prepare", last_name: "User", team: "east_midlands")
+    complete_user = create(:user, email: "complete.user@education.gov.uk", first_name: "Complete", last_name: "User", team: :north_west)
+    project = create(:transfer_project, :inactive, regional_delivery_officer: prepare_user)
+
+    visit all_handover_projects_path
+
+    expect(page).to have_content(project.urn)
+
+    click_link "Add handover details"
+
+    expect(page).to have_content("Check you have the right project")
+    expect(page).to have_content(project.urn)
+
+    click_link "Confirm"
+
+    expect(page).to have_content("Will RCS (Regional Casework Services) manage this project next?")
+
+    within "#assigned-to-regional-caseworker-team" do
+      choose "No"
+    end
+    fill_in "Handover comments", with: "Test handover comments.\n\nThese are the handover comments for tests."
+    fill_in "School SharePoint link", with: "https://educationgovuk.sharepoint.com/establishment"
+    fill_in "Incoming trust SharePoint link", with: "https://educationgovuk.sharepoint.com/incoming-trust"
+    fill_in "Outgoing trust SharePoint link", with: "https://educationgovuk.sharepoint.com/outgoing-trust"
+    click_button "Confirm"
+
+    expect(page).to have_content("Which region will complete this project?")
+
+    choose "North West"
+    fill_in "Who will complete this project?", with: complete_user.email
+    click_button "Confirm"
+
+    expect(page).to have_content("Project assigned")
+    expect(page).to have_link("add contact details")
+    expect(page).to have_link("return to the list of projects to handover")
+  end
+
+  scenario "to the Regional Casework Services team" do
+    prepare_user = create(:user, email: "prepare.user@education.gov.uk", first_name: "Prepare", last_name: "User", team: "east_midlands")
+    project = create(:transfer_project, :inactive, regional_delivery_officer: prepare_user)
+
+    visit all_handover_projects_path
+
+    expect(page).to have_content(project.urn)
+
+    click_link "Add handover details"
+
+    expect(page).to have_content("Check you have the right project")
+    expect(page).to have_content(project.urn)
+
+    click_link "Confirm"
+
+    expect(page).to have_content("Will RCS (Regional Casework Services) manage this project next?")
+
+    within "#assigned-to-regional-caseworker-team" do
+      choose "Yes"
+    end
+    fill_in "Handover comments", with: "Test handover comments.\n\nThese are the handover comments for tests."
+    fill_in "School SharePoint link", with: "https://educationgovuk.sharepoint.com/establishment"
+    fill_in "Incoming trust SharePoint link", with: "https://educationgovuk.sharepoint.com/incoming-trust"
+    fill_in "Outgoing trust SharePoint link", with: "https://educationgovuk.sharepoint.com/outgoing-trust"
+    click_button "Confirm"
+
+    expect(page).to have_content("Project handed over to Regional Casework Services")
+    expect(page).to have_link("add contact details")
+    expect(page).to have_link("return to the list of projects to handover")
+  end
+end

--- a/spec/features/all_projects/handover/user_can_handover_projects_spec.rb
+++ b/spec/features/all_projects/handover/user_can_handover_projects_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Users can handover projects" do
       click_link "Add handover details"
 
       expect(page).to have_content("Check you have the right project")
-      expect(page).to have_content("Conversion project")
+      expect(page).to have_content("Conversion")
       expect(page).to have_content(conversion_project.urn)
 
       click_link "Choose a different project"
@@ -46,7 +46,7 @@ RSpec.feature "Users can handover projects" do
       click_link "Add handover details"
 
       expect(page).to have_content("Check you have the right project")
-      expect(page).to have_content("Transfer project")
+      expect(page).to have_content("Transfer")
       expect(page).to have_content(transfer_project.urn)
 
       click_link "Choose a different project"

--- a/spec/forms/new_handover_stepped_form_spec.rb
+++ b/spec/forms/new_handover_stepped_form_spec.rb
@@ -128,7 +128,9 @@ RSpec.describe NewHandoverSteppedForm, type: :model do
 
     context "in the assign validation context" do
       context "for a conversion project" do
-        let(:regional_delivery_officer) { create(:regional_delivery_officer_user) }
+        let(:regional_delivery_officer) {
+          create(:regional_delivery_officer_user, email: "test.user@education.gov.uk")
+        }
         let(:project) { create(:conversion_project) }
         let(:params) { valid_conversion_attributes }
         subject { described_class.new(project, regional_delivery_officer, params) }
@@ -181,11 +183,19 @@ RSpec.describe NewHandoverSteppedForm, type: :model do
 
             expect(subject).to be_invalid(:assign)
           end
+
+          it "must have a user with the email address" do
+            params[:email] = "no.account@education.gov.uk"
+
+            expect(subject).to be_invalid(:assign)
+          end
         end
       end
 
       context "for a transfer project" do
-        let(:regional_delivery_officer) { create(:regional_delivery_officer_user) }
+        let(:regional_delivery_officer) {
+          create(:regional_delivery_officer_user, email: "test.user@education.gov.uk")
+        }
         let(:project) { create(:transfer_project) }
         let(:params) { valid_transfer_attributes }
         subject { described_class.new(project, regional_delivery_officer, params) }

--- a/spec/requests/all/handover/handovers_controller_spec.rb
+++ b/spec/requests/all/handover/handovers_controller_spec.rb
@@ -27,5 +27,69 @@ RSpec.describe All::Handover::HandoversController, type: :request do
         expect(response).to render_template("all/handover/projects/transfer/check")
       end
     end
+
+    context "with an invalid project UUID" do
+      it "returns not found" do
+        get "/projects/all/handover/NOT-A-UUID/check"
+
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+
+  describe "#create" do
+    context "when the form is invalid" do
+      let!(:project) { create(:conversion_project) }
+
+      it "renders the form with errors" do
+        post "/projects/all/handover/#{project.id}/new", params: invalid_params
+
+        expect(response).to render_template("all/handover/projects/conversion/new")
+        expect(response.body).to include("There is a problem")
+      end
+    end
+  end
+
+  describe "#assign" do
+    context "when the form is invalid" do
+      let!(:project) { create(:conversion_project) }
+
+      it "renders the form with errors" do
+        post "/projects/all/handover/#{project.id}/assign", params: invalid_params
+
+        expect(response).to render_template("all/handover/projects/assign")
+        expect(response.body).to include("There is a problem")
+      end
+    end
+  end
+
+  def valid_params
+    {
+      new_handover_stepped_form: {
+        assigned_to_regional_caseworker_team: false,
+        handover_note_body: "Handover note.",
+        establishment_sharepoint_link: "https://educationgovuk.sharepoint.com/establishment",
+        incoming_trust_sharepoint_link: "https://educationgovuk.sharepoint.com/incoming-trust",
+        outgoing_trust_sharepoint_link: "https://educationgovuk.sharepoint.com/outgoing-trust",
+        two_requires_improvement: true,
+        email: "test.user@education.gov.uk",
+        team: :west_midlands
+      }
+    }
+  end
+
+  def invalid_params
+    {
+      new_handover_stepped_form: {
+        assigned_to_regional_caseworker_team: nil,
+        handover_note_body: nil,
+        establishment_sharepoint_link: nil,
+        incoming_trust_sharepoint_link: nil,
+        outgoing_trust_sharepoint_link: nil,
+        two_requires_improvement: nil,
+        email: nil,
+        team: nil
+      }
+    }
   end
 end

--- a/spec/requests/all/handover/handovers_controller_spec.rb
+++ b/spec/requests/all/handover/handovers_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe All::Handover::ProjectsController, type: :request do
+RSpec.describe All::Handover::HandoversController, type: :request do
   before do
     user = create(:regional_delivery_officer_user)
     sign_in_with(user)

--- a/spec/requests/all/handover/projects_controller_spec.rb
+++ b/spec/requests/all/handover/projects_controller_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe All::Handover::ProjectsController, type: :request do
+  before do
+    user = create(:regional_delivery_officer_user)
+    sign_in_with(user)
+    mock_all_academies_api_responses
+  end
+
+  describe "#index" do
+    context "when there are no projects to hand over" do
+      it "shows a helpful message" do
+        get "/projects/all/handover/"
+
+        expect(response.body).to include("There are no projects to handover")
+      end
+    end
+
+    context "when there are projects" do
+      let!(:project) { create(:transfer_project, :inactive, urn: 123456) }
+      let!(:project) { create(:conversion_project, :inactive, urn: 165432) }
+
+      it "shows a table of the projects" do
+        create(:transfer_project, :inactive, urn: 123456)
+        create(:conversion_project, :inactive, urn: 165432)
+
+        get "/projects/all/handover/"
+
+        expect(response.body).to include "123456"
+        expect(response.body).to include "165432"
+      end
+    end
+  end
+end


### PR DESCRIPTION
There is a lot here, apologies! This is one journey with four paths and
we are handling it all with the fancy `NewHandoverSteppedForm` object so
it all comes at once!

This delivers a basic, working path for:

- handing over a conversion to Regional Casework Services
- handing over a conversion to a user in the Regional teams
- handing over a transfer to Regional Casework Services
- handing over a transfer to a user in the Regional teams

Designs are here:

 https://lucid.app/lucidspark/92056362-3523-413b-b954-7095607f95e9/edit?viewport_loc=13690%2C40250%2C5056%2C5276%2C0_0&invitationId=inv_1f6d15aa-a815-4f0e-91ac-c52940ae8ab8

The approach is that we don't want users to be able to return midway
through the steps (if they are on a path with steps) so we favour
rendering views over new paths - that means passing all the form
parameters to the second step and then posting them off - this feels
okay with so few attributes to manage and we do a similar thing for Date
Histories.

The bulk of the work is in the `HandoversController` which has to know
what type of project and render the right form views.

Most of the changes here are new views and the content to go with them.

We extended the `Projectable` controller concern to take care of invalid
UUIDs - this feels neater than the constraints we have in the routes (we
could switch everything else, but not here!).

We add validation that the email address matches up with a `User`.

We still need to:

- handle form a MAT projects (not sure these can come into Complete from Prepare yet?)
- autocomplete on the user email on the assign form
- add the journey to the navigation