### PR TITLE
Fix: DAO revocation notes on all projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - removed trust from the RPA radio button options text for conversions
 
+### Fixed
+
+- The note added during DAO revocation only appears on the associated project
+  notes, instead of all projects.
+
 ## [Release 92][release-92]
 
 ### Changed

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -9,9 +9,7 @@ class Note < ApplicationRecord
   default_scope { order(created_at: "desc") }
 
   scope :project_level_notes, ->(project) {
-    where(project: project)
-      .where(notable_type: nil).where(task_identifier: nil)
-      .or(where.not(notable_type: "SignificantDateHistoryReason"))
+    where(project: project).where(notable_type: [nil, "DaoRevocationReason"]).where(task_identifier: nil)
   }
 
   # When no value is provided, Rails will store an empty string. Instead, we want to ensure

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Note, type: :model do
     end
 
     describe "project_level_notes" do
+      let!(:other_project) { create(:conversion_project) }
       let!(:project) { create(:conversion_project) }
       let!(:project_level_note) { create(:note, project: project) }
       let!(:task_level_note) { create(:note, task_identifier: "handover", project: project) }
@@ -56,6 +57,12 @@ RSpec.describe Note, type: :model do
       it "does include dao revocation notes" do
         expect(subject).to include project_level_note
         expect(subject).to include dao_revocation_note
+      end
+
+      it "only include notes for the correct project" do
+        subject = Note.project_level_notes(other_project)
+
+        expect(subject).not_to include dao_revocation_note
       end
     end
   end


### PR DESCRIPTION
When we had our first DAO revocation in production it was noted that the
associated note was shown on all projects in the application.

This was caused by the `or` statement not limited the notes to only
those for the project.

A DAO Revocation note should appear in project notes, but only for the
project to which it is associated.

We have removed the `or` altogether in this fix.
