### PR TITLE
199543 & 199562: "complete" project without confirming receipt of grant payment certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- The "Receive declaration of expenditure certificate" task can now be marked as
+  "Not applicable" and the conversion project can be "completed" in this state.
+  This reflects the fact that voluntary conversion grants were discontinued in
+  Dec 2024.
+
 ## [Release-107][release-107]
 
 ### Fixed

--- a/app/forms/conversion/task/receive_grant_payment_certificate_task_form.rb
+++ b/app/forms/conversion/task/receive_grant_payment_certificate_task_form.rb
@@ -1,4 +1,4 @@
-class Conversion::Task::ReceiveGrantPaymentCertificateTaskForm < BaseTaskForm
+class Conversion::Task::ReceiveGrantPaymentCertificateTaskForm < BaseOptionalTaskForm
   include ActiveRecord::AttributeAssignment
 
   attribute :check_certificate, :boolean

--- a/app/forms/conversion/task/receive_grant_payment_certificate_task_form.rb
+++ b/app/forms/conversion/task/receive_grant_payment_certificate_task_form.rb
@@ -4,6 +4,7 @@ class Conversion::Task::ReceiveGrantPaymentCertificateTaskForm < BaseTaskForm
   attribute :check_certificate, :boolean
   attribute :save_certificate, :boolean
   attribute :date_received, :date
+  attribute :not_applicable
 
   def initialize(tasks_data, user)
     @date_param_errors = ActiveModel::Errors.new(self)
@@ -34,11 +35,26 @@ class Conversion::Task::ReceiveGrantPaymentCertificateTaskForm < BaseTaskForm
   end
 
   def save
+    if not_applicable
+      assign_not_applicable_response
+    else
+      assign_applicable_responses
+    end
+
+    @tasks_data.save!
+  end
+
+  private def assign_applicable_responses
     @tasks_data.assign_attributes(
       receive_grant_payment_certificate_date_received: date_received,
       receive_grant_payment_certificate_check_certificate: check_certificate,
       receive_grant_payment_certificate_save_certificate: save_certificate
     )
-    @tasks_data.save!
+  end
+
+  private def assign_not_applicable_response
+    @tasks_data.assign_attributes(
+      receive_grant_payment_certificate_not_applicable: not_applicable
+    )
   end
 end

--- a/app/models/conversion/project.rb
+++ b/app/models/conversion/project.rb
@@ -22,7 +22,6 @@ class Conversion::Project < Project
   MANDATORY_CONDITIONS = [
     :all_conditions_met?,
     :confirmed_date_and_in_the_past?,
-    :grant_payment_certificate_received?,
     :date_academy_opened_present?
   ]
 

--- a/app/views/conversions/tasks/receive_grant_payment_certificate/edit.html.erb
+++ b/app/views/conversions/tasks/receive_grant_payment_certificate/edit.html.erb
@@ -1,19 +1,18 @@
 <%= render(TaskList::TaskHeaderComponent.new(project: @project, task: @task)) %>
-
 <% content_for :pre_content_nav do %>
   <% render partial: "conversions/tasks/shared/back_link", locals: {project_id: @project.id} %>
 <% end %>
-
 <% content_for :page_title do %>
   <%= page_title(t("conversion.task.receive_grant_payment_certificate.title")) %>
 <% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @task, url: project_edit_task_path(@project, @task.class.identifier), method: :put do |form| %>
       <%= form.govuk_error_summary %>
-
-      <div class="govuk-form-group">
+      <div class="govuk-form-group govuk-!-margin-bottom-9">
+        <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :not_applicable)) %>
+      </div>
+      <div class="govuk-form-group govuk-!-margin-bottom-9">
         <% if @project.tasks_data.receive_grant_payment_certificate_date_received.nil? %>
           <%= form.govuk_date_field :date_received,
                 legend: {text: t("conversion.task.receive_grant_payment_certificate.date_received.title"), size: "s"} do %>
@@ -24,18 +23,14 @@
             <p><%= t("conversion.task.receive_grant_payment_certificate.date_received.received_info.html", date: @project.tasks_data.receive_grant_payment_certificate_date_received.to_fs(:govuk)) %></p>
           </div>
         <% end %>
-
       </div>
-
       <div class="govuk-form-group">
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :check_certificate)) %>
         <%= render(TaskList::CheckBoxActionComponent.new(task: @task, attribute: :save_certificate)) %>
       </div>
-
       <%= form.govuk_submit t("task_list.continue_button.text") if policy(@tasks_data).update? %>
     <% end %>
   </div>
