### PR TITLE
206152: Allow 'Form a MAT' handover with TRN instead of incoming UKPRN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## Fixed
+
+- Allow handover of (Form a MAT) projects with a TRN instead of incoming trust
+  UKPRN.
+
 ## [Release-110][release-110]
 
 ## Fixed

--- a/app/controllers/all/handover/handovers_controller.rb
+++ b/app/controllers/all/handover/handovers_controller.rb
@@ -27,7 +27,7 @@ class All::Handover::HandoversController < ApplicationController
   def create
     authorize Project, :handover?
 
-    return redirect_to_project if @project.incoming_trust_ukprn.blank?
+    return redirect_to_project if incoming_trust_ukprn_required?
 
     if @form.valid?
       case @form.assigned_to_regional_caseworker_team
@@ -43,10 +43,12 @@ class All::Handover::HandoversController < ApplicationController
     end
   end
 
+  private def incoming_trust_ukprn_required?
+    @project.incoming_trust_ukprn.blank? && @project.new_trust_reference_number.blank?
+  end
+
   private def redirect_to_project
-    flash[:error] = "This project is missing its incoming trust UKPRN so can not be handed over. " \
-      "Service support must delete this project and add the UKPRN in Prepare. " \
-      "The project can then be reimported to Complete."
+    flash[:error] = t("project.handover.create.error.missing_required_ukprn_html")
 
     redirect_to project_path(@project)
   end

--- a/config/locales/handover.en.yml
+++ b/config/locales/handover.en.yml
@@ -33,6 +33,14 @@ en:
               "false": "AO (Academy order)"
       new:
         title: Add handover details
+      create:
+        error:
+          missing_required_ukprn_html:
+            <h3 class="govuk-notification-banner__heading">This project is missing its incoming trust UKPRN so can not be handed over.</h3>
+
+            <p>If the project is part of a Form a MAT project and no UKPRN exists you must add a Trust reference number (TRN) instead of the incoming trust UKPRN.</p>
+
+            <p>Service support must delete this project and fix up the project in Prepare. The project can then be reimported to Complete.</p>
   helpers:
     legend:
       new_handover_form:


### PR DESCRIPTION
See [ticket 206152](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/206152)

In [PR 2109][] we recently (Release 110 on March 12 2025) added a
guard to the handover controller to show the user an error message if
the project which they were trying to handover was missing its
`incoming_trust_ukprn`. Previously the user was seeing a generic error
page after a validation failure behind the scenes.

It turns out we were a bit too broad with our test, as in the case of 'Form a
MAT' projects it's acceptable for the project to have a
`new_trust_reference_number` (TRN) instead of a UKPRN for the
incoming trust. See [3e5cb1be5fe9ee876cbd1e817e113bbdbd9cfd3f][] from
Feb 2024.

In this commit we tweak:

- our handover controller guard to only bail out if **both**
`incoming_trust_ukprn` and `new_trust_reference_number` are blank, and

- the error message to explain that the TRN is an alternative incoming
trust identifier for 'Form a MAT' projects.

[PR 2109]:
https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/2109

[3e5cb1be5fe9ee876cbd1e817e113bbdbd9cfd3f]:
https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/commit/3e5cb1be5fe9ee876cbd1e817e113bbdbd9cfd3f


![error_if_ukprn_and_trn_both_missing](https://github.com/user-attachments/assets/cfefb40f-17ab-4da9-b5a5-2625b1c59e6e)



## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
