### PR TITLE
Handle some common errors, previously seen as unhandled exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,8 +62,6 @@ gem "pagy"
 
 gem "mail-notify"
 
-gem "high_voltage"
-
 gem "nokogiri"
 
 gem "grape", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,7 +215,6 @@ GEM
       rack-test (~> 2)
     hashdiff (1.1.0)
     hashie (5.0.0)
-    high_voltage (4.0.0)
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
     htmlbeautifier (1.4.3)
@@ -567,7 +566,6 @@ DEPENDENCIES
   govuk_markdown (~> 2)
   grape (~> 2.0)
   grape-swagger (~> 2.1)
-  high_voltage
   htmlbeautifier
   jsbundling-rails (~> 1.3)
   launchy (~> 3.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
   rescue_from Api::AcademiesApi::Client::Error, with: :academies_api_client_error
   rescue_from Api::AcademiesApi::Client::UnauthorisedError, with: :academies_api_unauthorised_error
+  rescue_from ActionController::InvalidAuthenticityToken, with: :reset_user_session
 
   before_action :current_user_identifier
   before_action :set_notification
@@ -19,6 +20,10 @@ class ApplicationController < ActionController::Base
 
   def current_user_identifier
     @current_user_identifier = current_user ? current_user.email : "Anonymous"
+  end
+
+  private def reset_user_session
+    redirect_to sign_out_path
   end
 
   private def set_notification

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,13 @@
 class PagesController < ApplicationController
-  include HighVoltage::StaticPage
-
   skip_before_action :redirect_unauthenticated_user
+
+  def show
+    return not_found_error unless StaticPages.names.include?(static_page_name)
+
+    render static_page_name
+  end
+
+  private def static_page_name
+    params[:id]
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,7 @@ require "action_mailer/railtie"
 require "action_view/railtie"
 # require "action_cable/engine"
 # require "rails/test_unit/railtie"
+require_relative "../lib/middleware/handle_bad_encoding"
 
 require "govuk/components"
 
@@ -53,7 +54,9 @@ module DfeCompleteConversionsTransfersAndChanges
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks generators])
+    config.autoload_lib(ignore: %w[assets tasks generators middleware])
+
+    config.middleware.insert_before Rack::Runtime, HandleBadEncoding
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ require "action_view/railtie"
 # require "action_cable/engine"
 # require "rails/test_unit/railtie"
 require_relative "../lib/middleware/handle_bad_encoding"
+require_relative "../lib/middleware/handle_bad_query"
 
 require "govuk/components"
 
@@ -57,6 +58,7 @@ module DfeCompleteConversionsTransfersAndChanges
     config.autoload_lib(ignore: %w[assets tasks generators middleware])
 
     config.middleware.insert_before Rack::Runtime, HandleBadEncoding
