### PR TITLE
Add length validation to URN and UKPRN parameters in API

### DIFF
--- a/app/api/v1/conversions.rb
+++ b/app/api/v1/conversions.rb
@@ -5,7 +5,7 @@ class V1::Conversions < Grape::API
 
   resource :projects do
     params do
-      requires :urn, type: Integer, documentation: {example: "123456"}
+      requires :urn, type: Integer, documentation: {example: "123456"}, regexp: /\d{6}/
       requires :advisory_board_date, type: Date
       requires :advisory_board_conditions, type: String
       requires :provisional_conversion_date, type: Date, documentation: {example: (Date.today.at_beginning_of_month - 1.month).to_s}
@@ -19,7 +19,7 @@ class V1::Conversions < Grape::API
 
     resource :conversions do
       params do
-        requires :incoming_trust_ukprn, type: Integer, documentation: {example: "12345678"}
+        requires :incoming_trust_ukprn, type: Integer, documentation: {example: "12345678"}, regexp: /\d{8}/
       end
 
       desc "Create a conversion project" do

--- a/app/api/v1/transfers.rb
+++ b/app/api/v1/transfers.rb
@@ -5,7 +5,7 @@ class V1::Transfers < Grape::API
 
   resource :projects do
     params do
-      requires :urn, type: Integer, documentation: {example: "123456"}
+      requires :urn, type: Integer, documentation: {example: "123456"}, regexp: /\d{6}/
       requires :advisory_board_date, type: Date
       requires :advisory_board_conditions, type: String
       requires :provisional_transfer_date, type: Date, documentation: {example: (Date.today.at_beginning_of_month - 1.month).to_s}
@@ -14,7 +14,7 @@ class V1::Transfers < Grape::API
       requires :created_by_last_name, type: String, documentation: {example: "Last"}
       requires :inadequate_ofsted, type: Boolean, default: false
       requires :financial_safeguarding_governance_issues, type: Boolean, default: false
-      requires :outgoing_trust_ukprn, type: Integer
+      requires :outgoing_trust_ukprn, type: Integer, documentation: {example: "12345678"}, regexp: /\d{8}/
       requires :outgoing_trust_to_close, type: Boolean, default: false
       requires :prepare_id, type: Integer
       optional :group_id, type: String, documentation: {example: "GRP_12345678"}
@@ -22,7 +22,7 @@ class V1::Transfers < Grape::API
 
     resource :transfers do
       params do
-        requires :incoming_trust_ukprn, type: Integer, documentation: {example: "12345678"}
+        requires :incoming_trust_ukprn, type: Integer, documentation: {example: "12345678"}, regexp: /\d{8}/
       end
 
       desc "Create a transfer project" do

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -113,6 +113,22 @@ RSpec.describe V1::Conversions do
         expect(response.body).to include("invalid")
         expect(response.status).to eq(400)
       end
+
+      it "rejects URNs and UKPRNs which are too short" do
+        params = valid_conversion_parameters
+        params[:incoming_trust_ukprn] = 0
+        params[:urn] = 0
+
+        post "/api/v1/projects/conversions",
+          params: params,
+          as: :json,
+          headers: {Apikey: "testkey"}
+
+        expect(response.body).to include("urn is invalid")
+        expect(response.body).to include("incoming_trust_ukprn is invalid")
+        expect(response.body).to include("invalid")
+        expect(response.status).to eq(400)
+      end
     end
 
     context "when there is an error" do

--- a/spec/api/v1/transfers_spec.rb
+++ b/spec/api/v1/transfers_spec.rb
@@ -113,6 +113,22 @@ RSpec.describe V1::Transfers do
         expect(response.body).to include("invalid")
         expect(response.status).to eq(400)
       end
+
+      it "rejects URNs and UKPRNs which are too short" do
+        params = valid_transfer_parameters
+        params[:incoming_trust_ukprn] = 0
+        params[:urn] = 0
+
+        post "/api/v1/projects/transfers",
+          params: params,
+          as: :json,
+          headers: {Apikey: "testkey"}
+
+        expect(response.body).to include("urn is invalid")
+        expect(response.body).to include("incoming_trust_ukprn is invalid")
+        expect(response.body).to include("invalid")
+        expect(response.status).to eq(400)
+      end
     end
 
     context "when there is an error" do


### PR DESCRIPTION
We have had several instances of Conversion projects (not form a MAT) being sent over from Prepare without an incoming trust UKPRN.

After some investigation we realised the projects were being sent with a UKRPN of "0", which passes the API validation (which looks for an integer) but is not a valid UKPRN. So the projects end up in our "Handover" section with an unknown UKPRN and cannot be progressed by users.

It seems like Prepare parses a nil UKPRN to 0. If Prepare was passing nil or an empty string, our validation would have worked.

To stop this happening, tighten up the validation on our side to look for an integer which is 8 digits long (for UKPRN) or 6 digits long (for URN) using a regular expression.
