### PR TITLE
Fixes post deploy annotation error

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -55,7 +55,7 @@ jobs:
       id-token: write
 
     steps:  
-      - uses: DFE-Digital/deploy-azure-container-apps-action/.github/actions/build@v5.0.0
+      - uses: DFE-Digital/deploy-azure-container-apps-action/.github/actions/build@v5.1.0
         with:
           image-name: ${{ needs.set-env.outputs.image-name }}
           build-args: |
@@ -63,7 +63,7 @@ jobs:
             CURRENT_GIT_SHA="${{ needs.set-env.outputs.checked-out-sha }}"
             TIME_OF_BUILD="${{ needs.set-env.outputs.date }}"
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: DFE-Digital/deploy-azure-container-apps-action/.github/actions/import@v5.0.0
+      - uses: DFE-Digital/deploy-azure-container-apps-action/.github/actions/import@v5.1.0
         with: 
           image-name: ${{ needs.set-env.outputs.image-name }}
           azure-acr-name: ${{ secrets.ACR_NAME }}
@@ -97,10 +97,13 @@ jobs:
             aca_name: "ACA_CONTAINERAPP_WORKER_NAME"
             aca_client_id: "ACA_WORKER_CLIENT_ID"
     steps:
-      - uses: DFE-Digital/deploy-azure-container-apps-action/.github/actions/deploy@v5.0.0
+      - id: annotate
+        run: echo "ANNOTATE_RELEASE=${{ matrix.container_app == 'web' && 'yes' || 'no' }}" >> $GITHUB_ENV
+
+      - uses: DFE-Digital/deploy-azure-container-apps-action/.github/actions/deploy@v5.1.0
         with:
           image-name: ${{ needs.set-env.outputs.image-name }}
-        #  annotate-release: ${{ matrix.container_app == 'web' }}
+          annotate-release: ${{ env.ANNOTATE_RELEASE }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           azure-acr-name: ${{ secrets.ACR_NAME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Handle validation error when attempting to hand over a project missing its
   incoming trust UKPRN
 - "By month" view now makes clear its default to "Conversions.
+- Annotate release error for 'worker' no longer runs
 
 ## Changed
 


### PR DESCRIPTION
When we [switched from using workflows to composite actions](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/2112) to build image, a post deploy step `'annotate-release'` broke. The step is intended to only run for the 'web' app and not the 'worker', but was attempting to run for both.

We chose to merge those changes, as this error was not interfering with deployment, nor were any downstream consumers relying on the annotation step to run successfully. 

## Changes

Investigation revealed that the `'annotate-release'` step was running unexpectedly for 'worker' as a boolean was being set to trigger (or not) the process. This is an unsupported data type, and deploy-azure-container-apps-action was not able to evaluate the 'false' condition correctly. 

We now use v5.1 of DFE-Digital/deploy-azure-container-apps-action/ and set a string (`'yes'` or `'no'`) env variable to trigger the annotation only under the 'web' condition.

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
