### PR TITLE
194142 - Fix: Enforce uniqueness of URN for active/inactive projects with trigger

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,6 +41,8 @@
 **/*.db*
 **/*.dump*
 **/*.sql*
+# Allow trigger definitions
+!/db/triggers/*.sql*
 **/*.sqlite3*
 ### Environment variables
 **/.env

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,9 @@ require "govuk/components"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+adapter = ActiveRecord::ConnectionAdapters::SQLServerAdapter
+adapter.exclude_output_inserted_table_names["projects"] = "uniqueidentifier"
+
 module DfeCompleteConversionsTransfersAndChanges
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/db/migrate/20250108114547_add_enforce_uniqueness_of_project_urn_trigger.rb
+++ b/db/migrate/20250108114547_add_enforce_uniqueness_of_project_urn_trigger.rb
@@ -1,0 +1,16 @@
+class AddEnforceUniquenessOfProjectUrnTrigger < ActiveRecord::Migration[7.1]
+  def up
+    path = "#{Rails.root}/db/triggers/enforce_unique_urns_on_active_and_inactive_projects.sql"
+    sql = File.read(path)
+    ActiveRecord::Base.connection.execute sql
+  end
+
+  def down
+    sql = <<~SQL
+      IF OBJECT_ID ('EnforceUniquenessOfProjectUrn', 'TR') IS NOT NULL
+      DROP TRIGGER EnforceUniquenessOfProjectUrn;
+    SQL
+
+    execute sql
+  end
+end

--- a/db/triggers/enforce_unique_urns_on_active_and_inactive_projects.sql
+++ b/db/triggers/enforce_unique_urns_on_active_and_inactive_projects.sql
@@ -1,0 +1,42 @@
+CREATE TRIGGER EnforceUniquenessOfProjectUrn
+ON projects
+AFTER INSERT
+AS
+
+SET NOCOUNT ON;
+
+DECLARE @urn int;
+DECLARE @inserted_state int;
+
+SET @urn = (SELECT TOP 1
+  urn
+FROM inserted);
+SET @inserted_state = (SELECT TOP 1
+  state
+FROM inserted);
+
+
+IF EXISTS (
+    SELECT 'URN exists on active or inactive project'
+FROM projects
+
+-- including the row just 'inserted' is there > 1 project
+-- with the given URN in the active or inactive state?
+WHERE urn IN (
+        SELECT urn
+  FROM projects
+  WHERE urn = @urn
+    AND state IN (0, 4)
+  GROUP BY urn
+  HAVING COUNT(*) > 1
+    )
+
+  -- and is that just 'inserted' record in the inactive or active state?
+  AND @inserted_state IN (0, 4)
+)
+
+-- if YES, then raise an error and rollback this insertion
+BEGIN
+  RAISERROR ('Project URN in use', 16, 1);
+  ROLLBACK TRANSACTION;
+END

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,6 +8,15 @@ setup_database()
   echo "ENTRYPOINT: Running rake db:prepare…"
   # Migrate the database and if one doesn't exist then create one
   bundle exec rake db:prepare
+
+  # Manually add our EnforceUniquenessOfProjectUrn trigger
+  # In theory this trigger should be included in structure.sql if
+  # we opt to use that instead of schema.rb. But it isn't and in
+  # any case trying to load the structure from stucture.sql with TinyTDS
+  # fails due to lack of escaping on the "key# keyword....
+  echo "ENTRYPOINT: Running rake db:add_enforce_uniqueness_of_project_urn_trigger…"
+  bundle exec rake db:add_enforce_uniqueness_of_project_urn_trigger
+
   echo "ENTRYPOINT: Finished database setup."
 }
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,14 @@
+# :nocov:
+namespace :db do
+  desc "Add the EnforceUniquenessOfProjectUrn db trigger"
+  # In theory this trigger should be included in structure.sql if
+  # we opt to use that instead of schema.rb. But it isn't and in
+  # any case trying to load the structure from stucture.sql with TinyTDS
+  # fails due to lack of escaping on the "key# keyword....
+  task add_enforce_uniqueness_of_project_urn_trigger: :environment do
+    path = "#{Rails.root}/db/triggers/enforce_unique_urns_on_active_and_inactive_projects.sql"
+    sql = File.read(path)
+    ActiveRecord::Base.connection.execute sql
+  end
+end
+# :nocov:

--- a/spec/api/v1/conversions_spec.rb
+++ b/spec/api/v1/conversions_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 RSpec.describe V1::Conversions do
-  before { mock_successful_api_response_to_create_any_project }
+  before {
+    mock_successful_api_response_to_create_any_project
+  }
 
   describe "authorisation" do
     context "when there is no api key in the header" do

--- a/spec/api/v1/transfers_spec.rb
+++ b/spec/api/v1/transfers_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 RSpec.describe V1::Transfers do
-  before { mock_successful_api_response_to_create_any_project }
+  before {
+    mock_successful_api_response_to_create_any_project
+  }
 
   describe "authorisation" do
     context "when there is no api key in the header" do

