### PR TITLE
Play past OpenStruct loading issue with global 'require'

### DIFF
--- a/app/models/concerns/teamable.rb
+++ b/app/models/concerns/teamable.rb
@@ -26,9 +26,5 @@ module Teamable
     def regional_teams
       REGIONAL_TEAMS.values
     end
-
-    def user_teams
-      USER_TEAMS.values
-    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,8 +71,7 @@ class User < ApplicationRecord
   end
 
   def team_options
-    team_struct = Struct.new(:id, :name)
-    User.user_teams.map { |team| team_struct.new(team, I18n.t("user.teams.#{team}")) }
+    User.teams.keys.map { |team| OpenStruct.new(id: team, name: I18n.t("user.teams.#{team}")) }
   end
 
   private def apply_roles_based_on_team

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,7 @@
 require_relative "boot"
 
+require "ostruct"
+
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"


### PR DESCRIPTION
Play past OpenStruct loading issue with global 'require'

We've been seeing "uninitialize constant" errors for OpenStruct
like

```
uninitialized constant ProjectHelper::OpenStruct
```

which we only see the deployed environments, not in local development
or in CI.

This appears to be a file/class/module loading problem which occurs after
unrelated changes to the codebase.

To play past this issue we now explictly `require "ostruct"` from the
main `application.rb` file.