### PR TITLE
Ensure source is checked out for Sonar scan to work

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -151,6 +151,9 @@ jobs:
     needs: specs
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
         uses: actions/download-artifact@v4
         with:
           name: coverage-report


### PR DESCRIPTION
* without the source, the sonar-project.properties file is missing which prevents Sonarcloud from understanding how we want it to scan the project
