### PR TITLE
193814: identify authenticated user in app insights

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,8 +10,14 @@ class ApplicationController < ActionController::Base
   rescue_from Api::AcademiesApi::Client::Error, with: :academies_api_client_error
   rescue_from Api::AcademiesApi::Client::UnauthorisedError, with: :academies_api_unauthorised_error
 
+  before_action :current_user_identifier
+
   def not_found_error
     render "pages/page_not_found", status: :not_found
+  end
+
+  def current_user_identifier
+    @current_user_identifier = current_user ? current_user.email : "Anonymous"
   end
 
   private def user_not_authorized

--- a/app/javascript/application-insights.js
+++ b/app/javascript/application-insights.js
@@ -1,24 +1,33 @@
 import { ApplicationInsights } from '@microsoft/applicationinsights-web'
 import { ClickAnalyticsPlugin } from '@microsoft/applicationinsights-clickanalytics-js'
 
-const applicationInsightsConnectionString = document.head.querySelector('meta[name="application-insights-connection"]').content
+window.addEventListener('DOMContentLoaded', () => {
+  const applicationInsightsConnectionString = document.head.querySelector('meta[name="application-insights-connection"]').content
 
-const clickPluginInstance = new ClickAnalyticsPlugin()
-const clickPluginConfig = {
-  autoCapture: true
-}
-
-const appInsights = new ApplicationInsights({
-  config: {
-    connectionString: applicationInsightsConnectionString,
-    autoTrackPageVisitTime: true
-  },
-  extensions: [clickPluginInstance],
-  extensionConfig: {
-    [clickPluginInstance.identifier]: clickPluginConfig
+  const clickPluginInstance = new ClickAnalyticsPlugin()
+  const clickPluginConfig = {
+    autoCapture: true
   }
-}
-)
 
-appInsights.loadAppInsights()
-appInsights.trackPageView()
+  const appInsights = new ApplicationInsights({
+    config: {
+      connectionString: applicationInsightsConnectionString,
+      autoTrackPageVisitTime: true
+    },
+    extensions: [clickPluginInstance],
+    extensionConfig: {
+      [clickPluginInstance.identifier]: clickPluginConfig
+    }
+  }
+  )
+
+  const currentUserIdentifier = () => {
+    const currentUser = document.querySelector('#current-user')
+
+    return currentUser.dataset.identifier
+  }
+
+  appInsights.loadAppInsights()
+  appInsights.setAuthenticatedUserContext(currentUserIdentifier(), null, true)
+  appInsights.trackPageView()
+})

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,57 +7,43 @@
     <meta name="theme-color" content="#0b0c0c">
     <%= tag :meta, name: "application-insights-connection", content: ENV["ApplicationInsights__ConnectionString"] if enable_application_insights? %>
     <%= tag :meta, name: "google-tag-manager-connection", content: ENV["GOOGLE_TAG_MANAGER_ID"] if enable_google_tag_manager? %>
-
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
     <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_url("govuk-frontend/govuk/assets/images/favicon.ico") %>" type="image/x-icon">
     <link rel="mask-icon" href="<%= image_url("govuk-frontend/govuk/assets/images/govuk-mask-icon.svg") %>" color="#0b0c0c">
     <link rel="apple-touch-icon" sizes="180x180" href="<%= image_url("govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-180x180.png") %>">
     <link rel="apple-touch-icon" sizes="167x167" href="<%= image_url("govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-167x167.png") %>">
     <link rel="apple-touch-icon" sizes="152x152" href="<%= image_url("govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-152x152.png") %>">
     <link rel="apple-touch-icon" href="<%= image_url("govuk-frontend/govuk/assets/images/govuk-apple-touch-icon.png") %>">
-
     <meta property="og:image" content="<%= image_url("govuk-frontend/govuk/assets/images/govuk-opengraph-image.png") %>">
-
     <%= stylesheet_link_tag "application" %>
-
     <%= javascript_include_tag "application-insights" if enable_application_insights? %>
     <%= javascript_include_tag "google-tag-manager" if enable_google_tag_manager? %>
     <%= javascript_include_tag "govuk-frontend/govuk/all" %>
     <%= javascript_include_tag "dfefrontend" %>
     <%= javascript_include_tag "application", defer: true %>
-
   </head>
-
   <body class="govuk-template__body ">
+    <%= hidden_field_tag("current-user", nil, {"data-identifier" => @current_user_identifier}) %>
     <%= render partial: "shared/environment_banner" %>
-
     <%= render partial: "cookies/banner" unless optional_cookies_set? %>
-
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-
     <%= render partial: "shared/dfe_header" %>
-
     <div class="govuk-width-container " aria-label="phase banner" role="complementary">
       <%= govuk_phase_banner(
             tag: {text: t("phase_banner.phase")},
             text: t("phase_banner.phase_notice.html")
           ) %>
     </div>
-
     <%= yield :primary_navigation %>
-
     <div class="govuk-width-container ">
       <%= yield :pre_content_nav %>
       <main class="govuk-main-wrapper app-content" id="main-content" role="main">
         <%= render partial: "/shared/information_banner" if ENV["SHOW_INFORMATION_BANNER"].eql?("true") %>
         <%= render(NotificationBanner.new(flashes: flash)) %>
-
         <%= yield %>
       </main>
     </div>
-
     <%= render partial: "shared/dfe_footer" %>
   </body>
   <%= yield :footer_post_js %>

--- a/spec/features/home_page/track_user_with_appinsights_spec.rb
+++ b/spec/features/home_page/track_user_with_appinsights_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.feature "Track authenticated user using AppInsights" do
+  context "when the user is logged in" do
+    before do
+      user = create(:user, email: "test@education.gov.uk")
+      sign_in_with_user(user)
+    end
+    scenario "the DOM includes the user's email address for AppInsights" do
+      visit cookies_path
+
+      user_id = find("#current-user", visible: false)["data-identifier"]
+      expect(user_id).to eq("test@education.gov.uk")
+    end
+  end
+
+  context "when the user is NOT logged in" do
+    scenario "the DOM includes the magic string 'Anonymous' for AppInsights" do
+      visit cookies_path
+
+      user_id = find("#current-user", visible: false)["data-identifier"]
+      expect(user_id).to eq("Anonymous")
+    end
+  end
+end


### PR DESCRIPTION
## Track authenticated user in AppInsights

See [Ticket 193814](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/193814)

We use the email address to identify the user. To achieve this we:

- set the email of the "current user" in a hidden input in the DOM,
  defaulting to "Anonymous" if there is no logged-in user

- extract this email from the DOM when initialising AppInsights
  (we now need to wait for the DOM to be ready/loaded)

- set `appInsights.setAuthenticatedUserContext(currentUserEmail(), null, true)`
  see https://github.com/microsoft/ApplicationInsights-JS/blob/master/API-reference.md#setauthenticatedusercontext
  for details