### PR TITLE
Release 98

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release-98][release-98]
+
 ### Fixed
 
 - No longer unassign project on update when team is RCS.
@@ -2329,7 +2331,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-97...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-98...HEAD
+[release-98]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-97...release-98
 [release-97]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-96...release-97
 [release-96]:


### PR DESCRIPTION
### Fixed

- No longer unassign project on update when team is RCS.
- Header and DfE Navigation links are now always white, instead of being blue
  when in the "unvisited" state.