### PR TITLE
Release 93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release-93][release-93]
+
 ### Changed
 
 - removed trust from the RPA radio button options text for conversions
@@ -2291,7 +2293,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-92...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-93...HEAD
+[release-93]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-92...release-93
 [release-92]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-91...release-92
 [release-91]:


### PR DESCRIPTION
Changed

- removed trust from the RPA radio button options text for conversions

Fixed

- The note added during DAO revocation only appears on the associated project notes, instead of all projects.


