### PR TITLE
Adds declaration of expenditure task attributes to conversion tasks data table

### DIFF
--- a/db/migrate/20250604124333_add_conversion_declaration_of_expenditure_certificate_task_attributes.rb
+++ b/db/migrate/20250604124333_add_conversion_declaration_of_expenditure_certificate_task_attributes.rb
@@ -1,0 +1,5 @@
+class AddConversionDeclarationOfExpenditureCertificateTaskAttributes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :conversion_tasks_data, :declaration_of_expenditure_certificate_not_applicable, :boolean, default: false
+  end
+end


### PR DESCRIPTION
A user reported that a tick box for declaration of expenditure certificates was unable to be unticked. 

Investigation found that the `declaration_of_expenditure_certificate_not_applicable` on the table `conversion_tasks_data` is missing, while it is present on table `transfer_tasks_data`. 

## Changes

This PR introduces a migration to add this field to `conversion_tasks_data`.


## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
