### PR TITLE
Remove diffy gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,6 @@ group :development, :test do
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "rails-controller-testing"
-  gem "diffy"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,6 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.5.1)
-    diffy (3.4.2)
     docile (1.4.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
@@ -509,7 +508,6 @@ DEPENDENCIES
   capybara
   climate_control
   debug
-  diffy
   dotenv-rails
   erb_lint
   factory_bot_rails


### PR DESCRIPTION
This isn't used anywhere, so remove it so we don't have to keep updating it.

