### PR TITLE
Update Gemfile.lock after update to Ruby 3.4.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -622,7 +622,7 @@ DEPENDENCIES
   webmock (~> 3.17)
 
 RUBY VERSION
-   ruby 3.4.2p28
+   ruby 3.4.3p32
 
 BUNDLED WITH
    2.3.23


### PR DESCRIPTION
In 3ab1ad3fd12536ed221a4344966b7e0fca687e47 we upgraded to Ruby 3.4.3 but didn't update the `Gemfile.lock` at that time.

