### PR TITLE
Chore: provide 'attestations' permissions value for build-import step

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -51,11 +51,12 @@ jobs:
     needs: [ set-env ]
     environment: ${{ needs.set-env.outputs.environment }}
     permissions:
+      attestations: write
       packages: write
       id-token: write
 
-    steps:  
-      - uses: DFE-Digital/deploy-azure-container-apps-action/.github/actions/build@v5.1.0
+    steps:
+      - uses: DFE-Digital/deploy-azure-container-apps-action/.github/actions/build@v5.2.1
         with:
           image-name: ${{ needs.set-env.outputs.image-name }}
           build-args: |
@@ -63,8 +64,8 @@ jobs:
             CURRENT_GIT_SHA="${{ needs.set-env.outputs.checked-out-sha }}"
             TIME_OF_BUILD="${{ needs.set-env.outputs.date }}"
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: DFE-Digital/deploy-azure-container-apps-action/.github/actions/import@v5.1.0
-        with: 
+      - uses: DFE-Digital/deploy-azure-container-apps-action/.github/actions/import@v5.2.1
+        with:
           image-name: ${{ needs.set-env.outputs.image-name }}
           azure-acr-name: ${{ secrets.ACR_NAME }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -100,7 +101,7 @@ jobs:
       - id: annotate
         run: echo "ANNOTATE_RELEASE=${{ matrix.container_app == 'web' && 'yes' || 'no' }}" >> $GITHUB_ENV
 
-      - uses: DFE-Digital/deploy-azure-container-apps-action/.github/actions/deploy@v5.1.0
+      - uses: DFE-Digital/deploy-azure-container-apps-action/.github/actions/deploy@v5.2.1
         with:
           image-name: ${{ needs.set-env.outputs.image-name }}
           annotate-release: ${{ env.ANNOTATE_RELEASE }}


### PR DESCRIPTION
This is required following the update to v 2.72.0
of the az cli.

See https://github.com/DFE-Digital/deploy-azure-container-apps-action/releases/tag/v5.2.1


