### PR TITLE
(Fix) Force Header and DfE Nav links to always be white

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - No longer unassign project on update when team is RCS.
+- Header and DfE Navigation links are now always white, instead of being blue
+  when in the "unvisited" state.
 
 ## [Release-97][release-97]
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -110,3 +110,8 @@ address.govuk-address {
 
 // force skip link to be underline
 .govuk-skip-link { text-decoration: underline !important; }
+
+// force header and DfE navigation links to always be white
+a.dfe-header__link--service, a.dfe-header__navigation-link {
+  color: #ffffff;
+}


### PR DESCRIPTION
These were being overridden by the DfE styles, ending up blue when they should be white.
