### PR TITLE
(199772) Handle Pagy::OverflowError with 404 Not Found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Handle pagination errors gracefully.
+
 ## [Release-114][release-114]
 
 ### Changed

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
   rescue_from Api::AcademiesApi::Client::Error, with: :academies_api_client_error
   rescue_from Api::AcademiesApi::Client::UnauthorisedError, with: :academies_api_unauthorised_error
   rescue_from ActionController::InvalidAuthenticityToken, with: :reset_user_session
+  rescue_from Pagy::OverflowError, with: :not_found_error
 
   before_action :current_user_identifier
   before_action :set_notification

--- a/spec/requests/error_handling_spec.rb
+++ b/spec/requests/error_handling_spec.rb
@@ -46,4 +46,14 @@ RSpec.describe "Error handling", type: :request do
       expect(response).to redirect_to(sign_in_path)
     end
   end
+
+  context "when a page number which is out of range is requested" do
+    before { sign_in_with(create(:user)) }
+
+    it "is handled as '404 Not Found' without a Pagy::OverflowError" do
+      get "/projects/all/trusts?page=999"
+
+      expect(response).to render_template("pages/page_not_found", status: :not_found)
+    end
+  end
 end


### PR DESCRIPTION
See [Ticket 199772](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/199772)

We sometimes see unhandled `Page::OverflowError` exceptions when users ask our pagination system for a page which doesn't exist, e.g.

```
GET /projects/team/in-progress?page=2
```

Perhaps the user has bookmarked this page or left it open in their browser overnight. In the interim the number of their team's "in-progress" has reduced, so that they are now listed on a single page. Asking for page 2  then produces

```
Page::OverflowError: expected :page in 1..1; got 2
```

We now rescue this error and show the "Not found" template with status 404.

## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.

![rescue_page_overflow_as_not_found](https://github.com/user-attachments/assets/9150e6ff-f186-46b9-899f-41ca3edf32be)



