### PR TITLE
200841: Find inactive project to handover by urn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Find a project to be handed over by URN, if there are too many to show on a
+  single page.
+
 ## [Release-108][release-108]
 
 ### Changed

--- a/app/controllers/all/handover/projects_controller.rb
+++ b/app/controllers/all/handover/projects_controller.rb
@@ -5,6 +5,21 @@ class All::Handover::ProjectsController < ApplicationController
     authorize Project, :handover?
 
     @pager, @projects = pagy(Project.inactive.ordered_by_significant_date)
+    @enable_search = @pager.pages > 1
     AcademiesApiPreFetcherService.new.call!(@projects)
+  end
+
+  def search
+    authorize Project, :handover?
+
+    @search_result = Project.inactive.find_by(urn: params[:urn_query])
+
+    if @search_result.blank?
+      @failed_search_urn = params[:urn_query]
+      flash[:error] = "No project to be handed over with URN #{params[:urn_query]} was found"
+      redirect_to action: :index
+    else
+      render :index
+    end
   end
 end

--- a/app/views/all/handover/projects/_search_for_inactive_project.html.erb
+++ b/app/views/all/handover/projects/_search_for_inactive_project.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-inset-text">
+  <div class="dfe-body__search">
+    <div>
+      <%= form_with(method: :get, url: search_all_handover_projects_path) do |form| %>
+        <%= form.govuk_text_field(:urn_query, label: {text: t("search_for_inactive_projects.label")}, inputmode: "numeric", placeholder: t("search_for_inactive_projects.placeholder"), width: 10, autocomplete: "off") %>
+        <button class="govuk-button" type="submit">
+          <%= t("search.search") %>
+        </button>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/all/handover/projects/_search_result.html.erb
+++ b/app/views/all/handover/projects/_search_result.html.erb
@@ -1,0 +1,31 @@
+<h1 class="govuk-heading-m govuk-!-margin-top-5 govuk-!-margin-bottom-5">
+  A project to be handed over with URN
+  <%= @search_result.urn %>
+  was found
+</h1>
+<table class="govuk-table" name="projects_table" aria-label="Projects table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_name") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.school_urn") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.incoming_trust") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.provisional_conversion_or_transfer_date") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.advisory_board_date") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.summary.type.title") %></th>
+      <th class="govuk-table__header" scope="col"><%= t("project.table.headers.add_handover_details") %></th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__header govuk-table__cell"><%= project.establishment.name %></td>
+      <td class="govuk-table__cell"><%= project.urn %></td>
+      <td class="govuk-table__cell"><%= project.incoming_trust.name %></td>
+      <td class="govuk-table__cell"><%= project.significant_date.to_formatted_s(:significant_date) %></td>
+      <td class="govuk-table__cell"><%= project.advisory_board_date.to_fs(:govuk) %></td>
+      <td class="govuk-table__cell"><%= t("project.table.body.type_name.#{project.type_locale}") %></td>
+      <td class="govuk-table__cell">
+        <%= link_to t("project.table.body.add_handover_details"), check_all_handover_projects_path(project) %>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/all/handover/projects/index.html.erb
+++ b/app/views/all/handover/projects/index.html.erb
@@ -1,22 +1,22 @@
 <% content_for :primary_navigation do %>
   <%= render partial: "shared/navigation/all_projects_primary_navigation" %>
 <% end %>
-
 <% content_for :page_title do %>
   <%= page_title(t("project.all.handover.title")) %>
 <% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">
       <%= t("project.all.handover.title") %>
     </h1>
+    <%= render partial: "search_for_inactive_project" if @enable_search %>
     <%= t("project.all.handover.body_html") %>
   </div>
 </div>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render partial: "handover_table", locals: {projects: @projects, pager: @pager} %>
+    <%= render partial: "search_result", locals: {project: @search_result} if @search_result %>
+    <%= render partial: "failed_search", locals: {urn: @failed_search_urn} if @failed_search_urn %>
+    <%= render partial: "handover_table", locals: {projects: @projects, pager: @pager} if @projects %>
   </div>
 </div>

--- a/config/locales/search.en.yml
+++ b/config/locales/search.en.yml
@@ -20,3 +20,7 @@ en:
         <li>searching for something less specific</li>
         </ul>
     enter_search_term: Please enter a search term
+
+  search_for_inactive_projects:
+    label: "Search for project to be handed over:"
+    placeholder: Search by URN

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,6 +154,7 @@ Rails.application.routes.draw do
       namespace :all do
         namespace :handover do
           get "/", to: "projects#index"
+          get "/search", to: "projects#search", as: :search
           get "/:project_id/check", to: "handovers#check", as: :check
           get "/:project_id/new", to: "handovers#new", as: :new
           post "/:project_id/new", to: "handovers#create"

--- a/spec/features/all_projects/handover/user_can_view_a_list_of_projects_spec.rb
+++ b/spec/features/all_projects/handover/user_can_view_a_list_of_projects_spec.rb
@@ -26,4 +26,82 @@ RSpec.feature "Users can view a list of handover projects" do
       expect(page).to have_content(conversion_project.urn)
     end
   end
