### PR TITLE
200459 Fix: set local authority on imported projects

### DIFF
--- a/app/services/api/conversions/create_project_service.rb
+++ b/app/services/api/conversions/create_project_service.rb
@@ -22,6 +22,7 @@ class Api::Conversions::CreateProjectService < Api::BaseCreateProjectService
         regional_delivery_officer_id: user.id,
         tasks_data: tasks_data,
         region: establishment.region_code,
+        local_authority: establishment.local_authority,
         prepare_id: prepare_id,
         group: group,
         state: :inactive

--- a/app/services/api/transfers/create_project_service.rb
+++ b/app/services/api/transfers/create_project_service.rb
@@ -37,6 +37,7 @@ class Api::Transfers::CreateProjectService < Api::BaseCreateProjectService
         regional_delivery_officer_id: user.id,
         tasks_data: tasks_data,
         region: establishment.region_code,
+        local_authority: establishment.local_authority,
         new_trust_reference_number: new_trust_reference_number,
         new_trust_name: new_trust_name,
         prepare_id: prepare_id,

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe Api::Conversions::CreateProjectService do
     expect(subject.region).to eql "west_midlands"
   end
 
+  it "sets the project local authority from the establishment local authority" do
+    expect(subject.local_authority).to eql local_authority
+  end
+
   it "creates the user in the same regional team as the project establishment" do
     user = subject.regional_delivery_officer
 

--- a/spec/services/api/conversions/create_project_service_spec.rb
+++ b/spec/services/api/conversions/create_project_service_spec.rb
@@ -1,8 +1,14 @@
 require "rails_helper"
 
 RSpec.describe Api::Conversions::CreateProjectService do
+  let(:local_authority) { create(:local_authority) }
+
   before do
-    mock_successful_api_response_to_create_any_project
+    establishment = build(:academies_api_establishment)
+    mock_successful_api_response_to_create_any_project(
+      establishment: establishment,
+      local_authority: local_authority
+    )
   end
 
   subject { described_class.new(valid_parameters).call }

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -1,8 +1,14 @@
 require "rails_helper"
 
 RSpec.describe Api::Transfers::CreateProjectService, type: :model do
+  let(:local_authority) { create(:local_authority) }
+
   before do
-    mock_successful_api_response_to_create_any_project
+    establishment = build(:academies_api_establishment)
+    mock_successful_api_response_to_create_any_project(
+      establishment: establishment,
+      local_authority: local_authority
+    )
   end
 
   subject { described_class.new(valid_parameters).call }

--- a/spec/services/api/transfers/create_project_service_spec.rb
+++ b/spec/services/api/transfers/create_project_service_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe Api::Transfers::CreateProjectService, type: :model do
     expect(subject.region).to eql "west_midlands"
   end
 
+  it "sets the project local authority from the establishment local authority" do
+    expect(subject.local_authority).to eql local_authority
+  end
+
   it "creates the user in the same regional team as the project establishment" do
     user = subject.regional_delivery_officer
 

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -25,8 +25,12 @@ module AcademiesApiHelpers
   end
 
   # Successful API calls for any URN and UKPRN
-  def mock_successful_api_response_to_create_any_project
-    mock_academies_api_establishment_success(urn: any_args)
+  def mock_successful_api_response_to_create_any_project(establishment: nil, local_authority: nil)
+    mock_academies_api_establishment_success(
+      urn: any_args,
+      establishment: establishment,
+      local_authority: local_authority
+    )
     mock_academies_api_trust_success(ukprn: any_args)
   end
 
@@ -67,9 +71,9 @@ module AcademiesApiHelpers
   # Individual response for the getting an establishment
   #
   # Success
-  def mock_academies_api_establishment_success(urn:, establishment: nil)
+  def mock_academies_api_establishment_success(urn:, establishment: nil, local_authority: nil)
     establishment = build(:academies_api_establishment) if establishment.nil?
-    local_authority = build(:local_authority)
+    local_authority ||= build(:local_authority)
 
     test_client = Api::AcademiesApi::Client.new
     result = Api::AcademiesApi::Client::Result.new(establishment, nil)


### PR DESCRIPTION
See [200459: Imported projects missing LA](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/200459)

We failed to recognise that  projects (transfers and conversions) are not only created within the service via the GUI using the `CreateProjectForm` classes, but also programmatically in a pipeline job from the "Prepare" service. The classes responsible are:

 - `Api::Conversions::CreateProjectService` and
 - `Api::Transfers::CreateProjectService`

In this PR we extend these two services to set the local authority on the project being created from the local authority of the establishment returned by the Academies API.