### PR TITLE
Refactor Project#creator (step 2 of 4) backfill new FK

### DIFF
--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -51,6 +51,7 @@ class Conversion::CreateProjectForm < CreateProjectForm
       conversion_date: provisional_conversion_date,
       advisory_board_date: advisory_board_date,
       regional_delivery_officer_id: user.id,
+      creator_id: user.id,
       team: team,
       assigned_to: assigned_to,
       assigned_at: assigned_at,

--- a/app/forms/internal_contacts/edit_added_by_user_form.rb
+++ b/app/forms/internal_contacts/edit_added_by_user_form.rb
@@ -24,7 +24,7 @@ class InternalContacts::EditAddedByUserForm
 
   def update
     if valid?
-      project.update(regional_delivery_officer: user)
+      project.update(regional_delivery_officer: user, creator: user)
     else
       false
     end

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -50,6 +50,7 @@ class Transfer::CreateProjectForm < CreateProjectForm
       transfer_date: provisional_transfer_date,
       two_requires_improvement: two_requires_improvement,
       regional_delivery_officer_id: user.id,
+      creator_id: user.id,
       team: user.team,
       assigned_to: user,
       assigned_at: DateTime.now,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -39,8 +39,14 @@ class Project < ApplicationRecord
   validate :establishment_exists, if: -> { urn.present? }
 
   belongs_to :caseworker, class_name: "User", optional: true
-  belongs_to :regional_delivery_officer, class_name: "User", optional: true
   belongs_to :assigned_to, class_name: "User", optional: true
+
+  # Project#regional_delivery_officer is deprecated, in favour of Project#creator
+  #   as RCSs can also create transfers and conversions.
+  #   We'll leave the projects.regional_delivery_officer_id FK initially
+  #   and remove it in an additional PR / Deployment
+  belongs_to :creator, class_name: "User", optional: true
+  belongs_to :regional_delivery_officer, class_name: "User", optional: true
 
   scope :conversions, -> { where(type: "Conversion::Project") }
   scope :transfers, -> { where(type: "Transfer::Project") }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -50,7 +50,6 @@ class Project < ApplicationRecord
 
   scope :assigned, -> { where.not(assigned_to: nil) }
   scope :assigned_to_caseworker, ->(user) { where(assigned_to: user).or(where(caseworker: user)) }
-  scope :assigned_to_regional_delivery_officer, ->(user) { where(assigned_to: user).or(where(regional_delivery_officer: user)) }
 
   scope :unassigned_to_user, -> { where assigned_to: nil }
   scope :assigned_to_regional_caseworker_team, -> { where(team: "regional_casework_services") }

--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -20,6 +20,7 @@ class Api::Conversions::CreateProjectService < Api::BaseCreateProjectService
         advisory_board_conditions: advisory_board_conditions,
         directive_academy_order: directive_academy_order,
         regional_delivery_officer_id: user.id,
+        creator_id: user.id,
         tasks_data: tasks_data,
         region: establishment.region_code,
         prepare_id: prepare_id,

--- a/app/services/api/transfers/create_project_service.rb
+++ b/app/services/api/transfers/create_project_service.rb
@@ -35,6 +35,7 @@ class Api::Transfers::CreateProjectService < Api::BaseCreateProjectService
         transfer_date: provisional_transfer_date,
         two_requires_improvement: two_requires_improvement,
         regional_delivery_officer_id: user.id,
+        creator_id: user.id,
         tasks_data: tasks_data,
         region: establishment.region_code,
         new_trust_reference_number: new_trust_reference_number,

--- a/db/migrate/20241217170822_add_project_creator_id.rb
+++ b/db/migrate/20241217170822_add_project_creator_id.rb
@@ -1,0 +1,7 @@
+class AddProjectCreatorId < ActiveRecord::Migration[7.1]
+  def change
+    add_column :projects, :creator_id, :uuid, null: true
+    add_index :projects, :creator_id
+    add_foreign_key :projects, :users, column: :creator_id
+  end
+end

--- a/db/migrate/20241218105345_backfill_projects_creator_id.rb
+++ b/db/migrate/20241218105345_backfill_projects_creator_id.rb
@@ -1,0 +1,9 @@
+class BackfillProjectsCreatorId < ActiveRecord::Migration[7.1]
+  def change
+    Project.all.each do |project|
+      next if project.creator_id.present?
+
+      project.update_column(:creator_id, project.regional_delivery_officer_id)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_21_125140) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_17_170822) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -331,8 +331,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_21_125140) do
     t.integer "prepare_id"
     t.uuid "local_authority_main_contact_id"
     t.uuid "group_id"
+    t.uuid "creator_id"
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
+    t.index ["creator_id"], name: "index_projects_on_creator_id"
     t.index ["incoming_trust_ukprn"], name: "index_projects_on_incoming_trust_ukprn"
     t.index ["outgoing_trust_ukprn"], name: "index_projects_on_outgoing_trust_ukprn"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"
@@ -498,5 +500,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_21_125140) do
   add_foreign_key "notes", "users"
   add_foreign_key "projects", "users", column: "assigned_to_id"
   add_foreign_key "projects", "users", column: "caseworker_id"
+  add_foreign_key "projects", "users", column: "creator_id"
   add_foreign_key "projects", "users", column: "regional_delivery_officer_id"
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -570,21 +570,6 @@ RSpec.describe Project, type: :model do
       end
     end
 
-    describe "assigned_to_regional_delivery_officer scope" do
-      before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
-
-      it "returns projects which have the user as either the `regional_delivery_officer` or `assigned_to`" do
-        user = create(:user, :regional_delivery_officer)
-        other_project = create(:conversion_project)
-        rdo_project = create(:conversion_project, regional_delivery_officer: user)
-        assigned_to_project = create(:conversion_project, assigned_to: user)
-
-        projects = Project.assigned_to_regional_delivery_officer(user)
-        expect(projects).to include(rdo_project, assigned_to_project)
-        expect(projects).to_not include(other_project)
-      end
-    end
-
     describe "unassigned_to_user scope" do
       before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
 


### PR DESCRIPTION
**NB: this must be merged and deployed after [PR 2042](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/2042)**

---

This is step 2 in the refactoring process. Note that each step is **deployed** separately.

### 1. ([PR 2042](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/2042)) introduce new foreign key column
- create migration to:
	- add `projects.creator_id` column, allow to be null
	- add new index on `projects.creator_id`
	- add new foreign key constraint on `projects.creator_id`
- start setting new `projects.creator_id` in addition to existing `projects.regional_delivery_officer_id` (e.g. when a project is created, when the 'added_by' is updated) 

### 2. (**THIS PR**) back-fill new foreign key column
- run a data migration to populate the new `projects.creator_id` with existing references from `projects.regional_delivery_officer_id`

### 3. discontinue use of old foreign key column

- run migration to make `projects.creator_id` non-nullable
- Change code to use new `projects.creator_id` in all places.


### 4. remove old foreign key column
```
remove_index :projects, regional_delivery_officer_id
remove_foreign_key :projects, regional_delivery_officer_id
remove_column :projects, regional_delivery_officer_id
```