+    config.middleware.insert_before Rack::Runtime, HandleBadQuery
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/initializers/high_voltage.rb
+++ b/config/initializers/high_voltage.rb
@@ -1,3 +1,0 @@
-HighVoltage.configure do |config|
-  config.routes = false
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,17 @@
+class StaticPages
+  def self.names
+    %W[
+      academies_api_client_timeout
+      academies_api_client_unauthorised
+      accessibility
+      internal_server_error
+      maintenance
+      page_not_found
+      privacy
+    ]
+  end
+end
+
 VALID_UUID_REGEX = /[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i
 MONTH_1_12_REGEX = /(?:1[0-2]|[1-9])/
 YEAR_2000_2499_REGEX = /(?:(?:20|21|23|24)[0-9]{2})/
@@ -329,9 +343,10 @@ Rails.application.routes.draw do
   get "healthcheck" => "healthcheck#check"
   get "test-error" => "test_error#create", :as => :test_error
 
-  # High voltage configuration for static pages. Matches routes from the root of the domain. Uses
-  # HighVoltage::Constraints::RootRoute to validate that the view exists.
-  get "/*id" => "pages#show", :as => :page, :format => false, :constraints => HighVoltage::Constraints::RootRoute.new
+  get "*id" => "pages#show", :as => :page, :format => false,
+    :constraints => lambda { |request|
+                      StaticPages.names.include?(request.filtered_parameters[:id])
+                    }
 
   match "*unmatched", to: "application#not_found_error", via: :all
 end

--- a/lib/middleware/handle_bad_encoding.rb
+++ b/lib/middleware/handle_bad_encoding.rb
@@ -1,0 +1,15 @@
+class HandleBadEncoding
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    begin
+      Rack::Utils.parse_nested_query(env["REQUEST_URI"].to_s)
+    rescue Rack::QueryParser::InvalidParameterError
+      env["PATH_INFO"] = "/"
+    end
+
+    @app.call(env)
+  end
+end

--- a/lib/middleware/handle_bad_query.rb
+++ b/lib/middleware/handle_bad_query.rb
@@ -1,0 +1,15 @@
+class HandleBadQuery
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    begin
+      Rack::Utils.parse_nested_query(env["QUERY_STRING"].to_s)
+    rescue Rack::QueryParser::ParameterTypeError
+      env["QUERY_STRING"] = ""
+    end
+
+    @app.call(env)
+  end
+end

--- a/spec/lib/middleware/handle_bad_encoding_spec.rb
+++ b/spec/lib/middleware/handle_bad_encoding_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe HandleBadEncoding do
+  let(:app) { double(call: nil) }
+  let(:middleware) { HandleBadEncoding.new(app) }
+
+  context "when the REQUEST_URI causes a decoding error" do
+    it "sets the PATH_INFO to the homepage" do
+      middleware.call(
+        "REQUEST_URI" => "/%ff",
+        "PATH_INFO" => "/%ff"
+      )
+
+      expect(app).to have_received(:call).with(
+        "REQUEST_URI" => "/%ff",
+        "PATH_INFO" => "/"
+      )
+    end
+  end
+
+  context "when the REQUEST_URI causes NO decoding error" do
+    it "leaves the PATH_INFO unchanged" do
+      middleware.call(
+        "REQUEST_URI" => "/path/to/resource",
+        "PATH_INFO" => "/path/to/resource"
+      )
+
+      expect(app).to have_received(:call).with(
+        "REQUEST_URI" => "/path/to/resource",
+        "PATH_INFO" => "/path/to/resource"
+      )
+    end
+  end
+end

--- a/spec/lib/middleware/handle_bad_query_spec.rb
+++ b/spec/lib/middleware/handle_bad_query_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe HandleBadQuery do
+  let(:app) { double(call: nil) }
+  let(:middleware) { HandleBadQuery.new(app) }
+
+  context "when the QUERY_STRING causes a decoding error" do
+    it "sets the QUERY_STRING to the homepage" do
+      middleware.call(
+        "QUERY_STRING" => "x=&x%5B%5D=a"
+      )
+
+      expect(app).to have_received(:call).with(
+        "QUERY_STRING" => ""
+      )
+    end
+  end
+
+  context "when the QUERY_STRING causes NO decoding error" do
+    it "leaves the QUERY_STRING unchanged" do
+      middleware.call(
+        "QUERY_STRING" => "filter=active"
+      )
+
+      expect(app).to have_received(:call).with(
+        "QUERY_STRING" => "filter=active"
+      )
+    end
+  end
+end

--- a/spec/requests/error_handling_spec.rb
+++ b/spec/requests/error_handling_spec.rb
@@ -16,4 +16,14 @@ RSpec.describe "Error handling", type: :request do
       end
     end
   end
+
+  context "when a very long path is supplied in an attack" do
+    it "is handled without an Errno::ENAMETOOLONG error" do
+      very_long_path = "/%2525c0%2525ae%2525c0%2525ae%2525c0%2525af%2525c0%2525ae%2525c0%2525ae%2525c0%2525af%2525c0%2525ae%2525c0%2525ae%2525c0%2525af%2525c0%2525ae%2525c0%2525ae%2525c0%2525af%2525c0%2525ae%2525c0%2525ae%2525c0%2525af%2525c0%2525ae%2525c0%2525ae%2525c0%2525af%2525c0%2525ae%2525c0%2525ae%2525c0%2525af%2525c0%2525ae%2525c0%2525ae%2525c0%2525af/etc/passwd"
+
+      get very_long_path
+
+      expect(response).to redirect_to(sign_in_path)
+    end
+  end
 end

--- a/spec/requests/error_handling_spec.rb
+++ b/spec/requests/error_handling_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "Error handling", type: :request do
+  context "when a valid authenticity token isn't supplied" do
+    describe "DELETE to #server-status (or other bogus resource)" do
+      before do
+        ActionController::Base.allow_forgery_protection = true
+      end
+      after do
+        ActionController::Base.allow_forgery_protection = false
+      end
+
+      it "resets any session cookie, via the sign out mechanism" do
+        delete "/server-status"
+        expect(response).to redirect_to(sign_out_path)
+      end
+    end
+  end
+end

--- a/spec/requests/error_handling_spec.rb
+++ b/spec/requests/error_handling_spec.rb
@@ -26,4 +26,14 @@ RSpec.describe "Error handling", type: :request do
       expect(response).to redirect_to(sign_in_path)
     end
   end
+
+  context "when the hex code '%ff' (�) is received" do
+    it "is handled without an ActionController::BadRequest error" do
+      hex_code = "/%ff"
+
+      get hex_code
+
+      expect(response).to redirect_to(sign_in_path)
+    end
+  end
 end

--- a/spec/requests/error_handling_spec.rb
+++ b/spec/requests/error_handling_spec.rb
@@ -36,4 +36,14 @@ RSpec.describe "Error handling", type: :request do
       expect(response).to redirect_to(sign_in_path)
     end
   end
+
+  context "when an invalid query string is received" do
+    it "is handled without an ActionController::BadRequest error" do
+      invalid_query_string = "x=&x%5B%5D=a"
+
+      get "/users/sign_in?#{invalid_query_string}"
+
+      expect(response).to redirect_to(sign_in_path)
+    end
+  end
 end


### PR DESCRIPTION
See Slack channel [`#temp-ruby-complete-alerts`](https://ukgovernmentdfe.slack.com/archives/C089F7F3CD6) and [ticket 197151](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/197151)

In this PR we address 4 types of error which have been surfaced by our new Exception Notification process. These are currently manifesting as unhandled exceptions but in fact they are routine errors which can and should be handled by the application:

1. where `ActionController::InvalidAuthenticityToken` is raised as a result of a request having an an invalid auth token

2. where a very long request path was triggering an error in the `HighVoltage` gem

3. where a path with invalid encoding was causing Rack to raise `InvalidParameterError`  which is rescued by Rails as a internal `ActionController::BadRequest`

4. where a query string was causing Rack to raise `ParameterTypeError`  which is rescued by Rails as a internal `ActionController::BadRequest`

See the individual commits for details.