### PR TITLE
194142 Fix: prevent duplicate inserts by enforcing uniqueness of URN for active projects

### DIFF
--- a/db/migrate/20250205114547_add_unique_project_index_on_urn_and_state.rb
+++ b/db/migrate/20250205114547_add_unique_project_index_on_urn_and_state.rb
@@ -1,0 +1,5 @@
+class AddUniqueProjectIndexOnUrnAndState < ActiveRecord::Migration[7.1]
+  def change
+    add_index :projects, [:urn, :state], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_27_172701) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_05_114547) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -340,6 +340,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_27_172701) do
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"
     t.index ["tasks_data_id"], name: "index_projects_on_tasks_data_id"
     t.index ["tasks_data_type"], name: "index_projects_on_tasks_data_type"
+    t.index ["urn", "state"], name: "index_projects_on_urn_and_state", unique: true
     t.index ["urn"], name: "index_projects_on_urn"
   end
 

--- a/spec/api/v1/transfers_spec.rb
+++ b/spec/api/v1/transfers_spec.rb
@@ -1,7 +1,10 @@
 require "rails_helper"
 
 RSpec.describe V1::Transfers do
-  before { mock_successful_api_response_to_create_any_project }
+  before {
+    Project.destroy_all
+    mock_successful_api_response_to_create_any_project
+  }
 
   describe "authorisation" do
     context "when there is no api key in the header" do

--- a/spec/factories/conversion/create_project_form_factory.rb
+++ b/spec/factories/conversion/create_project_form_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :create_conversion_project_form, class: "Conversion::CreateProjectForm", aliases: [:create_project_form] do
-    urn { 123456 }
+    urn { rand(111111..999999) }
     incoming_trust_ukprn { 10061021 }
     provisional_conversion_date { {3 => 1, 2 => 1, 1 => 2030} }
     advisory_board_date { {3 => 1, 2 => 10, 1 => 2022} }

--- a/spec/factories/conversion/form_a_mat_project_factory.rb
+++ b/spec/factories/conversion/form_a_mat_project_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :form_a_mat_conversion_project, class: "Conversion::Project" do
     type { "Conversion::Project" }
-    urn { 123456 }
+    urn { rand(111111..999999) }
     new_trust_reference_number { "TR12345" }
     new_trust_name { "The New Trust" }
     conversion_date { (Date.today + 2.years).at_beginning_of_month }

--- a/spec/factories/conversion/project_factory.rb
+++ b/spec/factories/conversion/project_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :conversion_project, class: "Conversion::Project" do
     type { "Conversion::Project" }
-    urn { 123456 }
+    urn { rand(111111..999999) }
     incoming_trust_ukprn { 10061021 }
     conversion_date { (Date.today + 2.years).at_beginning_of_month }
     advisory_board_date { (Date.today - 2.weeks) }

--- a/spec/factories/transfer/create_project_form_factory.rb
+++ b/spec/factories/transfer/create_project_form_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :create_transfer_project_form, class: "Transfer::CreateProjectForm" do
-    urn { 123456 }
+    urn { rand(111111..999999) }
     incoming_trust_ukprn { 10061021 }
     outgoing_trust_ukprn { 10066123 }
     advisory_board_date { {3 => 1, 2 => 10, 1 => 2022} }

--- a/spec/factories/transfer/project_factory.rb
+++ b/spec/factories/transfer/project_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :transfer_project, class: "Transfer::Project" do
     type { "Transfer::Project" }
-    urn { 123456 }
+    urn { rand(111111..999999) }
     incoming_trust_ukprn { 10061021 }
     transfer_date { (Date.today + 2.years).at_beginning_of_month }
     advisory_board_date { (Date.today - 2.weeks) }

--- a/spec/features/all_projects/handover/handover_conversion_project_spec.rb
+++ b/spec/features/all_projects/handover/handover_conversion_project_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Handover a conversion project" do
   before do
+    Project.destroy_all
     application_user = create(:regional_delivery_officer_user)
     sign_in_with_user(application_user)
     mock_all_academies_api_responses

--- a/spec/features/all_projects/handover/handover_transfer_project_spec.rb
+++ b/spec/features/all_projects/handover/handover_transfer_project_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Handover a transfer project" do
   before do
+    Project.destroy_all
     application_user = create(:regional_delivery_officer_user)
     sign_in_with_user(application_user)
     mock_all_academies_api_responses

--- a/spec/features/all_projects/handover/user_can_handover_projects_spec.rb
+++ b/spec/features/all_projects/handover/user_can_handover_projects_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Users can handover projects" do
   before do
