### PR TITLE
Update create new project validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The 'export' menu items for Service Support users has moved to the All project
   section in-line with all other users.
+- You can no longer add a new project if it has already been added automatically
+  and is awaiting handover.
 
 ### Fixed
 

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -33,7 +33,7 @@ class Conversion::CreateProjectForm < CreateProjectForm
   end
 
   private def urn_unique_for_in_progress_conversions
-    errors.add(:urn, :duplicate) if Conversion::Project.active.where(urn: urn).any?
+    errors.add(:urn, :duplicate) if Conversion::Project.where(urn: urn, state: [:inactive, :active]).any?
   end
 
   def save(context = nil)

--- a/app/forms/create_project_form.rb
+++ b/app/forms/create_project_form.rb
@@ -71,8 +71,4 @@ class CreateProjectForm
 
     result.object
   end
-
-  private def urn_unique_for_in_progress_transfers
-    errors.add(:urn, :duplicate) if Transfer::Project.active.where(urn: urn).any?
-  end
 end

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -94,4 +94,8 @@ class Transfer::CreateProjectForm < CreateProjectForm
   rescue Api::AcademiesApi::Client::NotFoundError
     errors.add(:outgoing_trust_ukprn, :no_trust_found)
   end
+
+  private def urn_unique_for_in_progress_transfers
+    errors.add(:urn, :duplicate) if Transfer::Project.where(urn: urn, state: [:inactive, :active]).any?
+  end
 end

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -515,9 +515,20 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
       end
     end
 
-    context "when there is another in-progress project with the same urn" do
+    context "when there is another active project with the same urn" do
       it "is invalid" do
-        _project_with_urn = create(:conversion_project, urn: 121813)
+        _project_with_urn = create(:conversion_project, urn: 121813, state: :active)
+        form = build(form_factory.to_sym)
+
+        form.urn = 121813
+        expect(form).to be_invalid
+        expect(form.errors.messages[:urn]).to include I18n.t("errors.attributes.urn.duplicate")
+      end
+    end
+
+    context "when there is another inactive project with the same urn" do
+      it "is invalid" do
+        _project_with_urn = create(:conversion_project, urn: 121813, state: :inactive)
         form = build(form_factory.to_sym)
 
         form.urn = 121813

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -378,9 +378,20 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
       end
     end
 
-    context "when there is another in-progress project with the same urn" do
+    context "when there is another active project with the same urn" do
       it "is invalid" do
-        _project_with_urn = create(:transfer_project, urn: 121813)
+        _project_with_urn = create(:transfer_project, urn: 121813, state: :active)
+        form = build(:create_transfer_project_form)
+
+        form.urn = 121813
+        expect(form).to be_invalid
+        expect(form.errors.messages[:urn]).to include I18n.t("errors.attributes.urn.duplicate")
+      end
+    end
+
+    context "when there is another inactive project with the same urn" do
+      it "is invalid" do
+        _project_with_urn = create(:transfer_project, urn: 121813, state: :inactive)
         form = build(:create_transfer_project_form)
 
         form.urn = 121813


### PR DESCRIPTION
We now have projects potentially being created on the API and do not
want users to attempt to manually create the same project i.e the same
type of in-progress project with the same URN.

This work updates the validation to facilitate this and moves the actual
validation methods into better locations.
