### PR TITLE
Allow CI to pass without docker job

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -183,6 +183,7 @@ jobs:
     name: Docker
     runs-on: ubuntu-latest
     needs: build-and-cache
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The Docker job in our CI fails almost every time due to a known issue.

As we do not require the docker tests to pass in order to pass, we would
rather not show our branches as failing, when they really aren't.

Here we tell Github actions to not fail the CI workflow if the docker job
fails.