+    Project.destroy_all
     user = create(:regional_delivery_officer_user)
     sign_in_with_user(user)
     mock_all_academies_api_responses

--- a/spec/features/all_projects/handover/user_can_view_a_list_of_projects_spec.rb
+++ b/spec/features/all_projects/handover/user_can_view_a_list_of_projects_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Users can view a list of handover projects" do
   before do
+    Project.destroy_all
     user = create(:regional_delivery_officer_user)
     sign_in_with_user(user)
     mock_all_academies_api_responses

--- a/spec/features/conversions/users_can_create_converison_projects_in_a_group_spec.rb
+++ b/spec/features/conversions/users_can_create_converison_projects_in_a_group_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Users can create new conversion projects in a group" do
   let(:ukprn) { 10061021 }
 
   before do
+    Project.destroy_all
     sign_in_with_user(regional_delivery_officer)
   end
 

--- a/spec/features/project_information/users_can_view_school_details_spec.rb
+++ b/spec/features/project_information/users_can_view_school_details_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.feature "Users can view school details" do
   let(:user) { create(:user, :caseworker) }
-  let(:project) { create(:conversion_project, :with_conditions, caseworker: user) }
+  let(:project) { create(:conversion_project, :with_conditions, caseworker: user, urn: 888888) }
 
   before do
-    mock_successful_api_responses(urn: any_args, ukprn: any_args)
+    mock_successful_api_responses(urn: 888888, ukprn: any_args)
     sign_in_with_user(user)
     visit project_information_path(project)
   end
@@ -13,7 +13,7 @@ RSpec.feature "Users can view school details" do
   scenario "they can view the school details" do
     within("#schoolDetails") do
       expect(page).to have_content(project.establishment.name)
-      expect(page).to have_content(project.urn)
+      expect(page).to have_content(888888)
       expect(page).to have_content(project.establishment.type)
       expect(page).to have_content(project.establishment.phase)
     end

--- a/spec/features/projects/users_can_view_a_list_of_assigned_projects_spec.rb
+++ b/spec/features/projects/users_can_view_a_list_of_assigned_projects_spec.rb
@@ -29,9 +29,9 @@ RSpec.feature "Viewing assigned projects" do
   end
 
   context "when there are projects" do
-    let!(:in_progress_assigned_project) { create(:conversion_project, urn: 103835, assigned_to: user, conversion_date: (Date.today + 1.month).at_beginning_of_month) }
-    let!(:in_progress_assigned_project_next_year) { create(:conversion_project, urn: 103835, assigned_to: user, conversion_date: (Date.today + 1.year).at_beginning_of_month) }
-    let!(:completed_assigned_project) { create(:conversion_project, :completed, urn: 114067, assigned_to: user, completed_at: Date.yesterday) }
+    let!(:in_progress_assigned_project) { create(:conversion_project, assigned_to: user, conversion_date: (Date.today + 1.month).at_beginning_of_month) }
+    let!(:in_progress_assigned_project_next_year) { create(:conversion_project, assigned_to: user, conversion_date: (Date.today + 1.year).at_beginning_of_month) }
+    let!(:completed_assigned_project) { create(:conversion_project, :completed, assigned_to: user, completed_at: Date.yesterday) }
 
     context "when signed in as a Regional caseworker" do
       let(:user) { create(:regional_casework_services_user) }

--- a/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
+++ b/spec/features/transfers/users_can_create_a_transfer_project_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "Users can create new transfer projects" do
 
   context "single transferer projects" do
     before do
+      Project.destroy_all
       sign_in_with_user(regional_delivery_officer)
       visit transfers_new_path
     end
@@ -52,6 +53,7 @@ RSpec.feature "Users can create new transfer projects" do
 
   context "form a MAT transfer projects" do
     before do
+      Project.destroy_all
       sign_in_with_user(regional_delivery_officer)
       visit transfers_new_mat_path
     end

--- a/spec/features/transfers/users_can_create_transfer_projects_in_a_group_spec.rb
+++ b/spec/features/transfers/users_can_create_transfer_projects_in_a_group_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "Users can create new transfer projects in a group" do
   let(:outgoing_ukprn) { 10090252 }
 
   before do
+    Project.destroy_all
     sign_in_with_user(regional_delivery_officer)
   end
 

--- a/spec/features/users/users_can_manage_user_accounts_spec.rb
+++ b/spec/features/users/users_can_manage_user_accounts_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature "Users can manage user accounts" do
   let(:user) { create(:user, :service_support, first_name: "Service", last_name: "Support", email: "service.support@education.gov.uk") }
 
   before do
