### PR TITLE
Change healthcheck endpoint to render plain text

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -2,6 +2,8 @@ class HealthcheckController < ApplicationController
   skip_before_action :redirect_unauthenticated_user
 
   def check
-    render json: {status: "OK"}, status: :ok
+    return render plain: "Healthy" if ActiveRecord::Base.connected?
+
+    render plain: "Unhealthy"
   end
 end

--- a/spec/requests/healthcheck_controller_spec.rb
+++ b/spec/requests/healthcheck_controller_spec.rb
@@ -1,11 +1,27 @@
 require "rails_helper"
 
 RSpec.describe HealthcheckController, type: :request do
-  describe "#check" do
-    it "returns status 200" do
-      get healthcheck_path
+  describe "#healthcheck" do
+    context "when the database is connected" do
+      before { allow(ActiveRecord::Base).to receive(:connected?).and_return(true) }
 
-      expect(response).to have_http_status(200)
+      it "returns status 200 Healthy" do
+        get healthcheck_path
+
+        expect(response).to have_http_status(200)
+        expect(response.body).to eq("Healthy")
+      end
+    end
+
+    context "when the database is NOT connected" do
+      before { allow(ActiveRecord::Base).to receive(:connected?).and_return(false) }
+
+      it "returns status 200 Unhealthy" do
+        get healthcheck_path
+
+        expect(response).to have_http_status(200)
+        expect(response.body).to eq("Unhealthy")
+      end
     end
   end
 end


### PR DESCRIPTION
In PR #2030 we altered the API healthcheck (`/api/v1/healthcheck`) endpoint to return plain text instead of JSON. We forgot that we actually have two healthcheck endpoints, one simply at `/healthcheck`. Change this endpoint to also return plain text.

