### PR TITLE
Enable users to run this repository using Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,54 @@
+# Base devcontainer image
+#
+# https://github.com/devcontainers/images/tree/main/src/ruby
+FROM mcr.microsoft.com/devcontainers/ruby:3.3
+
+# Install build dependencies
+RUN apt-get update && apt-get install --no-install-recommends -y build-essential ca-certificates curl gnupg libpq-dev firefox-esr
+
+# Setup Node installation
+# https://github.com/nodesource/distributions#installation-instructions
+#
+# depends on ca-certificates, curl and gnupg
+#
+ENV NODE_MAJOR=18
+
+RUN mkdir -p /etc/apt/keyrings/ && curl --tlsv1.2 -sSf "https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key" \
+  | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
+  | tee /etc/apt/sources.list.d/nodesource.list
+
+# Setup Yarn installation
+# https://classic.yarnpkg.com/lang/en/docs/install/#debian-stable
+#
+RUN curl --proto "=https" --tlsv1.2 -sSf "https://dl.yarnpkg.com/debian/pubkey.gpg" | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && apt-get install --no-install-recommends -y nodejs yarn
+
+# Install FreeTDS
+# https://github.com/rails-sqlserver/tiny_tds#install
+# default FreeTDS version
+ARG FREETDS_VERSION=1.4.10
+ARG TDS_VERSION=7.3
+RUN \
+  curl --proto "=https" --tlsv1.2 -sSf \
+  "https://www.freetds.org/files/stable/freetds-${FREETDS_VERSION}.tar.gz" \
+  --output "freetds-${FREETDS_VERSION}.tar.gz" && \
+  tar -xvzf "freetds-${FREETDS_VERSION}.tar.gz" && \
+  rm "freetds-${FREETDS_VERSION}.tar.gz" && \
+  cd "freetds-${FREETDS_VERSION}" && \
+  ./configure --prefix=/usr/local --with-tdsver=${TDS_VERSION} && \
+  make && make install;
+
+# Install Geckodriver
+# https://github.com/mozilla/geckodriver/releases
+# default Geckodriver version
+ARG geckodriver_version=0.35.0
+RUN \
+  curl --proto "=https" --tlsv1.2 -sSf -L \
+    "https://github.com/mozilla/geckodriver/releases/download/v${geckodriver_version}/geckodriver-v${geckodriver_version}-linux64.tar.gz" \
+    --output "geckodriver-v${geckodriver_version}-linux64.tar.gz" && \
+    tar -xvzf "geckodriver-v${geckodriver_version}-linux64.tar.gz" && \
+    rm "geckodriver-v${geckodriver_version}-linux64.tar.gz" && \
+    chmod +x geckodriver && mv geckodriver* /usr/local/bin;

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "devcontainer",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "forwardPorts": [3000],
+  "portsAttributes": {
+    "3000": {
+      "label": "dfe-complete-application"
+    }
+  },
+  "onCreateCommand": ".devcontainer/setup.sh"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,39 @@
+name: dfe-complete
+services:
+  devcontainer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ../..:/workspaces:cached
+    networks:
+      - dev
+    command: sleep infinity
+  redis:
+    container_name: dfe-complete-redis-backing-service
+    image: redis:6
+    ports:
+      - 6379:6379
+    volumes:
+      - redis-data:/data
+    networks:
+      - dev
+  db:
+    container_name: dfe-complete-sql-backing-service
+    image: mcr.microsoft.com/azure-sql-edge:latest
+    environment:
+      ACCEPT_EULA: Y
+      MSSQL_SA_PASSWORD: ${DATABASE_PASSWORD}
+    ports:
+      - 1433:1433
+    volumes:
+      - sql-server-data:/var/opt/mssql
+    networks:
+      - dev
+
+networks:
+  dev:
+
+volumes:
+  sql-server-data:
+  redis-data:

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+# set rbenv to use the system (global) Ruby as it will be 3.3.5
+rbenv global
+
+# installl gems
+bundle install
+
+# install npm packages
+yarn
+
+# create databases
+bin/rails db:prepare

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -13,6 +13,12 @@
   <%= form_tag("/auth/azure_activedirectory_v2", method: "post") do %>
     <%= button_tag(t("sign_in.button", type: :submit), class: "govuk-button") %>
   <% end %>
