### PR TITLE
Return 'Healthy' or 'Unhealthy' string after db test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Return 'Healthy' or 'Unhealthy' string from /healthcheck endpoint to conform
+  to convention in RSD programme.
+
 ## [Release-98][release-98]
 
 ### Fixed

--- a/app/api/v1/healthcheck.rb
+++ b/app/api/v1/healthcheck.rb
@@ -1,8 +1,14 @@
 class V1::Healthcheck < Grape::API
-  desc "Api healthcheck endpoint returns 'OK'" do
+  content_type :txt, "text/plain"
+
+  desc "Api healthcheck endpoint checks db connection and returns 'Healthy' or 'Unhealthy'" do
     tags ["miscellaneous"]
   end
+
   get :healthcheck do
-    {status: "OK"}
+    content_type "text/plain"
+    body "Healthy" if ActiveRecord::Base.connected?
+
+    "Unhealthy"
   end
 end

--- a/spec/api/v1/healthcheck_spec.rb
+++ b/spec/api/v1/healthcheck_spec.rb
@@ -1,8 +1,21 @@
 require "rails_helper"
 
 RSpec.describe V1::Healthcheck do
-  it "returns OK" do
-    get "/api/v1/healthcheck"
-    expect(response.body).to eq({status: "OK"}.to_json)
+  context "when the db connection is up" do
+    before { allow(ActiveRecord::Base).to receive(:connected?).and_return(true) }
+
+    it "returns 'Healthy'" do
+      get "/api/v1/healthcheck"
+      expect(response.body).to eq("Healthy")
+    end
+  end
+
+  context "when the db connection is NOT up" do
+    before { allow(ActiveRecord::Base).to receive(:connected?).and_return(false) }
+
+    it "returns 'Unhealthy'" do
+      get "/api/v1/healthcheck"
+      expect(response.body).to eq("Unhealthy")
+    end
   end
 end


### PR DESCRIPTION
The other products in the programme are all returning a string rather than a JSON representation.

We now:

- conform to that convention
- include a db connection test

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
