### PR TITLE
Add pry-byebug for more debugging commands

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]
   gem "pry-rails"
+  gem "pry-byebug"
   gem "rspec-rails"
   gem "brakeman"
   gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,7 @@ GEM
     bullet (7.2.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    byebug (11.1.3)
     capybara (3.40.0)
       addressable
       matrix
@@ -303,6 +304,9 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
     public_suffix (5.0.5)
@@ -529,6 +533,7 @@ DEPENDENCIES
   omniauth-azure-activedirectory-v2
   omniauth-rails_csrf_protection
   pagy
+  pry-byebug
   pry-rails
   puma (~> 6.0)
   pundit (~> 2.2)


### PR DESCRIPTION
This provides handy debugging behaviour on top of pry, e.g.

- *break*: Manage breakpoints.

 - *step*: Step execution into the next line or method.
          Takes an optional numeric argument to step
          multiple times.

- *next*: Step over to the next line within the same frame.
          Also takes an optional numeric argument to step
          multiple lines.

- *finish*: Execute until current stack frame returns.

- *continue*: Continue program execution and end the Pry session.


