### PR TITLE
Fix: attempt to fix flaky autocomplete spec

### DIFF
--- a/spec/features/internal_contacts/users_can_edit_the_assigned_user_with_autocomplete_spec.rb
+++ b/spec/features/internal_contacts/users_can_edit_the_assigned_user_with_autocomplete_spec.rb
@@ -128,6 +128,9 @@ RSpec.feature "Users change the assigned user", driver: :headless_firefox do
 
       fill_in "Assign to", with: user.email
 
+      # give the autocomplete time to load
+      sleep(0.5)
+
       within(autocomplete_first_suggestion) do
         expect(page).to have_content("#{user.first_name} #{user.last_name} (#{user.email})")
       end
@@ -156,6 +159,9 @@ RSpec.feature "Users change the assigned user", driver: :headless_firefox do
       end
 
       fill_in "Assign to", with: user.email
+
+      # give the autocomplete time to load
+      sleep(0.5)
 
       within(autocomplete_first_suggestion) do
         expect(page).to have_content("#{user.first_name} #{user.last_name} (#{user.email})")


### PR DESCRIPTION
When running in CI we often see the autocomplete specs fail. We think
this might be caused by the suite running faster than the browser can
render the expected elements.

Elsewhere we have put a short sleep in to give the browser time to
load, so we do the same here.