--- a/spec/factories/conversion/create_project_form_factory.rb
+++ b/spec/factories/conversion/create_project_form_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :create_conversion_project_form, class: "Conversion::CreateProjectForm", aliases: [:create_project_form] do
-    urn { 123456 }
+    urn { rand(111111..999999) }
     incoming_trust_ukprn { 10061021 }
     provisional_conversion_date { {3 => 1, 2 => 1, 1 => 2030} }
     advisory_board_date { {3 => 1, 2 => 10, 1 => 2022} }

--- a/spec/factories/conversion/form_a_mat_project_factory.rb
+++ b/spec/factories/conversion/form_a_mat_project_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :form_a_mat_conversion_project, class: "Conversion::Project" do
     type { "Conversion::Project" }
-    urn { 123456 }
+    urn { rand(111111..999999) }
     new_trust_reference_number { "TR12345" }
     new_trust_name { "The New Trust" }
     conversion_date { (Date.today + 2.years).at_beginning_of_month }

--- a/spec/factories/conversion/project_factory.rb
+++ b/spec/factories/conversion/project_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :conversion_project, class: "Conversion::Project" do
     type { "Conversion::Project" }
-    urn { 123456 }
+    urn { rand(111111..999999) }
     incoming_trust_ukprn { 10061021 }
     conversion_date { (Date.today + 2.years).at_beginning_of_month }
     advisory_board_date { (Date.today - 2.weeks) }

--- a/spec/factories/transfer/create_project_form_factory.rb
+++ b/spec/factories/transfer/create_project_form_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :create_transfer_project_form, class: "Transfer::CreateProjectForm" do
-    urn { 123456 }
+    urn { rand(111111..999999) }
     incoming_trust_ukprn { 10061021 }
     outgoing_trust_ukprn { 10066123 }
     advisory_board_date { {3 => 1, 2 => 10, 1 => 2022} }

--- a/spec/factories/transfer/project_factory.rb
+++ b/spec/factories/transfer/project_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :transfer_project, class: "Transfer::Project" do
     type { "Transfer::Project" }
-    urn { 123456 }
+    urn { rand(111111..999999) }
     incoming_trust_ukprn { 10061021 }
     transfer_date { (Date.today + 2.years).at_beginning_of_month }
     advisory_board_date { (Date.today - 2.weeks) }

--- a/spec/features/project_information/users_can_view_school_details_spec.rb
+++ b/spec/features/project_information/users_can_view_school_details_spec.rb
@@ -2,10 +2,11 @@ require "rails_helper"
 
 RSpec.feature "Users can view school details" do
   let(:user) { create(:user, :caseworker) }
-  let(:project) { create(:conversion_project, :with_conditions, caseworker: user) }
+  let(:project) { create(:conversion_project, :with_conditions, caseworker: user, urn: 888888) }
+  let(:establishment) { build(:academies_api_establishment, urn: "888888") }
 
   before do
-    mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    mock_successful_api_responses(urn: 888888, ukprn: any_args, establishment: establishment)
     sign_in_with_user(user)
     visit project_information_path(project)
   end
@@ -13,7 +14,7 @@ RSpec.feature "Users can view school details" do
   scenario "they can view the school details" do
     within("#schoolDetails") do
       expect(page).to have_content(project.establishment.name)
-      expect(page).to have_content(project.urn)
+      expect(page).to have_content(888888)
       expect(page).to have_content(project.establishment.type)
       expect(page).to have_content(project.establishment.phase)
     end

--- a/spec/features/projects/users_can_view_a_list_of_assigned_projects_spec.rb
+++ b/spec/features/projects/users_can_view_a_list_of_assigned_projects_spec.rb
@@ -29,9 +29,9 @@ RSpec.feature "Viewing assigned projects" do
   end
 
   context "when there are projects" do
-    let!(:in_progress_assigned_project) { create(:conversion_project, urn: 103835, assigned_to: user, conversion_date: (Date.today + 1.month).at_beginning_of_month) }
-    let!(:in_progress_assigned_project_next_year) { create(:conversion_project, urn: 103835, assigned_to: user, conversion_date: (Date.today + 1.year).at_beginning_of_month) }
-    let!(:completed_assigned_project) { create(:conversion_project, :completed, urn: 114067, assigned_to: user, completed_at: Date.yesterday) }
+    let!(:in_progress_assigned_project) { create(:conversion_project, assigned_to: user, conversion_date: (Date.today + 1.month).at_beginning_of_month) }
+    let!(:in_progress_assigned_project_next_year) { create(:conversion_project, assigned_to: user, conversion_date: (Date.today + 1.year).at_beginning_of_month) }
+    let!(:completed_assigned_project) { create(:conversion_project, :completed, assigned_to: user, completed_at: Date.yesterday) }
 
     context "when signed in as a Regional caseworker" do
       let(:user) { create(:regional_casework_services_user) }

