### PR TITLE
removing trust from church and trust option in RPA task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- removed trust from the RPA radio button options text for conversions
+
 ## [Release 92][release-92]
 
 ### Changed

--- a/config/locales/conversion/tasks/risk_protection_arrangement.en.yml
+++ b/config/locales/conversion/tasks/risk_protection_arrangement.en.yml
@@ -14,7 +14,7 @@ en:
                   standard RPA unless they say otherwise.</p>
           responses:
             standard: Yes, joining standard RPA
-            church_or_trust: Yes, joining church or trust RPA
+            church_or_trust: Yes, joining church RPA
             commercial:
               option: No, buying commercial insurance
               hint_html:

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -163,7 +163,7 @@ RSpec.feature "Users can complete conversion tasks" do
     end
 
     scenario "the response can be church or trust" do
-      choose "Yes, joining church or trust RPA"
+      choose "Yes, joining church RPA"
       click_on I18n.t("task_list.continue_button.text")
 
       expect(project.reload.tasks_data.risk_protection_arrangement_option).to eq "church_or_trust"


### PR DESCRIPTION
## Changes

We've had user feedback to tell us that an academy cannot join a trust RPA. It much be standard, church or commercial insurance.

This work removes the text that refers to the trust RPA from the second radio button on the task.

## Before

![Screenshot 2024-10-22 at 10 53 49 am](https://github.com/user-attachments/assets/c694072a-e543-4e02-a883-97dad7fbf19f)

## After

![Screenshot 2024-10-22 at 10 53 28 am](https://github.com/user-attachments/assets/88d135f5-e962-4ee4-9f8c-c116bc9c6fbe)

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
