### PR TITLE
Serve Capybara assets from localhost:3000

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,6 +35,7 @@ end
 
 Capybara.configure do |config|
   config.automatic_label_click = true
+  config.asset_host = "http://localhost:3000"
 end
 
 # Checks for pending migrations and applies them before tests are run.


### PR DESCRIPTION
This allows us to see a styled page when debugging a test
and viewing the page with `save_and_open_page`.

![capybara_with_styles](https://github.com/user-attachments/assets/dde23d5b-1de1-4a21-b69f-11887b252fd5)
