### PR TITLE
Return false on healthcheck if db connection is cold

### DIFF
--- a/lib/ops/db_availability.rb
+++ b/lib/ops/db_availability.rb
@@ -1,6 +1,11 @@
 class Ops::DbAvailability
   def self.db_available?
-    return true if User.first && ActiveRecord::Base.connected?
+    begin
+      return true if User.first && ActiveRecord::Base.connected?
+    rescue ActiveRecord::ConnectionNotEstablished
+      return false
+    end
+
     false
   end
 end

--- a/spec/lib/ops/db_availability_spec.rb
+++ b/spec/lib/ops/db_availability_spec.rb
@@ -10,6 +10,17 @@ RSpec.describe "check DB availability" do
       end
     end
 
+    context "when the connection is cold and throws ActiveRecord::ConnectionNotEstablished" do
+      before do
+        create(:user)
+        allow(ActiveRecord::Base).to receive(:connected?).and_raise(ActiveRecord::ConnectionNotEstablished)
+      end
+
+      it "returns false " do
+        expect(Ops::DbAvailability.db_available?).to be false
+      end
+    end
+
     context "when the DB is not available" do
       before do
         allow(ActiveRecord::Base).to receive(:connected?).and_return(false)


### PR DESCRIPTION
When the application has been freshly started the db connection takes a second or two to get established.
If we ask `ActiveRecord::Base.connected?` during this period a `ActiveRecord::ConnectionNotEstablished` is raised.

We now rescue this in our `Ops::DbAvailability::db_available?` utility and return `false`.