+    Project.destroy_all
+    User.destroy_all
     sign_in_with_user(user)
   end
 

--- a/spec/features/users_can_create_and_view_and_delete_conversion_project_notes_spec.rb
+++ b/spec/features/users_can_create_and_view_and_delete_conversion_project_notes_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Users can create and view and delete conversion notes" do
   let(:task) { Conversion::Task::ArticlesOfAssociationTaskForm.new(project.tasks_data, user) }
 
   before do
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
     sign_in_with_user(user)
 
     travel_to Date.yesterday do

--- a/spec/features/users_can_create_and_view_and_delete_notes_spec.rb
+++ b/spec/features/users_can_create_and_view_and_delete_notes_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Users can create and view notes" do
   let(:new_note_body) { "Just shared some *important* documents with the solictor." }
 
   before do
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
     sign_in_with_user(user)
 
     travel_to Date.yesterday do

--- a/spec/features/users_can_create_and_view_and_delete_task_level_notes_spec.rb
+++ b/spec/features/users_can_create_and_view_and_delete_task_level_notes_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Users can create and view task level notes" do
   let(:note_body) { "Just had a very interesting phone call with the headteacher about land law" }
 
   before do
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
     sign_in_with_user(user)
 
     travel_to Date.yesterday do

--- a/spec/features/users_can_view_a_project_spec.rb
+++ b/spec/features/users_can_view_a_project_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Users can view a project" do
   let(:project) { create(:conversion_project, caseworker: user) }
 
   before do
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
     sign_in_with_user(user)
   end
 

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
   context "when the project is successfully created" do
     let(:establishment) { build(:academies_api_establishment) }
     before do
-      mock_academies_api_establishment_success(urn: 123456)
+      mock_academies_api_establishment_success(urn: any_args)
       mock_academies_api_trust_success(ukprn: 10061021)
 
       ActiveJob::Base.queue_adapter = :test
@@ -85,8 +85,7 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
         establishment = build(:academies_api_establishment, diocese_code: "0000")
         allow(establishment).to receive(:local_authority).and_return(local_authority)
         result = Api::AcademiesApi::Client::Result.new(establishment, nil)
-        allow_any_instance_of(Api::AcademiesApi::Client).to receive(:get_establishment).with(123456).and_return(result)
-
+        allow_any_instance_of(Api::AcademiesApi::Client).to receive(:get_establishment).and_return(result)
         project = build(:create_project_form).save
 
         expect(project.tasks_data.church_supplemental_agreement_not_applicable).to be true
@@ -616,7 +615,7 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
     let(:establishment) { build(:academies_api_establishment) }
 
     before do
-      mock_academies_api_establishment_success(urn: 123456)
+      mock_academies_api_establishment_success(urn: any_args)
       mock_academies_api_trust_success(ukprn: 10061021)
     end
 

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -517,6 +517,10 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
     let(:establishment) { build(:academies_api_establishment) }
 
     before do
+      Project.destroy_all
+      Note.destroy_all
+      Transfer::TasksData.destroy_all
+
       mock_academies_api_establishment_success(urn: 123456)
       mock_academies_api_trust_success(ukprn: 10061021)
     end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ApplicationMailer do
-  before { mock_successful_api_responses(urn: 123456, ukprn: 10061021) }
+  before { mock_successful_api_responses(urn: any_args, ukprn: 10061021) }
 
   describe "#url_to_project" do
     it "returns the correct url" do

--- a/spec/mailers/assigned_to_mailer_spec.rb
+++ b/spec/mailers/assigned_to_mailer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AssignedToMailer do
 
     subject(:send_mail) { described_class.assigned_notification(caseworker, project).deliver_now }
 
-    before { mock_successful_api_responses(urn: 123456, ukprn: 10061021) }
+    before { mock_successful_api_responses(urn: any_args, ukprn: 10061021) }
 
     it "sends an email with the correct personalisation" do
       expect_any_instance_of(Mail::Notify::Mailer)

--- a/spec/mailers/team_leader_mailer_spec.rb
+++ b/spec/mailers/team_leader_mailer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TeamLeaderMailer do
 
     subject(:send_mail) { described_class.new_conversion_project_created(team_leader, project).deliver_now }
 
-    before { mock_successful_api_responses(urn: 123456, ukprn: 10061021) }
+    before { mock_successful_api_responses(urn: any_args, ukprn: 10061021) }
 
     it "sends an email with the correct personalisation" do
       expect_any_instance_of(Mail::Notify::Mailer)