--- a/spec/features/users/users_can_manage_user_accounts_spec.rb
+++ b/spec/features/users/users_can_manage_user_accounts_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature "Users can manage user accounts" do
   let(:user) { create(:user, :service_support, first_name: "Service", last_name: "Support", email: "service.support@education.gov.uk") }
 
   before do
+    User.destroy_all
     sign_in_with_user(user)
   end
 

--- a/spec/features/users_can_create_and_view_and_delete_conversion_project_notes_spec.rb
+++ b/spec/features/users_can_create_and_view_and_delete_conversion_project_notes_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Users can create and view and delete conversion notes" do
   let(:task) { Conversion::Task::ArticlesOfAssociationTaskForm.new(project.tasks_data, user) }
 
   before do
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
     sign_in_with_user(user)
 
     travel_to Date.yesterday do

--- a/spec/features/users_can_create_and_view_and_delete_notes_spec.rb
+++ b/spec/features/users_can_create_and_view_and_delete_notes_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Users can create and view notes" do
   let(:new_note_body) { "Just shared some *important* documents with the solictor." }
 
   before do
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
     sign_in_with_user(user)
 
     travel_to Date.yesterday do

--- a/spec/features/users_can_create_and_view_and_delete_task_level_notes_spec.rb
+++ b/spec/features/users_can_create_and_view_and_delete_task_level_notes_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Users can create and view task level notes" do
   let(:note_body) { "Just had a very interesting phone call with the headteacher about land law" }
 
   before do
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
     sign_in_with_user(user)
 
     travel_to Date.yesterday do

--- a/spec/features/users_can_view_a_project_spec.rb
+++ b/spec/features/users_can_view_a_project_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Users can view a project" do
   let(:project) { create(:conversion_project, caseworker: user) }
 
   before do
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
     sign_in_with_user(user)
   end
 

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
   context "when the project is successfully created" do
     let(:establishment) { build(:academies_api_establishment) }
     before do
-      mock_academies_api_establishment_success(urn: 123456)
+      mock_academies_api_establishment_success(urn: any_args)
       mock_academies_api_trust_success(ukprn: 10061021)
 
       ActiveJob::Base.queue_adapter = :test
@@ -84,8 +84,7 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
         establishment = build(:academies_api_establishment, diocese_code: "0000")
         allow(establishment).to receive(:local_authority).and_return(create(:local_authority))
         result = Api::AcademiesApi::Client::Result.new(establishment, nil)
-        allow_any_instance_of(Api::AcademiesApi::Client).to receive(:get_establishment).with(123456).and_return(result)
-
+        allow_any_instance_of(Api::AcademiesApi::Client).to receive(:get_establishment).and_return(result)
         project = build(:create_project_form).save
 
         expect(project.tasks_data.church_supplemental_agreement_not_applicable).to be true
@@ -615,7 +614,7 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
     let(:establishment) { build(:academies_api_establishment) }
 
     before do
-      mock_academies_api_establishment_success(urn: 123456)
+      mock_academies_api_establishment_success(urn: any_args)
       mock_academies_api_trust_success(ukprn: 10061021)
     end
 

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -517,6 +517,9 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
     let(:establishment) { build(:academies_api_establishment) }
 
     before do
+      Note.destroy_all
+      Transfer::TasksData.destroy_all
+
       mock_academies_api_establishment_success(urn: 123456)
       mock_academies_api_trust_success(ukprn: 10061021)
     end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ApplicationMailer do
-  before { mock_successful_api_responses(urn: 123456, ukprn: 10061021) }
+  before { mock_successful_api_responses(urn: any_args, ukprn: 10061021) }
 
   describe "#url_to_project" do
     it "returns the correct url" do

--- a/spec/mailers/assigned_to_mailer_spec.rb
+++ b/spec/mailers/assigned_to_mailer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AssignedToMailer do
 
     subject(:send_mail) { described_class.assigned_notification(caseworker, project).deliver_now }
 
-    before { mock_successful_api_responses(urn: 123456, ukprn: 10061021) }
+    before { mock_successful_api_responses(urn: any_args, ukprn: 10061021) }
 
     it "sends an email with the correct personalisation" do
       expect_any_instance_of(Mail::Notify::Mailer)

--- a/spec/mailers/team_leader_mailer_spec.rb
+++ b/spec/mailers/team_leader_mailer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TeamLeaderMailer do
 
     subject(:send_mail) { described_class.new_conversion_project_created(team_leader, project).deliver_now }
 
