### PR TITLE
207661 Enforce presence of project's regional delivery officer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Handle pagination errors gracefully.
 
+### Changed
+
+- Enforce presence of the project's regional delivery officer.
+
 ## [Release-114][release-114]
 
 ### Changed

--- a/app/forms/conversion/create_project_form.rb
+++ b/app/forms/conversion/create_project_form.rb
@@ -73,7 +73,7 @@ class Conversion::CreateProjectForm < CreateProjectForm
         )
       end
 
-      @project.save
+      @project.save!
 
       @note = Note.create(body: handover_note_body, project: @project, user: user, task_identifier: :handover) if handover_note_body
       notify_team_leaders(@project) if assigned_to_regional_caseworker_team

--- a/app/forms/internal_contacts/edit_added_by_user_form.rb
+++ b/app/forms/internal_contacts/edit_added_by_user_form.rb
@@ -12,9 +12,7 @@ class InternalContacts::EditAddedByUserForm
   validate :user_is_assignable
 
   def self.new_from_project(project)
-    user_email = project.regional_delivery_officer_id.present? ? project.regional_delivery_officer.email : nil
-
-    new({email: user_email, project: project})
+    new({email: project.regional_delivery_officer.email, project: project})
   end
 
   def initialize(attrs = {})

--- a/app/forms/transfer/create_project_form.rb
+++ b/app/forms/transfer/create_project_form.rb
@@ -70,7 +70,7 @@ class Transfer::CreateProjectForm < CreateProjectForm
         )
       end
 
-      @project.save
+      @project.save!
       @note = Note.create(body: handover_note_body, project: @project, user: user, task_identifier: :handover) if handover_note_body
       @project.tasks_data.update!(
         inadequate_ofsted: inadequate_ofsted,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -40,7 +40,7 @@ class Project < ApplicationRecord
   validate :establishment_exists, if: -> { urn.present? }
 
   belongs_to :caseworker, class_name: "User", optional: true
-  belongs_to :regional_delivery_officer, class_name: "User", optional: true
+  belongs_to :regional_delivery_officer, class_name: "User", optional: false
   belongs_to :assigned_to, class_name: "User", optional: true
 
   scope :conversions, -> { where(type: "Conversion::Project") }

--- a/db/migrate/20250331144723_make_projects_regional_delivery_officer_id_non_nullable.rb
+++ b/db/migrate/20250331144723_make_projects_regional_delivery_officer_id_non_nullable.rb
@@ -1,0 +1,7 @@
+class MakeProjectsRegionalDeliveryOfficerIdNonNullable < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :projects, :regional_delivery_officer_id
+    change_column_null :projects, :regional_delivery_officer_id, false
+    add_index :projects, :regional_delivery_officer_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_27_163619) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_31_144723) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -308,7 +308,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_27_163619) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "incoming_trust_ukprn"
-    t.uuid "regional_delivery_officer_id"
+    t.uuid "regional_delivery_officer_id", null: false
     t.uuid "caseworker_id"
     t.datetime "assigned_at"
     t.date "advisory_board_date"

--- a/spec/factories/conversion/create_project_form_factory.rb
+++ b/spec/factories/conversion/create_project_form_factory.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     advisory_board_date { {3 => 1, 2 => 10, 1 => 2022} }
     establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/establishment-folder" }
     incoming_trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/trust-folder" }
-    user { association :user, :regional_delivery_officer }
+    user { association :user, :regional_delivery_officer, strategy: :create }
     handover_note_body { "Handover notes" }
     directive_academy_order { false }
     assigned_to_regional_caseworker_team { false }

--- a/spec/factories/transfer/create_project_form_factory.rb
+++ b/spec/factories/transfer/create_project_form_factory.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     establishment_sharepoint_link { "https://educationgovuk-my.sharepoint.com/establishment-folder" }
     incoming_trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/incoming-trust-folder" }
     outgoing_trust_sharepoint_link { "https://educationgovuk-my.sharepoint.com/outgoing-trust-folder" }
-    user { association :user, :regional_delivery_officer }
+    user { association :user, :regional_delivery_officer, strategy: :create }
     handover_note_body { "This is a handover note." }
     two_requires_improvement { false }
     inadequate_ofsted { false }

--- a/spec/forms/conversion/create_project_form_spec.rb
+++ b/spec/forms/conversion/create_project_form_spec.rb
@@ -681,10 +681,10 @@ RSpec.describe Conversion::CreateProjectForm, type: :model do
 
         context "when the group exists" do
           it "makes the association to the project" do
