### PR TITLE
Disable the Handover navigation

### DIFF
--- a/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
@@ -8,7 +8,11 @@
 
         <ul class="moj-primary-navigation__list">
 
-          <% if policy(:project).handover? %>
+          <%
+              # we are disbabling this navigation item for now
+              if false
+          %>
+
             <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.handover"), path: all_handover_projects_path, namespace: "/projects/all/handover"} %>
           <% end %>
 

--- a/spec/features/all_projects/handover/user_can_view_a_list_of_projects_spec.rb
+++ b/spec/features/all_projects/handover/user_can_view_a_list_of_projects_spec.rb
@@ -8,6 +8,8 @@ RSpec.feature "Users can view a list of handover projects" do
   end
 
   scenario "as a table" do
+    pending("Prepare application sending approved projects to us")
+
     conversion_project = create(:conversion_project, state: :inactive, urn: 123456, conversion_date: Date.new(2024, 2, 1))
     transfer_project = create(:transfer_project, state: :inactive, urn: 165432, transfer_date: Date.new(2024, 1, 1))
 


### PR DESCRIPTION
We don't want users to see this navigation item until the Prepare
application is successfully sending us projects.

