### PR TITLE
193590: Set PageVisitTime metric in AppInsights

### DIFF
--- a/app/javascript/application-insights.js
+++ b/app/javascript/application-insights.js
@@ -10,7 +10,8 @@ const clickPluginConfig = {
 
 const appInsights = new ApplicationInsights({
   config: {
-    connectionString: applicationInsightsConnectionString
+    connectionString: applicationInsightsConnectionString,
+    autoTrackPageVisitTime: true
   },
   extensions: [clickPluginInstance],
   extensionConfig: {


### PR DESCRIPTION
See ticket [193590: Add tracking of "Time on page" with AppInsights](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/193590)

This is to track "time on page".

See https://learn.microsoft.com/en-us/azure/azure-monitor/app/javascript-sdk-configuration


