### PR TITLE
(212141) Service support manages user's capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Service support can now manage a user's "capabilities"
+
 ## [Release-116][release-116]
 
 ### Changed

--- a/app/controllers/service_support/users_controller.rb
+++ b/app/controllers/service_support/users_controller.rb
@@ -45,6 +45,7 @@ class ServiceSupport::UsersController < ApplicationController
     @user.assign_attributes(user_params)
     if @user.valid?
       @user.save!
+      assign_capabilities
       redirect_to service_support_users_path, notice: I18n.t("user.edit.success", email: @user.email)
     else
       render :edit
@@ -67,6 +68,14 @@ class ServiceSupport::UsersController < ApplicationController
     else
       render :set_team
     end
+  end
+
+  private def assign_capabilities
+    desired_capabilities = params[:user][:capabilities].map do |name|
+      Capability.find_by(name: name)
+    end.compact
+
+    @user.capabilities = desired_capabilities
   end
 
   private def user_params

--- a/app/models/capability.rb
+++ b/app/models/capability.rb
@@ -29,4 +29,13 @@ class Capability < ApplicationRecord
       description: "Perform DevOps activities"
     )
   end
+
+  def self.all_capabilities
+    [
+      add_new_project,
+      assign_to_project,
+      manage_team,
+      devops
+    ]
+  end
 end

--- a/app/views/service_support/users/edit.html.erb
+++ b/app/views/service_support/users/edit.html.erb
@@ -24,6 +24,14 @@
           <%= form.govuk_check_box :manage_team, 1, 0, multiple: false, link_errors: true, label: {text: t("helpers.label.user.team_lead")} %>
         <% end %>
 
+        <%= form.govuk_check_boxes_fieldset :capabilities, legend: {size: "s"}, class: "capabilities" do %>
+          <p class="hint">Does the user need any special capabilities?</p>
+          <%= govuk_inset_text(text: "Use with caution. Capabilities override team-based permissions.") %>
+          <% Capability.all_capabilities.each do |capability| %>
+            <%= form.govuk_check_box :capabilities, capability.name, multiple: true, hint: {text: capability.description}, label: {text: capability.name}, checked: @user.capabilities.include?(capability) %>
+          <% end %>
+        <% end %>
+
         <%= form.govuk_check_boxes_fieldset :active, multiple: false, legend: {size: "s"}  do %>
           <%= t("helpers.hint.user.active.html") %>
           <%= form.govuk_check_box :active, 1, 0, multiple: false, link_errors: true, label: {text: t("helpers.label.user.active")} %>

--- a/spec/features/service_support/can_manage_user_capabilities_spec.rb
+++ b/spec/features/service_support/can_manage_user_capabilities_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.feature "Service support can manage user capabilties" do
+  scenario "can edit assigned capabilities" do
+    given_i_am_logged_in_as_a_service_support_user
+    and_a_user_has_capabilities_1_and_3_assigned
+    when_i_view_their_user_record
+    then_i_see_capabilities_1_and_3_are_assigned
+    and_i_see_guidance_and_warning_on_assigning_capabilities
+    and_i_see_further_info_on_each_capability
+
+    when_i_edit_their_capabilities_to_be_2_and_4
+    then_i_see_capabilities_2_and_4_are_assigned
+  end
+
+  def given_i_am_logged_in_as_a_service_support_user
+    service_support_user = FactoryBot.create(
+      :user,
+      :service_support,
+      first_name: "Service",
+      last_name: "Support",
+      email: "service.support@education.gov.uk"
+    )
+
+    sign_in_with_user(service_support_user)
+  end
+
+  def and_a_user_has_capabilities_1_and_3_assigned
+    @subject_user = create(:user, first_name: "Other", last_name: "User", email: "other.user@education.gov.uk")
+    @subject_user.capabilities = [Capability.all_capabilities.first, Capability.all_capabilities.third]
+  end
+
+  def when_i_view_their_user_record
+    visit edit_service_support_user_path(@subject_user)
+  end
+
+  def then_i_see_capabilities_1_and_3_are_assigned
+    within(".capabilities") do
+      expect(page).to have_field(Capability.all_capabilities.first.name, checked: true)
+      expect(page).to have_field(Capability.all_capabilities.third.name, checked: true)
+
+      expect(page).to have_field(Capability.all_capabilities.second.name, checked: false)
+      expect(page).to have_field(Capability.all_capabilities.fourth.name, checked: false)
+    end
+  end
+
+  def and_i_see_guidance_and_warning_on_assigning_capabilities
+    within(".capabilities") do
+      expect(page).to have_css(".hint", text: "Does the user need any special capabilities?")
+      expect(page).to have_css(".govuk-inset-text", text: "Use with caution")
+    end
+  end
+
+  def and_i_see_further_info_on_each_capability
+    within(".capabilities") do
+      Capability.all_capabilities.each do |capability|
+        expect(page).to have_css(".govuk-checkboxes__item .govuk-hint", text: capability.description)
+      end
+    end
+  end
+
+  def when_i_edit_their_capabilities_to_be_2_and_4
+    within(".capabilities") do
+      check Capability.all_capabilities.second.name
+      check Capability.all_capabilities.fourth.name
+
+      uncheck Capability.all_capabilities.first.name
+      uncheck Capability.all_capabilities.third.name
+    end
+
+    click_button("Save user")
+  end
+
+  def then_i_see_capabilities_2_and_4_are_assigned
+    visit edit_service_support_user_path(@subject_user)
+    within(".capabilities") do
+      expect(page).to have_field(Capability.all_capabilities.second.name, checked: true)
+      expect(page).to have_field(Capability.all_capabilities.fourth.name, checked: true)
+
+      expect(page).to have_field(Capability.all_capabilities.first.name, checked: false)
+      expect(page).to have_field(Capability.all_capabilities.third.name, checked: false)
+    end
+  end
+end


### PR DESCRIPTION
[Ticket 212141](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/212141)

- So that I can override specific permissions for a particular individual
- As a member of service support team editing a user record
- I want to be able to add/remove user capabilities

---

In [PR 2088][] we introduced "user capabilities" to overcome the
limitations of the complex rules in how certain key user attributes are
assigned. This code in the `User` model is called every time a user is saved:

```rb
private def apply_roles_based_on_team
  assign_attributes(
    assign_to_project: allowing_override_for(:assign_to_project) { is_regional_caseworker? || is_regional_delivery_officer? },
    manage_user_accounts: apply_service_support_role?,
    manage_conversion_urns: apply_service_support_role?,
    manage_local_authorities: apply_service_support_role?,
    add_new_project: allowing_override_for(:add_new_project) { is_regional_delivery_officer? },
    manage_team: allowing_override_for(:manage_team) { apply_team_lead_role? }
  )
end
```

Our user capabilities allow for the following to be overridden using
user capabilities:

- `add_new_project`
- `assign_to_project`
- `manage_team`

In [PR 2138][] we added a further capability (`devops`) to allow users
outside of the "service support" team to access the page which shows
the current "dual running" config on the Azure FrontDoor and its effect
on the service's routes.

In this change we provide a UI for members of the service support team
to view and manage these capabilities.

[PR 2088]:
https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/2088

[PR 2138]:
https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/2138/commits/f6f50e18965cbcc3f611b768858fa50c7f023b7f

## Screenshot

![Edit a user](https://github.com/user-attachments/assets/f89a2daf-ecd1-4ac4-9a3e-e27959a5edd9)


## Checklist

- [x] Attach this pull request to the appropriate card in DevOps.
- [x] Update the `CHANGELOG.md` if needed.