-    before { mock_successful_api_responses(urn: 123456, ukprn: 10061021) }
+    before { mock_successful_api_responses(urn: any_args, ukprn: 10061021) }
 
     it "sends an email with the correct personalisation" do
       expect_any_instance_of(Mail::Notify::Mailer)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -166,7 +166,6 @@ RSpec.describe Project, type: :model do
       describe "enforcing the uniqueness of the URN (db trigger EnforceUniquenessOfProjectUrn)" do
         before do
           mock_successful_api_responses(urn: any_args, ukprn: any_args)
-          Project.destroy_all
         end
 
         context "when an _inactive_ project exists with a given URN" do
@@ -207,6 +206,8 @@ RSpec.describe Project, type: :model do
 
         context "when _completed_, _deleted_ or _dao-revoked_ projects exists with a given URN" do
           before do
+            Project.destroy_all
+            expect(Project.count).to be_zero
             FactoryBot.create(:transfer_project, urn: 111111, state: :completed)
             FactoryBot.create(:transfer_project, urn: 222222, state: :deleted)
             FactoryBot.create(:transfer_project, urn: 333333, state: :dao_revoked)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -482,7 +482,10 @@ RSpec.describe Project, type: :model do
     end
 
     describe "ordered_by_completed_date scope" do
-      before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+      before {
+        Project.destroy_all
+        mock_successful_api_responses(urn: any_args, ukprn: any_args)
+      }
 
       it "only returns completed projects (state 1) ordered by completed date" do
         completed_project_1 = create(:conversion_project, completed_at: Date.today - 1.year, state: 1)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -163,6 +163,65 @@ RSpec.describe Project, type: :model do
       it { is_expected.to allow_value(123456).for(:urn) }
       it { is_expected.not_to allow_values(12345, 1234567).for(:urn) }
 
+      describe "enforcing the uniqueness of the URN (db trigger EnforceUniquenessOfProjectUrn)" do
+        before do
+          mock_successful_api_responses(urn: any_args, ukprn: any_args)
+          Project.destroy_all
+        end
+
+        context "when an _inactive_ project exists with a given URN" do
+          before do
+            FactoryBot.create(:transfer_project, urn: 333333, state: :inactive)
+          end
+
+          it "is NOT possible to create another _inactive_ project with that URN" do
+            expect {
+              FactoryBot.create(:transfer_project, urn: 333333, state: :inactive)
+            }.to raise_error(ActiveRecord::StatementInvalid, /TinyTds::Error/)
+          end
+
+          it "is NOT possible to create another _active_ project with that URN" do
+            expect {
+              FactoryBot.create(:transfer_project, urn: 333333, state: :active)
+            }.to raise_error(ActiveRecord::StatementInvalid, /TinyTds::Error/)
+          end
+        end
+
+        context "when an _active_ project exists with a given URN" do
+          before do
+            FactoryBot.create(:transfer_project, urn: 222222, state: :active)
+          end
+
+          it "is NOT possible to create another _active_ project with that URN" do
+            expect {
+              FactoryBot.create(:transfer_project, urn: 222222, state: :active)
+            }.to raise_error(ActiveRecord::StatementInvalid, /TinyTds::Error/)
+          end
+
+          it "is NOT possible to create another _inactive_ project with that URN" do
+            expect {
+              FactoryBot.create(:transfer_project, urn: 222222, state: :inactive)
+            }.to raise_error(ActiveRecord::StatementInvalid, /TinyTds::Error/)
+          end
+        end
+
+        context "when _completed_, _deleted_ or _dao-revoked_ projects exists with a given URN" do
+          before do
+            FactoryBot.create(:transfer_project, urn: 111111, state: :completed)
+            FactoryBot.create(:transfer_project, urn: 222222, state: :deleted)
+            FactoryBot.create(:transfer_project, urn: 333333, state: :dao_revoked)
+          end
+
+          it "IS possible to create another _active_ project with that URN" do
+            aggregate_failures do
+              expect(FactoryBot.create(:transfer_project, urn: 111111, state: :active).urn).to eq(111111)
+              expect(FactoryBot.create(:transfer_project, urn: 222222, state: :active).urn).to eq(222222)
+              expect(FactoryBot.create(:transfer_project, urn: 333333, state: :active).urn).to eq(333333)
+            end
+          end
+        end
+      end
+
       context "when no establishment with that URN exists in the API and the URN is present" do
         let(:no_establishment_found_result) do
           Api::AcademiesApi::Client::Result.new(nil, Api::AcademiesApi::Client::NotFoundError.new("Could not find establishment with URN: 12345"))

--- a/spec/models/statistics/user_statistics_spec.rb
+++ b/spec/models/statistics/user_statistics_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 RSpec.describe Statistics::UserStatistics, type: :model do
   subject { Statistics::UserStatistics.new }
 
+  before do
+    User.destroy_all
+  end
+
   describe "#users_count_per_team" do
     it "returns counts of users per team" do
       create(:user, email: "user1@education.gov.uk", team: "london")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe User do
   end
 
   describe "scopes" do