-            group = create(:project_group, group_identifier: "GRP_12345678", trust_ukprn: 1234567)
+            group = create(:project_group, group_identifier: "GRP_12345678", trust_ukprn: 12345678)
             form = build(
               :create_conversion_project_form,
-              incoming_trust_ukprn: 1234567,
+              incoming_trust_ukprn: 12345678,
               group_id: "GRP_12345678"
             )
 

--- a/spec/forms/internal_contacts/edit_added_by_user_form_spec.rb
+++ b/spec/forms/internal_contacts/edit_added_by_user_form_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe InternalContacts::EditAddedByUserForm, type: :model do
 
   it "can be initialized with attributes" do
     user = create(:user, :regional_delivery_officer, email: "case.worker@education.gov.uk")
-    project = create(:conversion_project, regional_delivery_officer: user)
+    project = create(:conversion_project)
 
     result = described_class.new({email: user.email, project: project})
 
@@ -27,14 +27,6 @@ RSpec.describe InternalContacts::EditAddedByUserForm, type: :model do
 
   describe "validations" do
     describe "email" do
-      it "is required" do
-        project = create(:conversion_project, regional_delivery_officer: nil)
-
-        result = described_class.new_from_project(project)
-
-        expect(result).to be_invalid
-      end
-
       it "must be an @education.gov.uk address" do
         user = create(:user, :caseworker)
         project = create(:conversion_project, regional_delivery_officer: user)
@@ -69,7 +61,7 @@ RSpec.describe InternalContacts::EditAddedByUserForm, type: :model do
     context "when the form is valid" do
       it "updates the project and returns true" do
         user = create(:user, :caseworker)
-        project = create(:conversion_project, regional_delivery_officer: nil)
+        project = create(:conversion_project)
 
         result = described_class.new({email: user.email, project: project}).update
 
@@ -80,11 +72,12 @@ RSpec.describe InternalContacts::EditAddedByUserForm, type: :model do
 
     context "when the form is invalid" do
       it "does not update the project and returns false" do
-        project = create(:conversion_project, regional_delivery_officer: nil)
+        user = create(:user, :regional_delivery_officer)
+        project = create(:conversion_project, regional_delivery_officer: user)
 
         result = described_class.new({email: "invlalid@email.address", project: project}).update
 
-        expect(project.reload.regional_delivery_officer).to be_nil
+        expect(project.reload.regional_delivery_officer).to eql(user)
         expect(result).to be false
       end
     end

--- a/spec/forms/transfer/create_project_form_spec.rb
+++ b/spec/forms/transfer/create_project_form_spec.rb
@@ -353,10 +353,10 @@ RSpec.describe Transfer::CreateProjectForm, type: :model do
 
         context "when the group exists" do
           it "makes the association to the project" do
-            group = create(:project_group, group_identifier: "GRP_12345678", trust_ukprn: 1234567)
+            group = create(:project_group, group_identifier: "GRP_12345678", trust_ukprn: 12345678)
             form = build(
               :create_transfer_project_form,
-              incoming_trust_ukprn: 1234567,
+              incoming_trust_ukprn: 12345678,
               group_id: "GRP_12345678"
             )
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -196,6 +196,14 @@ RSpec.describe Project, type: :model do
       end
     end
 
+    describe "#regional_delivery_officer association" do
+      it "enforces the presence of the ActiveRecord association" do
+        project = build(:transfer_project, regional_delivery_officer: nil)
+        project.valid?
+        expect(project.errors).to include(:regional_delivery_officer)
+      end
+    end
+
     describe "#incoming_trust_ukprn" do
       context "when the project does not have a new_trust_reference_number" do
         it { is_expected.to validate_presence_of(:incoming_trust_ukprn) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -202,6 +202,16 @@ RSpec.describe Project, type: :model do
         project.valid?
         expect(project.errors).to include(:regional_delivery_officer)
       end
+
+      context "when validation is bypassed" do
+        let(:project) { build(:transfer_project, regional_delivery_officer: nil) }
+
+        it "is enforced by the db" do
+          expect {
+            project.save(validate: false)
+          }.to raise_error(ActiveRecord::NotNullViolation)
+        end
+      end
     end
 
     describe "#incoming_trust_ukprn" do


### PR DESCRIPTION
## Changes

In order to prevent invalid records being created by the new .NET application with whom we are sharing a DB, we add some controls to ensure that a project always has its expected "regional delivery officer", which should be set on creation.

We:

- add application level validation
- make the `projects.regional_delivery_officer_id` foreign key non-nullable

Also: the two `CreateProjectForm` classes, which are used for creating projects manually from the UI as opposed to via the API, now call `Project#save!` to raise an error if invalid. 

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
