### PR TITLE
Fix: Pin forked AppInsights gem to tag rather than branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "uk_postcode", "~> 2.1.0"
 # application insights
 gem "application_insights",
   git: "https://github.com/dxw/ApplicationInsights-Ruby",
-  branch: "fix/correct-pattern-match-for-exception-handling"
+  tag: "fix-exception-handling"
 gem "exception_notification" # manually notify in Slack (Operation Id missing in AppInsights)
 gem "slack-notifier"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/dxw/ApplicationInsights-Ruby
-  revision: 51cb59a34e3e36ff406f9ec3c8332fb2a2ff89c5
-  branch: fix/correct-pattern-match-for-exception-handling
+  revision: 8131f8e66092ede1adc84db6cd2231c14163c0b4
+  tag: fix-exception-handling
   specs:
     application_insights (0.5.7)
 
@@ -291,6 +291,7 @@ GEM
     net-protocol (0.2.2)
       timeout
     net-smtp (0.5.0)
+      net-protocol
     nio4r (2.7.4)
     nokogiri (1.18.2-aarch64-linux-gnu)
       racc (~> 1.4)


### PR DESCRIPTION
We got caught out after rewording the fix commit on `fix/correct-pattern-match-for-exception-handling` not appreciating that pinning the gem to the branch was actually tieing it to SHA `51cb59a34e3e36ff406f9ec3c8332fb2a2ff89c5` which was of course replaced when rewording the commit.

We now use a tag to pin the forked gem: this is more obviously a pointer to a particular SHA.

