### PR TITLE
Removes not_applicable attribute setting from receive grant payment form for conversion

### DIFF
--- a/app/forms/conversion/task/receive_grant_payment_certificate_task_form.rb
+++ b/app/forms/conversion/task/receive_grant_payment_certificate_task_form.rb
@@ -4,7 +4,6 @@ class Conversion::Task::ReceiveGrantPaymentCertificateTaskForm < BaseOptionalTas
   attribute :check_certificate, :boolean
   attribute :save_certificate, :boolean
   attribute :date_received, :date
-  attribute :not_applicable
 
   def initialize(tasks_data, user)
     @date_param_errors = ActiveModel::Errors.new(self)


### PR DESCRIPTION
This PR builds on the bug approached in [PR 2168](https://github.com/DFE-Digital/dfe-complete-conversions-transfers-and-changes/pull/2168).

A user reported that a tick box for declaration of expenditure certificates was unable to be unticked. Further debugging allowed the box to be unticked, but the certificate status was still showing as NOT APPLICABLE in the task list.

## Changes

This PR removes the not_applicable attribute set in the `receive_grant_payment_certificate_task_form`. With this in place, the 'not applicable' attribute was being set for this form regardless of user input in the interface. This caused the certificate to show as NOT APPLICABLE even when unticked by the user. 

## Checklist

- [ ] Attach this pull request to the appropriate card in DevOps.
- [ ] Update the `CHANGELOG.md` if needed.
