### PR TITLE
Cache the trivydb for a day to mitigate TOOMANYREQUESTS error

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -206,7 +206,7 @@ jobs:
       -
         name: Generate tarball from image
         run: |
-          docker save -o vuln-image.tar ${{ steps.build.outputs.imageid }}
+          docker save -o ./vuln-image.tar ${{ steps.build.outputs.imageid }}
       - ## To avoid the trivy-db becoming outdated, we save the cache for one day
         name: Get TrivyDB data
         id: date
@@ -223,7 +223,7 @@ jobs:
         name: Scan Docker image for CVEs
         uses: aquasecurity/trivy-action@0.28.0
         with:
-          input: /github/workspace/vuln-image.tar
+          input: ./vuln-image.tar
           format: 'sarif'
           output: 'trivy-results.sarif'
           limit-severities-for-sarif: true

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -207,6 +207,18 @@ jobs:
         name: Generate tarball from image
         run: |
           docker save -o vuln-image.tar ${{ steps.build.outputs.imageid }}
+      - ## To avoid the trivy-db becoming outdated, we save the cache for one day
+        name: Get TrivyDB data
+        id: date
+        run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+      -
+        name: Restore TrivyDB cache
+        uses: actions/cache@v4
+        with:
+          path: cache/db
+          key: trivy-cache-${{ steps.date.outputs.date }}
+          restore-keys:
+            trivy-cache-
       -
         name: Scan Docker image for CVEs
         uses: aquasecurity/trivy-action@0.28.0
@@ -218,6 +230,10 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
           github-pat: ${{ secrets.GITHUB_TOKEN }}
+          cache-dir: "./cache"
+      -
+        name: change permissions for trivy.db
+        run: sudo chmod 0644 ./cache/db/trivy.db
       -
         name: Upload scan results to GitHub Security
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
## Changes

Occasionally we run into a problem where the Docker image scan task encounters a TOOMANYREQUESTS error and times out. By caching the vulnerability database we reduce the frequency that we need to check for new versions.
