### PR TITLE
(196052) Step 2 of 2: improve performance of local auth project page

### DIFF
--- a/app/controllers/project_groups_controller.rb
+++ b/app/controllers/project_groups_controller.rb
@@ -14,7 +14,7 @@ class ProjectGroupsController < ApplicationController
 
     @project_group = ProjectGroup.find(params[:id])
 
-    projects = @project_group.projects
+    projects = @project_group.projects.includes([:local_authority])
     AcademiesApiPreFetcherService.new.call!(projects)
 
     @grouped_projects = projects.sort_by { |project| project.establishment.name }

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -57,7 +57,7 @@ class Conversion::CreateProjectForm < CreateProjectForm
       directive_academy_order: directive_academy_order,
       two_requires_improvement: two_requires_improvement,
       region: region,
-      local_authority_id: local_authority.id,
+      local_authority: local_authority,
       tasks_data: new_tasks_data,
       new_trust_reference_number: new_trust_reference_number,
       new_trust_name: new_trust_name

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -54,7 +54,7 @@ class Transfer::CreateProjectForm < CreateProjectForm
       assigned_to: user,
       assigned_at: DateTime.now,
       region: region,
-      local_authority_id: local_authority.id,
+      local_authority: local_authority,
       tasks_data: Transfer::TasksData.new,
       new_trust_reference_number: new_trust_reference_number,
       new_trust_name: new_trust_name

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -6,6 +6,7 @@ class LocalAuthority < ApplicationRecord
   validates :address_postcode, presence: true, postcode: true
 
   has_one :director_of_child_services, class_name: "Contact::DirectorOfChildServices", dependent: :destroy
+  has_many :projects
 
   accepts_nested_attributes_for :director_of_child_services, reject_if: proc { |l| l[:name].blank? }, allow_destroy: true
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,8 +7,6 @@ class Project < ApplicationRecord
   attr_writer :establishment, :incoming_trust, :member_of_parliament
 
   delegated_type :tasks_data, types: %w[Conversion::TasksData, Transfer::TasksData], dependent: :destroy
-  delegate :local_authority_code, to: :establishment
-  delegate :local_authority, to: :establishment
   delegate :director_of_child_services, to: :local_authority
 
   has_many :notes, dependent: :destroy
@@ -22,6 +20,8 @@ class Project < ApplicationRecord
   belongs_to :incoming_trust_main_contact, inverse_of: :main_contact_for_incoming_trust, dependent: :destroy, class_name: "Contact", optional: true
   belongs_to :outgoing_trust_main_contact, inverse_of: :main_contact_for_outgoing_trust, dependent: :destroy, class_name: "Contact", optional: true
   belongs_to :local_authority_main_contact, inverse_of: :main_contact_for_local_authority, dependent: :destroy, class_name: "Contact", optional: true
+
+  belongs_to :local_authority, optional: true
 
   belongs_to :group, inverse_of: :projects, class_name: "ProjectGroup", optional: true
 
@@ -63,6 +63,7 @@ class Project < ApplicationRecord
   scope :ordered_by_created_at_date, -> { order(created_at: :desc) }
 
   scope :by_region, ->(region) { where(region: region) }
+  scope :by_local_authority, ->(local_authority) { where(local_authority: local_authority) }
 
   scope :by_trust_ukprn, ->(ukprn) { where(incoming_trust_ukprn: ukprn) }
 
@@ -118,7 +119,6 @@ class Project < ApplicationRecord
   end
 
   def director_of_child_services
-    local_authority = establishment.local_authority
     local_authority&.director_of_child_services
   end
 

--- a/app/services/by_local_authority_project_fetcher_service.rb
+++ b/app/services/by_local_authority_project_fetcher_service.rb
@@ -10,11 +10,20 @@ class ByLocalAuthorityProjectFetcherService
   end
 
   def projects_for_local_authority(local_authority_code)