--- a/spec/models/concerns/significant_date_spec.rb
+++ b/spec/models/concerns/significant_date_spec.rb
@@ -93,6 +93,8 @@ RSpec.describe SignificantDate do
     end
 
     describe ".ordered_by_significant_date" do
+      before { Project.destroy_all }
+
       it "shows the project that will convert earliest first" do
         last_project = create(:conversion_project, conversion_date: Date.today.beginning_of_month + 3.years)
         middle_project = create(:conversion_project, conversion_date: Date.today.beginning_of_month + 2.years)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -481,7 +481,10 @@ RSpec.describe Project, type: :model do
     end
 
     describe "ordered_by_completed_date scope" do
-      before { mock_successful_api_responses(urn: any_args, ukprn: any_args) }
+      before {
+        Project.destroy_all
+        mock_successful_api_responses(urn: any_args, ukprn: any_args)
+      }
 
       it "only returns completed projects (state 1) ordered by completed date" do
         completed_project_1 = create(:conversion_project, completed_at: Date.today - 1.year, state: 1)

--- a/spec/models/statistics/project_statistics_spec.rb
+++ b/spec/models/statistics/project_statistics_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
 
   describe "all projects" do
     before do
+      Project.destroy_all
       create_list(:conversion_project, 2, assigned_to: nil)
       create(:conversion_project)
       create(:conversion_project, :completed, completed_at: Date.today)
@@ -207,6 +208,7 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
 
   describe "projects per region" do
     before do
+      Project.destroy_all
       create(:conversion_project, region: :london, completed_at: nil)
       create(:conversion_project, :completed, region: :london, completed_at: Date.today + 2.years)
       create(:conversion_project, region: :south_east)
@@ -270,6 +272,8 @@ RSpec.describe Statistics::ProjectStatistics, type: :model do
   end
 
   describe "new projects this month" do
+    before { Project.destroy_all }
+
     it "returns a count of projects created in the current month" do
       create(:conversion_project, created_at: Time.now.beginning_of_month)
       create(:conversion_project, created_at: Time.now.beginning_of_month + 1.day)

--- a/spec/models/statistics/user_statistics_spec.rb
+++ b/spec/models/statistics/user_statistics_spec.rb
@@ -3,6 +3,11 @@ require "rails_helper"
 RSpec.describe Statistics::UserStatistics, type: :model do
   subject { Statistics::UserStatistics.new }
 
+  before do
+    Project.destroy_all
+    User.destroy_all
+  end
+
   describe "#users_count_per_team" do
     it "returns counts of users per team" do
       create(:user, email: "user1@education.gov.uk", team: "london")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe User do
   end
 
   describe "scopes" do
+    before {
+      Project.destroy_all
+      User.destroy_all
+    }
+
     let!(:caseworker) { create(:regional_casework_services_user) }
     let!(:caseworker_2) { create(:regional_casework_services_user, first_name: "Aaron", email: "aaron-caseworker@education.gov.uk") }
     let!(:team_leader) { create(:regional_casework_services_team_lead_user, first_name: "Zoe") }

--- a/spec/requests/all/handover/projects_controller_spec.rb
+++ b/spec/requests/all/handover/projects_controller_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe All::Handover::ProjectsController, type: :request do
   before do
+    Project.destroy_all
     user = create(:regional_delivery_officer_user)
     sign_in_with(user)
     mock_all_academies_api_responses
@@ -17,13 +18,12 @@ RSpec.describe All::Handover::ProjectsController, type: :request do
     end
 
     context "when there are projects" do
-      let!(:project) { create(:transfer_project, :inactive, urn: 123456) }
-      let!(:project) { create(:conversion_project, :inactive, urn: 165432) }
-
-      it "shows a table of the projects" do
+      before do
         create(:transfer_project, :inactive, urn: 123456)
         create(:conversion_project, :inactive, urn: 165432)
+      end
 
+      it "shows a table of the projects" do
         get "/projects/all/handover/"
 
         expect(response.body).to include "123456"

--- a/spec/requests/external_contacts/chair_of_governors_controller_spec.rb
+++ b/spec/requests/external_contacts/chair_of_governors_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ExternalContacts::ChairOfGovernorsController, type: :request do
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
   end
 
   describe "#create" do

--- a/spec/requests/external_contacts/headteachers_controller_spec.rb
+++ b/spec/requests/external_contacts/headteachers_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ExternalContacts::HeadteachersController, type: :request do
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
   end
 
   describe "#create" do

