### PR TITLE
Enforce presence of projects.region

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -27,6 +27,7 @@ class Project < ApplicationRecord
 
   validates :urn, presence: true
   validates :urn, urn: true
+  validates :region, presence: true
   validates :incoming_trust_ukprn, presence: true, unless: -> { new_trust_reference_number.present? }
   validates :incoming_trust_ukprn, ukprn: true, unless: -> { new_trust_reference_number.present? }
   validates :advisory_board_date, presence: true

--- a/db/migrate/20250327163619_make_projects_region_non_nullable.rb
+++ b/db/migrate/20250327163619_make_projects_region_non_nullable.rb
@@ -1,0 +1,6 @@
+class MakeProjectsRegionNonNullable < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :projects, :region, false
+    add_index :projects, :region
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_20_121430) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_27_163619) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -321,7 +321,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_20_121430) do
     t.date "significant_date"
     t.boolean "significant_date_provisional", default: true
     t.boolean "directive_academy_order", default: false
-    t.string "region"
+    t.string "region", null: false
     t.integer "academy_urn"
     t.uuid "tasks_data_id"
     t.string "tasks_data_type"
@@ -346,6 +346,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_20_121430) do
     t.index ["incoming_trust_ukprn"], name: "index_projects_on_incoming_trust_ukprn"
     t.index ["local_authority_id"], name: "index_projects_on_local_authority_id"
     t.index ["outgoing_trust_ukprn"], name: "index_projects_on_outgoing_trust_ukprn"
+    t.index ["region"], name: "index_projects_on_region"
     t.index ["regional_delivery_officer_id"], name: "index_projects_on_regional_delivery_officer_id"
     t.index ["tasks_data_id"], name: "index_projects_on_tasks_data_id"
     t.index ["tasks_data_type"], name: "index_projects_on_tasks_data_type"

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -182,6 +182,20 @@ RSpec.describe Project, type: :model do
       end
     end
 
+    describe "#region" do
+      it { is_expected.to validate_presence_of(:region) }
+
+      context "when validation is bypassed" do
+        let(:project) { build(:transfer_project, region: nil) }
+
+        it "is enforced by the db" do
+          expect {
+            project.save(validate: false)
+          }.to raise_error(ActiveRecord::NotNullViolation)
+        end
+      end
+    end
+
     describe "#incoming_trust_ukprn" do
       context "when the project does not have a new_trust_reference_number" do
         it { is_expected.to validate_presence_of(:incoming_trust_ukprn) }


### PR DESCRIPTION
There's no reason for `projects.region` be null. In this commit we:

- add application-level validation to enforce the presence of the `Project#region` attribute

- alter the db to make the `projects.region` column non-nullable. Now that we have another service creating records it's important to have a control at the db level, or we may continue to have invalid records inserted which cause "whiny-nil" errors

- add an index on project.region (I was surprised that this wasn't in place already)




