### PR TITLE
Give Service Support users access to see projects from Prepare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Service support users can see the "Handover" tab & view projects handed over
+  from Prepare
+
 ## [Release-94][release-94]
 
 ### Added

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -11,7 +11,7 @@ class ProjectPolicy
   end
 
   def handover?
-    @user.is_regional_delivery_officer?
+    @user.is_regional_delivery_officer? || @user.is_service_support?
   end
 
   def show?

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -179,9 +179,12 @@ RSpec.describe ProjectPolicy do
       expect(subject).to permit(build(:regional_delivery_officer_user))
     end
 
-    it "denies access if the user is not a regional delivery officer" do
+    it "grants access if the user is a service support user" do
+      expect(subject).to permit(build(:regional_delivery_officer_user))
+    end
+
+    it "denies access if the user is not a regional delivery officer or service support user" do
       expect(subject).not_to permit(build(:regional_casework_services_user))
-      expect(subject).not_to permit(build(:service_support_user))
       expect(subject).not_to permit(build(:inactive_user))
     end
   end


### PR DESCRIPTION
Grant PASS users access to the Handover tab, so they can see projects handed over from the Prepare application. This is so they can respond to user queries.

