### PR TITLE
200459 Enforce presence of project's local authority

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -21,7 +21,7 @@ class Project < ApplicationRecord
   belongs_to :outgoing_trust_main_contact, inverse_of: :main_contact_for_outgoing_trust, dependent: :destroy, class_name: "Contact", optional: true
   belongs_to :local_authority_main_contact, inverse_of: :main_contact_for_local_authority, dependent: :destroy, class_name: "Contact", optional: true
 
-  belongs_to :local_authority, optional: true
+  belongs_to :local_authority, optional: false
 
   belongs_to :group, inverse_of: :projects, class_name: "ProjectGroup", optional: true
 

--- a/db/migrate/20250211093654_add_fk_constraint_on_project_local_authority.rb
+++ b/db/migrate/20250211093654_add_fk_constraint_on_project_local_authority.rb
@@ -1,0 +1,5 @@
+class AddFkConstraintOnProjectLocalAuthority < ActiveRecord::Migration[7.1]
+  def change
+    add_foreign_key :projects, :local_authorities
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_27_172701) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_11_093654) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -498,6 +498,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_27_172701) do
   add_foreign_key "contacts", "projects"
   add_foreign_key "notes", "projects"
   add_foreign_key "notes", "users"
+  add_foreign_key "projects", "local_authorities"
   add_foreign_key "projects", "users", column: "assigned_to_id"
   add_foreign_key "projects", "users", column: "caseworker_id"
   add_foreign_key "projects", "users", column: "regional_delivery_officer_id"

--- a/spec/features/projects/local_authorities/users_can_view_projects_by_local_authority_spec.rb
+++ b/spec/features/projects/local_authorities/users_can_view_projects_by_local_authority_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Users can view a list of local authorities that have projectss" do
+RSpec.feature "Users can view a list of local authorities that have projects" do
   before do
     sign_in_with_user(user)
     mock_all_academies_api_responses
@@ -20,7 +20,7 @@ RSpec.feature "Users can view a list of local authorities that have projectss" d
     scenario "they see the trust listed and a link" do
       establishment = build(:academies_api_establishment, urn: 123456, local_authority_code: "100")
       local_authority = create(:local_authority, code: "100")
-      create(:conversion_project, urn: 123456)
+      create(:conversion_project, urn: 123456, local_authority: local_authority)
       allow_any_instance_of(Project).to receive(:establishment).and_return(establishment)
 
       visit all_local_authorities_projects_path

--- a/spec/features/projects/local_authorities/users_can_view_projects_for_a_local_authority_spec.rb
+++ b/spec/features/projects/local_authorities/users_can_view_projects_for_a_local_authority_spec.rb
@@ -19,8 +19,8 @@ RSpec.feature "Users can view a list of projects for a local authority" do
   context "when there are projects for the local authority" do
     scenario "they see the list of projects" do
       establishment = build(:academies_api_establishment, urn: 123456, local_authority_code: "100")
-      create(:local_authority, code: "100")
-      project = create(:conversion_project, urn: 123456)
+      local_authority = create(:local_authority, code: "100")
+      project = create(:conversion_project, urn: 123456, local_authority: local_authority)
       allow_any_instance_of(Project).to receive(:establishment).and_return(establishment)
 
       visit by_local_authority_all_local_authorities_projects_path("100")
@@ -32,9 +32,9 @@ RSpec.feature "Users can view a list of projects for a local authority" do
     end
 
     scenario "when there are enough projects to page they see a pager" do
-      create(:local_authority, code: "100")
+      local_authority = create(:local_authority, code: "100")
       21.times do
-        create(:conversion_project)
+        create(:conversion_project, local_authority: local_authority)
       end
       establishment = build(:academies_api_establishment, urn: 123456, local_authority_code: "100")
       allow_any_instance_of(Project).to receive(:establishment).and_return(establishment)

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -81,9 +81,8 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
 
     context "and the establishment has a diocese" do
       it "sets the church supplemental agreement task to not applicable" do
-        local_authority = LocalAuthority.new(id: "f0e04a51-3711-4d58-942a-dcb84938c818")
         establishment = build(:academies_api_establishment, diocese_code: "0000")
-        allow(establishment).to receive(:local_authority).and_return(local_authority)
+        allow(establishment).to receive(:local_authority).and_return(create(:local_authority))
         result = Api::AcademiesApi::Client::Result.new(establishment, nil)
         allow_any_instance_of(Api::AcademiesApi::Client).to receive(:get_establishment).with(123456).and_return(result)
 
@@ -603,7 +602,7 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
         region_code: "E"
       )
 
-      mock_all_academies_api_responses(establishment: establishment)
+      mock_all_academies_api_responses(establishment: establishment, local_authority: local_authority)
     end
 
     it "sets the #local_authority from the establishment" do

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
       region_code: "F"
     )
 
