### PR TITLE
Change API errors

### DIFF
--- a/app/services/api/base_create_project_service.rb
+++ b/app/services/api/base_create_project_service.rb
@@ -10,7 +10,7 @@ class Api::BaseCreateProjectService
 
     def initialize(message, validation_errors)
       super(message)
-      @validation_errors = validation_errors.messages
+      @validation_errors = validation_errors.details
     end
   end
 

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe V1::Conversions do
 
         expect(response.body).to include("validation_errors")
         expect(response.body).to include("created_by_email")
-        expect(response.body).to include("is invalid")
+        expect(response.body).to include("invalid")
         expect(response.status).to eq(400)
       end
     end
@@ -188,7 +188,7 @@ RSpec.describe V1::Conversions do
 
         expect(response.body).to include("validation_errors")
         expect(response.body).to include("created_by_email")
-        expect(response.body).to include("is invalid")
+        expect(response.body).to include("invalid")
         expect(response.status).to eq(400)
       end
     end

--- a/spec/api/v1/transfers_spec.rb
+++ b/spec/api/v1/transfers_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe V1::Transfers do
 
         expect(response.body).to include("validation_errors")
         expect(response.body).to include("created_by_email")
-        expect(response.body).to include("is invalid")
+        expect(response.body).to include("invalid")
         expect(response.status).to eq(400)
       end
     end
@@ -188,7 +188,7 @@ RSpec.describe V1::Transfers do
 
         expect(response.body).to include("validation_errors")
         expect(response.body).to include("created_by_email")
-        expect(response.body).to include("is invalid")
+        expect(response.body).to include("invalid")
         expect(response.status).to eq(400)
       end
     end


### PR DESCRIPTION
Returning the same validation as the application UI on the API can be a
little misleading, date formats are different for example.

This work changes from the error messages to the error details,
essentially the keys used to identify the validation error, which should
be descriptive enough for the API as it is only accessed by internal
developers.