-
   <div class="govuk-grid-column-one-third">
     <%= render partial: "shared/tasks/task_notes" %>
   </div>

--- a/config/locales/conversion/tasks/receive_grant_payment_certificate.en.yml
+++ b/config/locales/conversion/tasks/receive_grant_payment_certificate.en.yml
@@ -8,8 +8,12 @@ en:
         guidance_link: Update the grant assurance spreadsheet
         guidance:
           html:
-            <p>Regional Casework Services team members must <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&action=default&mobileredirect=true" target="_blank">update the support grant assurance report spreadsheet (opens in new tab)</a>.</p> 
+            <p>Regional Casework Services team members must <a href="https://educationgovuk.sharepoint.com/:x:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7BDC55D68D-3415-4923-A502-44B49DB05C0E%7D&file=Support%20Grant%20Certificate%20Assurance%20Report%20-%20RCS.xlsx&action=default&mobileredirect=true" target="_blank">update the support grant assurance report spreadsheet (opens in new tab)</a>.</p>
             <p>Do not update this grant assurance report spreadsheet if you work in a team in one of the Regions.</p>
+        not_applicable:
+          title: Not applicable
+          hint:
+            html: <p>No grant was received</p>
         check_certificate:
           title: Check the declaration of expenditure certificate is correct
           hint:

--- a/config/locales/conversion/tasks/share_information.en.yml
+++ b/config/locales/conversion/tasks/share_information.en.yml
@@ -2,7 +2,7 @@ en:
   conversion:
     task:
       share_information:
-        title: Share the grant certificate and information about opening
+        title: Share the information about opening
         hint:
           html:
             <p>Once you have confirmed that all conditions have been met, email your main contact at the school or trust to tell them the conversion will happen on the agreed date.</p>
@@ -17,7 +17,6 @@ en:
               <ul>
                 <li>confirmation the school will convert on the provisional date</li>
                 <li>the school's new URN</li>
-                <li>the <a href="https://www.gov.uk/government/publications/academy-support-grant" class="govuk-link" target="_blank">grant expenditure certificate (opens in new tab)</a> that they need to complete and return</li>
                 <li>the feedback form (if applicable)</li>
               </ul>
               <p>You can split this information over more than one email if you do not immediately have everything you need.</p>

--- a/config/locales/conversion_project.en.yml
+++ b/config/locales/conversion_project.en.yml
@@ -55,7 +55,6 @@ en:
         <ul>
         <li>The conversion date has been confirmed and is in the past</li>
         <li>The confirm all conditions have been met task is completed</li>
-        <li>The receive declaration of expenditure certificate task is completed</li>
         <li>The confirm the date the academy opened task is completed</li>
         </ul>
     form_a_mat:

--- a/db/migrate/20250220121430_add_not_applicable_to_receive_grant_payment_certificate_task.rb
+++ b/db/migrate/20250220121430_add_not_applicable_to_receive_grant_payment_certificate_task.rb
@@ -1,0 +1,5 @@
+class AddNotApplicableToReceiveGrantPaymentCertificateTask < ActiveRecord::Migration[7.1]
+  def change
+    add_column :conversion_tasks_data, :receive_grant_payment_certificate_not_applicable, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_13_131024) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_20_121430) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -165,6 +165,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_13_131024) do
     t.boolean "commercial_transfer_agreement_questions_received", default: false
     t.boolean "commercial_transfer_agreement_questions_checked", default: false
     t.boolean "commercial_transfer_agreement_saved", default: false
+    t.boolean "receive_grant_payment_certificate_not_applicable"
   end
 
   create_table "dao_revocation_reasons", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|

--- a/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
+++ b/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
@@ -64,7 +64,9 @@ RSpec.feature "Users can complete a conversion project" do
       expect(page).to have_content("The conversion date has been confirmed and is in the past")
       expect(page).to have_content("The confirm all conditions have been met task is completed")
       expect(page).to have_content("The confirm the date the academy opened task is completed")
-      expect(page).to have_content("receive declaration of expenditure certificate task")
+
+      # this is no longer required
+      expect(page).to_not have_content("receive declaration of expenditure certificate task")
 
       expect(project.reload.completed_at).to be_nil
     end

--- a/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
+++ b/spec/features/conversions/users_can_complete_a_conversion_project_spec.rb
@@ -60,6 +60,12 @@ RSpec.feature "Users can complete a conversion project" do
 
       expect(page).to_not have_content("Project completed")
       expect(page).to have_content("This project cannot be completed")
