### PR TITLE
Enable the Project Handover section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Enable the "Handover" section to show projects sent over from Prepare
+
 ## [Release-93][release-93]
 
 ### Changed

--- a/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
@@ -8,11 +8,7 @@
 
         <ul class="moj-primary-navigation__list">
 
-          <%
-              # we are disbabling this navigation item for now
-              if false
-          %>
-
+          <% if policy(:project).handover? %>
             <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.handover"), path: all_handover_projects_path, namespace: "/projects/all/handover"} %>
           <% end %>
 

--- a/spec/features/all_projects/handover/user_can_view_a_list_of_projects_spec.rb
+++ b/spec/features/all_projects/handover/user_can_view_a_list_of_projects_spec.rb
@@ -8,8 +8,6 @@ RSpec.feature "Users can view a list of handover projects" do
   end
 
   scenario "as a table" do
-    pending("Prepare application sending approved projects to us")
-
     conversion_project = create(:conversion_project, state: :inactive, urn: 123456, conversion_date: Date.new(2024, 2, 1))
     transfer_project = create(:transfer_project, state: :inactive, urn: 165432, transfer_date: Date.new(2024, 1, 1))
 


### PR DESCRIPTION
We are getting ready to accept projects from Prepare via our API.

In order for us to test projects have been sent over successfully, reveal the 'Handover' section for RDOs.

