### PR TITLE
Handover navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The LAESTAB, also known as the DfE number is now shown on the new academy
   details once available.
+- Conversion projects added automatically now show up in the All Projects >
+  handover section for triage and assignment by Regional Delivery Officers.
+- Transfer projects added automatically now show up in the All Projects >
+  handover section for triage and assignment by Regional Delivery Officers.
 
 ### Fixed
 

--- a/app/views/all/handover/projects/assign.html.erb
+++ b/app/views/all/handover/projects/assign.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title("Assign to user") %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @form, url: assign_all_handover_projects_path(@project) do |form| %>

--- a/app/views/all/handover/projects/assigned_region.html.erb
+++ b/app/views/all/handover/projects/assigned_region.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title("Project assigned") %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_panel(

--- a/app/views/all/handover/projects/assigned_regional_casework_services.html.erb
+++ b/app/views/all/handover/projects/assigned_regional_casework_services.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <%= page_title("Project handed over") %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_panel(

--- a/app/views/all/handover/projects/conversion/check.html.erb
+++ b/app/views/all/handover/projects/conversion/check.html.erb
@@ -1,7 +1,3 @@
-<% content_for :primary_navigation do %>
-  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
-<% end %>
-
 <% content_for :page_title do %>
   <%= page_title(t("project.handover.check.title")) %>
 <% end %>

--- a/app/views/all/handover/projects/transfer/check.html.erb
+++ b/app/views/all/handover/projects/transfer/check.html.erb
@@ -1,7 +1,3 @@
-<% content_for :primary_navigation do %>
-  <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
-<% end %>
-
 <% content_for :page_title do %>
   <%= page_title(t("project.handover.check.title")) %>
 <% end %>

--- a/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
@@ -8,6 +8,10 @@
 
         <ul class="moj-primary-navigation__list">
 
+          <% if policy(:project).handover? %>
+            <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.handover"), path: all_handover_projects_path, namespace: "/projects/all/handover"} %>
+          <% end %>
+
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.in_progress"), path: all_all_in_progress_projects_path, namespace: "/projects/all/in-progress"} %>
 
           <% if policy(:export).index? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -142,6 +142,7 @@ en:
       service_support: Service support
     primary:
       all_projects:
+        handover: Handover
         in_progress: In progress
         by_month: By month
         by_trust: By trust

--- a/spec/features/all_projects/handover/user_can_view_a_list_of_projects_spec.rb
+++ b/spec/features/all_projects/handover/user_can_view_a_list_of_projects_spec.rb
@@ -11,7 +11,9 @@ RSpec.feature "Users can view a list of handover projects" do
     conversion_project = create(:conversion_project, state: :inactive, urn: 123456, conversion_date: Date.new(2024, 2, 1))
     transfer_project = create(:transfer_project, state: :inactive, urn: 165432, transfer_date: Date.new(2024, 1, 1))
 
-    visit all_handover_projects_path
+    visit root_path
+    click_link "All projects"
+    click_link "Handover"
 
     expect(page).to have_content("Projects to handover")
     expect(page).to have_content("These projects have been worked on in Prepare")

--- a/spec/requests/all/handover/projects_controller_spec.rb
+++ b/spec/requests/all/handover/projects_controller_spec.rb
@@ -30,5 +30,16 @@ RSpec.describe All::Handover::ProjectsController, type: :request do
         expect(response.body).to include "165432"
       end
     end
+
+    context "when the user is not a regional delivery officer" do
+      it "does not show the handover navigation item" do
+        user = create(:regional_casework_services_user)
+        sign_in_with(user)
+
+        get "/projects/all"
+
+        expect(response.body).not_to include(all_handover_projects_path)
+      end
+    end
   end
 end


### PR DESCRIPTION
This is only shown to user with the permission (Regional Delivery
Officers right now).

We also ensure all the handover paths have a page title and the primary
navigation is not shown unless on the index view.