+
+      expect(page).to have_content("The conversion date has been confirmed and is in the past")
+      expect(page).to have_content("The confirm all conditions have been met task is completed")
+      expect(page).to have_content("The confirm the date the academy opened task is completed")
+      expect(page).to have_content("receive declaration of expenditure certificate task")
+
       expect(project.reload.completed_at).to be_nil
     end
   end

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -254,6 +254,44 @@ RSpec.feature "Users can complete conversion tasks" do
       click_on "Receive declaration of expenditure certificate"
     end
 
+    context "when 'not applicable' IS selected" do
+      before do
+        page.find_all(".govuk-checkboxes__input")
+          .find { |cb| cb["id"].match(/not_applicable/) }
+          .click
+      end
+
+      scenario "the 'not applicable' answer is saved" do
+        click_on I18n.t("task_list.continue_button.text")
+
+        expect(project.reload.tasks_data.receive_grant_payment_certificate_not_applicable)
+          .to be true
+      end
+
+      scenario "other values which are supplied are discarded" do
+        fill_in "Day", with: "1"
+        fill_in "Month", with: "1"
+        fill_in "Year", with: "2024"
+
+        page.find_all(".govuk-checkboxes__input")
+          .reject { |cb| cb["id"].match(/not_applicable/) }
+          .each { |checkbox| checkbox.click }
+
+        click_on I18n.t("task_list.continue_button.text")
+
+        aggregate_failures do
+          expect(project.reload.tasks_data.receive_grant_payment_certificate_date_received)
+            .to be_nil
+
+          expect(project.reload.tasks_data.receive_grant_payment_certificate_save_certificate)
+            .to be_nil
+
+          expect(project.reload.tasks_data.receive_grant_payment_certificate_check_certificate)
+            .to be_nil
+        end
+      end
+    end
+
     context "when 'not applicable' is NOT selected" do
       before do
         page.find_all(".govuk-checkboxes__input")

--- a/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
+++ b/spec/features/conversions/users_can_complete_conversion_tasks_spec.rb
@@ -249,30 +249,39 @@ RSpec.feature "Users can complete conversion tasks" do
 
   describe "the receive grant payment certificate task" do
     let(:project) { create(:conversion_project, assigned_to: user) }
-
-    context "when the task does not have a date" do
-      scenario "they can add a date" do
-        visit project_tasks_path(project)
-        click_on "Receive declaration of expenditure certificate"
-        page.find_all(".govuk-checkboxes__input").each { |checkbox| checkbox.click }
-        fill_in "Day", with: "1"
-        fill_in "Month", with: "1"
-        fill_in "Year", with: "2024"
-        click_on I18n.t("task_list.continue_button.text")
-
-        expect(project.reload.tasks_data.receive_grant_payment_certificate_date_received).to eq Date.new(2024, 1, 1)
-      end
+    before do
+      visit project_tasks_path(project)
+      click_on "Receive declaration of expenditure certificate"
     end
 
-    context "when the task has a date" do
-      let(:tasks_data) { create(:conversion_tasks_data, receive_grant_payment_certificate_date_received: Date.new(2024, 1, 1)) }
-      let(:project) { create(:conversion_project, assigned_to: user, tasks_data: tasks_data) }
+    context "when 'not applicable' is NOT selected" do
+      before do
+        page.find_all(".govuk-checkboxes__input")
+          .reject { |cb| cb["id"].match(/not_applicable/) }
+          .each { |checkbox| checkbox.click }
+      end
 
-      scenario "they see the date on the page but cannot add a new one" do
-        visit project_tasks_path(project)
-        click_on "Receive declaration of expenditure certificate"
-        expect(page).to have_content("DfE received the declaration of expenditure certificate on 1 January 2024.")
-        expect(page).to_not have_content("Enter the date you received the declaration of expenditure certificate")
+      context "when the task does not have a date" do
+        scenario "they can add a date" do
+          fill_in "Day", with: "1"
+          fill_in "Month", with: "1"
+          fill_in "Year", with: "2024"
+          click_on I18n.t("task_list.continue_button.text")
+
+          expect(project.reload.tasks_data.receive_grant_payment_certificate_date_received).to eq Date.new(2024, 1, 1)
+        end
+      end
+
+      context "when the task has a date" do
+        let(:tasks_data) { create(:conversion_tasks_data, receive_grant_payment_certificate_date_received: Date.new(2024, 1, 1)) }
+        let(:project) { create(:conversion_project, assigned_to: user, tasks_data: tasks_data) }
+
+        scenario "they see the date on the page but cannot add a new one" do
+          visit project_tasks_path(project)
+          click_on "Receive declaration of expenditure certificate"
+          expect(page).to have_content("DfE received the declaration of expenditure certificate on 1 January 2024.")
+          expect(page).to_not have_content("Enter the date you received the declaration of expenditure certificate")
+        end
       end
     end
   end

