### PR TITLE
Add X-Backend-Origin header to identify this service

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -85,6 +85,9 @@ module DfeCompleteConversionsTransfersAndChanges
     # use the cookies for the session and set the name of the cookie
     config.session_store :cookie_store, key: "SESSION"
 
+    # distinguish this service from the .NET version, during "dual-running"
+    config.action_dispatch.default_headers["X-Backend-Origin"] = "ruby"
+
     # set the X-Frame-Options header
     config.action_dispatch.default_headers["X-Frame-Options"] = "DENY"
     # set the HSTS header

--- a/spec/requests/x_headers_spec.rb
+++ b/spec/requests/x_headers_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe "X-Headers", type: :request do
+  describe "X-Backend-Origin" do
+    it "sets to 'ruby' to distinguish this service from the .NET service when 'dual-running'" do
+      get page_path(id: "page_not_found")
+
+      expect(response.headers.fetch("X-Backend-Origin")).to eq("ruby")
+    end
+  end
+end


### PR DESCRIPTION
This service is being [rewritten in .NET][] and we'll be running the two services side-by side, handing users off to the .NET version from this Ruby version for increasingly large portions of the user journeys.

This "dual-running" will work using "custom rerouting" from the [RSD Front Door service][] (Azure Front Door CDN). See this [initial configuration][]

In order to aid debugging and monitoring it's important to have visibility on which requests are handled by each version of the service.

In this commit we add an "experimental" response header (`X-Backed-Origin: ruby`) to identify the Ruby service. See the [Front Door config][] for the .NET version which will be added dynamically.

[rewritten in .NET]:
https://github.com/DFE-Digital/complete-conversions-transfers-changes

[RSD Front Door service]:
https://github.com/DFE-Digital/rsd-frontdoor

[initial configuration]:
https://github.com/DFE-Digital/rsd-frontdoor/commit/0589b9ec402a3561efaa4c0581bba05e22fb5b2c

[Front Door config]:
https://github.com/DFE-Digital/rsd-frontdoor/blob/0589b9ec402a3561efaa4c0581bba05e22fb5b2c/rulesets.tf#L171-L175