+    before {
+      User.destroy_all
+    }
+
     let!(:caseworker) { create(:regional_casework_services_user) }
     let!(:caseworker_2) { create(:regional_casework_services_user, first_name: "Aaron", email: "aaron-caseworker@education.gov.uk") }
     let!(:team_leader) { create(:regional_casework_services_team_lead_user, first_name: "Zoe") }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -96,6 +96,11 @@ RSpec.configure do |config|
     OmniAuth.config.mock_auth[:azure_activedirectory_v2] = nil
   end
 
+  config.before(:each) do
+    Project.destroy_all
+    LocalAuthority.destroy_all
+  end
+
   config.before(:suite) do
     Rails.application.load_tasks
   end

--- a/spec/requests/all/handover/projects_controller_spec.rb
+++ b/spec/requests/all/handover/projects_controller_spec.rb
@@ -31,13 +31,12 @@ RSpec.describe All::Handover::ProjectsController, type: :request do
     end
 
     context "when there are projects" do
-      let!(:project) { create(:transfer_project, :inactive, urn: 123456) }
-      let!(:project) { create(:conversion_project, :inactive, urn: 165432) }
-
-      it "shows a table of the projects" do
+      before do
         create(:transfer_project, :inactive, urn: 123456)
         create(:conversion_project, :inactive, urn: 165432)
+      end
 
+      it "shows a table of the projects" do
         get "/projects/all/handover/"
 
         expect(response.body).to include "123456"

--- a/spec/requests/external_contacts/chair_of_governors_controller_spec.rb
+++ b/spec/requests/external_contacts/chair_of_governors_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ExternalContacts::ChairOfGovernorsController, type: :request do
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
   end
 
   describe "#create" do

--- a/spec/requests/external_contacts/headteachers_controller_spec.rb
+++ b/spec/requests/external_contacts/headteachers_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ExternalContacts::HeadteachersController, type: :request do
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
   end
 
   describe "#create" do

--- a/spec/requests/external_contacts/incoming_trust_ceos_controller_spec.rb
+++ b/spec/requests/external_contacts/incoming_trust_ceos_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ExternalContacts::IncomingTrustCeosController, type: :request do
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
   end
 
   describe "#create" do

--- a/spec/requests/external_contacts/other_contacts_controller_spec.rb
+++ b/spec/requests/external_contacts/other_contacts_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ExternalContacts::OtherContactsController, type: :request do
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
   end
 
   describe "#create" do

--- a/spec/requests/external_contacts/outgoing_trust_ceos_controller_spec.rb
+++ b/spec/requests/external_contacts/outgoing_trust_ceos_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ExternalContacts::OutgoingTrustCeosController, type: :request do
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10059062)
+    mock_successful_api_responses(urn: any_args, ukprn: 10059062)
   end
 
   describe "#create" do

--- a/spec/requests/external_contacts_controller_spec.rb
+++ b/spec/requests/external_contacts_controller_spec.rb
@@ -2,15 +2,15 @@ require "rails_helper"
 
 RSpec.describe ExternalContactsController, type: :request do
   let(:user) { create(:user, :caseworker) }
+  let(:project) { create(:conversion_project) }
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
     mock_successful_persons_api_client
   end
 
   describe "#index" do
-    let(:project) { create(:conversion_project) }
     let(:project_id) { project.id }
 
     subject(:perform_request) do
@@ -30,7 +30,6 @@ RSpec.describe ExternalContactsController, type: :request do
 
     context "when the project has a director of child services" do
       it "includes the director of child services in the response" do
-        project = create(:conversion_project)
         director_of_child_services_contact = create(:director_of_child_services)
         allow_any_instance_of(Project).to receive(:director_of_child_services).and_return(director_of_child_services_contact)
 
@@ -42,7 +41,6 @@ RSpec.describe ExternalContactsController, type: :request do
   end
 
   describe "#new" do
-    let(:project) { create(:conversion_project) }
     let(:project_id) { project.id }
 
     subject(:perform_request) do
@@ -62,7 +60,6 @@ RSpec.describe ExternalContactsController, type: :request do
   end
 
   describe "#create" do
-    let(:project) { create(:conversion_project) }
     let(:project_id) { project.id }
     let(:mock_contact) { build(:project_contact) }
     let(:contact_type) { "headteacher" }
@@ -93,7 +90,6 @@ RSpec.describe ExternalContactsController, type: :request do
   end
 
   describe "#edit" do
-    let(:project) { create(:conversion_project) }
     let(:project_id) { project.id }
     let(:contact) { create(:project_contact, project: project) }
     let(:contact_id) { contact.id }
@@ -121,7 +117,6 @@ RSpec.describe ExternalContactsController, type: :request do
   end
 
   describe "#update" do
-    let(:project) { create(:conversion_project) }
     let(:project_id) { project.id }
     let(:contact) { create(:project_contact, project: project) }
     let(:contact_id) { contact.id }
