### PR TITLE
204455: FIX - Link 'By month' to current month's conversions to show active state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Handle validation error when attempting to hand over a project missing its
   incoming trust UKPRN
+- "By month" view now makes clear its default to "Conversions.
 
 ## [Release-109][release-109]
 

--- a/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
@@ -1,45 +1,27 @@
 <div class="moj-primary-navigation">
-
   <div class="moj-primary-navigation__container">
-
     <div class="moj-primary-navigation__nav">
-
       <nav class="moj-primary-navigation" aria-label="Primary navigation">
-
         <ul class="moj-primary-navigation__list">
-
           <% if policy(:project).handover? %>
             <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.handover"), path: all_handover_projects_path, namespace: "/projects/all/handover"} %>
           <% end %>
-
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.in_progress"), path: all_all_in_progress_projects_path, namespace: "/projects/all/in-progress"} %>
-
           <% if policy(:export).index? %>
             <% month = Date.today.month; year = Date.today.year %>
             <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_month"), path: date_range_all_by_month_conversions_projects_path(from_month: month, from_year: year, to_month: month, to_year: year), namespace: "/projects/all/by-month"} %>
           <% else %>
             <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_month"), path: next_month_all_by_month_conversions_projects_path, namespace: "/projects/all/by-month"} %>
           <% end %>
-
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_region"), path: all_regions_projects_path, namespace: "/projects/all/regions"} %>
-
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_user"), path: all_users_projects_path, namespace: "/projects/all/users"} %>
-
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_trust"), path: all_trusts_projects_path, namespace: "/projects/all/trusts"} %>
-
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_local_authority"), path: all_local_authorities_projects_path, namespace: "/projects/all/local-authorities"} %>
-
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.completed"), path: all_completed_projects_path, namespace: "/projects/all/completed"} %>
-
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.statistics"), path: all_statistics_projects_path, namespace: "/projects/all/statistics"} %>
-
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.exports"), path: all_export_projects_path, namespace: "/projects/all/export"} if policy(:export).index? %>
-
         </ul>
-
       </nav>
-
     </div>
   </div>
-
 </div>

--- a/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
+++ b/app/views/shared/navigation/_all_projects_primary_navigation.html.erb
@@ -15,7 +15,8 @@
           <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.in_progress"), path: all_all_in_progress_projects_path, namespace: "/projects/all/in-progress"} %>
 
           <% if policy(:export).index? %>
-            <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_month"), path: date_range_this_month_all_by_month_conversions_projects_path, namespace: "/projects/all/by-month"} %>
+            <% month = Date.today.month; year = Date.today.year %>
+            <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_month"), path: date_range_all_by_month_conversions_projects_path(from_month: month, from_year: year, to_month: month, to_year: year), namespace: "/projects/all/by-month"} %>
           <% else %>
             <%= render partial: "shared/navigation/primary_navigation_item", locals: {name: t("navigation.primary.all_projects.by_month"), path: next_month_all_by_month_conversions_projects_path, namespace: "/projects/all/by-month"} %>
           <% end %>

--- a/spec/features/all_projects/by_month/users_can_view_projects_by_month_spec.rb
+++ b/spec/features/all_projects/by_month/users_can_view_projects_by_month_spec.rb
@@ -10,6 +10,14 @@ RSpec.feature "Users can view projects by month" do
       expect(page).to have_content("Date range")
     end
 
+    scenario "the 'Conversions' tab is selected by default" do
+      sign_in_with_user(user)
+      click_on "By month"
+      within("nav[aria-label='Project index sub-navigation']") do
+        expect(page).to have_css("a[aria-current='page']", text: "Conversions")
+      end
+    end
+
     scenario "the user can download a CSV of conversion projects" do
       sign_in_with_user(user)
       click_on "By month"


### PR DESCRIPTION
See [ticket 204455](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/204455)

Previously the "By month" link in the main navigation was linking to:

`projects/all/by-month/conversions/from/to` 
(`date_range_this_month_all_by_month_conversions_projects_path`)

which was showing a list of conversions for the current month. But because the url was not matching the more literal "Conversions" link in the sub-nav:

`/projects/all/by-month/conversions/from/3/2025/to/3/2025` 
(`date_range_all_by_month_conversions_projects_path`)

the current "Conversions" tab was not being styled as active. In this commit we change the main nav's "By month" link to use the more explicit link style for the current month's conversions. In this way we now see that the default tab is "Conversions".

## Before

<img width="429" alt="before_ by_month" src="https://github.com/user-attachments/assets/52b367e1-45cc-4e48-855e-acb1729fa5ad" />

## After

<img width="669" alt="after_by_month" src="https://github.com/user-attachments/assets/5f512bbb-e963-4a11-beaf-b0e847cf0340" />

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