-    mock_all_academies_api_responses(establishment: establishment)
+    mock_all_academies_api_responses(establishment: establishment, local_authority: local_authority)
   end
 
   describe "validations" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_many(:notes).dependent(:destroy) }
     it { is_expected.to belong_to(:caseworker).required(false) }
     it { is_expected.to belong_to(:assigned_to).required(false) }
+    it { is_expected.to belong_to(:local_authority).required(true) }
     it { is_expected.to belong_to(:tasks_data).required(true) }
     it { is_expected.to belong_to(:main_contact).optional(true) }
     it { is_expected.to belong_to(:establishment_main_contact).optional(true) }

--- a/spec/requests/conversions/projects_controller_spec.rb
+++ b/spec/requests/conversions/projects_controller_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe Conversions::ProjectsController do
   let(:user) { create(:user, :caseworker) }
   let(:academies_api_timeout_error) { Api::AcademiesApi::Client::Error.new("Test Academies API timeout error") }
+  let(:local_authority) { create(:local_authority) }
 
   before do
-    local_authority = LocalAuthority.new(id: "f0e04a51-3711-4d58-942a-dcb84938c818")
     establishment = build(:academies_api_establishment, diocese_code: "0000")
     allow(establishment).to receive(:local_authority).and_return(local_authority)
     mock_all_academies_api_responses(establishment: establishment)

--- a/spec/requests/transfers/projects_controller_spec.rb
+++ b/spec/requests/transfers/projects_controller_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 RSpec.describe Transfers::ProjectsController do
   let(:user) { create(:user, :caseworker) }
   let(:academies_api_timeout_error) { Api::AcademiesApi::Client::Error.new("Test Academies API timeout error") }
+  let(:local_authority) { create(:local_authority) }
 
   before do
-    local_authority = LocalAuthority.new(id: "f0e04a51-3711-4d58-942a-dcb84938c818")
     establishment = build(:academies_api_establishment, diocese_code: "0000")
     allow(establishment).to receive(:local_authority).and_return(local_authority)
-    mock_all_academies_api_responses(establishment: establishment)
+    mock_all_academies_api_responses(establishment: establishment, local_authority: local_authority)
     sign_in_with(user)
   end
 

--- a/spec/support/academies_api_helpers.rb
+++ b/spec/support/academies_api_helpers.rb
@@ -1,7 +1,9 @@
 module AcademiesApiHelpers
   # Successful API calls for single and multiple establishments and trusts
-  def mock_all_academies_api_responses(establishment: nil)
+  def mock_all_academies_api_responses(establishment: nil, local_authority: nil)
     establishment ||= build(:academies_api_establishment)
+    local_authority ||= create(:local_authority)
+    allow(establishment).to receive(:local_authority).and_return(local_authority)
     trust = build(:academies_api_trust)
 
     establishments = build_list(:academies_api_establishment, 3)
@@ -37,7 +39,7 @@ module AcademiesApiHelpers
   # Successful API calls for editing a projects URN and UKPRN
   def mock_api_for_editing
     establishment = build(:academies_api_establishment)
-    local_authority = build(:local_authority)
+    local_authority = create(:local_authority)
     allow(establishment).to receive(:local_authority).and_return(local_authority)
 
     mock_establishment = Api::AcademiesApi::Client::Result.new(establishment, nil)
@@ -73,7 +75,7 @@ module AcademiesApiHelpers
   # Success
   def mock_academies_api_establishment_success(urn:, establishment: nil, local_authority: nil)
     establishment = build(:academies_api_establishment) if establishment.nil?
-    local_authority ||= build(:local_authority)
+    local_authority ||= create(:local_authority)
 
     test_client = Api::AcademiesApi::Client.new
     result = Api::AcademiesApi::Client::Result.new(establishment, nil)


### PR DESCRIPTION
### Enforce presence of `projects.local_authority_id`

Now that we have: 

- refactored `Project` to use an Active Record association on `LocalAuthority` rather than retrieving the local association from the `AcademiesApi::Establishment` ([PR 2073](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/2073))
- backfilled the existing records so that every project has its `local_authority_id` ([PR 2077](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/2077))
- extended the `Api::Conversions::CreateProjectService` and `Api::Transfers::CreateProjectService` to also set the local authority on projects imported automatically from Prepare ([PR 2085](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/2085)) 

we are in a position to enforce the referential integrity of the relationship: i.e. **every project must have an associated local authority record**.

We enforce this at two levels:

- in the application layer using the ActiveRecord validation system
- at the database layer with a foreign key constraint

#### Foreign key

The Rails DB migration adds a foreign key like:

![fk_on_project_local_authority](https://github.com/user-attachments/assets/0326f519-d21a-4acc-a902-2ae561aa1ac3)