@@ -169,7 +164,6 @@ RSpec.describe ExternalContactsController, type: :request do
   end
 
   describe "#destroy" do
-    let(:project) { create(:conversion_project) }
     let(:project_id) { project.id }
     let(:contact) { create(:project_contact) }
     let(:contact_id) { contact.id }
@@ -188,7 +182,6 @@ RSpec.describe ExternalContactsController, type: :request do
   end
 
   describe "#confirm_destroy" do
-    let(:project) { create(:conversion_project) }
     let(:project_id) { project.id }
     let(:contact) { create(:project_contact) }
     let(:contact_id) { contact.id }

--- a/spec/requests/notes_controller_spec.rb
+++ b/spec/requests/notes_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe NotesController, type: :request do
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
   end
 
   describe "#index" do

--- a/spec/requests/project_complete_spec.rb
+++ b/spec/requests/project_complete_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Completing projects", type: :request do
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
   end
 
   describe "the complete project button" do

--- a/spec/requests/project_information_controller_spec.rb
+++ b/spec/requests/project_information_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ProjectInformationController, type: :request do
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
   end
 
   describe "#show" do

--- a/spec/services/academies_api_pre_fetcher_service_spec.rb
+++ b/spec/services/academies_api_pre_fetcher_service_spec.rb
@@ -5,20 +5,19 @@ RSpec.describe AcademiesApiPreFetcherService do
     api_client = mock_academies_api_client_get_establishments_and_trusts
 
     25.times do
-      create(:conversion_project, urn: 123456, incoming_trust_ukprn: 10010010)
+      create(:conversion_project, incoming_trust_ukprn: 10010010)
     end
 
     projects = Project.all
 
     AcademiesApiPreFetcherService.new.call!(projects)
 
-    expect(projects.last.establishment).not_to be_nil
-    expect(projects.last.incoming_trust).not_to be_nil
-
     expect(api_client).to have_received(:get_establishments).exactly(2).times
     expect(api_client).to have_received(:get_trusts).exactly(2).times
 
     expect(api_client).to have_received(:get_establishment).exactly(25).times
+    expect(projects.last.establishment).not_to be_nil
+    expect(projects.last.incoming_trust).not_to be_nil
   end
 
   it "handles eager loading" do
@@ -38,7 +37,7 @@ RSpec.describe AcademiesApiPreFetcherService do
     mock_academies_api_client_get_establishments_and_trusts_failure
 
     10.times do
-      create(:conversion_project, urn: 123456, incoming_trust_ukprn: 10010010)
+      create(:conversion_project, incoming_trust_ukprn: 10010010)
     end
 
     projects = Project.all
@@ -56,7 +55,7 @@ RSpec.describe AcademiesApiPreFetcherService do
       allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new([establishment], nil))
 
       10.times do
-        create(:conversion_project, urn: 123456, incoming_trust_ukprn: 10010010)
+        create(:conversion_project, incoming_trust_ukprn: 10010010)
       end
 
       projects = Project.all

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -79,10 +79,12 @@ RSpec.describe Api::Conversions::CreateProjectService do
         last_name: "Last",
         team: :london
       )
+      initial_count = User.count
+
       user = subject.regional_delivery_officer
 
       expect(user).to eql existing_user
-      expect(User.count).to be 1
+      expect(User.count).to eq(initial_count)
     end
   end
 

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -83,10 +83,12 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
         last_name: "Last",
         team: :london
       )
+      initial_count = User.count
+
       user = subject.regional_delivery_officer
 
       expect(user).to eql existing_user
-      expect(User.count).to be 1
+      expect(User.count).to eq(initial_count)
     end
   end
 

--- a/spec/services/by_local_authority_project_fetcher_service_spec.rb
+++ b/spec/services/by_local_authority_project_fetcher_service_spec.rb
@@ -2,30 +2,54 @@ require "rails_helper"
 
 RSpec.describe ByLocalAuthorityProjectFetcherService do
   before do
-    establishment = build(:academies_api_establishment, local_authority_code: "909", urn: 121813)
-    another_establishment = build(:academies_api_establishment, local_authority_code: "213", urn: 121102)
-    yet_another_establishment = build(:academies_api_establishment, local_authority_code: "926", urn: 121583)
+    cumbria_establishment = build(:academies_api_establishment, local_authority_code: "909", urn: 121813)
+    cumbria_establishment2 = build(:academies_api_establishment, local_authority_code: "909", urn: 222222)
+    cumbria_establishment3 = build(:academies_api_establishment, local_authority_code: "909", urn: 333333)
+    westminster_establishment = build(:academies_api_establishment, local_authority_code: "213", urn: 121102)
+    norfolk_establishment = build(:academies_api_establishment, local_authority_code: "926", urn: 121583)
 
     fake_client = double(Api::AcademiesApi::Client,
       get_trust: Api::AcademiesApi::Client::Result.new(double, nil))
 
     allow(Api::AcademiesApi::Client).to receive(:new).and_return(fake_client)
