### PR TITLE
(211569) Fix broken link to guidance on 'commercial transfer agreement'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Service support can view re-routing rules for "dual-running" of service with
   the new .NET version
 
+### Fixed
+
+- Link to guidance on Commercial Transfer Agreement fixed
+
 ## [Release-115][release-115]
 
 ### Fixed

--- a/config/locales/conversion/tasks/commercial_transfer_agreement.en.yml
+++ b/config/locales/conversion/tasks/commercial_transfer_agreement.en.yml
@@ -8,7 +8,7 @@ en:
         guidance_link: How to check and assure the commercial transfer agreeement
         guidance:
           html:
-            <p>You can <a href="https://educationgovuk.sharepoint.com/sites/lvewp00030/SitePages/3-Conversion%20Process/Commercial%20Transfer%20Agreement%20(CTA)/Commercial%20Transfer%20Agreement.aspx" target="_blank">read guidance about how use check and assure the agreement (opens in new tab)</a> on SharePoint.</p>
+            <p>You can <a href="https://educationgovuk.sharepoint.com/:u:/r/sites/lvewp00030/SitePages/Commercial%20Transfer%20Agreement.aspx" target="_blank">read guidance about how use check and assure the agreement (opens in new tab)</a> on SharePoint.</p>
 
         agreed:
           title: Confirm commercial transfer agreement is agreed

--- a/config/locales/transfer/tasks/commercial_transfer_agreement.en.yml
+++ b/config/locales/transfer/tasks/commercial_transfer_agreement.en.yml
@@ -10,7 +10,7 @@ en:
         guidance_link: How to check and assure the commercial transfer agreeement
         guidance:
           html:
-            <p>You can <a href="https://educationgovuk.sharepoint.com/sites/lvewp00030/SitePages/3-Conversion%20Process/Commercial%20Transfer%20Agreement%20(CTA)/Commercial%20Transfer%20Agreement.aspx" target="_blank">read guidance about how use check and assure the agreement (opens in new tab)</a> on SharePoint.</p>
+            <p>You can <a href="https://educationgovuk.sharepoint.com/:u:/r/sites/lvewp00030/SitePages/Commercial%20Transfer%20Agreement.aspx" target="_blank">read guidance about how use check and assure the agreement (opens in new tab)</a> on SharePoint.</p>
 
         confirm_agreed:
           title: Confirm commercial transfer agreement is agreed


### PR DESCRIPTION
The link to the guidance about Commercial Transfer Agreement (aka CTA) on Sharepoint  was broken.

## Screenshots

### The Commercial Transfer Agreement task in the tasklist

![tasklist_cta_task](https://github.com/user-attachments/assets/fde6a3a7-ed28-4504-9240-74dcdf999835)

### The link to guidance on the Commercial Transfer Agreement task

![cta_step_link_to_guidance](https://github.com/user-attachments/assets/5bb9bae0-242a-491a-878c-b881e26d5808)

### The guidance now successfully linked to on Sharepoint

![cta_guidance_on_sharepoint](https://github.com/user-attachments/assets/3c173249-cb89-4d41-9d24-1e3938b0cf5d)



## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
