### PR TITLE
198181: Use "User Capabilities" to override role-related attribute setting

### DIFF
--- a/app/models/capability.rb
+++ b/app/models/capability.rb
@@ -1,0 +1,4 @@
+class Capability < ApplicationRecord
+  validates :name, uniqueness: true, presence: true
+  validates :description, presence: true
+end

--- a/app/models/capability.rb
+++ b/app/models/capability.rb
@@ -1,4 +1,25 @@
 class Capability < ApplicationRecord
   validates :name, uniqueness: true, presence: true
   validates :description, presence: true
+
+  def self.manage_team
+    find_or_create_by(
+      name: :manage_team,
+      description: "Capabilities dependent on the User#manage_team attribute"
+    )
+  end
+
+  def self.add_new_project
+    find_or_create_by(
+      name: :add_new_project,
+      description: "Capabilities dependent on the User#add_new_project attribute"
+    )
+  end
+
+  def self.assign_to_project
+    find_or_create_by(
+      name: :assign_to_project,
+      description: "Capabilities dependent on the User#assign_to_project attribute"
+    )
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,7 +69,9 @@ class User < ApplicationRecord
 
   # Override the db column temporarily while we test adding Transfers
   def add_new_project
-    is_regional_caseworker? || is_regional_delivery_officer?
+    is_regional_caseworker? ||
+      is_regional_delivery_officer? ||
+      UserCapability.has_capability?(user: self, capability_name: :add_new_project)
   end
 
   def team_options
@@ -82,7 +84,8 @@ class User < ApplicationRecord
       manage_user_accounts: apply_service_support_role?,
       manage_conversion_urns: apply_service_support_role?,
       manage_local_authorities: apply_service_support_role?,
-      add_new_project: is_regional_delivery_officer?,
+      add_new_project: is_regional_delivery_officer? ||
+        UserCapability.has_capability?(user: self, capability_name: :add_new_project),
       manage_team: apply_team_lead_role? ||
         UserCapability.has_capability?(user: self, capability_name: :manage_team)
     )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
 
   has_many :projects, foreign_key: "caseworker"
   has_many :notes
+  has_many :user_capabilities
+  has_many :capabilities, through: :user_capabilities
 
   scope :order_by_first_name, -> { order(first_name: :asc) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,7 +83,8 @@ class User < ApplicationRecord
       manage_conversion_urns: apply_service_support_role?,
       manage_local_authorities: apply_service_support_role?,
       add_new_project: is_regional_delivery_officer?,
-      manage_team: apply_team_lead_role?
+      manage_team: apply_team_lead_role? ||
+        UserCapability.has_capability?(user: self, capability_name: :manage_team)
     )
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,7 +80,8 @@ class User < ApplicationRecord
 
   private def apply_roles_based_on_team
     assign_attributes(
-      assign_to_project: is_regional_caseworker? || is_regional_delivery_officer?,
+      assign_to_project: is_regional_caseworker? || is_regional_delivery_officer? ||
+        UserCapability.has_capability?(user: self, capability_name: :assign_to_project),
       manage_user_accounts: apply_service_support_role?,
       manage_conversion_urns: apply_service_support_role?,
       manage_local_authorities: apply_service_support_role?,

--- a/app/models/user_capability.rb
+++ b/app/models/user_capability.rb
@@ -1,4 +1,11 @@
 class UserCapability < ApplicationRecord
   belongs_to :user, required: true
   belongs_to :capability, required: true
+
+  def self.has_capability?(user:, capability_name:)
+    capability = Capability.find_by(name: capability_name)
+    return false unless capability
+
+    user.capabilities.include?(capability)
+  end
 end

--- a/app/models/user_capability.rb
+++ b/app/models/user_capability.rb
@@ -1,0 +1,4 @@
+class UserCapability < ApplicationRecord
+  belongs_to :user, required: true
+  belongs_to :capability, required: true
+end

--- a/db/migrate/20250213122226_create_capability.rb
+++ b/db/migrate/20250213122226_create_capability.rb
@@ -1,0 +1,11 @@
+class CreateCapability < ActiveRecord::Migration[7.1]
+  def change
+    create_table :capabilities, id: :uuid do |t|
+      t.string :name, null: false
+      t.string :description, null: false
+
+      t.timestamps
+    end
+    add_index :capabilities, :name, unique: true
+  end
+end

--- a/db/migrate/20250213131024_create_user_capability.rb
+++ b/db/migrate/20250213131024_create_user_capability.rb
@@ -1,0 +1,14 @@
+class CreateUserCapability < ActiveRecord::Migration[7.1]
+  def change
+    create_table :user_capabilities, id: :uuid do |t|
+      t.uuid :user_id
+      t.uuid :capability_id
+
+      t.timestamps
+    end
+    add_foreign_key :user_capabilities, :capabilities
+    add_foreign_key :user_capabilities, :users
+    add_index :user_capabilities, :user_id
+    add_index :user_capabilities, :capability_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_11_093654) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_13_131024) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "api_key", null: false
     t.datetime "expires_at", null: false
     t.string "description"
