### PR TITLE
Add LAESTAB/DfE Number to new academy details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- The LAESTAB, also known as the DfE number is now shown on the new academy
+  details once available.
+
 ### Fixed
 
 - Do not show deleted projects in the "Added by you" page

--- a/app/models/gias/establishment.rb
+++ b/app/models/gias/establishment.rb
@@ -26,8 +26,11 @@ class Gias::Establishment < ApplicationRecord
   end
 
   def dfe_number
+    return unless local_authority_code.present? && establishment_number.present?
+
     "#{local_authority_code}/#{establishment_number}"
   end
+  alias_method :laestab, :dfe_number
 
   def has_diocese?
     diocese_code != DIOCESE_NOT_APPLICABLE_CODE

--- a/app/views/conversions/project_information/_academy_details.html.erb
+++ b/app/views/conversions/project_information/_academy_details.html.erb
@@ -21,6 +21,10 @@
                 row.with_value { project.academy.urn.to_s }
               end
               summary_list.with_row do |row|
+                row.with_key { t("project_information.show.academy_details.rows.laestab") }
+                row.with_value { project.academy.laestab }
+              end
+              summary_list.with_row do |row|
                 row.with_key { t("project_information.show.academy_details.rows.school_type") }
                 row.with_value { project.academy.type }
               end

--- a/config/locales/project_information.en.yml
+++ b/config/locales/project_information.en.yml
@@ -82,6 +82,7 @@ en:
           it can take one day for the data to be syncronised
         rows:
           urn: Academy URN (unique reference number)
+          laestab: LAESTAB (DfE number)
           academy_name: Name
           address: Address
           school_type: Type

--- a/spec/models/gias/establishment_spec.rb
+++ b/spec/models/gias/establishment_spec.rb
@@ -55,6 +55,18 @@ RSpec.describe Gias::Establishment do
       establishment = build(:gias_establishment, urn: 123456, local_authority_code: 123, establishment_number: 456)
       expect(establishment.dfe_number).to eq("123/456")
     end
+
+    it "returns nil when the codes are missing" do
+      establishment = build(:gias_establishment, urn: 123456, local_authority_code: nil, establishment_number: nil)
+      expect(establishment.dfe_number).to be_nil
+    end
+  end
+
+  describe "laestab" do
+    it "returns the local authority code and establishment number, formatted as a dfe_number" do
+      establishment = build(:gias_establishment, urn: 123456, local_authority_code: 123, establishment_number: 456)
+      expect(establishment.laestab).to eq("123/456")
+    end
   end
 
   describe "local_authority" do


### PR DESCRIPTION
This request came in the 'front door' from a service support user. We
already have the value as `dfe_number` to keep things as clear as we can
I've made an alias of that method and labelled the value with both
'LAESTAB' and 'DfE number'.