-    allow(fake_client).to receive(:get_establishment).with(establishment.urn).and_return(Api::AcademiesApi::Client::Result.new(establishment, nil))
-    allow(fake_client).to receive(:get_establishment).with(another_establishment.urn).and_return(Api::AcademiesApi::Client::Result.new(another_establishment, nil))
-    allow(fake_client).to receive(:get_establishment).with(yet_another_establishment.urn).and_return(Api::AcademiesApi::Client::Result.new(yet_another_establishment, nil))
-    allow(fake_client).to receive(:get_establishments).with(any_args).and_return(Api::AcademiesApi::Client::Result.new([establishment, another_establishment, establishment, yet_another_establishment], nil))
-    allow(fake_client).to receive(:get_trusts).and_return(Api::AcademiesApi::Client::Result.new([double("Trust", ukprn: 10010010)], nil))
+
+    allow(fake_client).to receive(:get_establishment).with(cumbria_establishment.urn)
+      .and_return(Api::AcademiesApi::Client::Result.new(cumbria_establishment, nil))
+
+    allow(fake_client).to receive(:get_establishment).with(cumbria_establishment2.urn)
+      .and_return(Api::AcademiesApi::Client::Result.new(cumbria_establishment2, nil))
+
+    allow(fake_client).to receive(:get_establishment).with(cumbria_establishment3.urn)
+      .and_return(Api::AcademiesApi::Client::Result.new(cumbria_establishment3, nil))
+
+    allow(fake_client).to receive(:get_establishment).with(westminster_establishment.urn)
+      .and_return(Api::AcademiesApi::Client::Result.new(westminster_establishment, nil))
+
+    allow(fake_client).to receive(:get_establishment).with(norfolk_establishment.urn)
+      .and_return(Api::AcademiesApi::Client::Result.new(norfolk_establishment, nil))
+
+    allow(fake_client).to receive(:get_establishments).with(any_args)
+      .and_return(Api::AcademiesApi::Client::Result.new([
+        cumbria_establishment,
+        cumbria_establishment2,
+        cumbria_establishment3,
+        westminster_establishment,
+        norfolk_establishment
+      ], nil))
+
+    allow(fake_client).to receive(:get_trusts)
+      .and_return(Api::AcademiesApi::Client::Result.new([double("Trust", ukprn: 10010010)], nil))
 
     cumbria = create(:local_authority, code: "909", name: "Cumbria County Council")
     westminster = create(:local_authority, code: "213", name: "Westminster City Council")
     norfolk = create(:local_authority, code: "926", name: "Norfolk County Council")
 
-    create(:conversion_project, local_authority: cumbria, urn: establishment.urn, conversion_date: Date.new(2024, 1, 1))
-    create(:conversion_project, local_authority: westminster, urn: another_establishment.urn)
-    create(:conversion_project, local_authority: cumbria, urn: establishment.urn, conversion_date: Date.new(2024, 2, 1))
+    create(:conversion_project, local_authority: cumbria, urn: cumbria_establishment.urn, conversion_date: Date.new(2024, 1, 1))
+    create(:conversion_project, local_authority: westminster, urn: westminster_establishment.urn)
+    create(:conversion_project, local_authority: cumbria, urn: cumbria_establishment2.urn, conversion_date: Date.new(2024, 2, 1))
 
-    create(:transfer_project, local_authority: cumbria, urn: establishment.urn, transfer_date: Date.new(2024, 3, 1))
-    create(:transfer_project, local_authority: norfolk, urn: yet_another_establishment.urn)
+    create(:transfer_project, local_authority: cumbria, urn: cumbria_establishment3.urn, transfer_date: Date.new(2024, 3, 1))
+    create(:transfer_project, local_authority: norfolk, urn: norfolk_establishment.urn)
   end
 
   describe "#local_authorities_with_projects" do

--- a/spec/services/by_trust_project_fetcher_service_spec.rb
+++ b/spec/services/by_trust_project_fetcher_service_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe ByTrustProjectFetcherService do
 
   describe "form a multi academy trust projects" do
     it "includes a form a MAT trust with the correct counts and details" do
-      mock_academies_api_establishment_success(urn: 123456)
+      mock_academies_api_establishment_success(urn: any_args)
 
       create(:transfer_project, :active, incoming_trust_ukprn: nil, new_trust_reference_number: "TR12345", new_trust_name: "BRAND NEW TRUST")
       create(:conversion_project, :active, incoming_trust_ukprn: nil, new_trust_reference_number: "TR12345", new_trust_name: "BRAND NEW TRUST")