+  end
+
+  create_table "capabilities", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "description", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_capabilities_on_name", unique: true
   end
 
   create_table "contacts", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
@@ -475,6 +483,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_11_093654) do
     t.boolean "commercial_transfer_agreement_questions_checked", default: false
   end
 
+  create_table "user_capabilities", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
+    t.uuid "user_id"
+    t.uuid "capability_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["capability_id"], name: "index_user_capabilities_on_capability_id"
+    t.index ["user_id"], name: "index_user_capabilities_on_user_id"
+  end
+
   create_table "users", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.string "email"
     t.datetime "created_at", null: false
@@ -502,4 +519,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_11_093654) do
   add_foreign_key "projects", "users", column: "assigned_to_id"
   add_foreign_key "projects", "users", column: "caseworker_id"
   add_foreign_key "projects", "users", column: "regional_delivery_officer_id"
+  add_foreign_key "user_capabilities", "capabilities"
+  add_foreign_key "user_capabilities", "users"
 end

--- a/spec/features/your_projects/users_can_view_their_projects_spec.rb
+++ b/spec/features/your_projects/users_can_view_their_projects_spec.rb
@@ -39,6 +39,33 @@ RSpec.feature "Users can view their projects" do
     expect(page).to_not have_content(project.urn)
   end
 
+  context "when they ARE in the Regional casework services team" do
+    context "and they are NOT a team manager" do
+      before {
+        user.save # perform the on_save callbacks
+        expect(user.manage_team).to be false
+      }
+
+      it "they can access the 'Your projects' section" do
+        visit in_progress_your_projects_path
+        expect(page).to have_link("Your project")
+      end
+    end
+
+    context "and they ARE a team manager" do
+      before {
+        user.update_column(:manage_team, true)
+        user.save # perform the on_save callbacks
+        expect(user.reload.manage_team).to be true
+      }
+
+      it "they can NOT access the 'Your projects' section" do
+        visit "/"
+        expect(page).to_not have_link("Your project")
+      end
+    end
+  end
+
   context "when they are NOT in the Regional casework services team" do
     let(:user) { create(:regional_delivery_officer_user) }
 

--- a/spec/features/your_projects/users_can_view_their_projects_spec.rb
+++ b/spec/features/your_projects/users_can_view_their_projects_spec.rb
@@ -63,6 +63,20 @@ RSpec.feature "Users can view their projects" do
         visit "/"
         expect(page).to_not have_link("Your project")
       end
+
+      context "when they have an overriding 'add_new_project' _capability_" do
+        before {
+          user.capabilities << Capability.add_new_project
+          user.save # perform the on_save callbacks
+          expect(user.add_new_project).to be true
+          expect(user.reload.manage_team).to be true
+        }
+
+        it "they can access the 'Your projects' section" do
+          visit in_progress_your_projects_path
+          expect(page).to have_link("Your project")
+        end
+      end
     end
   end
 

--- a/spec/models/capability_spec.rb
+++ b/spec/models/capability_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe Capability do
+  describe "enforces presence of #name and #description" do
+    let(:capability) do
+      Capability.new(name: nil, description: nil).tap do |capability|
+        capability.valid?
+      end
+    end
+
+    it "is invalid without #name" do
+      expect(capability.errors.full_messages).to include("Name can't be blank")
+    end
+
+    it "is invalid without #description" do
+      expect(capability.errors.full_messages).to include("Description can't be blank")
+    end
+  end
+  describe "enforces uniqueness of #name" do
+    context "when a capability with the same name already exists" do
+      before do
+        Capability.create(
+          name: :can_do_it,
+          description: "Can do it"
+        )
+      end
+
+      it("will not be valid") do
+        new_capability = Capability.new(
+          name: :can_do_it,
+          description: "Also can do it"
+        )
+
+        expect(new_capability.valid?).to be false
+      end
+    end
+  end
+end

--- a/spec/models/capability_spec.rb
+++ b/spec/models/capability_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Capability do
       expect(capability.errors.full_messages).to include("Description can't be blank")
     end
   end
+
   describe "enforces uniqueness of #name" do
     context "when a capability with the same name already exists" do
       before do
@@ -32,6 +33,119 @@ RSpec.describe Capability do
         )
 
         expect(new_capability.valid?).to be false
