### PR TITLE
205988: Fix link to transfer guidance on 'Request new urn and record' task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Link to accessible guidance on URN Transfers on Sharepoint from "Request new
+  URN and record" task
+
 ## [Release-111][release-111]
 
 ## Fixed

--- a/config/locales/transfer/tasks/request_new_urn_and_record.en.yml
+++ b/config/locales/transfer/tasks/request_new_urn_and_record.en.yml
@@ -7,7 +7,7 @@ en:
           html:
             <p>A transferring academy may need a new URN and record in Get Information About Schools. You may hear these academies described as "Fresh starts".</p>
             <p>This happens when an academy is transferring and is currently rated by Ofsted as inadequate, or has been given it at least 2 requires improvement ratings.</p>
-            <p>There is <a href="https://educationgovuk.sharepoint.com/:w:/r/sites/lvedfe00116/WorkplaceDocuments/ARDG%20Internal%20Guidance/6.%20Taking%20action%20with%20underperforming%20open%20academies%20and%20free%20schools/Academy%20transfer/Academy%20Transfer%20Project/Issuing_a_new_URN-policy_and%20guidance.docx?d=w60605f0926bc439d8c442258b6bc83c1&csf=1&web=1&e=WO1DHR" target="_blank">policy guidance for this process (opens in new tab)</a>.</p>
+            <p>There is <a href="https://educationgovuk.sharepoint.com/sites/lvewp00030/SitePages/2-Intervention/Academy%20Transfers/URN%20Academy%20transfer%20guidance%20-%20Policy%20approach%20and%20process%20.aspx" target="_blank">policy guidance for this process (opens in new tab)</a>.</p>
         not_applicable:
           title: Not applicable
         complete:


### PR DESCRIPTION
Previously our link to the "URN Transfer Guidance" on Sharepoint was to an inaccessible resource.


### Fixed link to accessible guidance

![fixed_guidance_link_on_request_new_urn_and_record](https://github.com/user-attachments/assets/07d5cb50-a9ac-4717-ab5f-d7c7998c2d34)

### Guidance on URN Transfer to which we now link successfully

<img width="785" alt="transfer_guidance_doc_on_sharepoint" src="https://github.com/user-attachments/assets/6f329bb2-0635-4dba-ae9b-e45f57dc1f57" />



## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
