### PR TITLE
Reduce complexity of deployment strategy

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -14,6 +14,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.environment }}-${{ github.run_number }}
 
+env:
+  IMAGE_NAME: complete-app
+
 jobs:
   set-env:
     name: Determine environment
@@ -23,6 +26,7 @@ jobs:
       branch: ${{ steps.var.outputs.branch }}
       checked-out-sha: ${{ steps.var.outputs.checked-out-sha }}
       date: ${{ steps.var.outputs.date }}
+      image-name: ${{ steps.var.outputs.image-name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,42 +43,63 @@ jobs:
           echo "branch=$GIT_BRANCH" >> $GITHUB_OUTPUT
           echo "checked-out-sha=${CHECKED_OUT_SHA}" >> $GITHUB_OUTPUT
           echo "date=${TIME}" >> $GITHUB_OUTPUT
+          echo "image-name=${{ env.IMAGE_NAME }}" >> $GITHUB_OUTPUT
 
-  deploy-image:
-    permissions:
-      id-token: write
-      contents: read
-      packages: write
-    name: Deploy '${{ needs.set-env.outputs.branch }}' to ${{ needs.set-env.outputs.environment }}
+  build:
+    name: Build
     needs: [ set-env ]
-    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@v3.1.0
-    strategy:
-      matrix:
-        suffix: [
-          "",
-          "-worker"
-        ]
-        include:
-          - suffix: ""
-            aca_name: "ACA_CONTAINERAPP_NAME"
-            aca_client_id: "ACA_CLIENT_ID"
-          - suffix: "-worker"
-            aca_name: "ACA_CONTAINERAPP_WORKER_NAME"
-            aca_client_id: "ACA_WORKER_CLIENT_ID"
-
+    permissions:
+      packages: write
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build.yml@v4.1.0
     with:
-      docker-image-name: 'complete-app'
-      docker-build-file-name: './Dockerfile'
       environment: ${{ needs.set-env.outputs.environment }}
+      docker-image-name: ${{ needs.set-env.outputs.image-name }}
       docker-build-args: |
         RAILS_ENV=development
         CURRENT_GIT_SHA="${{ needs.set-env.outputs.checked-out-sha }}"
         TIME_OF_BUILD="${{ needs.set-env.outputs.date }}"
-      annotate-release: ${{ matrix.suffix == '' }}
+
+  import:
+    name: Import
+    needs: [ set-env, build ]
+    permissions:
+      id-token: write
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/import.yml@v4.1.0
+    with:
+      environment: ${{ needs.set-env.outputs.environment }}
+      docker-image-name: ${{ needs.set-env.outputs.image-name }}
     secrets:
       azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
       azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       azure-acr-client-id: ${{ secrets.ACR_CLIENT_ID }}
+      azure-acr-name: ${{ secrets.ACR_NAME }}
+
+  deploy:
+    name: Deploy
+    needs: [ set-env, import ]
+    permissions:
+      id-token: write
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/deploy.yml@v4.1.0
+    strategy:
+      matrix:
+        container_app: [
+          "web",
+          "worker"
+        ]
+        include:
+          - container_app: "web"
+            aca_name: "ACA_CONTAINERAPP_NAME"
+            aca_client_id: "ACA_CLIENT_ID"
+          - container_app: "worker"
+            aca_name: "ACA_CONTAINERAPP_WORKER_NAME"
+            aca_client_id: "ACA_WORKER_CLIENT_ID"
+    with:
+      environment: ${{ needs.set-env.outputs.environment }}
+      docker-image-name: ${{ needs.set-env.outputs.image-name }}
+      annotate-release: ${{ matrix.container_app == 'web' }}
+    secrets:
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       azure-acr-name: ${{ secrets.ACR_NAME }}
       azure-aca-client-id: ${{ secrets[matrix.aca_client_id] }}
       azure-aca-name: ${{ secrets[matrix.aca_name] }}


### PR DESCRIPTION
## Changes

* This change will ensure that the build and import stages no longer use a matrix, thus speeding up the deployment

* As both the main web app and the worker use the same image, we only need to run the deployment stage as a matrix so that we can update both container apps