### PR TITLE
(Fix) Replace OpenStruct with Struct to fix loading issue

### DIFF
--- a/app/models/concerns/teamable.rb
+++ b/app/models/concerns/teamable.rb
@@ -26,5 +26,9 @@ module Teamable
     def regional_teams
       REGIONAL_TEAMS.values
     end
+
+    def user_teams
+      USER_TEAMS.values
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,7 +71,8 @@ class User < ApplicationRecord
   end
 
   def team_options
-    User.teams.keys.map { |team| OpenStruct.new(id: team, name: I18n.t("user.teams.#{team}")) }
+    team_struct = Struct.new(:id, :name)
+    User.user_teams.map { |team| team_struct.new(team, I18n.t("user.teams.#{team}")) }
   end
 
   private def apply_roles_based_on_team


### PR DESCRIPTION
## Changes

On the dev environment (but not locally) we saw an issue with OpenStruct
not being loaded correctly when adding or editing a user in the Service
Support view:

```
ActionView::Template::Error (uninitialized constant User::OpenStruct):
```

We had previously seen a similar issue with the CookiesForm which was
also not reproducible locally, and was fixed in PR https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/1735

The issue seems to be with OpenStruct not loading or being overriden
by _something_ else, but as it is not reproducible locally it is hard
to diagnose.

In PR https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/1735 we "fixed" the issue by creating an array of OpenStruct
objects for a 2-answer form. For the create/edit user form, we have
more than 2 answers and we also want these to be drawn from the
`User.user_teams` enum; we don't want to have to manually create an
OpenStruct for each User team in the User model, and create code
duplication.

Instead, use a plain Struct to generate these options from the
User.user_types enum. This does not have the same loading issues as
using OpenStruct.

A Struct is possibly a little slower than using OpenStruct, but as this
form is very rarely used (it is only for Service support users to add
or edit new platform users) this is an acceptable risk.

Also, while this might feel like a regression or a patch as opposed
to a proper fix, we should bear in mind that this application is due to
be replaced soon with a new .Net version.
## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