--- a/spec/services/by_user_project_fetcher_service_spec.rb
+++ b/spec/services/by_user_project_fetcher_service_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe ByUserProjectFetcherService do
     another_user = create(:user, first_name: "B", last_name: "User", email: "b.user@education.gov.uk", team: :north_west)
     yet_another_user = create(:user, first_name: "C", last_name: "User", email: "c.user@education.gov.uk", team: :service_support)
 
-    create(:conversion_project, urn: 121813, assigned_to: user)
-    create(:conversion_project, urn: 121102, assigned_to: user)
-    create(:conversion_project, urn: 117574, assigned_to: another_user)
-    create(:conversion_project, urn: 121583, assigned_to: nil)
-    create(:conversion_project, urn: 121583, assigned_to: yet_another_user)
-    create(:transfer_project, urn: 101133, assigned_to: user)
-    create(:transfer_project, urn: 112209, assigned_to: yet_another_user)
+    create(:conversion_project, assigned_to: user)
+    create(:conversion_project, assigned_to: user)
+    create(:conversion_project, assigned_to: another_user)
+    create(:conversion_project, assigned_to: nil)
+    create(:conversion_project, assigned_to: yet_another_user)
+    create(:transfer_project, assigned_to: user)
+    create(:transfer_project, assigned_to: yet_another_user)
 
     result = described_class.new.call
 

--- a/spec/services/import/local_authority_csv_importer_service_spec.rb
+++ b/spec/services/import/local_authority_csv_importer_service_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe Import::LocalAuthorityCsvImporterService do
     CSV
   end
 
-  before { allow(File).to receive(:open).with(csv_path, any_args).and_return(csv) }
+  before {
+    allow(File).to receive(:open).with(csv_path, any_args).and_return(csv)
+  }
 
   describe "#call" do
     it "upserts local authorities from the provided CSV" do

--- a/spec/services/import/user_csv_importer_service_spec.rb
+++ b/spec/services/import/user_csv_importer_service_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe Import::UserCsvImporterService do
     CSV
   end
 
-  before { allow(File).to receive(:open).and_return(users_csv) }
+  before {
+    User.destroy_all
+    allow(File).to receive(:open).and_return(users_csv)
+  }
 
   describe "#call" do
     let(:existing_user_email) { "jane.doe@education.gov.uk" }

--- a/spec/services/project_search_service_spec.rb
+++ b/spec/services/project_search_service_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe ProjectSearchService do
       context "when a match is found" do
         it "returns an array with the matches" do
           matching_project = create(:conversion_project, urn: 100000)
-          another_matching_project = create(:transfer_project, urn: 100000)
+          another_matching_project = create(:transfer_project, urn: 100000, state: :completed)
           not_matching_project = create(:conversion_project, urn: 123456)
 
           service = described_class.new
@@ -148,7 +148,7 @@ RSpec.describe ProjectSearchService do
       context "when a match is not found" do
         it "returns an empty result" do
           create(:conversion_project, urn: 100000)
-          create(:transfer_project, urn: 100000)
+          create(:transfer_project, urn: 100000, state: :completed)
 
           service = described_class.new
           result = service.search_by_urns("123456")

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -21,8 +21,8 @@ module AcademiesApiHelpers
   end
 
   # Successful API calls for the supplied URN and UKPRN
-  def mock_successful_api_responses(urn:, ukprn:)
-    mock_academies_api_establishment_success(urn:)
+  def mock_successful_api_responses(urn:, ukprn:, establishment: nil)
+    mock_academies_api_establishment_success(urn: urn, establishment: establishment)
     mock_academies_api_trust_success(ukprn:)
   end
 
@@ -58,7 +58,7 @@ module AcademiesApiHelpers
 
     test_client = Api::AcademiesApi::Client.new
 
-    allow(test_client).to receive(:get_establishment).with(123456).and_return(mock_establishment)
+    allow(test_client).to receive(:get_establishment).and_return(mock_establishment)
     allow(test_client).to receive(:get_trust).with(10059151).and_return(mock_before_incoming_trust)
     allow(test_client).to receive(:get_trust).with(10058882).and_return(mock_after_incoming_trust)
 


### PR DESCRIPTION
## Enforce uniqueness of URN for active/inactive projects with db trigger

See [Ticket 194142: Duplicate Projects on Complete (107926 and 135287)](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/194142)

We add a `EnforceUniquenessOfProjectUrn` db trigger to raise an
error and rollback "after insert" if that insert is attempting
to add a new project record where an existing active or inactive
project with the same URN exists.

We've been seeing some duplicate transfers and conversions being
created by our automated "handover" process between "prepare" and
"complete". Our "complete" API receives POSTs to:

- `/api/v1/projects/conversions` and
- `/api/v1/projects/conversions`

these are handled by:

- `Api::Conversions::CreateProjectService` and
- `Api::Transfers::CreateProjectService`

which both use the `UrnUniqueForApiValidator` to perform this
validation at the application level, but for a reliable
constraint we need to use a control at the database layer.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
