### PR TITLE
Check DB connection is available by fetching a record

### DIFF
--- a/app/api/v1/healthcheck.rb
+++ b/app/api/v1/healthcheck.rb
@@ -7,8 +7,9 @@ class V1::Healthcheck < Grape::API
 
   get :healthcheck do
     content_type "text/plain"
-    body "Healthy" if ActiveRecord::Base.connected?
 
-    "Unhealthy"
+    return body "Healthy" if Ops::DbAvailability.db_available?
+
+    body "Unhealthy"
   end
 end

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -2,7 +2,7 @@ class HealthcheckController < ApplicationController
   skip_before_action :redirect_unauthenticated_user
 
   def check
-    return render plain: "Healthy" if ActiveRecord::Base.connected?
+    return render plain: "Healthy" if Ops::DbAvailability.db_available?
 
     render plain: "Unhealthy"
   end

--- a/lib/ops/db_availability.rb
+++ b/lib/ops/db_availability.rb
@@ -1,0 +1,6 @@
+class Ops::DbAvailability
+  def self.db_available?
+    return true if User.first && ActiveRecord::Base.connected?
+    false
+  end
+end

--- a/spec/api/v1/healthcheck_spec.rb
+++ b/spec/api/v1/healthcheck_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe V1::Healthcheck do
   context "when the db connection is up" do
-    before { allow(ActiveRecord::Base).to receive(:connected?).and_return(true) }
+    before { allow(Ops::DbAvailability).to receive(:db_available?).and_return(true) }
 
     it "returns 'Healthy'" do
       get "/api/v1/healthcheck"
@@ -11,7 +11,7 @@ RSpec.describe V1::Healthcheck do
   end
 
   context "when the db connection is NOT up" do
-    before { allow(ActiveRecord::Base).to receive(:connected?).and_return(false) }
+    before { allow(Ops::DbAvailability).to receive(:db_available?).and_return(false) }
 
     it "returns 'Unhealthy'" do
       get "/api/v1/healthcheck"

--- a/spec/lib/ops/db_availability_spec.rb
+++ b/spec/lib/ops/db_availability_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "check DB availability" do
+  describe "db_available?" do
+    context "when the DB is available" do
+      it "returns true if there is a user" do
+        create(:user)
+
+        expect(Ops::DbAvailability.db_available?).to be true
+      end
+    end
+
+    context "when the DB is not available" do
+      before do
+        allow(ActiveRecord::Base).to receive(:connected?).and_return(false)
+      end
+
+      it "returns false if there is a user" do
+        create(:user)
+
+        expect(Ops::DbAvailability.db_available?).to be false
+      end
+
+      it "returns false if there is NO user and the db is NOT up" do
+        expect(Ops::DbAvailability.db_available?).to be false
+      end
+    end
+  end
+end

--- a/spec/requests/healthcheck_controller_spec.rb
+++ b/spec/requests/healthcheck_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe HealthcheckController, type: :request do
   describe "#healthcheck" do
     context "when the database is connected" do
-      before { allow(ActiveRecord::Base).to receive(:connected?).and_return(true) }
+      before { allow(Ops::DbAvailability).to receive(:db_available?).and_return(true) }
 
       it "returns status 200 Healthy" do
         get healthcheck_path
@@ -14,7 +14,7 @@ RSpec.describe HealthcheckController, type: :request do
     end
 
     context "when the database is NOT connected" do
-      before { allow(ActiveRecord::Base).to receive(:connected?).and_return(false) }
+      before { allow(Ops::DbAvailability).to receive(:db_available?).and_return(false) }
 
       it "returns status 200 Unhealthy" do
         get healthcheck_path


### PR DESCRIPTION
In a previous commit we attempted to check the DB is available by using `AxctiveRecord::Base.connection?`. However this will return false unless you have already opened a connection by (for example) fetching a record.

Change the healthcheck endpoints to check the db is connected by both fetching a record and then checking for DB availability. Put this into a helper module so we can reuse it in both checks.

