### PR TITLE
Handle AR::StatementInvalid in healthcheck

### DIFF
--- a/lib/ops/db_availability.rb
+++ b/lib/ops/db_availability.rb
@@ -2,7 +2,7 @@ class Ops::DbAvailability
   def self.db_available?
     begin
       return true if User.first && ActiveRecord::Base.connected?
-    rescue ActiveRecord::ConnectionNotEstablished
+    rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::StatementInvalid
       return false
     end
 

--- a/spec/lib/ops/db_availability_spec.rb
+++ b/spec/lib/ops/db_availability_spec.rb
@@ -21,6 +21,17 @@ RSpec.describe "check DB availability" do
       end
     end
 
+    context "when the connection is unavailable and throws ActiveRecord::StatementInvalid" do
+      before do
+        create(:user)
+        allow(ActiveRecord::Base).to receive(:connected?).and_raise(ActiveRecord::StatementInvalid)
+      end
+
+      it "returns false " do
+        expect(Ops::DbAvailability.db_available?).to be false
+      end
+    end
+
     context "when the DB is not available" do
       before do
         allow(ActiveRecord::Base).to receive(:connected?).and_return(false)


### PR DESCRIPTION
We're seeing the occasional ActiveRecord::StatementInvalid error from the healthcheck in the middle of the night. We assume this is a short maintenance outage:

	An ActiveRecord::StatementInvalid occurred while GET </healthcheck>
	was processed by healthcheck#check

	Exception

	TinyTds::Error: Database 'complete' on server 's184p01-comp' is not
	currently available.  Please retry the connection later.

In this commit we adjust our healthcheck's `DbAvailability.db_available?` method to handle this error and return `false`.