-    all_projects.includes(:assigned_to).select { |p| p.establishment.local_authority_code == local_authority_code }
+    local_authority_projects(LocalAuthority.find_by!(code: local_authority_code)).includes(:assigned_to)
   end
 
   private def projects_by_local_authority
     all_projects.group_by { |p| p.establishment.local_authority_code }
+  end
+
+  private def local_authority_projects(local_authority)
+    unless @local_authority_projects
+      @local_authority_projects = Project.active.by_local_authority(local_authority).ordered_by_significant_date
+      AcademiesApiPreFetcherService.new.call!(@local_authority_projects)
+    end
+
+    @local_authority_projects
   end
 
   private def all_projects

--- a/app/services/by_local_authority_project_fetcher_service.rb
+++ b/app/services/by_local_authority_project_fetcher_service.rb
@@ -1,6 +1,6 @@
 class ByLocalAuthorityProjectFetcherService
   def local_authorities_with_projects
-    projects = projects_by_local_authority
+    projects = grouped_projects
 
     if projects
       local_authorities = LocalAuthority.where(code: projects.keys)
@@ -13,10 +13,6 @@ class ByLocalAuthorityProjectFetcherService
     local_authority_projects(LocalAuthority.find_by!(code: local_authority_code)).includes(:assigned_to)
   end
 
-  private def projects_by_local_authority
-    all_projects.group_by { |p| p.establishment.local_authority_code }
-  end
-
   private def local_authority_projects(local_authority)
     unless @local_authority_projects
       @local_authority_projects = Project.active.by_local_authority(local_authority).ordered_by_significant_date
@@ -26,13 +22,12 @@ class ByLocalAuthorityProjectFetcherService
     @local_authority_projects
   end
 
-  private def all_projects
-    unless @all_projects
-      @all_projects = Project.active.ordered_by_significant_date
-      AcademiesApiPreFetcherService.new.call!(@all_projects)
-    end
-
-    @all_projects
+  private def grouped_projects
+    Project
+      .active
+      .ordered_by_significant_date
+      .includes(:local_authority)
+      .group_by { |p| p.local_authority.code }
   end
 
   private def build_local_authorities_objects(local_authorities, projects)

--- a/spec/factories/conversion/project_factory.rb
+++ b/spec/factories/conversion/project_factory.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     team { Project.teams["london"] }
     all_conditions_met { nil }
     state { 0 }
+    local_authority { LocalAuthority.first || create(:local_authority) }
 
     trait :completed do
       state { 1 }

--- a/spec/factories/local_authority_factory.rb
+++ b/spec/factories/local_authority_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :local_authority do
     name { "Cumbria County Council" }
-    code { 100 }
+    code { rand(100..9999).to_s }
     address_1 { "Cumbria House" }
     address_2 { "117 Botchergate" }
     address_3 { nil }

--- a/spec/factories/transfer/project_factory.rb
+++ b/spec/factories/transfer/project_factory.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
     outgoing_trust_ukprn { 10059062 }
     two_requires_improvement { false }
     state { 0 }
+    local_authority { LocalAuthority.first || create(:local_authority) }
 
     trait :completed do
       state { 1 }

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
 
     context "and the establishment has a diocese" do
       it "sets the church supplemental agreement task to not applicable" do
-        local_authority = instance_double(LocalAuthority, id: "f0e04a51-3711-4d58-942a-dcb84938c818")
+        local_authority = LocalAuthority.new(id: "f0e04a51-3711-4d58-942a-dcb84938c818")
         establishment = build(:academies_api_establishment, diocese_code: "0000")
         allow(establishment).to receive(:local_authority).and_return(local_authority)
         result = Api::AcademiesApi::Client::Result.new(establishment, nil)
@@ -593,13 +593,10 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
     end
   end
 
-  describe "#local_authority_id" do
-    before do
-      local_authority = instance_double(
-        LocalAuthority,
-        id: "f0e04a51-3711-4d58-942a-dcb84938c818"
-      )
+  describe "#local_authority" do
+    let(:local_authority) { create(:local_authority) }
 
