### PR TITLE
Revert "Exclude terraform folder from CI checks workflow"

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -2,13 +2,9 @@ name: CI Checks
 
 on:
   pull_request:
-    paths:
-      - '!terraform/'
   push:
     branches:
       - main
-    paths:
-      - '!terraform/'
 
 jobs:
   build:


### PR DESCRIPTION
Reverts DFE-Digital/dfe-complete-conversions-transfers-and-changes#2029

 This seems to have stopped CI checks for all branches.