--- a/spec/requests/external_contacts/incoming_trust_ceos_controller_spec.rb
+++ b/spec/requests/external_contacts/incoming_trust_ceos_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ExternalContacts::IncomingTrustCeosController, type: :request do
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
   end
 
   describe "#create" do

--- a/spec/requests/external_contacts/other_contacts_controller_spec.rb
+++ b/spec/requests/external_contacts/other_contacts_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ExternalContacts::OtherContactsController, type: :request do
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
   end
 
   describe "#create" do

--- a/spec/requests/external_contacts/outgoing_trust_ceos_controller_spec.rb
+++ b/spec/requests/external_contacts/outgoing_trust_ceos_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ExternalContacts::OutgoingTrustCeosController, type: :request do
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10059062)
+    mock_successful_api_responses(urn: any_args, ukprn: 10059062)
   end
 
   describe "#create" do

--- a/spec/requests/external_contacts_controller_spec.rb
+++ b/spec/requests/external_contacts_controller_spec.rb
@@ -2,15 +2,15 @@ require "rails_helper"
 
 RSpec.describe ExternalContactsController, type: :request do
   let(:user) { create(:user, :caseworker) }
+  let(:project) { create(:conversion_project) }
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
     mock_successful_persons_api_client
   end
 
   describe "#index" do
-    let(:project) { create(:conversion_project) }
     let(:project_id) { project.id }
 
     subject(:perform_request) do
@@ -30,7 +30,6 @@ RSpec.describe ExternalContactsController, type: :request do
 
     context "when the project has a director of child services" do
       it "includes the director of child services in the response" do
-        project = create(:conversion_project)
         director_of_child_services_contact = create(:director_of_child_services)
         allow_any_instance_of(Project).to receive(:director_of_child_services).and_return(director_of_child_services_contact)
 
@@ -42,7 +41,6 @@ RSpec.describe ExternalContactsController, type: :request do
   end
 
   describe "#new" do
-    let(:project) { create(:conversion_project) }
     let(:project_id) { project.id }
 
     subject(:perform_request) do
@@ -62,7 +60,6 @@ RSpec.describe ExternalContactsController, type: :request do
   end
 
   describe "#create" do
-    let(:project) { create(:conversion_project) }
     let(:project_id) { project.id }
     let(:mock_contact) { build(:project_contact) }
     let(:contact_type) { "headteacher" }
@@ -93,7 +90,6 @@ RSpec.describe ExternalContactsController, type: :request do
   end
 
   describe "#edit" do
-    let(:project) { create(:conversion_project) }
     let(:project_id) { project.id }
     let(:contact) { create(:project_contact, project: project) }
     let(:contact_id) { contact.id }
@@ -121,7 +117,6 @@ RSpec.describe ExternalContactsController, type: :request do
   end
 
   describe "#update" do
-    let(:project) { create(:conversion_project) }
     let(:project_id) { project.id }
     let(:contact) { create(:project_contact, project: project) }
     let(:contact_id) { contact.id }
@@ -169,7 +164,6 @@ RSpec.describe ExternalContactsController, type: :request do
   end
 
   describe "#destroy" do
-    let(:project) { create(:conversion_project) }
     let(:project_id) { project.id }
     let(:contact) { create(:project_contact) }
     let(:contact_id) { contact.id }
@@ -188,7 +182,6 @@ RSpec.describe ExternalContactsController, type: :request do
   end
 
   describe "#confirm_destroy" do
-    let(:project) { create(:conversion_project) }
     let(:project_id) { project.id }
     let(:contact) { create(:project_contact) }
     let(:contact_id) { contact.id }

--- a/spec/requests/notes_controller_spec.rb
+++ b/spec/requests/notes_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe NotesController, type: :request do
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
   end
 
   describe "#index" do

--- a/spec/requests/project_complete_spec.rb
+++ b/spec/requests/project_complete_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Completing projects", type: :request do
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
   end
 
   describe "the complete project button" do

--- a/spec/requests/project_information_controller_spec.rb
+++ b/spec/requests/project_information_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ProjectInformationController, type: :request do
 
   before do
     sign_in_with(user)
-    mock_successful_api_responses(urn: 123456, ukprn: 10061021)
+    mock_successful_api_responses(urn: any_args, ukprn: 10061021)
   end
 
   describe "#show" do

