### PR TITLE
Chore: Add not-null constraints to the notes table

### DIFF
--- a/db/migrate/20250508082822_add_constraints_to_notes.rb
+++ b/db/migrate/20250508082822_add_constraints_to_notes.rb
@@ -1,0 +1,13 @@
+class AddConstraintsToNotes < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :notes, :user_id
+    change_column_null :notes, :user_id, false
+    add_index :notes, :user_id
+
+    remove_index :notes, :project_id
+    change_column_null :notes, :project_id, false
+    add_index :notes, :project_id
+
+    change_column_null :notes, :body, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_31_144723) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_08_082822) do
   create_table "api_keys", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -281,9 +281,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_31_144723) do
   end
 
   create_table "notes", id: :uuid, default: -> { "newid()" }, force: :cascade do |t|
-    t.text "body"
-    t.uuid "project_id"
-    t.uuid "user_id"
+    t.text "body", null: false
+    t.uuid "project_id", null: false
+    t.uuid "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "task_identifier"

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -911,9 +911,10 @@ RSpec.describe Project, type: :model do
   describe "#handover_note" do
     it "returns the associated Note with the `handover` task identifier" do
       mock_successful_api_responses(urn: any_args, ukprn: any_args)
-      project = build(:conversion_project)
-      handover_note = create(:note, task_identifier: :handover, body: "Handover body", user: build(:user), project: project)
-      _other_note = create(:note, task_identifier: :stakeholder_kick_off, body: "Another body", user: build(:user), project: project)
+      project = create(:conversion_project)
+      user = create(:user)
+      handover_note = create(:note, task_identifier: :handover, body: "Handover body", user: user, project: project)
+      _other_note = create(:note, task_identifier: :stakeholder_kick_off, body: "Another body", user: user, project: project)
 
       expect(project.handover_note).to eq(handover_note)
     end


### PR DESCRIPTION
We're seeing a lot of invalid notes being created in the dev and test DBs by the new .NET version of the service which is under construction.

In the Ruby version, the `User` and `Project` associations are enforced, as is the presence of the `#body`.

In this migration we add these constraints to the `notes` table in the db itself.