--- a/spec/forms/conversion/tasks/receive_grant_payment_certificate_task_form_spec.rb
+++ b/spec/forms/conversion/tasks/receive_grant_payment_certificate_task_form_spec.rb
@@ -229,4 +229,55 @@ RSpec.describe Conversion::Task::ReceiveGrantPaymentCertificateTaskForm do
       end
     end
   end
+
+  describe "#status" do
+    context "when 'n/a' is selected" do
+      before do
+        form.assign_attributes({
+          not_applicable: true
+        }.with_indifferent_access)
+      end
+
+      it "is 'not_applicable'" do
+        expect(form.status).to eq(:not_applicable)
+      end
+    end
+
+    context "when 'n/a' is NOT selected" do
+      context "and all the other values are supplied" do
+        before do
+          form.assign_attributes(
+            {
+              "date_received(3i)": "27",
+              "date_received(2i)": "10",
+              "date_received(1i)": "2024",
+              check_certificate: "1",
+              save_certificate: "1"
+            }.with_indifferent_access
+          )
+        end
+
+        it "is 'completed'" do
+          expect(form.status).to eq(:completed)
+        end
+      end
+
+      context "and all the other values are NOT yet supplied" do
+        before do
+          form.assign_attributes(
+            {
+              "date_received(3i)": "27",
+              "date_received(2i)": "10",
+              "date_received(1i)": "2024",
+              check_certificate: "1"
+            }.with_indifferent_access
+          )
+        end
+
+        it "is 'in_progress" do
+          expect(form.status).to eq(:in_progress)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/conversion/project_spec.rb
+++ b/spec/models/conversion/project_spec.rb
@@ -201,8 +201,10 @@ RSpec.describe Conversion::Project do
 
       allow(project).to receive(:confirmed_date_and_in_the_past?).and_return(true)
       allow(project).to receive(:all_conditions_met?).and_return(true)
-      allow(project).to receive(:grant_payment_certificate_received?).and_return(true)
       allow(project).to receive(:date_academy_opened_present?).and_return(true)
+
+      # confirming receipt of the grant payment certification is no longer required
+      allow(project).to receive(:grant_payment_certificate_received?).and_return(false)
     end
 
     it "returns true when all the mandatory conditions are completed" do
@@ -221,10 +223,10 @@ RSpec.describe Conversion::Project do
       expect(project.completable?).to eq false
     end
 
-    it "returns false the grant payment certificate task is incomplete" do
+    it "returns true if the grant payment certificate task is unconfirmed (no longer mandatory)" do
       allow(project).to receive(:grant_payment_certificate_received?).and_return(false)
 
-      expect(project.completable?).to eq false
+      expect(project.completable?).to eq true
     end
 
     it "returns false the date the academy opened task is incomplete" do


### PR DESCRIPTION
### Background

In December 2024 "voluntary conversion grants" were discontinued.

Note that "sponsored conversion grants" still exist.

### Changes in this PR
In this PR we make the following changes related to the "conversion grant":

- the "Share information about opening" (`share_info`) task no longer refers to the "grant certificate" as "voluntary conversion grants" have been discontinued (See ticket [199562](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/199562)) 

- the "Receive declaration of expenditure certificate" (`receive_grant_payment_certificate`) task now:

	- has a new "Not applicable" option
	  
	- will show the "Not applicable" status in the task list, if that option has been selected
	  
- "completing" the project: it is now possible to "complete" the project without having confirmed in the "Receive declaration of expenditure certificate" (`receive_grant_payment_certificate`) task that the grant certificate has been received

See ticket [199543](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/199543) for these other changes.

### New "not applicable" option on "Receive declaration of expenditure certificate"
![199543_new_na_option_on_receive_grant_payment_certificate](https://github.com/user-attachments/assets/e6a28340-908f-44ec-a1ba-7145d16c7013)

---

### New "Not applicable" status for task in task list
![199543_new_na_status_in_tasklist_for_receive_grant_payment_certificate](https://github.com/user-attachments/assets/ca045d4a-c943-4c5d-926b-fe1a968d3ffa)

---

### Project can be "completed" without confirming receipt of grant confirmation
![199543_list_of_required_tasks_no_longer_includes_receive_grant_payment_cert](https://github.com/user-attachments/assets/7ffa2c25-6b6a-4edd-b9c2-fa0e1f4c31dc)

### 

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