--- a/spec/services/academies_api_pre_fetcher_service_spec.rb
+++ b/spec/services/academies_api_pre_fetcher_service_spec.rb
@@ -1,24 +1,25 @@
 require "rails_helper"
 
 RSpec.describe AcademiesApiPreFetcherService do
+  before { Project.destroy_all }
+
   it "prefetches Academies API data in batches of 20 and populates projects" do
     api_client = mock_academies_api_client_get_establishments_and_trusts
 
     25.times do
-      create(:conversion_project, urn: 123456, incoming_trust_ukprn: 10010010)
+      create(:conversion_project, incoming_trust_ukprn: 10010010)
     end
 
     projects = Project.all
 
     AcademiesApiPreFetcherService.new.call!(projects)
 
-    expect(projects.last.establishment).not_to be_nil
-    expect(projects.last.incoming_trust).not_to be_nil
-
     expect(api_client).to have_received(:get_establishments).exactly(2).times
     expect(api_client).to have_received(:get_trusts).exactly(2).times
 
     expect(api_client).to have_received(:get_establishment).exactly(25).times
+    expect(projects.last.establishment).not_to be_nil
+    expect(projects.last.incoming_trust).not_to be_nil
   end
 
   it "handles eager loading" do
@@ -38,7 +39,7 @@ RSpec.describe AcademiesApiPreFetcherService do
     mock_academies_api_client_get_establishments_and_trusts_failure
 
     10.times do
-      create(:conversion_project, urn: 123456, incoming_trust_ukprn: 10010010)
+      create(:conversion_project, incoming_trust_ukprn: 10010010)
     end
 
     projects = Project.all
@@ -56,7 +57,7 @@ RSpec.describe AcademiesApiPreFetcherService do
       allow(api_client).to receive(:get_establishments).and_return(Api::AcademiesApi::Client::Result.new([establishment], nil))
 
       10.times do
-        create(:conversion_project, urn: 123456, incoming_trust_ukprn: 10010010)
+        create(:conversion_project, incoming_trust_ukprn: 10010010)
       end
 
       projects = Project.all

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -69,10 +69,12 @@ RSpec.describe Api::Conversions::CreateProjectService do
         last_name: "Last",
         team: :london
       )
+      initial_count = User.count
+
       user = subject.regional_delivery_officer
 
       expect(user).to eql existing_user
-      expect(User.count).to be 1
+      expect(User.count).to eq(initial_count)
     end
   end
 

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -73,10 +73,12 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
         last_name: "Last",
         team: :london
       )
+      initial_count = User.count
+
       user = subject.regional_delivery_officer
 
       expect(user).to eql existing_user
-      expect(User.count).to be 1
+      expect(User.count).to eq(initial_count)
     end
   end
 

--- a/spec/services/by_local_authority_project_fetcher_service_spec.rb
+++ b/spec/services/by_local_authority_project_fetcher_service_spec.rb
@@ -2,30 +2,55 @@ require "rails_helper"
 
 RSpec.describe ByLocalAuthorityProjectFetcherService do
   before do
-    establishment = build(:academies_api_establishment, local_authority_code: "909", urn: 121813)
-    another_establishment = build(:academies_api_establishment, local_authority_code: "213", urn: 121102)
-    yet_another_establishment = build(:academies_api_establishment, local_authority_code: "926", urn: 121583)
+    Project.destroy_all
+    cumbria_establishment = build(:academies_api_establishment, local_authority_code: "909", urn: 121813)
+    cumbria_establishment2 = build(:academies_api_establishment, local_authority_code: "909", urn: 222222)
+    cumbria_establishment3 = build(:academies_api_establishment, local_authority_code: "909", urn: 333333)
+    westminster_establishment = build(:academies_api_establishment, local_authority_code: "213", urn: 121102)
+    norfolk_establishment = build(:academies_api_establishment, local_authority_code: "926", urn: 121583)
 
     fake_client = double(Api::AcademiesApi::Client,
       get_trust: Api::AcademiesApi::Client::Result.new(double, nil))
 
     allow(Api::AcademiesApi::Client).to receive(:new).and_return(fake_client)