+  <% if Rails.env.development? && ENV["CODESPACES"] %>
+    <%= form_tag("/auth/developer", method: "post") do %>
+      <%= button_tag("Developer login", class: "govuk-button") %>
+    <% end %>
+  <% end %>
+
   <h2 class="govuk-heading-m">Register for access</h2>
   <p class="govuk-body">If you do not have access you can <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-X7F89QcWu5CjlJXwF0TVktUMEpZSU5aTEVYVlIyRE1JSjdMREtIVDhWQiQlQCN0PWcu" class="govuk-link" rel="noreferrer noopener" target="_blank">sign up to use Complete conversions, transfers and changes (opens in new tab)</a>.</p>
   <p class="govuk-body">To register, you’ll need to provide your:</p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,4 +64,16 @@ Rails.application.configure do
   config.action_mailer.notify_settings = {
     api_key: ENV["GOV_NOTIFY_API_KEY"]
   }
+
+  # Extra Github Codespaces config
+  if ENV["CODESPACES"]
+    # add the code spaces host to the app hosts
+    config.hosts << ENV["CODESPACE_NAME"] + "-3000.app.github.dev"
+
+    # overide the omniauth callback, we cannot actually use this, but it is required to start the app
+    ENV["AZURE_REDIRECT_URI"] = "https://" + ENV["CODESPACE_NAME"] + "-3000.app.github.dev/auth/azure_activedirectory_v2/callback"
+
+    # disable CSRF as we cannot rely on the host being 'localhost'
+    config.action_controller.forgery_protection_origin_check = false
+  end
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -8,6 +8,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
         redirect_uri: ENV["AZURE_REDIRECT_URI"]
       }
     }
+  provider :developer if ENV["CODESPACES"] && Rails.env.development?
 end
 
 OmniAuth.config.logger = Rails.logger

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -1,5 +1,11 @@
 # Getting started
 
+## Codespaces
+
+If you are not a developer, or you are using a Windows machine,
+we recommend running this application using Github Codespaces.
+See [Running with Codespaces](/doc/running-with-codespaces.md).
+
 ## Getting the basics
 
 This is a Rails application, you will need access to:

--- a/doc/running-with-codespaces.md
+++ b/doc/running-with-codespaces.md
@@ -1,0 +1,49 @@
+# Running the application with Github Codespaces
+
+If you are not a developer and wish to run the application 
+(e.g. a Content Designer, UX) or are using a Windows machine, we recommend
+running this application using [Github Codespaces](https://github.com/features/codespaces).
+
+## Prerequisites
+
+You will need a Github account with read/write access to the repository. 
+
+You will also need for your Github account to be granted access to run Codespaces
+paid for by DfE Digital. To check if this is the case, click on the green "Code"
+button on the repository, and choose the "Codespaces". If you can see "Codespace
+usage for this repository is paid for by DFE-Digital." then you have the correct
+access.
+
+## Running a Codespace
+
+1. Click on the green "Code" button and choose "Codespaces" from the tabs
+1. Click the plus + icon
+1. The Codespace will start up in a new tab. Initial setup takes some time, but
+   once it has completed the initial setup will not need to run again (unless you
+   destroy and rebuild the Codespace)
+1. Once it has built you will be able to view the codebase in a virtual VS Code IDE 
+   running in your browser. If you wish to use another IDE, some others offer bridges
+   to connect to Codespaces, for example [JetBrains](https://docs.github.com/en/codespaces/developing-in-a-codespace/using-github-codespaces-in-your-jetbrains-ide)
+
+The above instructions will create a Codespace on the `main` branch. 
+
+To build a Codespace on a different branch, create a branch on the repository and follow
+the same instructions from that branch.
+
+## Post-creation setup
+
+After creating the Codespace, you will need to create a user and seed the database to 
+enable yourself to log in and see data. Open a terminal in your IDE and follow the 
+instructions in [Seeding the database](/doc/seeding-the-database.md)
+
+You will need to re-do the seeds every time you destroy and rebuild the Codespace, but
+*not* if you merely stop and restart the Codespace.
+
+### Logging into the application
+
+After you have created your user, you will need to log in via the "Developer login"
+button on the sign in page, using the same email address you used when creating a user
+while seeding the database. Input your name and email address in the basic login form.
+
+Unfortunately the Azure AD login does not work when running the application with
+Codespaces.


### PR DESCRIPTION
## Changes

We had a requirement to run this application on Windows instead of MacOS (which most developers use). After a lot of discussion it was decided that enabling Codespaces on this repo was the "simplest" solution of many complex ones! This PR adds the Codespaces config and instructions on how to use it.

Co-authored by @mec with help from @peteryates 