+
+  context "finding a particular inactive project" do
+    let(:max_projects_per_page) { Pagy::DEFAULT.fetch(:items) }
+
+    before do
+      max_projects_per_page.times { create(:conversion_project, state: :inactive) }
+    end
+
+    context "when all the _inactive_ projects can be shown on a single page" do
+      before do
+        visit root_path
+        click_link "All projects"
+        click_link "Handover"
+      end
+
+      scenario "there's no need to search for a particular _inactive_ project" do
+        expect(page).to_not have_content("Search for project to be handed over")
+      end
+    end
+
+    context "when NOT all the _inactive_ projects can be shown on a single page" do
+      let!(:target_project) { create(:conversion_project, state: :inactive, urn: 919191) }
+
+      let!(:active_project) { create(:conversion_project, state: :active, urn: 666333) }
+
+      before do
+        visit root_path
+        click_link "All projects"
+        click_link "Handover"
+      end
+
+      scenario "it's possible to search for a particular _inactive_ project" do
+        then_i_have_a_way_to_find_a_particular_inactive_project
+
+        when_i_search_for_a_particular_project_which_exists
+        then_i_find_that_particular_project
+        and_use_the_link_to_add_handover_details
+
+        when_i_search_for_a_particular_project_which_does_not_exist
+        then_i_see_a_helpful_message_and_can_search_again
+      end
+    end
+
+    def then_i_have_a_way_to_find_a_particular_inactive_project
+      expect(page).to have_field("Search for project to be handed over")
+    end
+
+    def when_i_search_for_a_particular_project_which_exists
+      within ".dfe-body__search" do
+        fill_in("Search by URN", with: target_project.urn)
+        click_button("Search")
+      end
+    end
+
+    def then_i_find_that_particular_project
+      expect(page).to have_content("A project to be handed over with URN #{target_project.urn} was found")
+      expect(page).to have_content(target_project.establishment.name)
+      expect(page).to_not have_content("Search for project to be handed over")
+    end
+
+    def and_use_the_link_to_add_handover_details
+      expect(page).to have_link("Add handover details", href: check_all_handover_projects_path(target_project))
+    end
+
+    def when_i_search_for_a_particular_project_which_does_not_exist
+      click_link "Handover"
+      within ".dfe-body__search" do
+        expect(page).to have_content("Search for project to be handed over")
+        fill_in("Search by URN", with: active_project.urn)
+        click_button("Search")
+      end
+    end
+
+    def then_i_see_a_helpful_message_and_can_search_again
+      expect(page).to have_content("No project to be handed over with URN #{active_project.urn} was found")
+      expect(page).to have_content("Search for project to be handed over")
+    end
+  end
 end

--- a/spec/requests/all/handover/projects_controller_spec.rb
+++ b/spec/requests/all/handover/projects_controller_spec.rb
@@ -7,6 +7,20 @@ RSpec.describe All::Handover::ProjectsController, type: :request do
     mock_all_academies_api_responses
   end
 
+  describe "#search" do
+    let(:active_record_relation) { double("active record relation", find_by: nil) }
+
+    before do
+      allow(Project).to receive(:inactive).and_return(active_record_relation)
+    end
+
+    it "attempts to find an inactive project for the given URN" do
+      get "/projects/all/handover/search", params: {urn_query: "123456"}
+
+      expect(Project.inactive).to have_received(:find_by).with(urn: "123456")
+    end
+  end
+
   describe "#index" do
     context "when there are no projects to hand over" do
       it "shows a helpful message" do

--- a/vendor/assets/stylesheets/dfefrontend.css
+++ b/vendor/assets/stylesheets/dfefrontend.css
@@ -1770,6 +1770,10 @@ p,
   }
 }
 
+.dfe-body__search label {
+  padding-bottom: 1em;
+}
+
 @media (max-width: 40.0525em) {
   .dfe-search__close {
     background-color: transparent;


### PR DESCRIPTION
## Show 'find inactive project' when there are many projects to handover

See ticket [200841](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/200841)

At certain times (e.g. now, start of March) there are a lot of projects to hand over, more than can be listed on a single index page.
    
If there is more than one page of projects to handover we now offer a  "Search for inactive project by URN" feature.
    
If a matching inactive project is found we provide a link to that project's "check handover details" page. If no matching inactive project exists we return the user to list of projects to be handed over.
    
### User story
   
- So that I can review a particular project which is to be handed over
- As a Regional Case Officer team leader at a time when there are over 20 projects in the "to be handed over" (inactive) state
- I want to locate this "to handover" (inactive) project without paging through multiple records

### Search facility displayed where quantity of projects requires pagination

![multiple_pages_search_offered](https://github.com/user-attachments/assets/ba8bcc05-4f52-4ff8-af2a-5b0568603f95)

---

### Project is found by URN

![found_inactive_project](https://github.com/user-attachments/assets/5e0c3acf-8713-4a06-8474-acd78501e8e2)

---

### Project is NOT found by URN

![not_found-redirect_to_list](https://github.com/user-attachments/assets/fda1a84d-134b-4cae-ba38-a4f3366b9b4f)

---

### Search facility NOT shown where quantity of projects does NOT require pagination

![single_page_no_search_needed](https://github.com/user-attachments/assets/b46b4059-28de-4c03-b17f-5334d65498da)


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
