### PR TITLE
Use fixed fork of application insights gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,9 @@ gem "faraday"
 gem "uk_postcode", "~> 2.1.0"
 
 # application insights
-gem "application_insights"
+gem "application_insights",
+  git: "https://github.com/dxw/ApplicationInsights-Ruby",
+  branch: "fix/correct-pattern-match-for-exception-handling"
 gem "exception_notification" # manually notify in Slack (Operation Id missing in AppInsights)
 gem "slack-notifier"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/dxw/ApplicationInsights-Ruby
+  revision: 51cb59a34e3e36ff406f9ec3c8332fb2a2ff89c5
+  branch: fix/correct-pattern-match-for-exception-handling
+  specs:
+    application_insights (0.5.7)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -83,7 +90,6 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
-    application_insights (0.5.6)
     ast (2.4.2)
     axe-core-api (4.10.2)
       dumb_delegator
@@ -285,7 +291,6 @@ GEM
     net-protocol (0.2.2)
       timeout
     net-smtp (0.5.0)
-      net-protocol
     nio4r (2.7.4)
     nokogiri (1.18.2-aarch64-linux-gnu)
       racc (~> 1.4)
@@ -565,7 +570,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-sqlserver-adapter
-  application_insights
+  application_insights!
   axe-core-rspec
   bootsnap
   brakeman


### PR DESCRIPTION
Our exception handling is being thwarted by an error in ApplicationInsights own exception handling. We need to fix this as we require AppInsights for general telemetry and metrics.

`TelemetryClient#track_exception` is throwing an
`undefined method '[]' for nil` error, coming out of:

```
/usr/local/bundle/gems/application_insights-0.5.6/lib/application_insights/telemetry_client.rb:86
:in 'block in ApplicationInsights::TelemetryClient#track_exception'
```

This is due to a failure in the regex which attempts to capture:

- file
- line
- method

from each line in the backtrace. Given:

`/home/roger/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/activerecord-sqlserver-adapter-7.1.11/lib/active_record/connection_adapters/sqlserver/database_statements.rb:429:in 'TinyTds::Result#each'`

we expect the match groups:

```

- file

	/home/roger/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/activerecord-sqlserver-adapter-7.1.11/lib/active_record/connection_adapters/sqlserver/database_statements.rb

- line

	429

- method

	TinyTds::Result#each

```

By replacing the backtick in the regex:

```
/^(?<file>.*):(?<line>\d+)(\.|:in `((?<method>.*)'$))/
```

 with a single quote, the matcher behaves as expected.

## Before (our exception is clobbered by AppInsight's)

<img width="498" alt="before" src="https://github.com/user-attachments/assets/610cca7b-62c3-4ba8-8152-8bcc51500ce7" />

## After (our exception and backtrace are preserved)

<img width="502" alt="after" src="https://github.com/user-attachments/assets/54b136b4-491a-4080-8b34-4fa3f4ffea71" />

