### PR TITLE
(Fix) Do not show deleted projects in the "Added by" page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Do not show deleted projects in the "Added by you" page
+
 ## [Release-90][release-90]
 
 ### Changed

--- a/app/controllers/your/projects_controller.rb
+++ b/app/controllers/your/projects_controller.rb
@@ -11,7 +11,7 @@ class Your::ProjectsController < ApplicationController
 
   def added_by
     authorize Project, :index?
-    @pager, @projects = pagy(Project.added_by(current_user).not_completed.not_inactive.ordered_by_significant_date.includes(:assigned_to))
+    @pager, @projects = pagy(Project.added_by(current_user).active.ordered_by_significant_date.includes(:assigned_to))
 
     AcademiesApiPreFetcherService.new.call!(@projects)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -58,7 +58,7 @@ class Project < ApplicationRecord
 
   scope :assigned_to, ->(user) { where(assigned_to_id: user.id) }
   scope :assigned_to_users, ->(users) { where(assigned_to_id: [users]) }
-  scope :added_by, ->(user) { where(regional_delivery_officer: user) }
+  scope :added_by, ->(user) { where(regional_delivery_officer: user).and(where.not(state: 2)) }
 
   scope :ordered_by_created_at_date, -> { order(created_at: :desc) }
 

--- a/spec/features/projects/added_by/user_can_view_the_projects_they_have_added_spec.rb
+++ b/spec/features/projects/added_by/user_can_view_the_projects_they_have_added_spec.rb
@@ -27,6 +27,7 @@ RSpec.feature "Viewing all projects a user has added" do
     let!(:sponsored_in_progress_project) { create(:conversion_project, urn: 112209, directive_academy_order: true, regional_delivery_officer: user) }
     let!(:voluntary_in_progress_project) { create(:conversion_project, urn: 103835, directive_academy_order: false, regional_delivery_officer: user) }
     let!(:inactive_project) { create(:conversion_project, :inactive, urn: 187356, regional_delivery_officer: user) }
+    let!(:deleted_project) { create(:conversion_project, :deleted, urn: 137904, regional_delivery_officer: user) }
     let!(:other_project) { create(:conversion_project) }
 
     scenario "they can view all in progress projects that they added" do
@@ -45,6 +46,7 @@ RSpec.feature "Viewing all projects a user has added" do
 
         expect(page).not_to have_content(completed_project.urn)
         expect(page).not_to have_content(inactive_project.urn)
+        expect(page).not_to have_content(deleted_project.urn)
         expect(page).not_to have_content(other_project.urn)
       end
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -680,9 +680,11 @@ RSpec.describe Project, type: :model do
         user = create(:user)
         added_project = create(:conversion_project, regional_delivery_officer: user)
         other_project = create(:conversion_project)
+        deleted_project = create(:conversion_project, :deleted, regional_delivery_officer: user)
 
         expect(Project.added_by(user)).to include(added_project)
         expect(Project.added_by(user)).to_not include(other_project)
+        expect(Project.added_by(user)).to_not include(deleted_project)
       end
     end
 


### PR DESCRIPTION
A user reported that they were seeing a deleted project in their "Added by" page. We were not explicitly excluding deleted projects from the "Added by" page or scope.

