### PR TITLE
197794: Send an exception notification when rescuing AcademiesApi::Client::Error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,7 +43,8 @@ class ApplicationController < ActionController::Base
     redirect_back(fallback_location: root_path)
   end
 
-  private def academies_api_client_error
+  private def academies_api_client_error(exception)
+    ExceptionNotifier.notify_exception(exception)
     render "pages/academies_api_client_timeout", status: 500
   end
 

--- a/spec/requests/conversions/projects_controller_spec.rb
+++ b/spec/requests/conversions/projects_controller_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Conversions::ProjectsController do
   let(:user) { create(:user, :caseworker) }
+  let(:academies_api_timeout_error) { Api::AcademiesApi::Client::Error.new("Test Academies API timeout error") }
 
   before do
     mock_all_academies_api_responses
@@ -11,14 +12,22 @@ RSpec.describe Conversions::ProjectsController do
   describe "academies API behaviour" do
     context "when the API times out" do
       before do
-        mock_academies_api_establishment_error(urn: 123456)
+        mock_academies_api_establishment_error(urn: 123456, error: academies_api_timeout_error)
         mock_academies_api_trust_error(ukprn: 10061021)
+        allow(ExceptionNotifier).to receive(:notify_exception)
       end
 
       it "renders the API time out page" do
         post conversions_path, params: {conversion_create_project_form: {urn: "123456"}}
 
         expect(response).to render_template("pages/academies_api_client_timeout")
+      end
+
+      it "sends an exception notification to our Slack channel" do
+        post conversions_path, params: {conversion_create_project_form: {urn: "123456"}}
+
+        expect(ExceptionNotifier).to have_received(:notify_exception)
+          .with(academies_api_timeout_error)
       end
     end
 

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -104,11 +104,11 @@ module AcademiesApiHelpers
   end
 
   # Error
-  def mock_academies_api_establishment_error(urn:)
+  def mock_academies_api_establishment_error(urn:, error: nil)
     test_client = Api::AcademiesApi::Client.new
     result = Api::AcademiesApi::Client::Result.new(
       nil,
-      Api::AcademiesApi::Client::Error.new("Test Academies API error")
+      error || Api::AcademiesApi::Client::Error.new("Test Academies API error")
     )
 
     allow(test_client).to receive(:get_establishment).with(urn).and_return(result)


### PR DESCRIPTION
Ticket [197794](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/197794) 

We continue to render the `pages/academies_api_client_timeout` view and return a 500 status, but we now send an "exception notification" to the Slack channel to give us visibility on these errors.
