### PR TITLE
198116 - Fix: Add note where missing from SignificantDateHistoryReason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Backfill missing note for SignificantDataHistoryReason
+
 ## [Release-101][release-101]
 
 ### Changed

--- a/db/migrate/20250127172701_backfill_missing_date_history_reason_notes.rb
+++ b/db/migrate/20250127172701_backfill_missing_date_history_reason_notes.rb
@@ -1,0 +1,63 @@
+class BackfillMissingDateHistoryReasonNotes < ActiveRecord::Migration[7.1]
+  def up
+    logger = proc { |msg|
+      Kernel.puts msg
+      Rails.logger.info msg
+    }
+
+    logger.call("Backfilling missing DateHistoryReason notes...")
+    diff =
+      SignificantDateHistoryReason.count -
+      SignificantDateHistoryReason.joins(:note).count
+
+    if diff.zero?
+      logger.call("All reasons already have a note")
+      return
+    end
+
+    logger.call("  -> There are #{diff} reasons which are missing a note:")
+
+    problem_reasons = SignificantDateHistoryReason
+      .left_outer_joins(:note)
+      .where("notes.id IS NULL")
+
+    problem_reasons_count = problem_reasons.count
+
+    if problem_reasons_count != diff
+      logger.call(
+        "  Error: the count of reasons without notes #{problem_reasons_count} is " \
+        "not the same as our earlier diff #{diff}"
+      )
+      return
+    end
+
+    logger.call(
+      "  Fixing up #{problem_reasons_count} SignificantDateHistoryReasons missing " \
+      "their Notes:"
+    )
+
+    problem_reasons.each do |reason|
+      date = reason.significant_date_history
+      begin
+        new_note = reason.create_note!(
+          user_id: date.user_id,
+          project_id: date.project_id,
+          body: "Blank (reason unknown)"
+        )
+
+        logger.call("  - yes: new note created: #{new_note.attributes}")
+      rescue ActiveRecord::RecordInvalid => error
+        logger.call("  - no: new note could not be created #{error}")
+      end
+    end
+
+    diff =
+      SignificantDateHistoryReason.count -
+      SignificantDateHistoryReason.joins(:note).count
+
+    logger.call(
+      "Finished backfilling missing DateHistoryReason notes. There are " \
+     "now #{diff} reasons missing a note."
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_21_125140) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_27_172701) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/migrations/backfill_missing_date_history_reason_notes_spec.rb
+++ b/spec/migrations/backfill_missing_date_history_reason_notes_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+migration_file = "db/migrate/20250127172701_backfill_missing_date_history_reason_notes.rb"
+require Rails.root.join(migration_file)
+
+RSpec.describe "Data migration to backfill SignificantDateHistoryReason notes" do
+  let(:migration) { BackfillMissingDateHistoryReasonNotes.new }
+  let(:problem_reason) { create(:date_history_reason) }
+
+  before do
+    mock_successful_api_response_to_create_any_project
+
+    2.times { create(:date_history_reason) }
+    problem_reason.note.delete
+  end
+
+  it "creates a note for the problem reason" do
+    expect(SignificantDateHistoryReason.count).to eq(3)
+    expect(Note.count).to eq(2)
+    expect(problem_reason.reload.note).not_to be_present
+
+    migration.up
+
+    expect(SignificantDateHistoryReason.count).to eq(3)
+    expect(Note.count).to eq(3)
+    expect(problem_reason.reload.note).to be_present
+  end
+
+  context "when the note's user can't be found (e.g. in dev env)" do
+    before do
+      problem_reason.significant_date_history.user.delete
+    end
+
+    it "does NOT create the missing note" do
+      expect(SignificantDateHistoryReason.count).to eq(3)
+      expect(Note.count).to eq(2)
+      expect(problem_reason.reload.note).not_to be_present
+
+      migration.up
+
+      expect(SignificantDateHistoryReason.count).to eq(3)
+      expect(Note.count).to eq(2)
+      expect(problem_reason.reload.note).not_to be_present
+    end
+
+    it "exits happily, i.e. the migration is done" do
+      expect(migration.up).to be true
+    end
+  end
+end


### PR DESCRIPTION
See Ticket [198116](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/198116) 

We've observed errors in production where a user is viewing the "Conversion data history" of a project at path such as:

`/projects/{projectId}/date-history`

due to a `SignificantDateHistoryReason` missing its `Note`.

On investigation we've found just one `Project` (and `SignificantDateHistory` record) affected by this problem where the "reason" for the change is blank:

```
irb(main):006> SignificantDateHistoryReason.count
=> 3621

irb(main):007> SignificantDateHistoryReason.joins(:note).count
=> 3620
```

The affected record was created on July 1st 2024. We note that since commit [31b50fb7174651649b385fe683bd384c81e5405f][] on June 24th (Release 75) there has been validation on the presence of the note to accompany the reason for the change. i.e. the user has to supply some narrative. See [new_earlier_form_spec.rb][].

Given that it was created after the validation was implemented it's not understood how this `SignificantDateHistoryReason` comes to be in this state:

```
{"id"=>"45829896-F491-46D3-9B49-191CFBB7193B",
 "created_at"=>Mon, 01 Jul 2024 10:21:16.484692000 BST +01:00,
 "updated_at"=>Mon, 01 Jul 2024 10:21:16.484692000 BST +01:00,
 "reason_type"=>"buildings",
 "significant_date_history_id"=>"AC104E94-B80F-4F95-B6F0-A7C56DE5A39D"}

irb(main):023> reason.note
=> nil
```

However, for now we take a pragmatic approach:

- trust that all future significant date changes will have the expected note(s) attached to their reason(s). Our unit tests verify this.

- create a data migration to identify any `SignificantDateHistoryReason`s which are missing their `Note` and create the necessary note, with the content of "Blank (reason unknown)".

That data migration, in this commit, produces output to the logs e.g:

>  Backfilling missing DateHistoryReason notes...
>
>  -> There are 1 reasons which are missing a note:
>
>  Fixing up 1 SignificantDateHistoryReasons missing their Notes:
>
>  * new note created: {
>  	"id"=>"124DDFFE-4504-4C92-B7E5-3863C29C610E",
>	"body"=>"Blank (reason unknown)",
>	"project_id"=>"344F56D4-D52B-4000-A09B-5F94903B8464",
>	"user_id"=>"D84B857D-94D7-4A21-A15D-4904637A21ED",
>	"created_at"=>Tue, 28 Jan 2025 11:20:03.184581000 GMT +00:00,
>	"updated_at"=>Tue, 28 Jan 2025 11:20:03.184581000 GMT +00:00,
>	"task_identifier"=>nil,
>	"notable_id"=>"2BAAA6D5-8340-4342-A2D2-58DDB80D6F4A",
>	"notable_type"=>"SignificantDateHistoryReason"}
>
>  Finished backfilling missing DateHistoryReason notes. There are now 0 reasons missing a note.

[31b50fb7174651649b385fe683bd384c81e5405f]:
https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/commit/31b50fb7174651649b385fe683bd384c81e5405f

[new_earlier_form_spec.rb]:
https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/blob/7026c42ef29b333cccba0aea49e94bc4ec86f103/spec/forms/date_history/reasons/new_earlier_form_spec.rb#L22-L27


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
