### PR TITLE
Release 111

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+## [Release-111][release-111]
+
 ## Fixed
 
 - Allow handover of (Form a MAT) projects with a TRN instead of incoming trust
@@ -2437,7 +2439,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   project's team leader
 
 [unreleased]:
-  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-110...HEAD
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-111...HEAD
+[release-111]:
+  https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-110...release-111
 [release-110]:
   https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/compare/release-109...release-110
 [release-109]:


### PR DESCRIPTION
## Release 111

### Fixed

- Allow handover of (Form a MAT) projects with a TRN instead of incoming trust UKPRN.
- Ensure that we don't send the "New project to assign" email on update if the project is already assigned to a caseworker.
- Send the "New project to assign" email when a project created by Prepare is handed over.
