### PR TITLE
Show a error msg if project to hand over is missing UKPRN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## Fixed
+
+- Handle validation error when attempting to hand over a project missing its
+  incoming trust UKPRN
+
 ## [Release-109][release-109]
 
 ### Changed

--- a/app/controllers/all/handover/handovers_controller.rb
+++ b/app/controllers/all/handover/handovers_controller.rb
@@ -27,6 +27,8 @@ class All::Handover::HandoversController < ApplicationController
   def create
     authorize Project, :handover?
 
+    return redirect_to_project if @project.incoming_trust_ukprn.blank?
+
     if @form.valid?
       case @form.assigned_to_regional_caseworker_team
       when true
@@ -39,6 +41,14 @@ class All::Handover::HandoversController < ApplicationController
     else
       render new_template_path
     end
+  end
+
+  private def redirect_to_project
+    flash[:error] = "This project is missing its incoming trust UKPRN so can not be handed over. " \
+      "Service support must delete this project and add the UKPRN in Prepare. " \
+      "The project can then be reimported to Complete."
+
+    redirect_to project_path(@project)
   end
 
   private def new_template_path


### PR DESCRIPTION
See Ticket [202355](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/202355) 

We regularly see the scenario in support where: 

- a project has been imported from Prepare into Complete without an  "incoming trust UKPRN" to identify the trust which will be managing the new academy. 
- the user attempts to "hand over" the project (move it from the "inactive" or "to be handed over" state)
- the user sees a generic error message

Behind the scenes a validation error has occurred when the `NewHandoverForm` attempts to assign the project and set its state to "active":

```
ActiveRecord::RecordInvalid:
  Validation failed: 
  Incoming trust ukprn UKPRN must be 8 digits long and start with a 1. 
  For example, 12345678.
``` 

In this PR we anticipate this scenario and show the user a message explaining that the project must:

- be deleted in Complete
- corrected in Prepare
- resubmitted to Complete



![cant_handover_missing_ukprn](https://github.com/user-attachments/assets/0ed1efd9-1173-4834-976a-4b1089e3a806)



## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
