### PR TITLE
Switches to composite actions instead of workflows for build and push image

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   set-env:
     name: Determine environment
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       environment: ${{ steps.var.outputs.environment }}
       branch: ${{ steps.var.outputs.branch }}
@@ -45,41 +45,44 @@ jobs:
           echo "date=${TIME}" >> $GITHUB_OUTPUT
           echo "image-name=${{ env.IMAGE_NAME }}" >> $GITHUB_OUTPUT
 
-  build:
-    name: Build
+  build-import:
+    name: Build & Import
+    runs-on: ubuntu-24.04
     needs: [ set-env ]
+    environment: ${{ needs.set-env.outputs.environment }}
     permissions:
       packages: write
-    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build.yml@v4.1.0
-    with:
-      environment: ${{ needs.set-env.outputs.environment }}
-      docker-image-name: ${{ needs.set-env.outputs.image-name }}
-      docker-build-args: |
-        RAILS_ENV=development
-        CURRENT_GIT_SHA="${{ needs.set-env.outputs.checked-out-sha }}"
-        TIME_OF_BUILD="${{ needs.set-env.outputs.date }}"
-
-  import:
-    name: Import
-    needs: [ set-env, build ]
-    permissions:
       id-token: write
-    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/import.yml@v4.1.0
-    with:
-      environment: ${{ needs.set-env.outputs.environment }}
-      docker-image-name: ${{ needs.set-env.outputs.image-name }}
-    secrets:
-      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      azure-acr-client-id: ${{ secrets.ACR_CLIENT_ID }}
-      azure-acr-name: ${{ secrets.ACR_NAME }}
+
+    steps:  
+      - uses: DFE-Digital/deploy-azure-container-apps-action/.github/actions/build@v5.0.0
+        with:
+          image-name: ${{ needs.set-env.outputs.image-name }}
+          build-args: |
+            RAILS_ENV=development
+            CURRENT_GIT_SHA="${{ needs.set-env.outputs.checked-out-sha }}"
+            TIME_OF_BUILD="${{ needs.set-env.outputs.date }}"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: DFE-Digital/deploy-azure-container-apps-action/.github/actions/import@v5.0.0
+        with: 
+          image-name: ${{ needs.set-env.outputs.image-name }}
+          azure-acr-name: ${{ secrets.ACR_NAME }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-acr-client-id: ${{ secrets.ACR_CLIENT_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID || '' }}
+          AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION_ID || '' }}
+          AZURE_ACR_CLIENT_ID: ${{ secrets.ACR_CLIENT_ID || '' }}
 
   deploy:
     name: Deploy
-    needs: [ set-env, import ]
+    runs-on: ubuntu-24.04
+    needs: [ set-env, build-import ]
+    environment: ${{ needs.set-env.outputs.environment }}
     permissions:
       id-token: write
-    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/deploy.yml@v4.1.0
     strategy:
       matrix:
         container_app: [
@@ -93,14 +96,18 @@ jobs:
           - container_app: "worker"
             aca_name: "ACA_CONTAINERAPP_WORKER_NAME"
             aca_client_id: "ACA_WORKER_CLIENT_ID"
-    with:
-      environment: ${{ needs.set-env.outputs.environment }}
-      docker-image-name: ${{ needs.set-env.outputs.image-name }}
-      annotate-release: ${{ matrix.container_app == 'web' }}
-    secrets:
-      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      azure-acr-name: ${{ secrets.ACR_NAME }}
-      azure-aca-client-id: ${{ secrets[matrix.aca_client_id] }}
-      azure-aca-name: ${{ secrets[matrix.aca_name] }}
-      azure-aca-resource-group: ${{ secrets.ACA_RESOURCE_GROUP }}
+    steps:
+      - uses: DFE-Digital/deploy-azure-container-apps-action/.github/actions/deploy@v5.0.0
+        with:
+          image-name: ${{ needs.set-env.outputs.image-name }}
+        #  annotate-release: ${{ matrix.container_app == 'web' }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-acr-name: ${{ secrets.ACR_NAME }}
+          azure-aca-client-id: ${{ secrets[matrix.aca_client_id] }}
+          azure-aca-name: ${{ secrets[matrix.aca_name] }}
+          azure-aca-resource-group: ${{ secrets.ACA_RESOURCE_GROUP }}
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID || '' }}
+          AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION_ID || '' }}
+          AZURE_ACA_CLIENT_ID: ${{ secrets.ACA_CLIENT_ID || '' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Find a project to be handed over by URN, if there are too many to show on a
   single page.
+- The build and push image configuration now uses composite actions instead of
+  workflows.
 
 ## [Release-108][release-108]
 


### PR DESCRIPTION
Alters the build and push image yml config to use composite actions instead of workflows. 

This is a requirement of upgrading to deploy-azure-container-apps-action to v5, which otherwise constitutes a breaking change. 

This upgrade was introduced by the renovate [PR 2097 'DFE-Digital/deploy-azure-container-apps-action action to v5'](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/2097).

## Changes

This commit includes the v5 upgrade, and reconfigures the build, import and deploy steps to use github actions instead of workflows.

**Please note:** the annotate-release value in the deploy job is commented out. We are currently experiencing problems with this annotation step - the expected behaviour is that it run only in the 'web' container app of the deploy matrix, however it is also running in 'worker', and that is failing. 

As this does neither interfere with the deployment, nor with any downstream consumers of that annotation (there are none) we are going to separately debug this once the composite actions changes are merged.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
