### PR TITLE
205969: Send 'new project to assign email' on handover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Allow handover of (Form a MAT) projects with a TRN instead of incoming trust
   UKPRN.
+- Ensure that we don't send the "New project to assign" email on update if the
+  project is already assigned to a caseworker.
+- Send the "New project to assign" email when a project created by Prepare is
+  handed over.
 
 ## [Release-110][release-110]
 

--- a/app/controllers/all/handover/handovers_controller.rb
+++ b/app/controllers/all/handover/handovers_controller.rb
@@ -33,6 +33,7 @@ class All::Handover::HandoversController < ApplicationController
       case @form.assigned_to_regional_caseworker_team
       when true
         @form.save
+        notify_team_leaders(@project)
         render "all/handover/projects/assigned_regional_casework_services"
       when false
         @form.save
@@ -75,5 +76,11 @@ class All::Handover::HandoversController < ApplicationController
       :outgoing_trust_sharepoint_link,
       :two_requires_improvement
     )
+  end
+
+  private def notify_team_leaders(project)
+    User.team_leaders.each do |team_leader|
+      TeamLeaderMailer.new_conversion_project_created(team_leader, project).deliver_later if team_leader.active
+    end
   end
 end

--- a/app/forms/conversion/edit_project_form.rb
+++ b/app/forms/conversion/edit_project_form.rb
@@ -50,9 +50,13 @@ class Conversion::EditProjectForm < EditProjectForm
 
       project.save
       update_handover_note if handover_note_body.present?
-      notify_team_leaders(project) if assigned_to_regional_caseworker_team
+      notify_team_leaders(project) if assigned_to_regional_caseworker_team && unassigned?
     end
 
     project
+  end
+
+  private def unassigned?
+    project.assigned_to.blank?
   end
 end

--- a/app/forms/transfer/edit_project_form.rb
+++ b/app/forms/transfer/edit_project_form.rb
@@ -75,9 +75,13 @@ class Transfer::EditProjectForm < EditProjectForm
       project.save!
       project.tasks_data.save!
       update_handover_note if handover_note_body.present?
-      notify_team_leaders(project) if assigned_to_regional_caseworker_team
+      notify_team_leaders(project) if assigned_to_regional_caseworker_team && unassigned?
     end
 
     project
+  end
+
+  private def unassigned?
+    project.assigned_to.blank?
   end
 end

--- a/spec/forms/transfer/edit_project_form_spec.rb
+++ b/spec/forms/transfer/edit_project_form_spec.rb
@@ -281,24 +281,50 @@ RSpec.describe Transfer::EditProjectForm, type: :model do
     end
 
     describe "hand over to RCS team" do
-      it "emails the RCS team leaders if the field is updated" do
-        team_leader = create(:user, :team_leader)
-
-        updated_params = {assigned_to_regional_caseworker_team: "true", handover_note_body: "Some notes"}
-
-        subject.update(updated_params)
-
-        expect(ActionMailer::MailDeliveryJob)
-          .to(have_been_enqueued.on_queue("default")
-                                .with("TeamLeaderMailer", "new_conversion_project_created", "deliver_now", args: [team_leader, project]))
-      end
-
       it "does not unassign the project's assigned user" do
         updated_params = {assigned_to_regional_caseworker_team: "true"}
 
         subject.update(updated_params)
 
         expect(project.reload.assigned_to).to eq(user)
+      end
+
+      describe "sending 'new project to assign' email" do
+        context "when assigned to RCS team but NOT assigned to a caseworker" do
+          before do
+            allow(project).to receive(:assigned_to).and_return(nil)
+          end
+
+          it "emails the RCS team leaders" do
+            team_leader = create(:user, :team_leader)
+
+            updated_params = {assigned_to_regional_caseworker_team: "true", handover_note_body: "Some notes"}
+
+            subject.update(updated_params)
+
+            expect(ActionMailer::MailDeliveryJob)
+              .to(have_been_enqueued.on_queue("default")
+                                    .with("TeamLeaderMailer", "new_conversion_project_created", "deliver_now", args: [team_leader, project]))
+          end
+        end
+      end
+
+      context "when assigned to RCS and already assigned to a caseworker" do
+        before do
+          allow(project).to receive(:assigned_to).and_return(build(:user))
+        end
+
+        it "does not send the 'new project to assign email'" do
+          team_leader = create(:user, :team_leader)
+
+          updated_params = {assigned_to_regional_caseworker_team: "true", handover_note_body: "Some notes"}
+
+          subject.update(updated_params)
+
+          expect(ActionMailer::MailDeliveryJob)
+            .not_to(have_been_enqueued.on_queue("default")
+                                  .with("TeamLeaderMailer", "new_conversion_project_created", "deliver_now", args: [team_leader, project]))
+        end
       end
     end
   end


### PR DESCRIPTION
## Notify RCS leads of 'new project to assign' on handover
    
See [ticket 205969](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/205969)

### Defective behavioiur

Two classes of defective behaviour were identified:

1. Projects handed over from Prepare go un-notified
2. Notifications sent when project already assigned

### Changes in this PR

When a project is created in Complete by Prepare through the API it
first goes into the "inactive" state. After it's:
    
 - been checked
- had any missing details added
- been successfully "handed over" (which includes having a valid UKPRN for the incoming trust)
    
it's state is changed to "active". 

If it's assigned to the RCS team, at this point we now send the "new project to
assign" email notification to all RCS team leaders.

We also change the two `EditProjectForm` classes to verify when updating a project via the UI that the conversion / transfer has not already been assigned to a caseworker before sending the email notification. 

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