+      end
+    end
+  end
+
+  describe "capability finders" do
+    describe "::manage_team" do
+      context "when the team exists" do
+        let!(:existing_capability) do
+          Capability.create(
+            name: :manage_team,
+            description: "Capabilities dependent on the User#manage_team attribute"
+          )
+        end
+
+        it "returns the existing capability" do
+          expect(Capability.manage_team).to eq(existing_capability)
+        end
+      end
+
+      context "when the capability does not exist" do
+        it "creates the capability" do
+          allow(Capability).to receive(:find_or_create_by)
+
+          Capability.manage_team
+
+          expect(Capability).to have_received(:find_or_create_by)
+            .with(
+              name: :manage_team,
+              description: "Capabilities dependent on the User#manage_team attribute"
+            )
+        end
+
+        it "returns that newly created capability" do
+          newly_created_capability = Capability.manage_team
+
+          expect(newly_created_capability).to be_persisted
+          expect(newly_created_capability.name).to eq("manage_team")
+          expect(newly_created_capability.description).to match(/User#manage_team attribute/)
+        end
+      end
+    end
+
+    describe "::add_new_project" do
+      context "when the team exists" do
+        let!(:existing_capability) do
+          Capability.create(
+            name: :add_new_project,
+            description: "Capabilities dependent on the User#add_new_project attribute"
+          )
+        end
+
+        it "returns the existing capability" do
+          expect(Capability.add_new_project).to eq(existing_capability)
+        end
+      end
+
+      context "when the capability does not exist" do
+        it "creates the capability" do
+          allow(Capability).to receive(:find_or_create_by)
+
+          Capability.add_new_project
+
+          expect(Capability).to have_received(:find_or_create_by)
+            .with(
+              name: :add_new_project,
+              description: "Capabilities dependent on the User#add_new_project attribute"
+            )
+        end
+
+        it "returns that newly created capability" do
+          newly_created_capability = Capability.add_new_project
+
+          expect(newly_created_capability).to be_persisted
+          expect(newly_created_capability.name).to eq("add_new_project")
+          expect(newly_created_capability.description).to match(/User#add_new_project attribute/)
+        end
+      end
+    end
+
+    describe "::assign_to_project" do
+      context "when the team exists" do
+        let!(:existing_capability) do
+          Capability.create(
+            name: :assign_to_project,
+            description: "Capabilities dependent on the User#assign_to_project attribute"
+          )
+        end
+
+        it "returns the existing capability" do
+          expect(Capability.assign_to_project).to eq(existing_capability)
+        end
+      end
+
+      context "when the capability does not exist" do
+        it "creates the capability" do
+          allow(Capability).to receive(:find_or_create_by)
+
+          Capability.assign_to_project
+
+          expect(Capability).to have_received(:find_or_create_by)
+            .with(
+              name: :assign_to_project,
+              description: "Capabilities dependent on the User#assign_to_project attribute"
+            )
+        end
+
+        it "returns that newly created capability" do
+          newly_created_capability = Capability.assign_to_project
+
+          expect(newly_created_capability).to be_persisted
+          expect(newly_created_capability.name).to eq("assign_to_project")
+          expect(newly_created_capability.description).to match(/User#assign_to_project attribute/)
+        end
       end
     end
   end

--- a/spec/models/user_capability_spec.rb
+++ b/spec/models/user_capability_spec.rb
@@ -1,0 +1,6 @@
+require "rails_helper"
+
+RSpec.describe UserCapability do
+  it { is_expected.to belong_to(:user).optional(false) }
+  it { is_expected.to belong_to(:capability).optional(false) }
+end

--- a/spec/models/user_capability_spec.rb
+++ b/spec/models/user_capability_spec.rb
@@ -3,4 +3,32 @@ require "rails_helper"
 RSpec.describe UserCapability do
   it { is_expected.to belong_to(:user).optional(false) }
   it { is_expected.to belong_to(:capability).optional(false) }
+
+  describe "#has_capability?(user:, capability:)" do
+    let(:capability) do
+      Capability.create(name: :add_project, description: "May create projects")
+    end
+
+    let(:other_capability) do
+      Capability.create(name: :superpower, description: "May wield superpower")
+    end
+
+    let(:user) { create(:user) }
+
+    before do
+      user.capabilities << capability
+    end
+
+    it "returns true when the capability is present" do
+      expect(UserCapability.has_capability?(user: user, capability_name: :add_project)).to be true
+    end
+
+    it "returns false when the capability is NOT present" do
+      expect(UserCapability.has_capability?(user: user, capability_name: :superpower)).to be false
+    end
+
+    it "returns false when the capability does not exist" do
+      expect(UserCapability.has_capability?(user: user, capability_name: :missing_capability)).to be false
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -276,6 +276,21 @@ RSpec.describe User do
             expect(user.manage_team).to be true
           end
         end
+
+        context "when the user has the add_new_project capability" do
+          before do
+            user.capabilities << Capability.add_new_project
+            user.save
+          end
+
+          it "sets the User#add_new_project method (overrides the db attribute)" do
+            expect(user.add_new_project).to be true
+          end
+
+          it "sets the User#add_new_project attribute" do
+            expect(user.read_attribute(:add_new_project)).to be true
+          end
+        end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe User do
     it { is_expected.to have_db_column(:latest_session).of_type :datetime }
   end
 
+  describe "associations" do
+    it { is_expected.to have_many(:capabilities) }
+  end
+
   describe "scopes" do
     let!(:caseworker) { create(:regional_casework_services_user) }
     let!(:caseworker_2) { create(:regional_casework_services_user, first_name: "Aaron", email: "aaron-caseworker@education.gov.uk") }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -256,6 +256,27 @@ RSpec.describe User do
           expect(user.manage_team).to be false
         end
       end
+
+      describe "when overriding with user capabilities" do
+        let(:user) { create(:user) }
+
+        before do
+          expect(user.manage_team).to be false
+          expect(user.add_new_project).to be false
+          expect(user.assign_to_project).to be false
+        end
+
+        context "when the user has the manage_team capability" do
+          before do
+            user.capabilities << Capability.manage_team
+            user.save
+          end
+
+          it "sets the User#manage_team attribute" do
+            expect(user.manage_team).to be true
+          end
+        end
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -291,6 +291,17 @@ RSpec.describe User do
             expect(user.read_attribute(:add_new_project)).to be true
           end
         end
+
+        context "when the user has the assign_to_project capability" do
+          before do
+            user.capabilities << Capability.assign_to_project
+            user.save
+          end
+
+          it "sets the User#assign_to_project attribute" do
+            expect(user.assign_to_project).to be true
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Use "User Capabilities" to override role-related attribute setting

The way user roles is managed in Complete (Ruby) has grown quite complex and tangled over time. In this PR we introduce a mechanism to define capabilities on a per-user basis. This can be used to:

1. solve an immediate and urgent support requirement to allow an Regional casework services team member to i) assign projects, ii) be assigned projects, iii) add new projects
2. refactor the existing role/permission behaviour to make it clearer and more maintainable