-    allow(fake_client).to receive(:get_establishment).with(establishment.urn).and_return(Api::AcademiesApi::Client::Result.new(establishment, nil))
-    allow(fake_client).to receive(:get_establishment).with(another_establishment.urn).and_return(Api::AcademiesApi::Client::Result.new(another_establishment, nil))
-    allow(fake_client).to receive(:get_establishment).with(yet_another_establishment.urn).and_return(Api::AcademiesApi::Client::Result.new(yet_another_establishment, nil))
-    allow(fake_client).to receive(:get_establishments).with(any_args).and_return(Api::AcademiesApi::Client::Result.new([establishment, another_establishment, establishment, yet_another_establishment], nil))
-    allow(fake_client).to receive(:get_trusts).and_return(Api::AcademiesApi::Client::Result.new([double("Trust", ukprn: 10010010)], nil))
+
+    allow(fake_client).to receive(:get_establishment).with(cumbria_establishment.urn)
+      .and_return(Api::AcademiesApi::Client::Result.new(cumbria_establishment, nil))
+
+    allow(fake_client).to receive(:get_establishment).with(cumbria_establishment2.urn)
+      .and_return(Api::AcademiesApi::Client::Result.new(cumbria_establishment2, nil))
+
+    allow(fake_client).to receive(:get_establishment).with(cumbria_establishment3.urn)
+      .and_return(Api::AcademiesApi::Client::Result.new(cumbria_establishment3, nil))
+
+    allow(fake_client).to receive(:get_establishment).with(westminster_establishment.urn)
+      .and_return(Api::AcademiesApi::Client::Result.new(westminster_establishment, nil))
+
+    allow(fake_client).to receive(:get_establishment).with(norfolk_establishment.urn)
+      .and_return(Api::AcademiesApi::Client::Result.new(norfolk_establishment, nil))
+
+    allow(fake_client).to receive(:get_establishments).with(any_args)
+      .and_return(Api::AcademiesApi::Client::Result.new([
+        cumbria_establishment,
+        cumbria_establishment2,
+        cumbria_establishment3,
+        westminster_establishment,
+        norfolk_establishment
+      ], nil))
+
+    allow(fake_client).to receive(:get_trusts)
+      .and_return(Api::AcademiesApi::Client::Result.new([double("Trust", ukprn: 10010010)], nil))
 
     cumbria = create(:local_authority, code: "909", name: "Cumbria County Council")
     westminster = create(:local_authority, code: "213", name: "Westminster City Council")
     norfolk = create(:local_authority, code: "926", name: "Norfolk County Council")
 
-    create(:conversion_project, local_authority: cumbria, urn: establishment.urn, conversion_date: Date.new(2024, 1, 1))
-    create(:conversion_project, local_authority: westminster, urn: another_establishment.urn)
-    create(:conversion_project, local_authority: cumbria, urn: establishment.urn, conversion_date: Date.new(2024, 2, 1))
+    create(:conversion_project, local_authority: cumbria, urn: cumbria_establishment.urn, conversion_date: Date.new(2024, 1, 1))
+    create(:conversion_project, local_authority: westminster, urn: westminster_establishment.urn)
+    create(:conversion_project, local_authority: cumbria, urn: cumbria_establishment2.urn, conversion_date: Date.new(2024, 2, 1))
 
-    create(:transfer_project, local_authority: cumbria, urn: establishment.urn, transfer_date: Date.new(2024, 3, 1))
-    create(:transfer_project, local_authority: norfolk, urn: yet_another_establishment.urn)
+    create(:transfer_project, local_authority: cumbria, urn: cumbria_establishment3.urn, transfer_date: Date.new(2024, 3, 1))
+    create(:transfer_project, local_authority: norfolk, urn: norfolk_establishment.urn)
   end
 
   describe "#local_authorities_with_projects" do

--- a/spec/services/by_trust_project_fetcher_service_spec.rb
+++ b/spec/services/by_trust_project_fetcher_service_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe ByTrustProjectFetcherService do
 
   describe "form a multi academy trust projects" do
     it "includes a form a MAT trust with the correct counts and details" do
-      mock_academies_api_establishment_success(urn: 123456)
+      mock_academies_api_establishment_success(urn: any_args)
 
       create(:transfer_project, :active, incoming_trust_ukprn: nil, new_trust_reference_number: "TR12345", new_trust_name: "BRAND NEW TRUST")
       create(:conversion_project, :active, incoming_trust_ukprn: nil, new_trust_reference_number: "TR12345", new_trust_name: "BRAND NEW TRUST")

--- a/spec/services/by_user_project_fetcher_service_spec.rb
+++ b/spec/services/by_user_project_fetcher_service_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe ByUserProjectFetcherService do
     another_user = create(:user, first_name: "B", last_name: "User", email: "b.user@education.gov.uk", team: :north_west)
     yet_another_user = create(:user, first_name: "C", last_name: "User", email: "c.user@education.gov.uk", team: :service_support)
 
