### PR TITLE
Make Projects#local_authority_id non-nullable

### DIFF
--- a/db/migrate/20250218140039_make_projects_local_authority_id_non_nullable.rb
+++ b/db/migrate/20250218140039_make_projects_local_authority_id_non_nullable.rb
@@ -1,0 +1,7 @@
+class MakeProjectsLocalAuthorityIdNonNullable < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :projects, :local_authority_id
+    change_column_null :projects, :local_authority_id, false
+    add_index :projects, :local_authority_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -340,7 +340,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_20_121430) do
     t.integer "prepare_id"
     t.uuid "local_authority_main_contact_id"
     t.uuid "group_id"
-    t.uuid "local_authority_id"
+    t.uuid "local_authority_id", null: false
     t.index ["assigned_to_id"], name: "index_projects_on_assigned_to_id"
     t.index ["caseworker_id"], name: "index_projects_on_caseworker_id"
     t.index ["incoming_trust_ukprn"], name: "index_projects_on_incoming_trust_ukprn"


### PR DESCRIPTION
This will ensure that projects always have their local authority set.

This will reduce the number of errors we see in the development environment caused by projects created by the .NET app which is under-construction and which has incomplete validation.

