### PR TITLE
(199738) Avoid attempting to return an excessive number of search results

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -7,6 +7,8 @@ class SearchController < ApplicationController
     @query = query
     @count = @results.count
     @pager, @results = pagy_array(@results)
+  rescue ProjectSearchService::SearchError => error
+    render "pages/search_error", locals: {error_message: error.message}
   end
 
   def user

--- a/app/services/project_search_service.rb
+++ b/app/services/project_search_service.rb
@@ -1,4 +1,6 @@
 class ProjectSearchService
+  class SearchError < RuntimeError; end
+
   def search(query)
     if urn_pattern(query)
       search_by_urns(query)
@@ -21,8 +23,12 @@ class ProjectSearchService
   end
 
   def search_by_words(query)
+    raise SearchError.new("Search term too short") if query.length <= 3
+
     establishment_results = search_establishments_by_name(query)
+
     return [] if establishment_results.empty?
+    raise SearchError.new("Too many results") if establishment_results.count > 100
 
     urns = establishment_results.pluck(:urn)
     search_by_urns(urns)

--- a/app/views/pages/search_error.html.erb
+++ b/app/views/pages/search_error.html.erb
@@ -1,0 +1,17 @@
+<% content_for :page_title do %>
+  <%= page_title(t("pages.search_error.title")) %>
+<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t("pages.search_error.title") %></h1>
+    <p class="govuk-body">
+      <%= t("pages.search_error.body_text") %>
+    </p>
+    <p class="govuk-body govuk-!-font-weight-bold">
+      <%= error_message %>
+    </p>
+    <p class="govuk-body">
+      <%= t("pages.search_error.email_help", email: support_email).html_safe %>
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,6 +133,11 @@ en:
       title: Sorry, there is a problem with the service
       body_text: The service has an internal server error. Refresh the page and if the problem continues, try again later.
       email_help: Email the support team at %{email} if the problem still occurs.
+    search_error:
+      title: Sorry, there is a problem with your search
+      body_text: "The search failed with the error: "
+      email_help: Email the support team at %{email} if you are unable to find the transfer or conversion you need.
+
   navigation:
     header:
       your_projects: Your projects

--- a/spec/features/users_can_search_for_projects_spec.rb
+++ b/spec/features/users_can_search_for_projects_spec.rb
@@ -20,4 +20,28 @@ RSpec.feature "Users can search for projects" do
     expect(page).to have_content("Search results for \"100001\"")
     expect(page).to have_content("1 result found")
   end
+
+  scenario "Users see a helpful error message if there is an error" do
+    visit root_path
+
+    expect(page).to have_content("Search this website")
+
+    fill_in "searchterm", with: too_short_term
+    click_on(class: "dfe-search__submit")
+
+    expect(page).to have_content(search_error_title)
+    expect(page).to have_content(search_error_for_too_short_term)
+  end
+
+  def too_short_term
+    "a"
+  end
+
+  def search_error_title
+    "there is a problem with your search"
+  end
+
+  def search_error_for_too_short_term
+    "term too short"
+  end
 end


### PR DESCRIPTION
See https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/199738

We've seen errors coming from the project search module when the search results are very numerous, which then causes an excessive number of requests to the Academies API. 

These errors have only been seen in the development environment but could just as easily occur in production if a user searches for "the" or "1".

We add two guard clauses to avoid attempting to fetch large quantities of records from the Academies API:

- if the search term given is less than 4 characters we raise with "Search term too short"

- if the number of results is more than 100 we raise with "Too many results"

These "Search Errors" are handled by showing the user a new "search error" page which gives them helpful information on the problem:

![helpful_search_error_page](https://github.com/user-attachments/assets/83e37fde-ccee-4fef-a71e-5050a72cd3ca)