-    create(:conversion_project, urn: 121813, assigned_to: user)
-    create(:conversion_project, urn: 121102, assigned_to: user)
-    create(:conversion_project, urn: 117574, assigned_to: another_user)
-    create(:conversion_project, urn: 121583, assigned_to: nil)
-    create(:conversion_project, urn: 121583, assigned_to: yet_another_user)
-    create(:transfer_project, urn: 101133, assigned_to: user)
-    create(:transfer_project, urn: 112209, assigned_to: yet_another_user)
+    create(:conversion_project, assigned_to: user)
+    create(:conversion_project, assigned_to: user)
+    create(:conversion_project, assigned_to: another_user)
+    create(:conversion_project, assigned_to: nil)
+    create(:conversion_project, assigned_to: yet_another_user)
+    create(:transfer_project, assigned_to: user)
+    create(:transfer_project, assigned_to: yet_another_user)
 
     result = described_class.new.call
 

--- a/spec/services/import/user_csv_importer_service_spec.rb
+++ b/spec/services/import/user_csv_importer_service_spec.rb
@@ -11,7 +11,11 @@ RSpec.describe Import::UserCsvImporterService do
     CSV
   end
 
-  before { allow(File).to receive(:open).and_return(users_csv) }
+  before {
+    Project.destroy_all
+    User.destroy_all
+    allow(File).to receive(:open).and_return(users_csv)
+  }
 
   describe "#call" do
     let(:existing_user_email) { "jane.doe@education.gov.uk" }

--- a/spec/services/project_search_service_spec.rb
+++ b/spec/services/project_search_service_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe ProjectSearchService do
       context "when a match is found" do
         it "returns an array with the matches" do
           matching_project = create(:conversion_project, urn: 100000)
-          another_matching_project = create(:transfer_project, urn: 100000)
+          another_matching_project = create(:transfer_project, urn: 100000, state: :completed)
           not_matching_project = create(:conversion_project, urn: 123456)
 
           service = described_class.new
@@ -148,7 +148,7 @@ RSpec.describe ProjectSearchService do
       context "when a match is not found" do
         it "returns an empty result" do
           create(:conversion_project, urn: 100000)
-          create(:transfer_project, urn: 100000)
+          create(:transfer_project, urn: 100000, state: :completed)
 
           service = described_class.new
           result = service.search_by_urns("123456")

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -52,7 +52,7 @@ module AcademiesApiHelpers
 
     test_client = Api::AcademiesApi::Client.new
 
-    allow(test_client).to receive(:get_establishment).with(123456).and_return(mock_establishment)
+    allow(test_client).to receive(:get_establishment).and_return(mock_establishment)
     allow(test_client).to receive(:get_trust).with(10059151).and_return(mock_before_incoming_trust)
     allow(test_client).to receive(:get_trust).with(10058882).and_return(mock_after_incoming_trust)
 
@@ -68,7 +68,7 @@ module AcademiesApiHelpers
   #
   # Success
   def mock_academies_api_establishment_success(urn:, establishment: nil)
-    establishment = build(:academies_api_establishment) if establishment.nil?
+    establishment = build(:academies_api_establishment, urn: urn.to_s) if establishment.nil?
     local_authority = build(:local_authority)
 
     test_client = Api::AcademiesApi::Client.new


### PR DESCRIPTION
### Enforce uniqueness of URN for active projects

See ticket [194142](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/194142)

We add a composite uniqueness index on the `projects` table
to ensure that only one project in an active state with a given
URN can exist.

We've been seeing some duplicate transfers and conversions being
created by our automated "handover" process between "prepare" and
"complete". Our "complete" API receives POSTs to:

- `/api/v1/projects/conversions` and
- `/api/v1/projects/conversions`

these are handled by:

- `Api::Conversions::CreateProjectService` and
- `Api::Transfers::CreateProjectService`

which both use the `UrnUniqueForApiValidator` to perform this
validation at the application level, but for a reliable
constraint we need to use a control at the database layer.

As new projects are added with the "active" state it's sufficient to
use the rule that no two projects may have the same state and URN.

When deploying this change we'll need to identify any existing projects 
which violate this rule and handle them, probably by moving
all but the most recent duplicate into the deleted state. 

See the list of [project states][] .

[project states]:
https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/blob/fa42c6bca30696c4ca34b3fe2a3db568244f3294/app/models/project.rb#L92C1-L98C4

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [ ] Understand if production contains records which violate this new constraint. If so 
   add a data migration to fix up before adding the unique index
- [ ] Update the `CHANGELOG.md` if needed.
