### PR TITLE
Handover assignment uses autocomplete

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -25,5 +25,15 @@ if (addedByTarget) {
   )
 }
 
+const handoverByTarget = document.getElementById('handover-assign-form-group')
+if (handoverByTarget) {
+  const autocomplete = new UserAutocomplete()
+  autocomplete.init(
+    handoverByTarget.id,
+    'new_handover_stepped_form[email]',
+    'Who will complete this project?'
+  )
+}
+
 // set the js-enabled class on the body if JS is enabled
 document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled')

--- a/app/views/all/handover/projects/assign.html.erb
+++ b/app/views/all/handover/projects/assign.html.erb
@@ -4,9 +4,13 @@
 
       <%= form.govuk_error_summary %>
 
-      <%= form.govuk_collection_radio_buttons :team, @form.class.list_of_teams, :id, :name %>
+      <div class="govuk-form-group">
+        <%= form.govuk_collection_radio_buttons :team, @form.class.list_of_teams, :id, :name %>
+      </div>
 
-      <%= form.govuk_text_field :email, label: {size: "m"}, width: 20 %>
+      <div id="handover-assign-form-group">
+        <%= form.govuk_text_field :email, label: {size: "m"}, width: 20 %>
+      </div>
 
       <%= form.hidden_field :assigned_to_regional_caseworker_team %>
       <%= form.hidden_field :handover_note_body %>

--- a/spec/features/all_projects/handover/handover_autocomplete_spec.rb
+++ b/spec/features/all_projects/handover/handover_autocomplete_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.feature "Handover with autocomplete", driver: :headless_firefox do
+  before do
+    user = create(:regional_delivery_officer_user)
+    mock_all_academies_api_responses
+    sign_in_with_user(user)
+  end
+
+  after do
+    sign_out
+    # we need to wait after signing out otherwise we get flaking sessions
+    sleep(0.4)
+  end
+
+  scenario "can handover to regional teams" do
+    create(
+      :regional_delivery_officer_user,
+      first_name: "Test",
+      last_name: "User",
+      email: "test.user@education.gov.uk",
+      team: :north_west
+    )
+    project = create(:conversion_project, :inactive)
+
+    visit new_all_handover_projects_path(project)
+
+    within "#assigned-to-regional-caseworker-team" do
+      choose "No"
+    end
+    fill_in "Handover comments", with: "Test handover comments.\n\nThese are the handover comments for tests."
+    fill_in "School SharePoint link", with: "https://educationgovuk.sharepoint.com/establishment"
+    fill_in "Incoming trust SharePoint link", with: "https://educationgovuk.sharepoint.com/incoming-trust"
+    within "#two-requires-improvement" do
+      choose "No"
+    end
+    click_button "Confirm"
+
+    choose "North West"
+    fill_in "Who will complete this project?", with: "test.user@education.gov.uk"
+
+    sleep(0.5) # give it time to render the autocomplete!
+
+    within("ul.autocomplete__menu") do
+      expect(page).to have_content("Test User (test.user@education.gov.uk)")
+      find("li.autocomplete__option").click
+    end
+    click_button "Confirm"
+
+    expect(page).to have_content("Project assigned")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,10 @@ Capybara.register_driver :headless_firefox do |app|
   Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
 end
 
+Capybara.configure do |config|
+  config.automatic_label_click = true
+end
+
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
 begin


### PR DESCRIPTION
When assigning a Regional Delivery Officer to a project we progressively
enhance the email field into a autocomplete that looks up known users.

To test this we have to configure Capybara to `allow_label_click`
because the GOV.UK forms use hidden form elements.

Based on #1931