This PR focuses on [1] (see support tickets [196438](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/196438) and [198181](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/198181))

In this work we define 3 new Capabilities which can be used to override user attributes:

- `add_new_project`
- `assign_to_project`
- `manage_team`

which are included in a group of `User` attributes set in a callback "before save":

```rb
private def apply_roles_based_on_team
  assign_attributes(
    assign_to_project: is_regional_caseworker? || is_regional_delivery_officer?,
    manage_user_accounts: apply_service_support_role?,
    manage_conversion_urns: apply_service_support_role?,
    manage_local_authorities: apply_service_support_role?,
    add_new_project: is_regional_delivery_officer?,
    manage_team: apply_team_lead_role?
  )
end
```

This logic is particularly tricky and opaque as the definition of "regional caseworker" excludes team managers:

```rb
def is_regional_caseworker?
  team == "regional_casework_services" && manage_team == false
end
```

which is itself set in this callback on each save and is defined in even more opaque and indirect logic:

```rb
private def apply_team_lead_role?
  manage_team && can_be_team_lead?
end

private def can_be_team_lead?
 is_regional_delivery_officer? || team == "regional_casework_services"
end
```

This work allows user capabilities to be used to over-ride the existing logic on a per-user basis without attempting a general refactoring of the role code. We end up with 3 `allowing_override_for(capability_name, &block)` wrappers within the `apply_roles_based_on_team` call back code:

```rb
 private def apply_roles_based_on_team
    assign_attributes(
      assign_to_project: allowing_override_for(:assign_to_project) { is_regional_caseworker? || is_regional_delivery_officer? },
      manage_user_accounts: apply_service_support_role?,
      manage_conversion_urns: apply_service_support_role?,
      manage_local_authorities: apply_service_support_role?,
      add_new_project: allowing_override_for(:add_new_project) { is_regional_delivery_officer? },
      manage_team: allowing_override_for(:manage_team) { apply_team_lead_role? }
    )
  end
```

### RCS team member (team manager) can't see "Your projects"

![rcs_with_team_missing_your_projects](https://github.com/user-attachments/assets/acbaaf58-4100-4a59-84f8-340385561929)


---


### RCS team member (team manager) with over-riding capability can see "Your projects"

![rcs_with_team_plus_override_has_your_projects](https://github.com/user-attachments/assets/e7a10a8b-b4e3-4f08-9bcc-6ed083101f2c)


