### PR TITLE
(210076) Fix: toggle User#manage_team via UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Handle pagination errors gracefully.
+- Allow 'manage team' user attribute to be set by service support
 
 ### Changed
 

--- a/app/views/service_support/users/edit.html.erb
+++ b/app/views/service_support/users/edit.html.erb
@@ -19,9 +19,9 @@
       <div class="govuk-form-group">
         <%= form.govuk_collection_radio_buttons :team, @user.team_options, :id, :name %>
 
-        <%= form.govuk_check_boxes_fieldset :team_leader, multiple: false, legend: {size: "s"}  do %>
+        <%= form.govuk_check_boxes_fieldset :manage_team, multiple: false, legend: {size: "s"}  do %>
           <%= t("helpers.hint.user.team_lead.html") %>
-          <%= form.govuk_check_box :team_leader, 1, 0, multiple: false, link_errors: true, label: {text: t("helpers.label.user.team_lead")} %>
+          <%= form.govuk_check_box :manage_team, 1, 0, multiple: false, link_errors: true, label: {text: t("helpers.label.user.team_lead")} %>
         <% end %>
 
         <%= form.govuk_check_boxes_fieldset :active, multiple: false, legend: {size: "s"}  do %>

--- a/app/views/service_support/users/edit.html.erb
+++ b/app/views/service_support/users/edit.html.erb
@@ -19,8 +19,8 @@
       <div class="govuk-form-group">
         <%= form.govuk_collection_radio_buttons :team, @user.team_options, :id, :name %>
 
-        <%= form.govuk_check_boxes_fieldset :manage_team, multiple: false, legend: {size: "s"}  do %>
-          <%= t("helpers.hint.user.team_lead.html") %>
+        <%= form.govuk_check_boxes_fieldset :manage_team, multiple: false, legend: {size: "s"} do %>
+          <%= t("helpers.hint.user.manage_team_attribute.html") %>
           <%= form.govuk_check_box :manage_team, 1, 0, multiple: false, link_errors: true, label: {text: t("helpers.label.user.team_lead")} %>
         <% end %>
 

--- a/config/locales/user.en.yml
+++ b/config/locales/user.en.yml
@@ -67,7 +67,7 @@ en:
     legend:
       user:
         team: User team
-        team_leader: Team lead
+        manage_team: Team lead or team manager
         active: Active user
     label:
       user:

--- a/config/locales/user.en.yml
+++ b/config/locales/user.en.yml
@@ -80,8 +80,10 @@ en:
       user:
         email: "@education.gov.uk email addresses only"
         team: All users must belong in one of the following teams. Sub-teams within these are not required.
-        team_lead:
-          html: <p>If the user is a lead or manager within the team, check this box.</p>
+        manage_team_attribute:
+          html: <p>If the user is a lead or manager within the team, check this box.
+                However, note that this will only be applied for RDOs and RCS team members.
+                If the user is a member of a different team they will need to have a user-specific "Manage Team Capability" set. Raise a support ticket to request this.</p>
         active:
           html:
             <p>Inactive users cannot access the application and will not show up in list of users.</p>

--- a/spec/features/users/users_can_manage_user_accounts_spec.rb
+++ b/spec/features/users/users_can_manage_user_accounts_spec.rb
@@ -66,6 +66,18 @@ RSpec.feature "Users can manage user accounts" do
     expect(existing_user.reload.team).to eql "north_east"
   end
 
+  scenario "existing users can have the 'manage_team' property set" do
+    existing_user = create(:user, :regional_delivery_officer, team: "london", manage_team: false)
+
+    visit edit_service_support_user_path(existing_user)
+
+    choose "North East"
+    check "User is a team lead or manager"
+    click_on "Save user"
+
+    expect(existing_user.reload.manage_team).to be true
+  end
+
   scenario "exisiting users cannot be made invalid" do
     existing_user = create(:user, :regional_delivery_officer, team: "london")
 

--- a/spec/features/users/users_can_manage_user_accounts_spec.rb
+++ b/spec/features/users/users_can_manage_user_accounts_spec.rb
@@ -73,9 +73,17 @@ RSpec.feature "Users can manage user accounts" do
 
     choose "North East"
     check "User is a team lead or manager"
+    and_i_see_guidance_on_setting_manage_team_attribute
     click_on "Save user"
 
     expect(existing_user.reload.manage_team).to be true
+  end
+
+  def and_i_see_guidance_on_setting_manage_team_attribute
+    expect(page).to have_content("note that this will only be applied for RDOs and RCS team members")
+    expect(page).to have_content(
+      "If the user is a member of a different team they will need to have a user-specific \"Manage Team Capability\" set"
+    )
   end
 
   scenario "exisiting users cannot be made invalid" do


### PR DESCRIPTION
Ticket [210076](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/210076)

In e5fb0398172082431f56104fa43d951b4c1c8667 we renamed `User#team_leader` to `User#manage_team` -- but failed to change the form used by service support team members to edit the attribute via the UI.

Now it's again possible to toggle this "manage_team" property using the form at:

`/service-support/users/{userId}/edit`

We also add some guidance to advise the user that setting the `User#manage_team` attribute:
    
> will only be applied for RDOs and RCS team members. If the user is a member of a different team they will need to have a user-specific "Manage Team Capability" set. Raise a support ticket to request this.

## Screenshot


![edit_user_manage_team](https://github.com/user-attachments/assets/75c67c2f-8636-4188-8d74-da70e5ec6785)


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