+    before do
       establishment = instance_double(
         Api::AcademiesApi::Establishment,
         local_authority: local_authority,
@@ -609,9 +606,9 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
       mock_all_academies_api_responses(establishment: establishment)
     end
 
-    it "sets the #local_authority_id code from the establishment" do
+    it "sets the #local_authority from the establishment" do
       project = build(:create_transfer_project_form).save
-      expect(project.local_authority_id).to eq("f0e04a51-3711-4d58-942a-dcb84938c818")
+      expect(project.local_authority).to eq(local_authority)
     end
   end
 

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -1,12 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Transfer::CreateProjectForm, type: :model do
-  before do
-    local_authority = instance_double(
-      LocalAuthority,
-      id: "f0e04a51-3711-4d58-942a-dcb84938c818"
-    )
+  let(:local_authority) { create(:local_authority) }
 
+  before do
     establishment = instance_double(
       Api::AcademiesApi::Establishment,
       local_authority: local_authority,
@@ -480,25 +477,10 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
     end
   end
 
-  describe "#local_authority_id" do
-    before do
-      local_authority = instance_double(
-        LocalAuthority,
-        id: "f0e04a51-3711-4d58-942a-dcb84938c818"
-      )
-
-      establishment = instance_double(
-        Api::AcademiesApi::Establishment,
-        local_authority: local_authority,
-        region_code: "E"
-      )
-
-      mock_all_academies_api_responses(establishment: establishment)
-    end
-
-    it "sets the #local_authority_id code from the establishment" do
+  describe "#local_authority" do
+    it "sets the #local_authority from the establishment" do
       project = build(:create_transfer_project_form).save
-      expect(project.local_authority_id).to eq("f0e04a51-3711-4d58-942a-dcb84938c818")
+      expect(project.local_authority).to eq(local_authority)
     end
   end
 

--- a/spec/helpers/contacts_helper_spec.rb
+++ b/spec/helpers/contacts_helper_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe ContactsHelper, type: :helper do
     end
 
     it "includes the local authority name when the category is 'local_authority'" do
+      allow(project).to receive(:local_authority).and_return(build(:local_authority))
       category = "local_authority"
       expect(helper.category_header(category, project)).to eq("#{project.local_authority.name} contacts")
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -772,7 +772,7 @@ RSpec.describe Project, type: :model do
       allow_any_instance_of(Api::AcademiesApi::Establishment).to receive(:local_authority).and_return(local_authority)
     end
 
-    subject { described_class.new(urn: urn) }
+    subject { described_class.new(urn: urn, local_authority: local_authority) }
 
     context "when there is a director of child services" do
       let!(:director) { create(:director_of_child_services, local_authority: local_authority) }
@@ -883,30 +883,6 @@ RSpec.describe Project, type: :model do
       _other_note = create(:note, task_identifier: :stakeholder_kick_off, body: "Another body", user: build(:user), project: project)
 
       expect(project.handover_note).to eq(handover_note)
-    end
-  end
-
-  describe "delegation" do
-    it "delegates local_authority to establishment" do
-      local_authotity = double(code: 100)
-      establishment = double
-      project = build(:conversion_project)
-      allow(establishment).to receive(:local_authority).and_return(local_authotity)
-      allow(project).to receive(:establishment).and_return(establishment)
-
-      expect(project.local_authority.code).to eql 100
-    end
-
-    it "delegates director_of_child_services to local_authority" do
-      director_of_child_services = double(email: "director.child@domain.com")
-      local_authotity = double
-      establishment = double
-      project = build(:conversion_project)
-      allow(local_authotity).to receive(:director_of_child_services).and_return(director_of_child_services)
-      allow(establishment).to receive(:local_authority).and_return(local_authotity)
-      allow(project).to receive(:establishment).and_return(establishment)
-
-      expect(project.director_of_child_services.email).to eql "director.child@domain.com"
     end
   end
 

--- a/spec/services/by_local_authority_project_fetcher_service_spec.rb
+++ b/spec/services/by_local_authority_project_fetcher_service_spec.rb
@@ -16,16 +16,16 @@ RSpec.describe ByLocalAuthorityProjectFetcherService do
     allow(fake_client).to receive(:get_establishments).with(any_args).and_return(Api::AcademiesApi::Client::Result.new([establishment, another_establishment, establishment, yet_another_establishment], nil))
     allow(fake_client).to receive(:get_trusts).and_return(Api::AcademiesApi::Client::Result.new([double("Trust", ukprn: 10010010)], nil))
 
-    create(:local_authority, code: "909", name: "Cumbria County Council")
-    create(:local_authority, code: "213", name: "Westminster City Council")
-    create(:local_authority, code: "926", name: "Norfolk County Council")
+    cumbria = create(:local_authority, code: "909", name: "Cumbria County Council")
+    westminster = create(:local_authority, code: "213", name: "Westminster City Council")
+    norfolk = create(:local_authority, code: "926", name: "Norfolk County Council")
 
-    create(:conversion_project, urn: establishment.urn, conversion_date: Date.new(2024, 1, 1))
-    create(:conversion_project, urn: another_establishment.urn)
-    create(:conversion_project, urn: establishment.urn, conversion_date: Date.new(2024, 2, 1))
+    create(:conversion_project, local_authority: cumbria, urn: establishment.urn, conversion_date: Date.new(2024, 1, 1))
+    create(:conversion_project, local_authority: westminster, urn: another_establishment.urn)
+    create(:conversion_project, local_authority: cumbria, urn: establishment.urn, conversion_date: Date.new(2024, 2, 1))
 
-    create(:transfer_project, urn: establishment.urn, transfer_date: Date.new(2024, 3, 1))
-    create(:transfer_project, urn: yet_another_establishment.urn)
+    create(:transfer_project, local_authority: cumbria, urn: establishment.urn, transfer_date: Date.new(2024, 3, 1))
+    create(:transfer_project, local_authority: norfolk, urn: yet_another_establishment.urn)
   end
 
   describe "#local_authorities_with_projects" do
@@ -85,8 +85,9 @@ RSpec.describe ByLocalAuthorityProjectFetcherService do
       expect(projects_for_local_authority.last.transfer_date).to eql Date.new(2024, 3, 1)
     end
 
-    it "returns an empty array when there are no projects for the supplied local authority code" do
-      expect(described_class.new.projects_for_local_authority("101")).to eql []
+    it "returns an empty AR relation when there are no projects for the supplied local authority code" do
+      unused_local_authority = create(:local_authority)
+      expect(described_class.new.projects_for_local_authority(unused_local_authority.code)).to be_empty
     end
 
     it "only fetches project and related date once" do

--- a/spec/services/by_local_authority_project_fetcher_service_spec.rb
+++ b/spec/services/by_local_authority_project_fetcher_service_spec.rb
@@ -61,19 +61,6 @@ RSpec.describe ByLocalAuthorityProjectFetcherService do
 
       expect(described_class.new.local_authorities_with_projects).to eql []
     end
-
-    it "only fetches projects and related data once" do
-      spy = AcademiesApiPreFetcherService.new
-      allow(AcademiesApiPreFetcherService).to receive(:new).and_return(spy)
-      allow(spy).to receive(:call!).and_call_original
-
-      result = described_class.new
-
-      result.local_authorities_with_projects
-      result.local_authorities_with_projects
-
-      expect(spy).to have_received(:call!).once
-    end
   end
 
   describe "#projects_for_local_authority" do


### PR DESCRIPTION
See https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/2073 and ticket [196052](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/196052)

Now that we've successfully back-filled the new `projects.local_authority_id` foreign key we can proceed to:

- i) start using the new association
- ii) fix up the slow pages (e.g. projects/all/local-authorities) to get the benefit of the refactoring

**NB: this work has already been reviewed and merged (https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/2064). However, we decided to deploy in 2 discrete steps -- hence the two new PRs.**



