### PR TITLE
Revert "Merge pull request #2020 from DFE-Digital/release-98"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
-## [Release-98][release-98]
-
 ### Fixed
 
 - No longer unassign project on update when team is RCS.
@@ -2331,9 +2329,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-98...HEAD
-[release-98]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-97...release-98
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-97...HEAD
 [release-97]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-96...release-97
 [release-96]:


### PR DESCRIPTION
This reverts commit 7869128c063135ac4cc6f763f27f24513802fd7e, reversing changes made to 76f6af3f5c96286590561da68f4972d581cef578.

We've encountered a problem with the loading of OpenStruct which we're going to fix with
 https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/2022 before recreating the release branch / tag

