### PR TITLE
Remove duplicate navigation item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Transfer projects added automatically now show up in the All Projects >
   handover section for triage and assignment by Regional Delivery Officers.
 
+### Changed
+
+- The 'export' menu items for Service Support users has moved to the All project
+  section in-line with all other users.
+
 ### Fixed
 
 - Do not show deleted projects in the "Added by you" page

--- a/app/policies/export_policy.rb
+++ b/app/policies/export_policy.rb
@@ -29,10 +29,4 @@ class ExportPolicy
 
     false
   end
-
-  def service_support?
-    return true if @user.service_support_team?
-
-    false
-  end
 end

--- a/app/views/all/export/projects/index.html.erb
+++ b/app/views/all/export/projects/index.html.erb
@@ -1,9 +1,5 @@
 <% content_for :primary_navigation do %>
-  <% if policy(:export).service_support? %>
-    <%= render partial: "shared/navigation/service_support_primary_navigation" %>
-  <% else %>
     <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
-  <% end %>
 <% end %>
 
 <% content_for :page_title do %>

--- a/app/views/shared/navigation/_service_support_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_service_support_primary_navigation.html.erb
@@ -16,8 +16,6 @@
 
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.service_support.upload_gias_data"), path: service_support_upload_gias_establishments_new_path, namespace: "/service-support/upload"} %>
 
-          <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.exports"), path: all_export_projects_path, namespace: "/projects/all/export"} %>
-
         </ul>
 
       </nav>

--- a/spec/features/all_projects/export/export_users_can_see_an_export_landing_page_spec.rb
+++ b/spec/features/all_projects/export/export_users_can_see_an_export_landing_page_spec.rb
@@ -26,7 +26,8 @@ RSpec.feature "Export users can see the exports landing page" do
     user = create(:user, team: :business_support)
 
     sign_in_with_user(user)
-    click_on "Exports"
+    click_link "All projects"
+    click_link "Exports"
 
     expect(page).to have_content("funding agreement letter contacts, RPA and start-up grants")
     expect(page).to have_content("pre-opening grants for schools becoming academies")
@@ -38,7 +39,8 @@ RSpec.feature "Export users can see the exports landing page" do
     user = create(:user, team: :service_support)
 
     sign_in_with_user(user)
-    click_on "Exports"
+    click_link "All projects"
+    click_link "Exports"
 
     expect(page).to have_content("funding agreement letter contacts, RPA and start-up grants")
     expect(page).to have_content("pre-opening grants for schools becoming academies")


### PR DESCRIPTION
We think this is from a time when Service Support could not access the
All projects section. There is no good reasons to have two different
export menus and we loos a tiny bit of view logic!
