### PR TITLE
Show form a MAT projects for Handover

### DIFF
--- a/app/views/all/handover/projects/conversion/check.html.erb
+++ b/app/views/all/handover/projects/conversion/check.html.erb
@@ -33,14 +33,27 @@
             row.with_key { t("project.handover.check.summary.form_a_mat") }
             row.with_value { t(@project.form_a_mat?) }
           end
-          summary_list.with_row do |row|
-            row.with_key { t("project.handover.check.summary.incoming_trust.name") }
-            row.with_value { @project.incoming_trust.name }
+
+          if @project.form_a_mat?
+            summary_list.with_row do |row|
+              row.with_key { t("project.handover.check.summary.new_trust.name") }
+              row.with_value { @project.new_trust_name }
+            end
+            summary_list.with_row do |row|
+              row.with_key { t("project.handover.check.summary.new_trust.reference") }
+              row.with_value { @project.new_trust_reference_number }
+            end
+          else
+            summary_list.with_row do |row|
+              row.with_key { t("project.handover.check.summary.incoming_trust.name") }
+              row.with_value { @project.incoming_trust.name }
+            end
+            summary_list.with_row do |row|
+              row.with_key { t("project.handover.check.summary.incoming_trust.ukprn") }
+              row.with_value { @project.incoming_trust.ukprn }
+            end
           end
-          summary_list.with_row do |row|
-            row.with_key { t("project.handover.check.summary.incoming_trust.ukprn") }
-            row.with_value { @project.incoming_trust.ukprn }
-          end
+
           summary_list.with_row do |row|
             row.with_key { t("project.handover.check.summary.advisory_board_date") }
             row.with_value { @project.advisory_board_date.to_fs(:govuk) }

--- a/app/views/all/handover/projects/transfer/check.html.erb
+++ b/app/views/all/handover/projects/transfer/check.html.erb
@@ -33,14 +33,27 @@
             row.with_key { t("project.handover.check.summary.form_a_mat") }
             row.with_value { t(@project.form_a_mat?) }
           end
-          summary_list.with_row do |row|
-            row.with_key { t("project.handover.check.summary.incoming_trust.name") }
-            row.with_value { @project.incoming_trust.name }
+
+          if @project.form_a_mat?
+            summary_list.with_row do |row|
+              row.with_key { t("project.handover.check.summary.new_trust.name") }
+              row.with_value { @project.new_trust_name }
+            end
+            summary_list.with_row do |row|
+              row.with_key { t("project.handover.check.summary.new_trust.reference") }
+              row.with_value { @project.new_trust_reference_number }
+            end
+          else
+            summary_list.with_row do |row|
+              row.with_key { t("project.handover.check.summary.incoming_trust.name") }
+              row.with_value { @project.incoming_trust.name }
+            end
+            summary_list.with_row do |row|
+              row.with_key { t("project.handover.check.summary.incoming_trust.ukprn") }
+              row.with_value { @project.incoming_trust.ukprn }
+            end
           end
-          summary_list.with_row do |row|
-            row.with_key { t("project.handover.check.summary.incoming_trust.ukprn") }
-            row.with_value { @project.incoming_trust.ukprn }
-          end
+
           summary_list.with_row do |row|
             row.with_key { t("project.handover.check.summary.outgoing_trust.name") }
             row.with_value { @project.outgoing_trust.name }

--- a/config/locales/handover.en.yml
+++ b/config/locales/handover.en.yml
@@ -16,6 +16,9 @@ en:
           outgoing_trust:
             name: Outgoing trust name
             ukprn: Outgoing trust UKPRN
+          new_trust:
+            name: New trust
+            reference: Trust reference number
           advisory_board_date: Advisory board date
           provisional_conversion_date: Provisional conversion date
           provisional_transfer_date: Provisional transfer date

--- a/spec/features/all_projects/handover/user_can_handover_projects_spec.rb
+++ b/spec/features/all_projects/handover/user_can_handover_projects_spec.rb
@@ -29,6 +29,33 @@ RSpec.feature "Users can handover projects" do
       expect(page).to have_content("Projects to handover")
       expect(page).to have_content("These projects have been worked on in Prepare")
     end
+
+    context "when the conversion is a forming a MAT" do
+      let!(:conversion_project) {
+        create(
+          :conversion_project,
+          :form_a_mat,
+          state: :inactive, urn: 123456,
+          conversion_date: Date.new(2024, 2, 1)
+        )
+      }
+
+      scenario "they can check they have the right project and cancel if not" do
+        visit all_handover_projects_path
+        click_link "Add handover details"
+
+        expect(page).to have_content("Check you have the right project")
+        expect(page).to have_content("Conversion")
+        expect(page).to have_content(conversion_project.urn)
+        expect(page).to have_content(conversion_project.new_trust_reference_number)
+        expect(page).to have_content(conversion_project.new_trust_name)
+
+        click_link "Choose a different project"
+
+        expect(page).to have_content("Projects to handover")
+        expect(page).to have_content("These projects have been worked on in Prepare")
+      end
+    end
   end
 
   context "when the project is a transfer" do
@@ -53,6 +80,33 @@ RSpec.feature "Users can handover projects" do
 
       expect(page).to have_content("Projects to handover")
       expect(page).to have_content("These projects have been worked on in Prepare")
+    end
+
+    context "when the transfer is a forming a MAT" do
+      let!(:transfer_project) {
+        create(
+          :transfer_project,
+          :form_a_mat,
+          state: :inactive, urn: 123456,
+          transfer_date: Date.new(2024, 2, 1)
+        )
+      }
+
+      scenario "they can check they have the right project and cancel if not" do
+        visit all_handover_projects_path
+        click_link "Add handover details"
+
+        expect(page).to have_content("Check you have the right project")
+        expect(page).to have_content("Transfer")
+        expect(page).to have_content(transfer_project.urn)
+        expect(page).to have_content(transfer_project.new_trust_reference_number)
+        expect(page).to have_content(transfer_project.new_trust_name)
+
+        click_link "Choose a different project"
+
+        expect(page).to have_content("Projects to handover")
+        expect(page).to have_content("These projects have been worked on in Prepare")
+      end
     end
   end
 end


### PR DESCRIPTION
The only difference here is that the incoming trust is replaced by a new
trust and reference number, everything else is the same so we've popped
the logic into the view.

Based on #1931

